### PR TITLE
Fix endpoint panic when verbose policy logging is enabled

### DIFF
--- a/pkg/endpoint/creator/creator.go
+++ b/pkg/endpoint/creator/creator.go
@@ -105,7 +105,9 @@ func (c *endpointCreator) ParseEndpoint(epJSON []byte) (*endpoint.Endpoint, erro
 	return endpoint.ParseEndpoint(
 		c.epParams,
 		c.params.DNSRulesService,
-		c.params.Proxy, epJSON)
+		c.params.Proxy,
+		epJSON,
+		c.policyLogger())
 }
 
 func (c *endpointCreator) AddIngressEndpoint(ctx context.Context) error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -919,7 +919,8 @@ func FilterEPDir(dirFiles []os.DirEntry) []string {
 // caller must call `SetIdentity()` to make the returned endpoint's identity useful.
 func ParseEndpoint(p EndpointParams,
 	dnsRulesAPI DNSRulesAPI,
-	proxy EndpointProxy, epJSON []byte) (*Endpoint, error) {
+	proxy EndpointProxy, epJSON []byte,
+	policyDebugLog io.Writer) (*Endpoint, error) {
 	ep := Endpoint{
 		dnsRulesAPI:      dnsRulesAPI,
 		epBuildQueue:     p.EPBuildQueue,
@@ -941,6 +942,7 @@ func ParseEndpoint(p EndpointParams,
 		allocator:        p.Allocator,
 		ctMapGC:          p.CTMapGC,
 		kvstoreSyncher:   p.KVStoreSynchronizer,
+		policyDebugLog:   policyDebugLog,
 	}
 
 	if err := ep.UnmarshalJSON(epJSON); err != nil {

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -5,6 +5,7 @@ package endpoint
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -68,4 +69,25 @@ func TestPolicyLog(t *testing.T) {
 	require.True(t, bytes.Contains(buf, []byte("testing policy logging")))
 	require.True(t, bytes.Contains(buf, []byte("testing PolicyDebug")))
 	require.True(t, bytes.Contains(buf, []byte("Test Value")))
+}
+
+func TestPolicyLogAfterEndpointRestore(t *testing.T) {
+	logger := hivetest.Logger(t)
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	p := createEndpointParams(t, nil, do.repo, do.fetcher)
+	model := newTestEndpointModel(12345, StateReady)
+
+	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	require.NoError(t, err)
+	ep.Options.SetValidated(option.DebugPolicy, option.OptionEnabled)
+
+	ep.unconditionalRLock()
+	epJSON, err := json.Marshal(ep)
+	ep.runlock()
+	require.NoError(t, err)
+
+	restoredEP, err := ParseEndpoint(p, nil, nil, epJSON)
+	require.NoError(t, err)
+
+	restoredEP.PolicyDebug("testing restored endpoint PolicyDebug")
 }

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -86,8 +86,10 @@ func TestPolicyLogAfterEndpointRestore(t *testing.T) {
 	ep.runlock()
 	require.NoError(t, err)
 
-	restoredEP, err := ParseEndpoint(p, nil, nil, epJSON)
+	var policyLog bytes.Buffer
+	restoredEP, err := ParseEndpoint(p, nil, nil, epJSON, &policyLog)
 	require.NoError(t, err)
 
 	restoredEP.PolicyDebug("testing restored endpoint PolicyDebug")
+	require.Contains(t, policyLog.String(), "testing restored endpoint PolicyDebug")
 }

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -307,7 +307,7 @@ type fakeParser struct {
 }
 
 func (f *fakeParser) ParseEndpoint(epJSON []byte) (*Endpoint, error) {
-	return ParseEndpoint(f.p, nil, nil, epJSON)
+	return ParseEndpoint(f.p, nil, nil, epJSON, nil)
 }
 
 var _ EndpointParser = &fakeParser{}


### PR DESCRIPTION
The endpoint policy debug logging assumes that the `policyDebugLog` field is set unconditionally. However, we didn't set the field when restoring the endpoint from JSON, leading to nil pointer exceptions when verbose policy logging was enabled.

Prepared using AIL:2 - had AI analyze the stack trace and implemented the fix myself. The test is AI generated though, so maybe AIL:3 actually?

Fixes a commit by me, not cc'ing myself :grin: 

Fixes: #47777

```release-note
Resolve a endpoint manager crash for restored endpoints with verbose policy logging enabled.
```

