### PR TITLE
[v1.19] improvements for BPF verifier log parser

### DIFF
--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -385,6 +385,10 @@ func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, la
 		}
 	}
 	stackDepthLine = strings.TrimPrefix(strings.TrimSpace(stackDepthLine), "stack depth ")
+	// On newer kernels, the stack depth line may look as follows, so we need
+	// to remove the max info at the end.
+	//   stack depth 144+255 max 400
+	stackDepthLine = strings.Split(stackDepthLine, " max ")[0]
 
 	// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
 	//   144+280+120

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -91,7 +91,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_lxc", kv, lxcLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "lxc", endpointProg, endpointObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "lxc", endpointProg, endpointObj, kv, i, &records))
 			i++
 		}
 	})
@@ -100,7 +100,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_host", kv, hostLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "host", hostEndpointProg, hostEndpointObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "host", hostEndpointProg, hostEndpointObj, kv, i, &records))
 			i++
 		}
 	})
@@ -109,7 +109,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_network", kv, networkLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "network", networkProg, networkObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "network", networkProg, networkObj, kv, i, &records))
 			i++
 		}
 	})
@@ -118,7 +118,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_overlay", kv, overlayLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "overlay", overlayProg, overlayObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "overlay", overlayProg, overlayObj, kv, i, &records))
 			i++
 		}
 	})
@@ -127,7 +127,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_sock", kv, sockLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "sock", "bpf_sock.c", "bpf_sock.o", i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "sock", "bpf_sock.c", "bpf_sock.o", kv, i, &records))
 			i++
 		}
 	})
@@ -136,7 +136,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_wireguard", kv, wireguardLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "wireguard", wireguardProg, wireguardObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "wireguard", wireguardProg, wireguardObj, kv, i, &records))
 			i++
 		}
 	})
@@ -145,13 +145,13 @@ func TestPrivilegedVerifier(t *testing.T) {
 		t.Parallel()
 		i := 1
 		for perm := range buildPermutations("bpf_xdp", kv, xdpLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "xdp", xdpProg, xdpObj, i, &records))
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, "xdp", xdpProg, xdpObj, kv, i, &records))
 			i++
 		}
 	})
 }
 
-func compileAndLoad[T any](perm buildPermutation[T], collection, source, output string, build int, records *verifierComplexityRecords) func(t *testing.T) {
+func compileAndLoad[T any](perm buildPermutation[T], collection, source, output string, kv kernelVersion, build int, records *verifierComplexityRecords) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
@@ -193,7 +193,7 @@ func compileAndLoad[T any](perm buildPermutation[T], collection, source, output 
 				spec,
 				constants,
 				collection,
-				build, ii,
+				kv, build, ii,
 				records,
 			))
 			ii++
