### PR TITLE
cilium-cli: don't count pods rejected before running as live

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2793,11 +2793,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to list same node pods: %w", err)
 	}
-	if len(sameNodePods.Items) != 1 {
-		return fmt.Errorf("unexpected number of same node pods: %d", len(sameNodePods.Items))
+	sameNodePodItems := k8s.LivePods(sameNodePods.Items)
+	if len(sameNodePodItems) != 1 {
+		return fmt.Errorf("unexpected number of same node pods: %d", len(sameNodePodItems))
 	}
 	sameNodePod := Pod{
-		Pod: sameNodePods.Items[0].DeepCopy(),
+		Pod: sameNodePodItems[0].DeepCopy(),
 	}
 
 	for _, cp := range ct.clientPods {
@@ -2812,11 +2813,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("unable to list other node pods: %w", err)
 		}
-		if len(otherNodePods.Items) != 1 {
-			return fmt.Errorf("unexpected number of other node pods: %d", len(otherNodePods.Items))
+		otherNodePodItems := k8s.LivePods(otherNodePods.Items)
+		if len(otherNodePodItems) != 1 {
+			return fmt.Errorf("unexpected number of other node pods: %d", len(otherNodePodItems))
 		}
 		otherNodePod := Pod{
-			Pod: otherNodePods.Items[0].DeepCopy(),
+			Pod: otherNodePodItems[0].DeepCopy(),
 		}
 
 		for _, cp := range ct.clientPods {

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -32,6 +32,12 @@ const (
 	ShortTimeout = 30 * time.Second
 
 	PollInterval = 1 * time.Second
+
+	// daemonSetRejectionGrace is how much longer WaitForDaemonSet keeps polling
+	// past LongTimeout when the DaemonSet is only held back by pods that were
+	// rejected before running. kubelet's rejection backoff reaches roughly four
+	// minutes, so this has to cover one burst plus the scheduling that follows.
+	daemonSetRejectionGrace = 5 * time.Minute
 )
 
 // WaitForDeployment waits until the specified deployment becomes ready.
@@ -58,11 +64,22 @@ func WaitForDeployment(ctx context.Context, log Logger, client *k8s.Client, name
 }
 
 // WaitForDaemonSet waits until the specified daemonset becomes ready.
+//
+// A node condition such as DiskPressure makes kubelet reject the pods bound to
+// it, and each rejection is retried on an exponential backoff that reaches
+// several minutes on its own. LongTimeout cannot outlast one such burst, so
+// when the deadline is reached and the only thing holding the DaemonSet back is
+// pods that were rejected without ever running, keep polling for a bounded
+// grace period instead of failing. Anything else, including a container that
+// ran and crashed, still fails at LongTimeout.
 func WaitForDaemonSet(ctx context.Context, log Logger, client *k8s.Client, namespace string, name string) error {
 	log.Logf("⌛ [%s] Waiting for DaemonSet %s/%s to become ready...", client.ClusterName(), namespace, name)
 
-	ctx, cancel := context.WithTimeout(ctx, LongTimeout)
+	ctx, cancel := context.WithTimeout(ctx, LongTimeout+daemonSetRejectionGrace)
 	defer cancel()
+
+	deadline := time.Now().Add(LongTimeout)
+	graceGranted := false
 	for {
 		err := client.CheckDaemonSetStatus(ctx, namespace, name)
 		if err == nil {
@@ -71,13 +88,58 @@ func WaitForDaemonSet(ctx context.Context, log Logger, client *k8s.Client, names
 
 		log.Debugf("[%s] DaemonSet %s/%s is not yet ready: %s", client.ClusterName(), namespace, name, err)
 
+		if !graceGranted && time.Now().After(deadline) {
+			rejected := supersededDaemonSetPods(ctx, client, namespace, name)
+			if len(rejected) == 0 {
+				return fmt.Errorf("timeout reached waiting for DaemonSet %s/%s to become ready (last error: %w)",
+					namespace, name, err)
+			}
+			graceGranted = true
+			log.Logf("⌛ [%s] DaemonSet %s/%s is held back by pods rejected before running (%s), waiting up to %s more...",
+				client.ClusterName(), namespace, name, strings.Join(rejected, ", "), daemonSetRejectionGrace)
+		}
+
 		select {
 		case <-time.After(PollInterval):
 		case <-ctx.Done():
+			if rejected := supersededDaemonSetPods(ctx, client, namespace, name); len(rejected) > 0 {
+				return fmt.Errorf("timeout reached waiting for DaemonSet %s/%s to become ready, pods rejected before running: %s (last error: %w)",
+					namespace, name, strings.Join(rejected, ", "), err)
+			}
 			return fmt.Errorf("timeout reached waiting for DaemonSet %s/%s to become ready (last error: %w)",
 				namespace, name, err)
 		}
 	}
+}
+
+// supersededDaemonSetPods returns "pod (reason)" for every pod of the DaemonSet
+// that reached a terminal state without ever running its workload, but only if
+// no other pod failed for a different reason. A pod that ran and crashed leaves
+// the result empty, so its DaemonSet is never granted the extra grace period.
+func supersededDaemonSetPods(ctx context.Context, client *k8s.Client, namespace, name string) []string {
+	ds, err := client.GetDaemonSet(ctx, namespace, name, metav1.GetOptions{})
+	if err != nil || ds == nil {
+		return nil
+	}
+
+	pods, err := client.ListPods(ctx, namespace, metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(ds.Spec.Selector),
+	})
+	if err != nil || pods == nil {
+		return nil
+	}
+
+	var rejected []string
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodFailed {
+			continue
+		}
+		if !k8s.IsSupersededPodRejection(pod.Status.Reason) {
+			return nil
+		}
+		rejected = append(rejected, fmt.Sprintf("%s (%s)", pod.Name, pod.Status.Reason))
+	}
+	return rejected
 }
 
 // WaitForPodDNS waits until src can query the DNS server on dst successfully.

--- a/cilium-cli/k8s/pods.go
+++ b/cilium-cli/k8s/pods.go
@@ -3,6 +3,10 @@
 
 package k8s
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 // IsSupersededPodRejection reports whether a Failed pod reached its terminal
 // state by admission-rejection or eviction rather than by running and crashing.
 // Such pods (e.g. bound to a node still carrying node.cilium.io/agent-not-ready
@@ -16,4 +20,19 @@ func IsSupersededPodRejection(reason string) bool {
 		return true
 	}
 	return false
+}
+
+// LivePods returns the pods that are not terminal, controller-superseded
+// leftovers. Listing pods by label selector alone also returns such leftovers,
+// which carry no pod IP and are never going to run, so counting them makes a
+// healthy single-replica deployment look like it has two pods.
+func LivePods(pods []corev1.Pod) []corev1.Pod {
+	live := make([]corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodFailed && IsSupersededPodRejection(pod.Status.Reason) {
+			continue
+		}
+		live = append(live, pod)
+	}
+	return live
 }

--- a/cilium-cli/k8s/pods.go
+++ b/cilium-cli/k8s/pods.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+// IsSupersededPodRejection reports whether a Failed pod reached its terminal
+// state by admission-rejection or eviction rather than by running and crashing.
+// Such pods (e.g. bound to a node still carrying node.cilium.io/agent-not-ready
+// :NoExecute) are already replaced by a healthy sibling from the controller, so
+// they must not fail `status --wait`. A container that ran and crashed has an
+// empty pod-level Status.Reason and is therefore still surfaced.
+func IsSupersededPodRejection(reason string) bool {
+	switch reason {
+	case "TaintToleration", "NodeAffinity", "NodeLost", "Evicted",
+		"Shutdown", "Preempting", "UnexpectedAdmissionError":
+		return true
+	}
+	return false
+}

--- a/cilium-cli/k8s/pods_test.go
+++ b/cilium-cli/k8s/pods_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSupersededPodRejection(t *testing.T) {
+	for _, reason := range []string{"TaintToleration", "NodeAffinity", "NodeLost", "Evicted", "Shutdown", "Preempting", "UnexpectedAdmissionError"} {
+		assert.True(t, IsSupersededPodRejection(reason), reason)
+	}
+	for _, reason := range []string{"", "OOMKilled", "Error", "ContainerCannotRun"} {
+		assert.False(t, IsSupersededPodRejection(reason), reason)
+	}
+}

--- a/cilium-cli/k8s/pods_test.go
+++ b/cilium-cli/k8s/pods_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsSupersededPodRejection(t *testing.T) {
@@ -16,4 +18,38 @@ func TestIsSupersededPodRejection(t *testing.T) {
 	for _, reason := range []string{"", "OOMKilled", "Error", "ContainerCannotRun"} {
 		assert.False(t, IsSupersededPodRejection(reason), reason)
 	}
+}
+
+func pod(name string, phase corev1.PodPhase, reason string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.PodStatus{Phase: phase, Reason: reason},
+	}
+}
+
+func TestLivePods(t *testing.T) {
+	// A superseded leftover alongside its healthy replacement.
+	live := LivePods([]corev1.Pod{
+		pod("echo-evicted", corev1.PodFailed, "Evicted"),
+		pod("echo-running", corev1.PodRunning, ""),
+	})
+	assert.Len(t, live, 1)
+	assert.Equal(t, "echo-running", live[0].Name)
+
+	// Genuine failures are kept, so a broken deployment is still surfaced.
+	live = LivePods([]corev1.Pod{
+		pod("echo-oom", corev1.PodFailed, ""),
+		pod("echo-running", corev1.PodRunning, ""),
+	})
+	assert.Len(t, live, 2)
+
+	// The reason alone is not enough, the pod has to be terminal.
+	live = LivePods([]corev1.Pod{pod("echo-running", corev1.PodRunning, "Evicted")})
+	assert.Len(t, live, 1)
+
+	// Everything evicted leaves nothing live, which still trips the callers.
+	live = LivePods([]corev1.Pod{pod("echo-evicted", corev1.PodFailed, "Evicted")})
+	assert.Empty(t, live)
+
+	assert.Empty(t, LivePods(nil))
 }

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -276,21 +276,6 @@ func (k *K8sStatusCollector) daemonSetStatus(ctx context.Context, status *Status
 	return false, nil
 }
 
-// isSupersededPodRejection reports whether a Failed pod reached its terminal
-// state by admission-rejection or eviction rather than by running and crashing.
-// Such pods (e.g. bound to a node still carrying node.cilium.io/agent-not-ready
-// :NoExecute) are already replaced by a healthy sibling from the controller, so
-// they must not fail `status --wait`. A container that ran and crashed has an
-// empty pod-level Status.Reason and is therefore still surfaced.
-func isSupersededPodRejection(reason string) bool {
-	switch reason {
-	case "TaintToleration", "NodeAffinity", "NodeLost", "Evicted",
-		"Shutdown", "Preempting", "UnexpectedAdmissionError":
-		return true
-	}
-	return false
-}
-
 type podStatusCallback func(ctx context.Context, status *Status, name string, pod *corev1.Pod)
 
 func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name, filter string, callback podStatusCallback) error {
@@ -317,7 +302,7 @@ func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name
 			// is terminal and already superseded by a healthy replacement from
 			// the controller. The Deployment/DaemonSet gate remains authoritative
 			// for real availability, so don't fail the status on such leftovers.
-			if isSupersededPodRejection(pod.Status.Reason) {
+			if k8s.IsSupersededPodRejection(pod.Status.Reason) {
 				break
 			}
 			status.AddAggregatedError(name, pod.Name, fmt.Errorf("pod has failed: %s - %s", pod.Status.Reason, pod.Status.Message))

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -266,15 +266,6 @@ func TestPodStatusSkipsSupersededRejection(t *testing.T) {
 	assert.Equal(t, 1, status.totalErrors())
 }
 
-func TestIsSupersededPodRejection(t *testing.T) {
-	for _, reason := range []string{"TaintToleration", "NodeAffinity", "NodeLost", "Evicted", "Shutdown", "Preempting", "UnexpectedAdmissionError"} {
-		assert.True(t, isSupersededPodRejection(reason), reason)
-	}
-	for _, reason := range []string{"", "OOMKilled", "Error", "ContainerCannotRun"} {
-		assert.False(t, isSupersededPodRejection(reason), reason)
-	}
-}
-
 func TestFormat(t *testing.T) {
 	client := newK8sStatusMockClient()
 	assert.NotNil(t, client)

--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -104,6 +104,7 @@ const (
 	kubernetesLeasesFileName                 = "k8s-leases-<ts>.yaml"
 	kubernetesMetricsFileName                = "k8s-metrics-<ts>.yaml"
 	kubernetesTopNodesFileName               = "k8s-node-memory-cpu-usage-<ts>.txt"
+	kubernetesNodeDiskUsageFileName          = "k8s-node-disk-usage-<ts>.txt"
 	kubernetesTopPodsFileName                = "k8s-pod-memory-cpu-usage-<ts>.txt"
 	kubernetesNamespacesFileName             = "k8s-namespaces-<ts>.yaml"
 	kubernetesNetworkPoliciesFileName        = "k8s-networkpolicies-<ts>.yaml"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -655,6 +655,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Kubernetes nodes disk usage",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				output, err := c.collectNodeDiskUsage(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to collect Kubernetes nodes disk usage: %w", err)
+				}
+				if err := c.WriteString(kubernetesNodeDiskUsageFileName, output); err != nil {
+					return fmt.Errorf("failed to collect Kubernetes nodes disk usage: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting Kubernetes pods memory/cpu usage",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
@@ -3677,6 +3691,101 @@ func (c *Collector) formatNodeMetricsAsTable(rawMetrics string) (string, error) 
 	tw.Flush()
 
 	return sb.String(), nil
+}
+
+// nodeStatsSummary is the subset of kubelet's /stats/summary that describes
+// disk usage, which is what kubelet evicts pods on.
+type nodeStatsSummary struct {
+	Node struct {
+		NodeName string `json:"nodeName"`
+		Fs       struct {
+			AvailableBytes *uint64 `json:"availableBytes"`
+			CapacityBytes  *uint64 `json:"capacityBytes"`
+			UsedBytes      *uint64 `json:"usedBytes"`
+			InodesFree     *uint64 `json:"inodesFree"`
+		} `json:"fs"`
+		Runtime struct {
+			ImageFs struct {
+				AvailableBytes *uint64 `json:"availableBytes"`
+				CapacityBytes  *uint64 `json:"capacityBytes"`
+				UsedBytes      *uint64 `json:"usedBytes"`
+			} `json:"imageFs"`
+		} `json:"runtime"`
+	} `json:"node"`
+}
+
+// collectNodeDiskUsage reports per-node nodefs and imagefs usage, along with
+// the DiskPressure condition. kubelet evicts pods on ephemeral-storage
+// exhaustion, and without this the only trace left in a sysdump is the
+// resulting eviction events, which say nothing about what filled the disk.
+func (c *Collector) collectNodeDiskUsage(ctx context.Context) (string, error) {
+	nodes, err := c.Client.ListNodes(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get nodes: %w", err)
+	}
+
+	var sb strings.Builder
+	tw := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tNODEFS USED\tNODEFS CAPACITY\tNODEFS(%)\tIMAGEFS USED\tIMAGEFS CAPACITY\tINODES FREE\tDISKPRESSURE")
+
+	for _, node := range nodes.Items {
+		diskPressure := "<unknown>"
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeDiskPressure {
+				diskPressure = string(cond.Status)
+				break
+			}
+		}
+
+		// Kubelet's stats endpoint is not always reachable through the API
+		// server proxy, so a failure here must not lose the rest of the table.
+		raw, err := c.Client.GetRaw(ctx, fmt.Sprintf("/api/v1/nodes/%s/proxy/stats/summary", node.Name))
+		if err != nil {
+			fmt.Fprintf(tw, "%s\t<error: %s>\t\t\t\t\t\t%s\n", node.Name, err, diskPressure)
+			continue
+		}
+
+		fmt.Fprintln(tw, formatNodeDiskUsageRow(node.Name, raw, diskPressure))
+	}
+
+	tw.Flush()
+
+	return sb.String(), nil
+}
+
+// formatNodeDiskUsageRow renders one tab-separated row of the node disk usage
+// table from a kubelet stats summary payload.
+func formatNodeDiskUsageRow(nodeName, rawSummary, diskPressure string) string {
+	var summary nodeStatsSummary
+	if err := json.Unmarshal([]byte(rawSummary), &summary); err != nil {
+		return fmt.Sprintf("%s\t<unparseable: %s>\t\t\t\t\t\t%s", nodeName, err, diskPressure)
+	}
+
+	pct := func(used, capacity *uint64) string {
+		if used == nil || capacity == nil || *capacity == 0 {
+			return "<unknown>"
+		}
+		return fmt.Sprintf("%.0f%%", float64(*used)/float64(*capacity)*100)
+	}
+	mib := func(v *uint64) string {
+		if v == nil {
+			return "<unknown>"
+		}
+		return fmt.Sprintf("%dMi", *v/(1024*1024))
+	}
+	count := func(v *uint64) string {
+		if v == nil {
+			return "<unknown>"
+		}
+		return strconv.FormatUint(*v, 10)
+	}
+
+	fs, imageFs := summary.Node.Fs, summary.Node.Runtime.ImageFs
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+		nodeName,
+		mib(fs.UsedBytes), mib(fs.CapacityBytes), pct(fs.UsedBytes, fs.CapacityBytes),
+		mib(imageFs.UsedBytes), mib(imageFs.CapacityBytes),
+		count(fs.InodesFree), diskPressure)
 }
 
 // formatPodMetricsAsTable formats the raw pod metrics JSON into a table format like kubectl top pods

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -781,3 +781,52 @@ func Test_untar(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid path in tar entry")
 	})
 }
