### PR TITLE
clustermesh: fix service export sync on missing CRDs

### DIFF
--- a/clustermesh-apiserver/clustermesh/serviceexport_sync.go
+++ b/clustermesh-apiserver/clustermesh/serviceexport_sync.go
@@ -6,7 +6,9 @@ package clustermesh
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -70,7 +72,7 @@ func registerServiceExportSync(jg job.Group, cfg ServiceExportSyncParameters) {
 		job.OneShot(
 			"serviceexport-sync",
 			func(ctx context.Context, _ cell.Health) error {
-				(&serviceExportSync{
+				return (&serviceExportSync{
 					logger:      cfg.Logger,
 					enabled:     cfg.Config.EnableMCSAPI,
 					clusterName: cfg.ClusterInfo.Name,
@@ -85,8 +87,11 @@ func registerServiceExportSync(jg job.Group, cfg ServiceExportSyncParameters) {
 					namespaceManager: cfg.NamespaceManager,
 					namespaces:       cfg.Namespaces,
 				}).loop(ctx)
-				return nil
 			},
+			job.WithRetry(-1, &job.ExponentialBackoff{
+				Min: time.Second,
+				Max: time.Minute,
+			}),
 		),
 		job.OneShot(
 			"run-serviceexport-store",
@@ -114,7 +119,7 @@ type serviceExportSync struct {
 	namespaces       resource.Resource[*slim_corev1.Namespace]
 }
 
-func (s *serviceExportSync) loop(ctx context.Context) {
+func (s *serviceExportSync) loop(ctx context.Context) error {
 	if s.syncCallback == nil {
 		s.syncCallback = func(ctx context.Context) {}
 	}
@@ -126,31 +131,25 @@ func (s *serviceExportSync) loop(ctx context.Context) {
 		// as it's the only cluster mesh type that can be disabled separately.
 		// This is especially useful in the case of the kvstoremesh.
 		s.store.Synced(ctx, s.syncCallback)
-		return
+		return nil
 	}
 
 	if s.clientset != nil /* clientset is nil in tests */ {
 		err := client.CheckCRD(ctx, s.clientset, mcsapiv1beta1.SchemeGroupVersion.WithKind("serviceexports"))
 		if err != nil {
-			s.logger.Warn("starting synchronizing service exports without the required CRD installed", logfields.Error, err)
-			// Also pretend that the service exports are synced for the same reason
-			// as above.
-			s.store.Synced(ctx, s.syncCallback)
-			return
+			return fmt.Errorf("required ServiceExport CRD is not installed: %w", err)
 		}
 	}
 
 	serviceEvents := s.services.Events(ctx)
 	serviceStore, err := s.services.Store(ctx)
 	if err != nil {
-		s.logger.Error("can't init service store", logfields.Error, err)
-		return
+		return fmt.Errorf("can't init service store: %w", err)
 	}
 	serviceExportsEvents := s.serviceExports.Events(ctx)
 	serviceExportStore, err := s.serviceExports.Store(ctx)
 	if err != nil {
-		s.logger.Error("can't init service export store", logfields.Error, err)
-		return
+		return fmt.Errorf("can't init service export store: %w", err)
 	}
 
 	namespaceEvents := s.namespaces.Events(ctx)
@@ -227,6 +226,8 @@ func (s *serviceExportSync) loop(ctx context.Context) {
 			ev.Done(errors.Join(errs...))
 		}
 	}
+
+	return nil
 }
 
 func (s *serviceExportSync) syncMCSAPIServiceSpec(

--- a/clustermesh-apiserver/clustermesh/testdata/serviceexports-crd-upgrade.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/serviceexports-crd-upgrade.txtar
@@ -1,0 +1,104 @@
+#! --cluster-id=1 --cluster-name=cluster1 --clustermesh-enable-mcs-api
+
+# Start with the ServiceExport CRD missing the required v1beta1 version
+k8s/add serviceexport-crd-v1alpha1.yaml
+hive/start
+
+# The failed CRD check must fail and we shouldn't have created the synced marker
+* health --levels=degraded --match=job-serviceexport-sync
+kvstore/list -o plain cilium/synced synced.actual
+! grep -q '^# cilium/synced/cluster1/cilium/state/serviceexports/v1$' synced.actual
+
+# Upgrade the CRD and export a service
+k8s/update serviceexport-crd-v1beta1.yaml
+k8s/add namespace.yaml service.yaml serviceexport.yaml
+
+# Verify that the sync job recovers without a restart
+kvstore/list -o json cilium/state/serviceexports serviceexports.actual
+* cmp serviceexports.actual serviceexports.expected
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster1/cilium/state/serviceexports/v1$' synced.actual
+health/ok --match=job-serviceexport-sync
+
+# ----
+
+-- namespace.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+
+-- serviceexport-crd-v1alpha1.yaml --
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: ServiceExport
+    plural: serviceexports
+    singular: serviceexport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+
+-- serviceexport-crd-v1beta1.yaml --
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: ServiceExport
+    plural: serviceexports
+    singular: serviceexport
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: basic
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    name: basic
+  sessionAffinity: None
+
+-- serviceexport.yaml --
+apiVersion: multicluster.x-k8s.io/v1beta1
+kind: ServiceExport
+metadata:
+  name: basic
+  namespace: default
+  creationTimestamp: "2026-01-01T00:00:00Z"
+
+-- serviceexports.expected --
+# cilium/state/serviceexports/v1/cluster1/default/basic
+{
+  "cluster": "cluster1",
+  "name": "basic",
+  "namespace": "default",
+  "exportCreationTimestamp": "2026-01-01T00:00:00Z",
+  "ports": [
+    {
+      "name": "http",
+      "protocol": "TCP",
+      "port": 80
+    }
+  ],
+  "type": "ClusterSetIP",
+  "sessionAffinity": "None"
+}


### PR DESCRIPTION
The service export sync logic incorrectly finish the syncing process early when we weren't able to find the CRDs which could affect both CRD upgrade when the clustermesh-apiserver new version start before the cilium-operator had a chance to finish upgrading the CRDs or when enabling MCS-API on a running cluster with a similar configuration.

This commit fixes that by ensuring that we retry launching the sync without actually setting the store as synced which both influence clustermesh-apiserver readiness and the resource sync marker.

Used AIL-1 here

Fixes #47793

```release-note
clustermesh: fix MCS-API CRD install/upgrade when clustermesh-apiserver is started before the CRD version is actually installed
```