@@ -206,6 +206,7 @@ func loadAndRecordComplexity(
 	spec *ebpf.CollectionSpec,
 	constants any,
 	collection string,
+	kv kernelVersion,
 	build, load int,
 	records *verifierComplexityRecords,
 ) func(t *testing.T) {
@@ -343,11 +344,19 @@ func loadAndRecordComplexity(
 				t.Fatalf("Failed to parse verifier log for program %s: %v", n, err)
 			}
 
-			stackDepth, stackDepthIndex, err := parseStackDepth(s, p.VerifierLog, lastLineIndex, lastOff)
-			if err != nil {
-				t.Fatalf("Failed to parse stack depth for program %s: %v", n, err)
+			stackDepthIndex := strings.LastIndex(p.VerifierLog[:lastLineIndex], "\n")
+			// On older kernels, the max field is missing in verifier logs so
+			// we can't easily retrieve the max stack size. We'll just return
+			// it for bpf-next, where it's likely already the highest value
+			// anyway.
+			if kv == kernelVersionNetNext {
+				var stackDepth int
+				stackDepth, stackDepthIndex, err = parseStackDepth(s, p.VerifierLog, lastLineIndex, lastOff)
+				if err != nil {
+					t.Fatalf("Failed to parse stack depth for program %s: %v", n, err)
+				}
+				r.StackDepth = stackDepth
 			}
-			r.StackDepth = stackDepth
 
 			// Extract the third to last line, which looks like:
 			//   verification time 355643 usec

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -319,6 +319,7 @@ func loadAndRecordComplexity(
 			// The part of the log we are interested in is at the end. And looks like this:
 			//   verification time 355643 usec
 			//   stack depth 144+280+120
+			//   insns processed 12591+75421+455  <-- only on newer kernels
 			//   processed 88467 insns (limit 1000000) max_states_per_insn 44 total_states 4141 peak_states 1137 mark_read 56
 
 			// Remove trailing newline so strings.LastIndex finds the newline ahead of the last log line.
@@ -374,7 +375,16 @@ func loadAndRecordComplexity(
 //	stack depth 144+280+120
 func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, lastOff int) (int, int, error) {
 	stackDepthIndex := strings.LastIndex(verifierLogs[:lastLineIndex], "\n")
-	stackDepthLine := strings.TrimPrefix(strings.TrimSpace(verifierLogs[stackDepthIndex+1:lastOff]), "stack depth ")
+	stackDepthLine := verifierLogs[stackDepthIndex+1 : lastOff]
+	if !strings.Contains(stackDepthLine, "stack depth ") {
+		lastOff = stackDepthIndex + 1
+		stackDepthIndex = strings.LastIndex(verifierLogs[:stackDepthIndex], "\n")
+		stackDepthLine = verifierLogs[stackDepthIndex+1 : lastOff]
+		if !strings.Contains(stackDepthLine, "stack depth ") {
+			return 0, stackDepthIndex, fmt.Errorf("Couldn't find stack depths line in verifier logs")
+		}
+	}
+	stackDepthLine = strings.TrimPrefix(strings.TrimSpace(stackDepthLine), "stack depth ")
 
 	// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
 	//   144+280+120
@@ -383,7 +393,7 @@ func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, la
 	for part := range strings.SplitSeq(stackDepthLine, "+") {
 		depth, err := strconv.Atoi(part)
 		if err != nil {
-			return 0, stackDepthIndex, nil
+			return 0, stackDepthIndex, err
 		}
 		depths = append(depths, depth)
 	}

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -343,23 +343,11 @@ func loadAndRecordComplexity(
 				t.Fatalf("Failed to parse verifier log for program %s: %v", n, err)
 			}
 
-			// Extract the second to last line, which looks like:
-			//   stack depth 144+280+120
-			stackDepthIndex := strings.LastIndex(p.VerifierLog[:lastLineIndex], "\n")
-			stackDepthLine := strings.TrimPrefix(strings.TrimSpace(p.VerifierLog[stackDepthIndex+1:lastOff]), "stack depth ")
-
-			// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
-			//   144+280+120
-			// Split and parse to ints
-			var depths []int
-			for part := range strings.SplitSeq(stackDepthLine, "+") {
-				depth, err := strconv.Atoi(part)
-				if err != nil {
-					t.Fatalf("Failed to parse stack depth for program %s: %v", n, err)
-				}
-				depths = append(depths, depth)
+			stackDepth, stackDepthIndex, err := parseStackDepth(s, p.VerifierLog, lastLineIndex, lastOff)
+			if err != nil {
+				t.Fatalf("Failed to parse stack depth for program %s: %v", n, err)
 			}
-			r.StackDepth = maxStackDepth(s, depths)
+			r.StackDepth = stackDepth
 
 			// Extract the third to last line, which looks like:
 			//   verification time 355643 usec
@@ -379,6 +367,27 @@ func loadAndRecordComplexity(
 			records.Add(r)
 		}
 	}
+}
+
+// Extract the second to last line, which looks like:
+//
+//	stack depth 144+280+120
+func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, lastOff int) (int, int, error) {
+	stackDepthIndex := strings.LastIndex(verifierLogs[:lastLineIndex], "\n")
+	stackDepthLine := strings.TrimPrefix(strings.TrimSpace(verifierLogs[stackDepthIndex+1:lastOff]), "stack depth ")
+
+	// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
+	//   144+280+120
+	// Split and parse to ints
+	var depths []int
+	for part := range strings.SplitSeq(stackDepthLine, "+") {
+		depth, err := strconv.Atoi(part)
+		if err != nil {
+			return 0, stackDepthIndex, nil
+		}
+		depths = append(depths, depth)
+	}
+	return maxStackDepth(s, depths), stackDepthIndex, nil
 }
 
 func maxStackDepth(spec *ebpf.ProgramSpec, stackDepths []int) int {

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/hivetest"
 
@@ -388,62 +387,18 @@ func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, la
 	// On newer kernels, the stack depth line may look as follows, so we need
 	// to remove the max info at the end.
 	//   stack depth 144+255 max 400
-	stackDepthLine = strings.Split(stackDepthLine, " max ")[0]
+	stackDepthInfo := strings.Split(stackDepthLine, " max ")
 
-	// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
-	//   144+280+120
-	// Split and parse to ints
-	var depths []int
-	for part := range strings.SplitSeq(stackDepthLine, "+") {
-		depth, err := strconv.Atoi(part)
-		if err != nil {
-			return 0, stackDepthIndex, err
-		}
-		depths = append(depths, depth)
-	}
-	return maxStackDepth(s, depths), stackDepthIndex, nil
-}
-
-func maxStackDepth(spec *ebpf.ProgramSpec, stackDepths []int) int {
-	insns := spec.Instructions
-	graph := make(map[string][]string)
-	sizes := make(map[string]int)
-
-	// The stack depths in the verifier log are in the same order as the functions in the instructions.
-	// We iterate through the instructions, and whenever we see a function definition, we take the next stack depth
-	// from the log and associate it with that function. Also record calls to construct a call graph.
-	var cur string
-	for _, insn := range insns {
-		if insn.IsFunctionCall() {
-			graph[cur] = append(graph[cur], insn.Reference())
-			continue
-		}
-		if fn := btf.FuncMetadata(&insn); fn != nil {
-			cur = fn.Name
-			sizes[cur] = stackDepths[0]
-			stackDepths = stackDepths[1:]
-		}
+	// The max field isn't reported on older kernels.
+	if len(stackDepthInfo) != 2 {
+		return 0, stackDepthIndex, fmt.Errorf("Couldn't find max stack depth value in verifier logs")
 	}
 
-	// Recursively visit the call graph to calculate the maximum stack depth, by summing the stack sizes of called
-	// functions. This is safe to do since the verifier will have rejected any program with recursive calls, so we know
-	// the graph is acyclic.
-	maxDepth := 0
-	var visit func(callstack []string)
-	visit = func(callstack []string) {
-		depth := 0
-		for _, fn := range callstack {
-			depth += sizes[fn]
-		}
-		maxDepth = max(maxDepth, depth)
-
-		for _, callee := range graph[callstack[len(callstack)-1]] {
-			visit(append(callstack, callee))
-		}
+	maxDepth, err := strconv.Atoi(stackDepthInfo[1])
+	if err != nil {
+		return 0, stackDepthIndex, err
 	}
-	visit([]string{spec.Name})
-
-	return maxDepth
+	return maxDepth, stackDepthIndex, nil
 }
 
 type verifierComplexityRecord struct {

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -38,16 +38,19 @@ type verifierComplexityRecord struct {
 	Load       string `json:"load"`
 	Program    string `json:"program"`
 
-	InsnsProcessed   int `json:"insns_processed"`
-	MaxStatesPerInsn int `json:"max_states_per_insn"`
-	TotalStates      int `json:"total_states"`
-	PeakStates       int `json:"peak_states"`
-	MarkRead         int `json:"mark_read"`
+	InsnsProcessed     int `json:"insns_processed"`
+	OrigInsnsProcessed int `json:"orig_insns_processed"`
+	MaxStatesPerInsn   int `json:"max_states_per_insn"`
+	TotalStates        int `json:"total_states"`
+	PeakStates         int `json:"peak_states"`
+	MarkRead           int `json:"mark_read"`
 
 	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
 	StackDepth                   int `json:"stack_depth"`
+	OrigStackDepth               int `json:"orig_stack_depth"`
 
-	MapCount int `json:"map_count"`
+	MapCount     int `json:"map_count"`
+	OrigMapCount int `json:"orig_map_count"`
 }
 
 func main() {
@@ -100,20 +103,20 @@ func main() {
 func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord) {
 	diffRecords := calcDiffRecords(oldRecords, newRecords, true)
 
-	minMaxInsnsProcessed := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
-		return r.InsnsProcessed
+	minMaxInsnsProcessed := calcMinMax(diffRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.InsnsProcessed, r.OrigInsnsProcessed
 	})
-	printTopMinMax("largest differences by instructions processed", minMaxInsnsProcessed, percentInsnsProcessed, colorRelativeChange)
+	printTopMinMax("largest differences by instructions processed", minMaxInsnsProcessed, percentInsnsProcessedDiff, colorRelativeChange)
 
-	minMaxStackDepth := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
-		return r.StackDepth
+	minMaxStackDepth := calcMinMax(diffRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.StackDepth, r.OrigStackDepth
 	})
-	printTopMinMax("largest differences by stack depth", minMaxStackDepth, percentStackDepth, colorRelativeChange)
+	printTopMinMax("largest differences by stack depth", minMaxStackDepth, percentStackDepthDiff, colorRelativeChange)
 
-	minMaxMapCount := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
-		return r.MapCount
+	minMaxMapCount := calcMinMax(diffRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.MapCount, r.OrigMapCount
 	})
-	printTopMinMax("largest differences by map count", minMaxMapCount, percentMapCount, colorRelativeChange)
+	printTopMinMax("largest differences by map count", minMaxMapCount, percentMapCountDiff, colorRelativeChange)
 }
 
 func printCurrentState(newRecords map[string]verifierComplexityRecord) []error {
@@ -124,24 +127,24 @@ func printCurrentState(newRecords map[string]verifierComplexityRecord) []error {
 		sortedNewRecords = append(sortedNewRecords, newRecords[key])
 	}
 
-	minMaxInsnsProcessed := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
-		return r.InsnsProcessed
+	minMaxInsnsProcessed := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.InsnsProcessed, r.OrigInsnsProcessed
 	})
 	err := printTopMinMax("largest instructions processed", minMaxInsnsProcessed, percentInsnsProcessed, colorAbsoluteValueExponential)
 	if len(err) > 0 {
 		errors = append(errors, err...)
 	}
 
-	minMaxStackDepth := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
-		return r.StackDepth
+	minMaxStackDepth := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.StackDepth, r.OrigStackDepth
 	})
 	err = printTopMinMax("largest stack depth", minMaxStackDepth, percentStackDepth, colorAbsoluteValue)
 	if len(err) > 0 {
 		errors = append(errors, err...)
 	}
 
