### PR TITLE
datapath: turn ARP off on the base devices before bringing them up

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -100,12 +100,24 @@ func setupVethPair(logger *slog.Logger, sysctl sysctl.Sysctl, name, peerName str
 	if err != nil {
 		return fmt.Errorf("failed to get link by name %s: %w", name, err)
 	}
-	if err := enableForwarding(logger, sysctl, veth); err != nil {
-		return fmt.Errorf("failed to enable forwarding on veth: %w", err)
-	}
 	peer, err := safenetlink.LinkByName(peerName)
 	if err != nil {
 		return fmt.Errorf("failed to get link by name %s: %w", peerName, err)
+	}
+
+	// Turn ARP off before bringing the links up. The kernel skips duplicate
+	// address detection on NOARP devices, so the kernel-generated IPv6
+	// link-local is added as permanent instead of spending up to a second in
+	// the tentative state, invisible to netlink subscribers.
+	if err := netlink.LinkSetARPOff(veth); err != nil {
+		return fmt.Errorf("failed to set ARP off for %s: %w", name, err)
+	}
+	if err := netlink.LinkSetARPOff(peer); err != nil {
+		return fmt.Errorf("failed to set ARP off for %s: %w", peerName, err)
+	}
+
+	if err := enableForwarding(logger, sysctl, veth); err != nil {
+		return fmt.Errorf("failed to enable forwarding on veth: %w", err)
 	}
 	if err := enableForwarding(logger, sysctl, peer); err != nil {
 		return fmt.Errorf("failed to enable forwarding on peer: %w", err)
@@ -130,13 +142,6 @@ func setupBaseDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mtu int) (netlin
 	linkNet, err := safenetlink.LinkByName(defaults.SecondHostDevice)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get link for %s: %w", defaults.SecondHostDevice, err)
-	}
-
-	if err := netlink.LinkSetARPOff(linkHost); err != nil {
-		return nil, nil, fmt.Errorf("failed to set ARP off for %s: %w", linkHost.Attrs().Name, err)
-	}
-	if err := netlink.LinkSetARPOff(linkNet); err != nil {
-		return nil, nil, fmt.Errorf("failed to set ARP off for %s: %w", linkNet.Attrs().Name, err)
 	}
 
 	if err := netlink.LinkSetMTU(linkHost, mtu); err != nil {

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -8,6 +8,7 @@ package loader
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -15,6 +16,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	fakebigtcp "github.com/cilium/cilium/pkg/datapath/linux/bigtcp/fake"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -103,6 +105,69 @@ func TestPrivilegedSetupDev(t *testing.T) {
 
 		err = netlink.LinkDel(dummy)
 		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+// TestPrivilegedSetupBaseDeviceIPv6NotTentative checks that the IPv6 link-local
+// addresses of the base devices are usable as soon as setupBaseDevice returns.
+// Bringing a link up before turning ARP off leaves the kernel-generated
+// link-local tentative for as long as duplicate address detection takes, and
+// the kernel does not notify subscribers about tentative addresses, so the
+// devices table stays without an IPv6 address for cilium_net and the from-proxy
+// routes cannot be installed.
+func TestPrivilegedSetupBaseDeviceIPv6NotTentative(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+
+	prevConfigEnableIPv4 := option.Config.EnableIPv4
+	prevConfigEnableIPv6 := option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4 = prevConfigEnableIPv4
+		option.Config.EnableIPv6 = prevConfigEnableIPv6
+	})
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+
+	ns := netns.NewNetNS(t)
+
+	ns.Do(func() error {
+		_, _, err := setupBaseDevice(logger, sysctl, 1500)
+		require.NoError(t, err)
+
+		for _, devName := range []string{defaults.HostDevice, defaults.SecondHostDevice} {
+			link, err := safenetlink.LinkByName(devName)
+			require.NoError(t, err)
+
+			require.NotZero(t, link.Attrs().RawFlags&unix.IFF_NOARP,
+				"%s should have ARP off", devName)
+
+			// The kernel adds the link-local from a workqueue, so wait for it
+			// to show up and assert on the flags it is created with. With ARP
+			// off it is created permanent, otherwise it starts out tentative.
+			// Polled inline because the network namespace is per-thread, so
+			// the wait cannot run on another goroutine.
+			var addrs []netlink.Addr
+			for range 5000 {
+				addrs, err = safenetlink.AddrList(link, netlink.FAMILY_V6)
+				require.NoError(t, err)
+				if len(addrs) > 0 {
+					break
+				}
+				time.Sleep(time.Millisecond)
+			}
+			require.NotEmpty(t, addrs, "%s should get an IPv6 link-local address", devName)
+
+			for _, addr := range addrs {
+				require.Zero(t, addr.Flags&unix.IFA_F_TENTATIVE,
+					"%s address %s was created tentative, duplicate address detection was not skipped", devName, addr.IP)
+				require.Zero(t, addr.Flags&unix.IFA_F_DADFAILED,
+					"%s address %s failed duplicate address detection", devName, addr.IP)
+			}
+		}
 
 		return nil
 	})


### PR DESCRIPTION
The clustermesh conformance job fails check-log-errors on the IPv6 native-routing legs with one warning from a freshly booted agent: "failed to find valid IPv6 address for cilium_net". setupVethPair brings cilium_host and cilium_net up before setupBaseDevice turns ARP off on them, so the kernel runs duplicate address detection on the link-locals it generates for both ends, and it does not notify netlink subscribers about an address while detection is running. The devices table therefore has no IPv6 address for cilium_net during that window, and that link-local is the nexthop the from-proxy IPv6 routes use. The orchestrator's retry ten seconds later succeeds, but the warning alone fails the job.

Turning ARP off before bringing the links up makes the kernel skip detection, so the address is created permanent and is visible immediately. That is the correct order regardless, since these are NOARP devices. Measured in a netns with the real setup sequence, the address goes from unusable for 750ms to usable within 5ms, and raising dad_transmits no longer widens the window. The added test fails ten out of ten runs against unpatched main.

This PR was prepared with AIL:3.
