### PR TITLE
gateway-api/gamma: refresh CEC owner refs on route recreation

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -383,6 +383,7 @@ func (r *gammaReconciler) ensureEnvoyConfig(ctx context.Context, desired *cilium
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
 		cec.Spec = desired.Spec
+		cec.OwnerReferences = desired.OwnerReferences
 		setMergedLabelsAndAnnotations(cec, desired)
 		return nil
 	})

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -6,15 +6,18 @@ package gateway_api
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -168,4 +171,190 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_gammaReconciler_Reconcile_BackendRequestHeaderModifier(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	cecTranslator := translation.NewCECTranslator(translation.Config{
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+
+	base := readInputDir(t, "testdata/gamma/base")
+	input := readInputDir(t, "testdata/gamma/mesh-request-header-modifier-backend/input")
+	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(append(base, input...)...).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.GammaHTTPRouteParentRefsIndex, indexers.IndexHTTPRouteByGammaService).
+		WithIndex(&gatewayv1.GRPCRoute{}, indexers.GammaGRPCRouteParentRefsIndex, indexers.IndexGRPCRouteByGammaService).
+		WithStatusSubresource(&corev1.Service{}).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+		WithInterceptorFuncs(typeMetaInterceptor(scheme)).
+		Build()
+
+	r := &gammaReconciler{
+		Client:         c,
+		translator:     gatewayAPITranslator,
+		logger:         logger,
+		controllerName: defaultControllerName,
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKeyEcho})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	actualCEC := &ciliumv2.CiliumEnvoyConfig{}
+	err = c.Get(t.Context(), serviceKeyEcho, actualCEC)
+	require.NoError(t, err)
+
+	cecYAML := toYaml(t, actualCEC)
+	for _, want := range []string{
+		"requestHeadersToAdd:",
+		"key: X-Header-Set",
+		"value: set-overwrites-values",
+		"key: X-Header-Add",
+		"value: add-appends-values",
+		"requestHeadersToRemove:",
+		"- X-Header-Remove",
+	} {
+		assert.Contains(t, cecYAML, want)
+	}
+
+	actualHR := &gatewayv1.HTTPRoute{}
+	err = c.Get(t.Context(), types.NamespacedName{
+		Namespace: "gateway-conformance-mesh",
+		Name:      "mesh-request-header-modifier",
+	}, actualHR)
+	require.NoError(t, err)
+
+	hrYAML := toYaml(t, actualHR)
+	assert.True(t, strings.Contains(hrYAML, "filters:") || strings.Contains(hrYAML, "requestHeaderModifier:"))
+}
+
+func Test_gammaReconciler_Reconcile_ReplacesOwnerReferencesForRecreatedRoute(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	cecTranslator := translation.NewCECTranslator(translation.Config{
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+
+	base := readInputDir(t, "testdata/gamma/base")
+	originalInput := readInputDir(t, "testdata/gamma/mesh-request-header-modifier/input")
+	recreatedInput := readInputDir(t, "testdata/gamma/mesh-request-header-modifier-backend/input")
+	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+
+	setRouteIdentity := func(objs []client.Object, uid string) {
+		t.Helper()
+
+		for _, obj := range objs {
+			hr, ok := obj.(*gatewayv1.HTTPRoute)
+			if !ok {
+				continue
+			}
+			if hr.Name != "mesh-request-header-modifier" || hr.Namespace != "gateway-conformance-mesh" {
+				continue
+			}
+			hr.SetUID(types.UID(uid))
+			hr.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    "HTTPRoute",
+			})
+		}
+	}
+
+	setRouteIdentity(originalInput, "old-route-uid")
+	setRouteIdentity(recreatedInput, "new-route-uid")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(base...).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.GammaHTTPRouteParentRefsIndex, indexers.IndexHTTPRouteByGammaService).
+		WithIndex(&gatewayv1.GRPCRoute{}, indexers.GammaGRPCRouteParentRefsIndex, indexers.IndexGRPCRouteByGammaService).
+		WithStatusSubresource(&corev1.Service{}).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+		WithInterceptorFuncs(typeMetaInterceptor(scheme)).
+		Build()
+
+	r := &gammaReconciler{
+		Client:         c,
+		translator:     gatewayAPITranslator,
+		logger:         logger,
+		controllerName: defaultControllerName,
+	}
+
+	for _, obj := range originalInput {
+		require.NoError(t, c.Create(t.Context(), obj.DeepCopyObject().(client.Object)))
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKeyEcho})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	actualCEC := &ciliumv2.CiliumEnvoyConfig{}
+	err = c.Get(t.Context(), serviceKeyEcho, actualCEC)
+	require.NoError(t, err)
+	require.Len(t, actualCEC.OwnerReferences, 1)
+	assert.Equal(t, "old-route-uid", string(actualCEC.OwnerReferences[0].UID))
+
+	originalRoute := &gatewayv1.HTTPRoute{}
+	err = c.Get(t.Context(), types.NamespacedName{
+		Namespace: "gateway-conformance-mesh",
+		Name:      "mesh-request-header-modifier",
+	}, originalRoute)
+	require.NoError(t, err)
+	require.NoError(t, c.Delete(t.Context(), originalRoute))
+
+	for _, obj := range recreatedInput {
+		require.NoError(t, c.Create(t.Context(), obj.DeepCopyObject().(client.Object)))
+	}
+
+	result, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKeyEcho})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	err = c.Get(t.Context(), serviceKeyEcho, actualCEC)
+	require.NoError(t, err)
+	require.Len(t, actualCEC.OwnerReferences, 1)
+	assert.Equal(t, "new-route-uid", string(actualCEC.OwnerReferences[0].UID))
 }

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier-backend/input/httproute-mesh-request-header-modifier-backend.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier-backend/input/httproute-mesh-request-header-modifier-backend.yaml
@@ -1,0 +1,93 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-request-header-modifier
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /set
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: set-overwrites-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /add
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+          - name: X-Header-Add
+            value: add-appends-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /remove
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          remove:
+          - X-Header-Remove
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /multiple
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set-1
+            value: header-set-1
+          - name: X-Header-Set-2
+            value: header-set-2
+          add:
+          - name: X-Header-Add-1
+            value: header-add-1
+          - name: X-Header-Add-2
+            value: header-add-2
+          - name: X-Header-Add-3
+            value: header-add-3
+          remove:
+          - X-Header-Remove-1
+          - X-Header-Remove-2
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /case-insensitivity
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: header-set
+          add:
+          - name: X-Header-Add
+            value: header-add
+          remove:
+          - X-Header-Remove


### PR DESCRIPTION
When a GAMMA HTTPRoute is deleted and recreated with the same name, the generated CiliumEnvoyConfig is updated in place. Before this change, ensureEnvoyConfig() only replaced the spec and left the previous OwnerReferences unchanged.

That meant the CEC could still be owned by the old route UID after the new route had been reconciled. In delete-and-recreate flows, Kubernetes garbage collection could then remove the CEC under the replacement route.

Therefore, this commit updates the GAMMA CEC patch path to refresh OwnerReferences from the desired object as well.

Note: it seemed as a pure golden input/output test wasn't ideal here to test the edge usecase