-	minMaxMapCount := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
-		return r.MapCount
+	minMaxMapCount := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) (int, int) {
+		return r.MapCount, r.OrigMapCount
 	})
 	err = printTopMinMax("largest map count", minMaxMapCount, percentMapCount, colorAbsoluteValue)
 	if len(err) > 0 {
@@ -188,7 +191,7 @@ func dumpDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 	}
 }
 
-func printTopMinMax(title string, minMaxes map[string]minMax, percentFn func(i int) float64,
+func printTopMinMax(title string, minMaxes map[string]minMax, percentFn func(i, o int) float64,
 	fmtFn func(s string, i int, p float64) (string, error)) []error {
 	fmt.Printf("## Top %d %s\n", NumberTopValues, title)
 	fmt.Println("Collection/Program | Min | Max")
@@ -200,10 +203,10 @@ func printTopMinMax(title string, minMaxes map[string]minMax, percentFn func(i i
 		}
 
 		mm := minMaxes[key]
-		minPercent := percentFn(mm.min)
+		minPercent := percentFn(mm.min, mm.origMin)
 		min, _ := fmtFn(mm.minKey, mm.min, minPercent)
 
-		maxPercent := percentFn(mm.max)
+		maxPercent := percentFn(mm.max, mm.origMax)
 		max, err := fmtFn(mm.maxKey, mm.max, maxPercent)
 
 		fmt.Printf("%s | %s | %s\n", key, min, max)
@@ -215,16 +218,28 @@ func printTopMinMax(title string, minMaxes map[string]minMax, percentFn func(i i
 	return errors
 }
 
-func percentInsnsProcessed(i int) float64 {
+func percentInsnsProcessed(i, _ int) float64 {
 	return float64(i) / float64(MaxInsnsProcessed) * 100
 }
 
-func percentStackDepth(i int) float64 {
+func percentInsnsProcessedDiff(diff, orig int) float64 {
+	return float64(diff) / float64(orig) * 100
+}
+
+func percentStackDepth(i, _ int) float64 {
 	return float64(i) / float64(MaxStackDepth) * 100
 }
 
-func percentMapCount(i int) float64 {
+func percentStackDepthDiff(diff, orig int) float64 {
+	return float64(diff) / float64(orig) * 100
+}
+
+func percentMapCount(i, _ int) float64 {
 	return float64(i) / float64(MaxMapCount) * 100
+}
+
+func percentMapCountDiff(diff, orig int) float64 {
+	return float64(diff) / float64(orig) * 100
 }
 
 func colorRelativeChange(program string, i int, p float64) (string, error) {
@@ -281,31 +296,38 @@ func texOrange(s string) string {
 }
 
 type minMax struct {
-	minKey string
-	min    int
-	maxKey string
-	max    int
+	minKey  string
+	origMin int
+	min     int
+	maxKey  string
+	origMax int
+	max     int
 }
 
-func calcMinMax(records []verifierComplexityRecord, metric func(r verifierComplexityRecord) int) map[string]minMax {
+func calcMinMax(records []verifierComplexityRecord, metric func(r verifierComplexityRecord) (int, int)) map[string]minMax {
 	minMaxRecords := map[string]minMax{}
 	for _, r := range records {
+		val, origVal := metric(r)
 		mm, ok := minMaxRecords[collectionProgramKey(r)]
 		if !ok {
 			mm = minMax{
-				min:    metric(r),
-				minKey: kernelBuildLoadKey(r),
-				max:    metric(r),
-				maxKey: kernelBuildLoadKey(r),
+				origMin: origVal,
+				min:     val,
+				minKey:  kernelBuildLoadKey(r),
+				origMax: origVal,
+				max:     val,
+				maxKey:  kernelBuildLoadKey(r),
 			}
 		}
-		if metric(r) < mm.min {
+		if val < mm.min {
 			mm.minKey = kernelBuildLoadKey(r)
-			mm.min = metric(r)
+			mm.origMin = origVal
+			mm.min = val
 		}
-		if metric(r) > mm.max {
+		if val > mm.max {
 			mm.maxKey = kernelBuildLoadKey(r)
-			mm.max = metric(r)
+			mm.origMax = origVal
+			mm.max = val
 		}
 		minMaxRecords[collectionProgramKey(r)] = mm
 	}
@@ -362,16 +384,19 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 			Load:       newRecord.Load,
 			Program:    newRecord.Program,
 
-			InsnsProcessed:   newRecord.InsnsProcessed - oldRecord.InsnsProcessed,
-			MaxStatesPerInsn: newRecord.MaxStatesPerInsn - oldRecord.MaxStatesPerInsn,
-			TotalStates:      newRecord.TotalStates - oldRecord.TotalStates,
-			PeakStates:       newRecord.PeakStates - oldRecord.PeakStates,
-			MarkRead:         newRecord.MarkRead - oldRecord.MarkRead,
+			InsnsProcessed:     newRecord.InsnsProcessed - oldRecord.InsnsProcessed,
+			OrigInsnsProcessed: oldRecord.InsnsProcessed,
+			MaxStatesPerInsn:   newRecord.MaxStatesPerInsn - oldRecord.MaxStatesPerInsn,
+			TotalStates:        newRecord.TotalStates - oldRecord.TotalStates,
+			PeakStates:         newRecord.PeakStates - oldRecord.PeakStates,
+			MarkRead:           newRecord.MarkRead - oldRecord.MarkRead,
 
 			VerificationTimeMicroseconds: newRecord.VerificationTimeMicroseconds - oldRecord.VerificationTimeMicroseconds,
 			StackDepth:                   newRecord.StackDepth - oldRecord.StackDepth,
+			OrigStackDepth:               oldRecord.StackDepth,
 
-			MapCount: newRecord.MapCount - oldRecord.MapCount,
+			MapCount:     newRecord.MapCount - oldRecord.MapCount,
+			OrigMapCount: oldRecord.MapCount,
 		})
 	}
 

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -39,7 +39,6 @@ type verifierComplexityRecord struct {
 	Program    string `json:"program"`
 
 	InsnsProcessed   int `json:"insns_processed"`
-	InsnsLimit       int `json:"insns_limit"`
 	MaxStatesPerInsn int `json:"max_states_per_insn"`
 	TotalStates      int `json:"total_states"`
 	PeakStates       int `json:"peak_states"`
@@ -364,7 +363,6 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 			Program:    newRecord.Program,
 
 			InsnsProcessed:   newRecord.InsnsProcessed - oldRecord.InsnsProcessed,
-			InsnsLimit:       newRecord.InsnsLimit - oldRecord.InsnsLimit,
 			MaxStatesPerInsn: newRecord.MaxStatesPerInsn - oldRecord.MaxStatesPerInsn,
 			TotalStates:      newRecord.TotalStates - oldRecord.TotalStates,
 			PeakStates:       newRecord.PeakStates - oldRecord.PeakStates,
@@ -389,7 +387,6 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 					Program:    oldRecord.Program,
 
 					InsnsProcessed:   -oldRecord.InsnsProcessed,
-					InsnsLimit:       -oldRecord.InsnsLimit,
 					MaxStatesPerInsn: -oldRecord.MaxStatesPerInsn,
 					TotalStates:      -oldRecord.TotalStates,
 					PeakStates:       -oldRecord.PeakStates,

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"slices"
 	"sort"
@@ -29,6 +30,8 @@ const (
 
 	// Number of top values to display.
 	NumberTopValues = 15
+
+	valuesToSkip = math.MinInt
 )
 
 type verifierComplexityRecord struct {
@@ -109,6 +112,9 @@ func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord
 	printTopMinMax("largest differences by instructions processed", minMaxInsnsProcessed, percentInsnsProcessedDiff, colorRelativeChange)
 
 	minMaxStackDepth := calcMinMax(diffRecords, func(r verifierComplexityRecord) (int, int) {
+		if r.Kernel != "bpf-next" {
+			return math.MinInt, math.MinInt
+		}
 		return r.StackDepth, r.OrigStackDepth
 	})
 	printTopMinMax("largest differences by stack depth", minMaxStackDepth, percentStackDepthDiff, colorRelativeChange)
@@ -136,6 +142,9 @@ func printCurrentState(newRecords map[string]verifierComplexityRecord) []error {
 	}
 
 	minMaxStackDepth := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) (int, int) {
+		if r.Kernel != "bpf-next" {
+			return math.MinInt, math.MinInt
+		}
 		return r.StackDepth, r.OrigStackDepth
 	})
 	err = printTopMinMax("largest stack depth", minMaxStackDepth, percentStackDepth, colorAbsoluteValue)
@@ -308,6 +317,9 @@ func calcMinMax(records []verifierComplexityRecord, metric func(r verifierComple
 	minMaxRecords := map[string]minMax{}
 	for _, r := range records {
 		val, origVal := metric(r)
+		if val == valuesToSkip || origVal == valuesToSkip {
+			continue
+		}
 		mm, ok := minMaxRecords[collectionProgramKey(r)]
 		if !ok {
 			mm = minMax{


### PR DESCRIPTION
Backport a bunch of improvements for the verifier log parsing. This brings a fix-up for https://github.com/cilium/cilium/pull/47814.

* [ ] #45657
* [ ] #45880 (dropped one patch that was reverted later)
* [ ] #46109
* [ ] #46182 (dropped lvh image bump, minor adjustments)

```upstream-prs
45657 45880 46109 46182
```