### PR TITLE
gateway-api: cleanup unused gateway api code

### DIFF
--- a/operator/pkg/gateway-api/endpointslice_reconcile_test.go
+++ b/operator/pkg/gateway-api/endpointslice_reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 )
 
@@ -268,7 +269,7 @@ func Test_endpointSliceReconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().
-				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 				WithObjects(tt.objects...).
 				Build()
 

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -25,6 +25,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
@@ -94,7 +95,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 				t.Run(serviceKey.String(), func(t *testing.T) {
 					base := readInputDir(t, "testdata/gamma/base")
 					input := readInputDir(t, fmt.Sprintf("testdata/gamma/%s/input", tt.name))
-					scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+					scheme := testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 
 					c := fake.NewClientBuilder().
 						WithScheme(scheme).
@@ -200,7 +201,7 @@ func Test_gammaReconciler_Reconcile_BackendRequestHeaderModifier(t *testing.T) {
 
 	base := readInputDir(t, "testdata/gamma/base")
 	input := readInputDir(t, "testdata/gamma/mesh-request-header-modifier-backend/input")
-	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+	scheme := testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -280,7 +281,7 @@ func Test_gammaReconciler_Reconcile_ReplacesOwnerReferencesForRecreatedRoute(t *
 	base := readInputDir(t, "testdata/gamma/base")
 	originalInput := readInputDir(t, "testdata/gamma/mesh-request-header-modifier/input")
 	recreatedInput := readInputDir(t, "testdata/gamma/mesh-request-header-modifier-backend/input")
-	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+	scheme := testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 
 	setRouteIdentity := func(objs []client.Object, uid string) {
 		t.Helper()

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -29,6 +29,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/loading"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -410,7 +411,7 @@ func Test_Conformance(t *testing.T) {
 				}
 				optionalKinds = append(optionalKinds, k)
 			}
-			scheme := helpers.TestScheme(optionalKinds)
+			scheme := testhelpers.TestScheme(optionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 			clientBuilder := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(append(base, input...)...).
@@ -835,7 +836,7 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 
 			objects := append([]client.Object{gw, svc, cec}, tc.objects...)
 			c := fake.NewClientBuilder().
-				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 				WithObjects(objects...).
 				Build()
 
@@ -913,7 +914,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 
 	t.Run("deletes owned stale CEC when desired is nil", func(t *testing.T) {
 		c := fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(gw, ownedCEC()).
 			Build()
 		r := &gatewayReconciler{
@@ -932,7 +933,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 		foreign.OwnerReferences[0].UID = types.UID("other-uid")
 		foreign.OwnerReferences[0].Name = "other-gateway"
 		c := fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(gw, foreign).
 			Build()
 		r := &gatewayReconciler{
@@ -947,7 +948,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 
 	t.Run("no error when no CEC exists", func(t *testing.T) {
 		c := fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(gw).
 			Build()
 		r := &gatewayReconciler{
@@ -1093,7 +1094,10 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 			r := &gatewayReconciler{
 				client: func() client.WithWatch {
 					return fake.NewClientBuilder().
-						WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+						WithScheme(testhelpers.TestScheme(
+							helpers.AllOptionalKinds,
+							helpers.RegisterGatewayAPITypesToScheme,
+						)).
 						Build()
 				}(),
 			}
@@ -1170,7 +1174,7 @@ func Test_gatewayReconciler_setAddressStatus_updatesAcceptedListenerProgrammedCo
 	}
 
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(svc).
 		Build()
 
@@ -1289,7 +1293,7 @@ func testReconciler(t *testing.T, obj ...client.Object) (*gatewayReconciler, cli
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
 	fakeClient := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(obj...).
 		WithStatusSubresource(&gatewayv1.HTTPRoute{}, &gatewayv1.GRPCRoute{}).
 		Build()
@@ -1588,7 +1592,7 @@ func Test_gatewayAddressStatusManager_SetStaticAddressStatus(t *testing.T) {
 			gw := gateway(tc.specAddr)
 			setGatewayProgrammed(gw, metav1.ConditionTrue, "Gateway Programmed", gatewayv1.GatewayReasonProgrammed)
 			c := fake.NewClientBuilder().
-				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 				WithObjects(gw, service(tc.ingress...)).
 				Build()
 			err := NewGatewayAddressStatusManager(c, hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))).SetStaticAddressStatus(t.Context(), gw)

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -79,29 +79,6 @@ func gatewayStatusProgrammedCondition(gw *gatewayv1.Gateway, scheduled metav1.Co
 	}
 }
 
-func gatewayStatusReadyCondition(gw *gatewayv1.Gateway, scheduled bool, msg string) metav1.Condition {
-	switch scheduled {
-	case true:
-		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayConditionReady),
-			Status:             metav1.ConditionTrue,
-			Reason:             string(gatewayv1.GatewayReasonReady),
-			Message:            msg,
-			ObservedGeneration: gw.GetGeneration(),
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		}
-	default:
-		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayConditionReady),
-			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.GatewayReasonListenersNotReady),
-			Message:            msg,
-			ObservedGeneration: gw.GetGeneration(),
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		}
-	}
-}
-
 func listenerProgrammedCondition(generation int64, ready bool, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
 	switch ready {
 	case true:

--- a/operator/pkg/gateway-api/gateway_status_test.go
+++ b/operator/pkg/gateway-api/gateway_status_test.go
@@ -74,64 +74,6 @@ func Test_gatewayStatusScheduledCondition(t *testing.T) {
 	}
 }
 
-func Test_gatewayStatusReadyCondition(t *testing.T) {
-	type args struct {
-		gw    *gatewayv1.Gateway
-		ready bool
-		msg   string
-	}
-	tests := []struct {
-		name string
-		args args
-		want metav1.Condition
-	}{
-		{
-			name: "ready",
-			args: args{
-				gw: &gatewayv1.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Generation: 100,
-					},
-				},
-				ready: true,
-				msg:   "Listener Ready",
-			},
-			want: metav1.Condition{
-				Type:               "Ready",
-				Status:             "True",
-				ObservedGeneration: 100,
-				Reason:             "Ready",
-				Message:            "Listener Ready",
-			},
-		},
-		{
-			name: "unready",
-			args: args{
-				gw: &gatewayv1.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Generation: 100,
-					},
-				},
-				ready: false,
-				msg:   "Listener Pending",
-			},
-			want: metav1.Condition{
-				Type:               "Ready",
-				Status:             "False",
-				ObservedGeneration: 100,
-				Reason:             "ListenersNotReady",
-				Message:            "Listener Pending",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := gatewayStatusReadyCondition(tt.args.gw, tt.args.ready, tt.args.msg)
-			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "gatewayStatusAcceptedCondition() = %v, want %v", got, tt.want)
-		})
-	}
-}
-
 func Test_listenerProgrammedCondition(t *testing.T) {
 	type args struct {
 		generation int64

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	gwconformance "sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
@@ -96,7 +97,7 @@ var (
 
 func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(gwcFixture...).
 		WithObjects(cgwccFixture...).
 		WithStatusSubresource(&gatewayv1.GatewayClass{}).

--- a/operator/pkg/gateway-api/gatewayclass_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_test.go
@@ -17,45 +17,6 @@ import (
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
-func Test_matchesControllerName(t *testing.T) {
-	testCases := []struct {
-		name     string
-		object   client.Object
-		expected bool
-	}{
-		{
-			name: "matches",
-			object: &gatewayv1.GatewayClass{
-				Spec: gatewayv1.GatewayClassSpec{
-					ControllerName: "foo",
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "does not match",
-			object: &gatewayv1.GatewayClass{
-				Spec: gatewayv1.GatewayClassSpec{
-					ControllerName: "bar",
-				},
-			},
-			expected: false,
-		},
-		{
-			name:     "not a GatewayClass",
-			object:   &corev1.Service{},
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gwc, ok := tc.object.(*gatewayv1.GatewayClass)
-			require.Equal(t, tc.expected, ok && string(gwc.Spec.ControllerName) == "foo")
-		})
-	}
-}
-
 func Test_referencedConfig(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -31,16 +31,6 @@ func GroupPtr(name string) *gatewayv1.Group {
 	return &group
 }
 
-func KindPtr(name string) *gatewayv1.Kind {
-	kind := gatewayv1.Kind(name)
-	return &kind
-}
-
-func ObjectNamePtr(name string) *gatewayv1.ObjectName {
-	objectName := gatewayv1.ObjectName(name)
-	return &objectName
-}
-
 func groupDerefOr(group *gatewayv1.Group, defaultGroup string) string {
 	if group != nil && *group != "" {
 		return string(*group)

--- a/operator/pkg/gateway-api/helpers/conditions_test.go
+++ b/operator/pkg/gateway-api/helpers/conditions_test.go
@@ -129,12 +129,12 @@ func TestConditionChanged(t *testing.T) {
 			name:     "check condition reason differs",
 			expected: true,
 			a: metav1.Condition{
-				Type:   string(gatewayv1.GatewayConditionReady),
+				Type:   string(gatewayv1.GatewayClassConditionStatusAccepted),
 				Status: metav1.ConditionFalse,
 				Reason: "foo",
 			},
 			b: metav1.Condition{
-				Type:   string(gatewayv1.GatewayConditionReady),
+				Type:   string(gatewayv1.GatewayClassConditionStatusAccepted),
 				Status: metav1.ConditionFalse,
 				Reason: "bar",
 			},

--- a/operator/pkg/gateway-api/helpers/gateway_test.go
+++ b/operator/pkg/gateway-api/helpers/gateway_test.go
@@ -82,7 +82,7 @@ func TestSNIHostnamesIntersect(t *testing.T) {
 
 func Test_hasMatchingController(t *testing.T) {
 	logger := hivetest.Logger(t)
-	c := fake.NewClientBuilder().WithScheme(TestScheme(AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...).Build()
+	c := fake.NewClientBuilder().WithScheme(testhelpers.TestScheme(AllOptionalKinds, RegisterGatewayAPITypesToScheme)).WithObjects(testhelpers.ControllerTestFixture...).Build()
 	fn := GatewayHasMatchingControllerFn(t.Context(), c, "io.cilium/gateway-controller", logger)
 
 	t.Run("invalid object", func(t *testing.T) {

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -6,17 +6,11 @@ package helpers
 import (
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
-
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
 var RequiredGVKs = []schema.GroupVersionKind{
@@ -43,19 +37,6 @@ func GatewayV1GVK(kind string) schema.GroupVersionKind {
 		Version: gatewayv1.GroupVersion.Version,
 		Kind:    kind,
 	}
-}
-
-func TestScheme(optionalKinds []schema.GroupVersionKind) *runtime.Scheme {
-	scheme := runtime.NewScheme()
-
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-
-	RegisterGatewayAPITypesToScheme(scheme, optionalKinds)
-
-	return scheme
 }
 
 func RegisterGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []schema.GroupVersionKind) error {

--- a/operator/pkg/gateway-api/helpers/secrets_test.go
+++ b/operator/pkg/gateway-api/helpers/secrets_test.go
@@ -30,7 +30,7 @@ func withSecretIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
 }
 
 func Test_getGatewaysForSecret(t *testing.T) {
-	c := withSecretIndexes(fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...)).Build()
+	c := withSecretIndexes(fake.NewClientBuilder().WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).WithObjects(testhelpers.ControllerTestFixture...)).Build()
 	logger := hivetest.Logger(t)
 
 	t.Run("secret is used in gateway", func(t *testing.T) {
@@ -95,7 +95,7 @@ func Test_getGatewaysForSecret(t *testing.T) {
 		}
 
 		c := withSecretIndexes(fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(secret, gwc, gw)).
 			Build()
 
@@ -161,7 +161,7 @@ func Test_getGatewaysForSecretInListenerSet(t *testing.T) {
 	}
 
 	c := withSecretIndexes(fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(testhelpers.ControllerTestFixture...).
 		WithObjects(lsSecret, gw, ls)).
 		Build()
@@ -261,7 +261,7 @@ func Test_getGatewaysForSecretFromBothGatewayAndListenerSet(t *testing.T) {
 	}
 
 	c := withSecretIndexes(fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(testhelpers.ControllerTestFixture...).
 		WithObjects(sharedSecret, gwA, gwB, ls)).
 		Build()
@@ -340,7 +340,7 @@ func Test_getGatewaysForSecretDeduplication(t *testing.T) {
 	}
 
 	c := withSecretIndexes(fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(testhelpers.ControllerTestFixture...).
 		WithObjects(sharedSecret, gw, ls)).
 		Build()

--- a/operator/pkg/gateway-api/helpers/testhelpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/testhelpers/schemes.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testhelpers
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+// TestScheme returns a scheme containing the core test types, required Gateway
+// API types, and the requested optional Gateway API types.
+func TestScheme(
+	optionalKinds []schema.GroupVersionKind,
+	registerGatewayAPITypes func(*runtime.Scheme, []schema.GroupVersionKind) error,
+) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(ciliumv2.AddToScheme(scheme))
+	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(registerGatewayAPITypes(scheme, optionalKinds))
+
+	return scheme
+}

--- a/operator/pkg/gateway-api/indexers/grpcroute_test.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute_test.go
@@ -18,6 +18,7 @@ import (
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
 func TestIndexGRPCRouteByGateway(t *testing.T) {
@@ -188,7 +189,7 @@ func TestIndexGRPCRouteByBackendServiceImport(t *testing.T) {
 
 func TestGenerateIndexerGRPCRoutebyBackendServiceIncludesRequestMirror(t *testing.T) {
 	indexer := GenerateIndexerGRPCRoutebyBackendService(
-		fake.NewClientBuilder().WithScheme(helpers.TestScheme(nil)).Build(),
+		fake.NewClientBuilder().WithScheme(testhelpers.TestScheme(nil, helpers.RegisterGatewayAPITypesToScheme)).Build(),
 		slog.New(slog.DiscardHandler),
 	)
 

--- a/operator/pkg/gateway-api/indexers/httproute_test.go
+++ b/operator/pkg/gateway-api/indexers/httproute_test.go
@@ -18,6 +18,7 @@ import (
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
 func TestIndexHTTPRouteByGateway(t *testing.T) {
@@ -270,7 +271,7 @@ func TestIndexHTTPRouteByBackendServiceImport(t *testing.T) {
 
 func TestGenerateIndexerHTTPRouteByBackendServiceIncludesFilterBackends(t *testing.T) {
 	indexer := GenerateIndexerHTTPRouteByBackendService(
-		fake.NewClientBuilder().WithScheme(helpers.TestScheme(nil)).Build(),
+		fake.NewClientBuilder().WithScheme(testhelpers.TestScheme(nil, helpers.RegisterGatewayAPITypesToScheme)).Build(),
 		slog.New(slog.DiscardHandler),
 	)
 

--- a/operator/pkg/gateway-api/loading/loading_listenerset_test.go
+++ b/operator/pkg/gateway-api/loading/loading_listenerset_test.go
@@ -17,6 +17,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
 func fromPtr(f gatewayv1.FromNamespaces) *gatewayv1.FromNamespaces {
@@ -157,7 +158,7 @@ func Test_isListenerSetAllowed_fromSelector(t *testing.T) {
 
 	t.Run("matching label allowed", func(t *testing.T) {
 		c := fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "infra-ns", Labels: map[string]string{"team": "infra"}}}).
 			Build()
 		ls := &gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "infra-ns"}}
@@ -166,7 +167,7 @@ func Test_isListenerSetAllowed_fromSelector(t *testing.T) {
 
 	t.Run("non-matching label rejected", func(t *testing.T) {
 		c := fake.NewClientBuilder().
-			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 			WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Labels: map[string]string{"team": "platform"}}}).
 			Build()
 		ls := &gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns"}}

--- a/operator/pkg/gateway-api/loading/loading_services_test.go
+++ b/operator/pkg/gateway-api/loading/loading_services_test.go
@@ -20,6 +20,7 @@ import (
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 )
 
@@ -151,7 +152,7 @@ func TestLoadLoadsOnlyReferencedServices(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(
 			gw,
 			gwc,

--- a/operator/pkg/gateway-api/predicates/gateway_test.go
+++ b/operator/pkg/gateway-api/predicates/gateway_test.go
@@ -20,7 +20,7 @@ const testGatewayControllerName = "io.cilium/gateway-controller"
 
 func Test_gatewayReconcilePredicate(t *testing.T) {
 	logger := hivetest.Logger(t)
-	c := fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...).Build()
+	c := fake.NewClientBuilder().WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).WithObjects(testhelpers.ControllerTestFixture...).Build()
 	predicate := GatewayOwnedByController(helpers.GatewayHasMatchingControllerFn(t.Context(), c, testGatewayControllerName, logger))
 
 	t.Run("update keeps handoff reconcile when old gateway matched", func(t *testing.T) {

--- a/operator/pkg/gateway-api/secretsync_test.go
+++ b/operator/pkg/gateway-api/secretsync_test.go
@@ -19,6 +19,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
 const testGatewayControllerName = "io.cilium/gateway-controller"
@@ -73,7 +74,7 @@ func TestSecretSyncHandlerEnqueueListenerSetTLSSecretsIncludingCrossNamespaceRef
 	}
 
 	fakeClient := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(gatewayClass, gateway, listenerSet).
 		Build()
 

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -15,6 +15,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 )
 
@@ -123,7 +124,7 @@ func Test_setTCPRouteStatusesPrunesDetachedParents(t *testing.T) {
 		}}}},
 	}
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithStatusSubresource(&gatewayv1.TCPRoute{}).
 		WithObjects(route).
 		Build()
@@ -152,7 +153,7 @@ func Test_setUDPRouteStatusesPrunesDetachedParents(t *testing.T) {
 		}}}},
 	}
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithStatusSubresource(&gatewayv1.UDPRoute{}).
 		WithObjects(route).
 		Build()

--- a/operator/pkg/gateway-api/watch-handlers/gamma_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/gamma_test.go
@@ -20,13 +20,14 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
 // TestEnqueueRequestForGAMMAHTTPRouteOnlyMatchesServiceParents ensures that only
 // core Service parents resolve to a GAMMA Service. Any other parent kind sharing
 // a name with a Service in the same namespace must not enqueue that Service.
 func TestEnqueueRequestForGAMMAHTTPRouteOnlyMatchesServiceParents(t *testing.T) {
-	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+	scheme := testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 
 	// A valid GAMMA Service whose name collides with the ListenerSet and the
 	// Gateway referenced as parents below.

--- a/operator/pkg/gateway-api/watch-handlers/namespaces_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/namespaces_test.go
@@ -18,7 +18,7 @@ import (
 
 func Test_getGatewaysForNamespace(t *testing.T) {
 	c := fake.NewClientBuilder().
-		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
 		WithObjects(testhelpers.NamespaceFixtures...).
 		WithObjects(testhelpers.ControllerTestFixture...).
 		Build()

--- a/operator/pkg/gateway-api/watch-handlers/service_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/service_test.go
@@ -19,13 +19,14 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 )
 
 const testGatewayControllerName = "io.cilium/gateway-controller"
 
 func TestEnqueueRequestForBackendServiceIncludesGRPCTCPAndUDP(t *testing.T) {
-	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+	scheme := testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Remove a variety of unused functions, functions that have no callers, functions that are only called by tests without exercising any production logic. 

```release-note
gateway-api: cleanup unused helper functions
```
