### PR TITLE
gateway-api: report all route validation errors in status

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1987,6 +1987,32 @@ func (r *gatewayReconciler) parentIsMatchingGateway(ctx context.Context, parent 
 	return hasMatchingControllerFn(gw)
 }
 
+// collectValidationConditions runs the given route validators and returns the
+// conditions of the failed ones. Conditions sharing the same type are merged
+// into a single condition by joining their messages, so that independent
+// validation failures are all reported instead of overwriting each other.
+func collectValidationConditions(validators ...func() (metav1.Condition, bool)) []metav1.Condition {
+	var conds []metav1.Condition
+	for _, validate := range validators {
+		cond, invalid := validate()
+		if !invalid {
+			continue
+		}
+		merged := false
+		for i := range conds {
+			if conds[i].Type == cond.Type {
+				conds[i].Message = conds[i].Message + "; " + cond.Message
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			conds = append(conds, cond)
+		}
+	}
+	return conds
+}
+
 func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	scopedLog.DebugContext(ctx, "Updating HTTPRoute statuses for Gateway", numRoutes, len(httpRoutes.Items))
 	for httpRouteIndex, original := range httpRoutes.Items {
@@ -2011,14 +2037,12 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Route-specific checks will go in here separately if required.
 
-		for _, validate := range []func() (metav1.Condition, bool){
+		for _, cond := range collectValidationConditions(
 			i.ValidateHeaderModifier,
 			i.ValidateMatchRegexps,
-		} {
-			if cond, invalid := validate(); invalid {
-				for _, parent := range hr.Status.Parents {
-					i.SetParentCondition(parent.ParentRef, cond)
-				}
+		) {
+			for _, parent := range hr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
 			}
 		}
 
@@ -2092,14 +2116,12 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 			return fmt.Errorf("failure during GRPCRoute checks: %w", err)
 		}
 
-		for _, validate := range []func() (metav1.Condition, bool){
+		for _, cond := range collectValidationConditions(
 			i.ValidateHeaderModifier,
 			i.ValidateMatchRegexps,
-		} {
-			if cond, invalid := validate(); invalid {
-				for _, parent := range grpcr.Status.Parents {
-					i.SetParentCondition(parent.ParentRef, cond)
-				}
+		) {
+			for _, parent := range grpcr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
 			}
 		}
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1366,6 +1366,52 @@ func findRouteAcceptedCondition(conds []metav1.Condition) *metav1.Condition {
 	return nil
 }
 
+func TestCollectValidationConditions(t *testing.T) {
+	accepted := func(msg string) func() (metav1.Condition, bool) {
+		return func() (metav1.Condition, bool) {
+			return metav1.Condition{
+				Type:    string(gatewayv1.RouteConditionAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+				Message: msg,
+			}, true
+		}
+	}
+	valid := func() (metav1.Condition, bool) { return metav1.Condition{}, false }
+
+	t.Run("no failures", func(t *testing.T) {
+		assert.Empty(t, collectValidationConditions(valid, valid))
+	})
+
+	t.Run("single failure", func(t *testing.T) {
+		conds := collectValidationConditions(valid, accepted("err-B"))
+		require.Len(t, conds, 1)
+		assert.Equal(t, "err-B", conds[0].Message)
+		assert.Equal(t, metav1.ConditionFalse, conds[0].Status)
+		assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), conds[0].Reason)
+	})
+
+	t.Run("failures of same type are merged", func(t *testing.T) {
+		conds := collectValidationConditions(accepted("err-A"), accepted("err-B"))
+		require.Len(t, conds, 1)
+		assert.Equal(t, "err-A; err-B", conds[0].Message)
+	})
+
+	t.Run("failures of different types are kept separate", func(t *testing.T) {
+		resolvedRefs := func() (metav1.Condition, bool) {
+			return metav1.Condition{
+				Type:    string(gatewayv1.RouteConditionResolvedRefs),
+				Status:  metav1.ConditionFalse,
+				Message: "err-C",
+			}, true
+		}
+		conds := collectValidationConditions(accepted("err-A"), resolvedRefs)
+		require.Len(t, conds, 2)
+		assert.Equal(t, "err-A", conds[0].Message)
+		assert.Equal(t, "err-C", conds[1].Message)
+	})
+}
+
 func TestGatewayReconciler_statuses(t *testing.T) {
 	ciliumGWClass := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "cilium"},
@@ -1437,7 +1483,32 @@ func TestGatewayReconciler_statuses(t *testing.T) {
 			},
 		}
 
-		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute)
+		doubleInvalidRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "double-invalid-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchRegularExpression),
+							Value: new("[invalid"),
+						},
+					}},
+					Filters: []gatewayv1.HTTPRouteFilter{{
+						Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+							Set: []gatewayv1.HTTPHeader{{Name: "Host", Value: "example.com"}},
+						},
+					}},
+				}},
+			},
+		}
+
+		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute, doubleInvalidRoute)
 
 		hrList := &gatewayv1.HTTPRouteList{}
 		require.NoError(t, c.List(ctx, hrList))