+
+func TestFormatNodeDiskUsageRow(t *testing.T) {
+	// Shape and field names as served by kubelet's /stats/summary, trimmed to
+	// the disk fields. Sizes are those of the AKS 30 GB OS disk nodes.
+	summary := `{
+	  "node": {
+	    "nodeName": "aks-nodepool1-16135303-vmss000003",
+	    "fs": {
+	      "availableBytes": 3221225472,
+	      "capacityBytes": 30089314304,
+	      "usedBytes": 26868088832,
+	      "inodesFree": 1835008
+	    },
+	    "runtime": {
+	      "imageFs": {
+	        "availableBytes": 3221225472,
+	        "capacityBytes": 30089314304,
+	        "usedBytes": 20401094656
+	      }
+	    }
+	  }
+	}`
+
+	row := formatNodeDiskUsageRow("aks-nodepool1-16135303-vmss000003", summary, "True")
+	fields := strings.Split(row, "\t")
+	assert.Len(t, fields, 8)
+	assert.Equal(t, "aks-nodepool1-16135303-vmss000003", fields[0])
+	assert.Equal(t, "25623Mi", fields[1])
+	assert.Equal(t, "28695Mi", fields[2])
+	assert.Equal(t, "89%", fields[3])
+	assert.Equal(t, "19456Mi", fields[4])
+	assert.Equal(t, "28695Mi", fields[5])
+	assert.Equal(t, "1835008", fields[6])
+	assert.Equal(t, "True", fields[7])
+
+	// Missing stats must not panic or drop the node from the table.
+	row = formatNodeDiskUsageRow("node-without-stats", `{"node":{"nodeName":"node-without-stats"}}`, "False")
+	fields = strings.Split(row, "\t")
+	assert.Len(t, fields, 8)
+	assert.Equal(t, "<unknown>", fields[1])
+	assert.Equal(t, "<unknown>", fields[3])
+	assert.Equal(t, "False", fields[7])
+
+	// A garbage payload keeps the node and its condition visible.
+	row = formatNodeDiskUsageRow("node-broken", "not json", "Unknown")
+	assert.Contains(t, row, "node-broken")
+	assert.Contains(t, row, "unparseable")
+	assert.Contains(t, row, "Unknown")
+}


### PR DESCRIPTION
The AKS connectivity test setup failed with "unexpected number of other node pods: 2" on a cluster that had already recovered: a node had gone under DiskPressure, kubelet evicted the pods bound to it, and listing pods by label selector returns those terminal leftovers alongside the healthy replacement. The echo pod count now skips pods that were rejected before ever running. WaitForDeployment already ran for the same deployments and stays authoritative, and a container that ran and crashed has an empty pod-level reason so it is still counted and still reported.

The DaemonSet wait hit the same eviction burst but cannot be fixed by filtering, since a rejected pod really does mean a replica is missing. kubelet's rejection backoff reaches about four minutes, which the five minute timeout cannot outlast, so it gave up a minute after the node was healthy again. It now polls for a bounded grace period past the timeout, but only while every failed pod was rejected before running, and names those pods in the error. Node disk usage was invisible in the sysdump, so the last commit collects nodefs and imagefs per node along with the DiskPressure condition.

This PR was prepared with AIL:3.
