### PR TITLE
[v1.19] Docs backport 2026-08-06

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:41e30ce5620eb17f929e020ccdc83af66505afdc@sha256:51f0d515dc8fcd7ffe5fad0ada3e77f6f91a008419542ec3a37a82731f9f96d1
+        uses: docker://quay.io/cilium/docs-builder:e6773ed21ab03066c0f24e68f342f18804a8ee0a@sha256:d3beff6d6408c09f6e1dbc637f7e98962b7d1fd2a81bf1d2a27ff8817dafb51f
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -31,10 +31,12 @@ DOCS_BASE_IMG ?= cilium/docs-base
 base-image: Dockerfile ## Build the docs-base image for updating the requirements.txt file.
 	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
 
-DOCS_BUILDER_IMG ?= cilium/docs-builder
+DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
+DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's#:.*##')
+
 ifndef SKIP_BUILDER_IMAGE
 builder-image: Dockerfile $(REQUIREMENTS) ## Build the docs-builder image for rendering and checking the documentation.
-	$(call build_image,$<,docs-builder,$(DOCS_BUILDER_IMG))
+	$(call build_image,$<,docs-builder,$(DOCS_BUILDER_REPO))
 else
 builder-image:
 	@echo "SKIP_BUILDER_IMAGE set, assuming image is already present and up-to-date."

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -32,7 +32,7 @@ base-image: Dockerfile ## Build the docs-base image for updating the requirement
 	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
 
 DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
-DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's#:.*##')
+DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's/:.*//')
 
 ifndef SKIP_BUILDER_IMAGE
 builder-image: Dockerfile $(REQUIREMENTS) ## Build the docs-builder image for rendering and checking the documentation.

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -31,7 +31,7 @@ DOCS_BASE_IMG ?= cilium/docs-base
 base-image: Dockerfile ## Build the docs-base image for updating the requirements.txt file.
 	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
 
-DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
+DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:e6773ed21ab03066c0f24e68f342f18804a8ee0a@sha256:d3beff6d6408c09f6e1dbc637f7e98962b7d1fd2a81bf1d2a27ff8817dafb51f
 DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's/:.*//')
 
 ifndef SKIP_BUILDER_IMAGE

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -159,6 +159,7 @@ run_linter() {
     ignored_messages="${ignored_messages}|Duplicate implicit target name:"
     ignored_messages="${ignored_messages}|\(ERROR/3\) Indirect hyperlink target \".*\"  refers to target \"${CONF_PY_TARGET_NAMES}\", which does not exist."
     ignored_messages="${ignored_messages}|\(ERROR/3\) Unknown target name: \"${CONF_PY_TARGET_NAMES}\"."
+    ignored_messages="${ignored_messages}|.*expected a single document in the stream.*"
     ignored_messages="${ignored_messages})"
     # Filter out the AttributeError reports that are due to a bug in rstcheck,
     # see https://github.com/rstcheck/rstcheck-core/issues/3.

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -164,6 +164,7 @@ run_linter() {
     # Filter out the AttributeError reports that are due to a bug in rstcheck,
     # see https://github.com/rstcheck/rstcheck-core/issues/3.
     rstcheck \
+        --sphinx-source-dir "${script_dir}" \
         --report-level info \
         --ignore-languages "bash,c" \
         --ignore-messages "${ignored_messages}" \

--- a/Documentation/configuration/sctp.rst
+++ b/Documentation/configuration/sctp.rst
@@ -10,7 +10,7 @@
 SCTP support (beta)
 *******************
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 Enabling
 ========

--- a/Documentation/contributing/development/reviewers_committers/review_docs.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_docs.rst
@@ -91,7 +91,7 @@ dedicated banner, as follows:
 
 .. code-block:: rst
 
-   .. include:: /Documentation/beta.rst
+   .. include:: /beta.rst
 
 Upgrade notes
 ~~~~~~~~~~~~~

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -204,7 +204,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
     .. group-tab:: Alibaba ACK
 
-        .. include:: ../beta.rst
+        .. include:: /beta.rst
 
         .. note::
 

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -4,7 +4,7 @@
 Multi-Cluster Services API (Beta)
 *********************************
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 This tutorial will guide you to through the support of `Multi-Cluster Services API (MCS-API)`_ in Cilium.
 

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -151,20 +151,20 @@ ServiceImport backend, for example:
    spec:
       parentRefs:
       - group: gateway.networking.k8s.io
-         kind: Gateway
-         name: my-gateway
-         namespace: default
+        kind: Gateway
+        name: my-gateway
+        namespace: default
       rules:
       - backendRefs:
-         - group: multicluster.x-k8s.io
-            kind: ServiceImport
-            name: rebel-base-mcsapi
-            port: 80
-         matches:
-         - method: GET
-            path:
-            type: PathPrefix
-            value: /
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+          name: rebel-base-mcsapi
+          port: 80
+        matches:
+        - method: GET
+          path:
+          type: PathPrefix
+          value: /
 
 
 The Gateway API implementation of Cilium fully support its own MCS-API implementation.

--- a/Documentation/network/clustermesh/services.rst
+++ b/Documentation/network/clustermesh/services.rst
@@ -67,7 +67,7 @@ Below example will expose remote endpoint without sharing local endpoints.
 Synchronizing Kubernetes EndpointSlice (Beta)
 #############################################
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 By default Kubernetes EndpointSlice synchronization is disabled on non Headless Global services.
 To have Cilium discover remote clusters endpoints of a Global Service

--- a/Documentation/network/concepts/fragmentation.rst
+++ b/Documentation/network/concepts/fragmentation.rst
@@ -36,4 +36,4 @@ have been processed by Cilium's datapath by checking the following metrics:
 These packets are the basis for path MTU discovery and indicate that packets
 along a network path are exceeding max MTU size of the network.
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst

--- a/Documentation/network/kube-router.rst
+++ b/Documentation/network/kube-router.rst
@@ -14,7 +14,7 @@ This guide explains how to configure Cilium and kube-router to co-operate to
 use kube-router for BGP peering and route propagation and Cilium for policy
 enforcement and load-balancing.
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 Deploy kube-router
 ##################

--- a/Documentation/network/kubernetes/identity-management-mode.rst
+++ b/Documentation/network/kubernetes/identity-management-mode.rst
@@ -28,7 +28,7 @@ reliability of network policies and cluster scalability.
 Enable Identity Management by the Cilium Operator (Beta)
 =========================================================
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 The Cilium Agents manage CIDs by default. This section describes the steps necessary for enabling CID management by the Cilium Operator.
 

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -10,7 +10,7 @@
 L2 Announcements / L2 Aware LB (Beta)
 *************************************
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 L2 Announcements is a feature which makes services visible and reachable on 
 the local area network. This feature is primarily intended for on-premises

--- a/Documentation/network/multicast.rst
+++ b/Documentation/network/multicast.rst
@@ -10,7 +10,7 @@
 Multicast Support in Cilium (Beta)
 **********************************
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 The multicast capability allows user application to distribute data feeds to
 multiple consumers in the Kubernetes cluster.

--- a/Documentation/network/servicemesh/envoy-load-balancing.rst
+++ b/Documentation/network/servicemesh/envoy-load-balancing.rst
@@ -16,7 +16,7 @@ load-balancing. Once enabled, the traffic to a Kubernetes service will be
 redirected to a Cilium-managed Envoy proxy for load balancing. This feature
 is independent of the :ref:`gs_ingress` feature.
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 Deploy Test Applications
 ========================

--- a/Documentation/network/vtep.rst
+++ b/Documentation/network/vtep.rst
@@ -10,7 +10,7 @@
 VXLAN Tunnel Endpoint (VTEP) Integration (beta)
 ***********************************************
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 The VTEP integration allows third party VTEP devices to send and receive traffic to
 and from Cilium-managed pods directly using VXLAN. This allows for example external

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -719,7 +719,7 @@ If a migration has gone wrong, it possible to start with a clean slate. Ensure t
 Migration with the "Double Write" identity allocation mode
 ##########################################################
 
-.. include:: ../beta.rst
+.. include:: /beta.rst
 
 The "Double Write" Identity Allocation Mode allows Cilium to allocate identities as KVStore values *and* as CRDs at the
 same time. This mode also has two versions: one where the source of truth comes from the kvstore (``--identity-allocation-mode=doublewrite-readkvstore``),

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -18,5 +18,5 @@ sphinxcontrib-websupport==1.2.4
 sphinxext-rediraffe==0.3.0
 
 # Linters
-rstcheck==6.2.5
+rstcheck==6.3.0
 yamllint==1.38.0

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -16,21 +16,20 @@ sphinxcontrib-spelling==8.0.2
 sphinxcontrib-websupport==1.2.4
 sphinxext-rediraffe==0.3.0
 # Linters
-rstcheck==6.2.5
+rstcheck==6.3.0
 yamllint==1.38.0
 ## The following requirements were added by pip freeze:
 alabaster==1.0.0
-annotated-doc==0.0.4
-annotated-types==0.7.0
+annotated-doc==0.0.5
+annotated-types==0.8.0
 attrs==26.1.0
 babel==2.18.0
-certifi==2026.4.22
-charset-normalizer==3.4.7
-click==8.4.0
+certifi==2026.7.22
+charset-normalizer==3.4.9
 colorama==0.4.6
-deepmerge==2.0
+deepmerge==2.1.0
 docutils==0.22.4
-idna==3.15
+idna==3.18
 imagesize==2.0.0
 Jinja2==3.1.6
 jsonschema==4.26.0
@@ -40,8 +39,8 @@ markdown-it-py==4.2.0
 MarkupSafe==3.0.3
 mdit-py-plugins==0.6.1
 mdurl==0.1.2
-mistune==3.2.1
-packaging==26.2
+mistune==3.3.4
+packaging==26.3
 pathspec==1.1.1
 picobox==4.0.0
 pydantic==2.13.4
@@ -53,10 +52,10 @@ referencing==0.37.0
 requests==2.34.2
 rich==15.0.0
 roman-numerals==4.1.0
-rpds-py==0.30.0
-rstcheck-core==1.3.0
+rpds-py==2026.6.3
+rstcheck-core==1.3.1
 shellingham==1.5.4
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
 sphinx_mdinclude==0.6.2
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0
@@ -66,8 +65,8 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
-tornado==6.5.5
-typer==0.25.1
+tornado==6.5.7
+typer==0.27.1
 typing-inspection==0.4.2
-typing_extensions==4.15.0
+typing_extensions==4.16.0
 urllib3==2.7.0

--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -10,7 +10,7 @@
 Ztunnel Transparent Encryption (Beta)
 *************************************
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 This guide explains how to configure Cilium to use ztunnel for transparent
 encryption and mutual TLS (mTLS) authentication between Cilium-managed endpoints.

--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -458,7 +458,7 @@ use a :ref:`CiliumCIDRGroup` to reduce identity usage.
 Selecting nodes with CIDR / ipBlock
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: ../../beta.rst
+.. include:: /beta.rst
 
 By default, CIDR-based selectors do not match in-cluster entities (pods or nodes).
 Optionally, you can direct the policy engine to select nodes by CIDR / ipBlock.

--- a/Documentation/update-docs-builder-image.sh
+++ b/Documentation/update-docs-builder-image.sh
@@ -11,10 +11,15 @@ image_full=${1}
 image="${image_full%%:*}"
 root_dir="$(git rev-parse --show-toplevel)"
 
+usage_globs=(
+    ".github/workflows/"
+    "Documentation/Makefile"
+)
+
 cd "${root_dir}"
 
 # shellcheck disable=SC2207
-used_by=($(git grep -l "${image}:" .github/workflows/))
+used_by=($(git grep -l "${image}:" -- "${usage_globs[@]}"))
 
 for i in "${used_by[@]}" ; do
   sed -E "s#${image}:.*#${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"


### PR DESCRIPTION
- https://github.com/cilium/cilium/pull/45774
- https://github.com/cilium/cilium/pull/46033
- https://github.com/cilium/cilium/pull/47750
  - Minor conflicts; notes in commit messages. Dropped Gateway API examples
    link reference as it's not relevant for this branch.

I made some minor updates to commits in https://github.com/cilium/cilium/pull/47750 because the docs dependencies were
updated in https://github.com/cilium/cilium/pull/47744. This fixes up the commits to ensure that `rstcheck` dependency is
bumped to v6.3.0. Once this PR is merged, we can rebase https://github.com/cilium/cilium/pull/47679 to drop the docs
update dependency.

```upstream-prs
45774 46033 47750
```