@@ -1460,6 +1531,17 @@ func TestGatewayReconciler_statuses(t *testing.T) {
 		invalidAcceptedCond := findRouteAcceptedCondition(updatedInvalidRoute.Status.Parents[0].Conditions)
 		assert.NotNil(t, invalidAcceptedCond)
 		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
+
+		var updatedDoubleInvalidRoute gatewayv1.HTTPRoute
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: doubleInvalidRoute.Name, Namespace: doubleInvalidRoute.Namespace}, &updatedDoubleInvalidRoute))
+		require.Len(t, updatedDoubleInvalidRoute.Status.Parents, 1)
+
+		doubleInvalidAcceptedCond := findRouteAcceptedCondition(updatedDoubleInvalidRoute.Status.Parents[0].Conditions)
+		require.NotNil(t, doubleInvalidAcceptedCond)
+		assert.Equal(t, metav1.ConditionFalse, doubleInvalidAcceptedCond.Status)
+		assert.Contains(t, doubleInvalidAcceptedCond.Message, `"Host" header is not supported`,
+			"header modifier failure must not be overwritten by the regex failure")
+		assert.Contains(t, doubleInvalidAcceptedCond.Message, "Invalid regular expression in path match")
 	})
 
 	t.Run("setGRPCRouteStatuses sets related parent statuses", func(t *testing.T) {


### PR DESCRIPTION
 

`ValidateHeaderModifier` write an `Accepted=False` condition. But `ValidateMatchRegexps` writes the same condition type, and `helpers.MergeConditions` matches by type and replaces in place.

In `setHTTPRouteStatuses` in gateway_reconcile.go both run in one loop, so the regex message overwrites the header modifier message. `setGRPCRouteStatuses` has the same loop, same defect.

For example, a user creates the following invalid configuration:

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: my-route
  namespace: default
spec:
  parentRefs:
  - name: my-gateway
  rules:
  - matches:
    - path:
        type: RegularExpression
        value: "/api/(v1"          # malformed regex
    filters:
    - type: RequestHeaderModifier
      requestHeaderModifier:
        set:
        - name: Host                # rewriting the Host header is not allowed
          value: example.com
    backendRefs:
    - name: my-service
      port: 8080
```

The resulting status is missing one of the errors:

```
status:
  parents:
  - parentRef:
      name: my-gateway
    conditions:
    - type: Accepted
      status: "False"
      reason: UnsupportedValue
      message: 'Invalid regular expression .... `/api/(v1`'
```

This should be improved to report both errors:

```
    conditions:
    - type: Accepted
      status: "False"
      reason: UnsupportedValue
      message: 'Invalid HTTPRoute header modifier: "Host" header is not supported; use URLRewrite.hostname instead; Invalid regular expression in path match: error parsing regexp: missing closing ): `/api/(v1`'
```

<!-- Description of change -->

Fixes: #issue-number

```release-note
gateway-api: report all route validation errors in statu
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
