### PR TITLE
bpf: lb: use dedicated new_backend bool

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -205,6 +205,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif /* ENABLE_NODEPORT */
 
 	if (svc) {
+		bool new_backend __maybe_unused = false;
 		const struct lb4_backend *backend;
 
 #if defined(ENABLE_L7_LB)
@@ -231,7 +232,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 
 		ret = lb4_local(get_ct_map4(&tuple), ctx, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				&backend, ext_err, NULL);
+				&backend, &new_backend, ext_err, NULL);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
@@ -383,6 +384,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 #endif /* ENABLE_NODEPORT */
 
 	if (svc) {
+		bool new_backend __maybe_unused = false;
 		const struct lb6_backend *backend;
 
 #if defined(ENABLE_L7_LB)
@@ -401,7 +403,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 
 		ret = lb6_local(get_ct_map6(&tuple), ctx, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				&backend, ext_err, NULL);
+				&backend, &new_backend, ext_err, NULL);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -53,8 +53,7 @@ struct ct_state {
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
 	      closing:1,
-	      new_backend:1,	/* Service connection was assigned a new backend */
-	      reserved:6;
+	      reserved:7;
 	__u32 src_sec_id;
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1381,6 +1381,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     const struct lb6_service *svc,
 				     struct ct_state *state,
 				     const struct lb6_backend **selected_backend,
+				     bool *new_backend,
 				     __s8 *ext_err,
 				     const struct lb6_backend *forced_backend)
 {
@@ -1442,7 +1443,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (backend == NULL)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -1490,7 +1491,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}
@@ -2207,6 +2208,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     const struct lb4_service *svc,
 				     struct ct_state *state,
 				     const struct lb4_backend **selected_backend,
+				     bool *new_backend,
 				     __s8 *ext_err,
 				     const struct lb4_backend *forced_backend)
 {
@@ -2272,7 +2274,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (backend == NULL)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -2320,7 +2322,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -131,7 +131,7 @@ static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused)
 #define NEED_DSR_INFO	(1 << 16)
 
 static __always_inline bool
-nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
+nodeport_need_dsr_info(__u8 nexthdr, bool syn, bool new_backend)
 {
 	/* We only need to embed the DSR info into the first packet of a connection
 	 * (since it will then be cached on the backend node).
@@ -140,9 +140,7 @@ nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
 	 * We also send DSR info for the first TCP packet towards a new backend,
 	 * so that it can at least RevDNAT its RST reply.
 	 */
-	return (nexthdr != IPPROTO_TCP) ||
-	       ct_state->new_backend ||
-	       ct_state->syn;
+	return (nexthdr != IPPROTO_TCP) || syn || new_backend;
 }
 
 #if defined(ENABLE_IPV4)
@@ -1382,6 +1380,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 					    bool *punt_to_stack __maybe_unused,
 					    __s8 *ext_err)
 {
+	bool new_backend __maybe_unused = false;
 	struct ct_state ct_state_svc = {};
 	const struct lb6_backend *backend;
 	const struct lb6_backend *forced_be_p __maybe_unused = NULL;
@@ -1446,7 +1445,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 		}
 	}
 	ret = lb6_local(get_ct_map6(tuple), ctx, fraginfo, l4_off,
-			key, tuple, svc, &ct_state_svc, &backend,
+			key, tuple, svc, &ct_state_svc, &backend, &new_backend,
 			ext_err, forced_be_p);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE) {
@@ -1535,7 +1534,9 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		__u32 port = key->dport;
 
-		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+		if (nodeport_need_dsr_info(tuple->nexthdr,
+					   ct_state_svc.syn,
+					   new_backend))
 			port |= NEED_DSR_INFO;
 
 		ctx_store_meta(ctx, CB_PORT, port);
@@ -2710,6 +2711,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 					    bool *punt_to_stack __maybe_unused,
 					    __s8 *ext_err)
 {
+	bool new_backend __maybe_unused = false;
 	const struct lb4_backend *backend;
 	struct ct_state ct_state_svc = {};
 	__u32 cluster_id = 0;
@@ -2796,7 +2798,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 		}
 		ret = lb4_local(get_ct_map4(tuple), ctx, fraginfo, l4_off,
 				key, tuple, svc, &ct_state_svc, &backend,
-				ext_err, tmp);
+				&new_backend, ext_err, tmp);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
 				if (!CONFIG(enable_no_service_endpoints_routable))
@@ -2911,7 +2913,9 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		__u32 port = key->dport;
 
-		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+		if (nodeport_need_dsr_info(tuple->nexthdr,
+					   ct_state_svc.syn,
+					   new_backend))
 			port |= NEED_DSR_INFO;
 
 		ctx_store_meta(ctx, CB_PORT, port);


### PR DESCRIPTION
Update the change introduced by
64527fb1c31e ("bpf: dsr: always forward DSR info to newly selected remote backend"), and transport the `new_backend` information via a dedicated bool. This seems to help with BPF program complexity.