### PR TITLE
policy: fix bug causing policies using label selectors of long namespace labels being dropped

### DIFF
--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapi_fake "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/fake"
+	policyv1alpha2 "sigs.k8s.io/network-policy-api/apis/v1alpha2"
 
 	cilium_fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
 	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
@@ -91,6 +92,9 @@ func init() {
 
 	// Add mcsapi
 	mcsapi_fake.AddToScheme(Scheme)
+
+	// Add policy.networking.k8s.io/v1alpha2
+	policyv1alpha2.AddToScheme(Scheme)
 
 	fake.AddToScheme(KubernetesScheme)
 }

--- a/pkg/labels/validation.go
+++ b/pkg/labels/validation.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	k8sconsts "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
@@ -105,7 +106,9 @@ func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorLi
 // IsValidCiliumLabelKey tests whether the value passed is a valid cilium's representation of
 // label key.
 // Cilium label key supports an additional optional source prefix along with k8s label key.
-// The label source prefix is delimited with ':'
+// The label source prefix is delimited with ':'. A prefix "io.cilium.k8s.namespace.labels." is also
+// supported and is used when selecting namespace labels. Both these prefixes and the delimiter are not
+// counted when calculating the length of a label key.
 func IsValidCiliumLabelKey(key string) []string {
 	var (
 		source   string
@@ -125,6 +128,12 @@ func IsValidCiliumLabelKey(key string) []string {
 	default:
 		return append(errs, labelKeyErrMultipleSourceDelimiter)
 	}
+
+	// Namespace labels are represented internally by prepending a Cilium-owned
+	// prefix to the original Kubernetes label key. Validate the original key so
+	// the synthetic prefix does not consume either the 63-byte name limit or the
+	// 253-byte DNS prefix limit.
+	labelKey = strings.TrimPrefix(labelKey, k8sconsts.PodNamespaceMetaLabelsPrefix)
 
 	return append(errs, content.IsLabelKey(labelKey)...)
 }

--- a/pkg/labels/validation_test.go
+++ b/pkg/labels/validation_test.go
@@ -35,6 +35,10 @@ func TestValidateLabels(t *testing.T) {
 		{"k8s:app.kubernetes.io": "value"},
 		{"k8s:app.k8s.io/name": "value"},
 		{"reserved:k8s-app": "foo"},
+		{"k8s:" + strings.Repeat("a", 63): "foo"},
+		{"k8s:io.cilium.k8s.namespace.labels." + strings.Repeat("a", 63): "foo"},
+		{"k8s:" + strings.Repeat("a", 253) + "/" + strings.Repeat("b", 63): "test"},
+		{"k8s:io.cilium.k8s.namespace.labels." + strings.Repeat("a", 253) + "/" + strings.Repeat("b", 63): "test"},
 	}
 	for i := range successCases {
 		errs := ValidateLabels(successCases[i], field.NewPath("field"))
@@ -55,7 +59,12 @@ func TestValidateLabels(t *testing.T) {
 		{map[string]string{"nospecialchars^=@": "bar"}, namePartErrMsg},
 		{map[string]string{"cantendwithadash-": "bar"}, namePartErrMsg},
 		{map[string]string{"only/one/slash": "bar"}, nameErrMsg},
-		{map[string]string{strings.Repeat("a", 254): "bar"}, maxLengthErrMsg},
+		{map[string]string{strings.Repeat("a", 64): "bar"}, maxLengthErrMsg},
+		{map[string]string{"src:" + strings.Repeat("a", 64): "bar"}, maxLengthErrMsg},
+		{map[string]string{"k8s:test.com/" + strings.Repeat("a", 64): "bar"}, maxLengthErrMsg},
+		{map[string]string{"k8s:" + strings.Repeat("a", 254) + "/test": "bar"}, maxLengthErrMsg},
+		{map[string]string{"k8s:io.cilium.k8s.namespace.labels." + strings.Repeat("a", 254) + "/test": "bar"}, maxLengthErrMsg},
+		{map[string]string{"k8s:io.cilium.k8s.namespace.labels." + strings.Repeat("a", 64): "bar"}, maxLengthErrMsg},
 		{map[string]string{":empty-source": "bar"}, labelSourceRegexErrMsg},
 		{map[string]string{"k8s:empty:source": "bar"}, labelKeyErrMultipleSourceDelimiter},
 	}

--- a/pkg/policy/cell/script_cmds.go
+++ b/pkg/policy/cell/script_cmds.go
@@ -8,18 +8,21 @@ import (
 	"os"
 
 	"github.com/cilium/hive/script"
+	policyv1alpha2 "sigs.k8s.io/network-policy-api/apis/v1alpha2"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8s "github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
-	"github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	policyutils "github.com/cilium/cilium/pkg/policy/utils"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
-	parse := func(s *script.State, args []string, del bool) (api.Rules, ipcachetypes.ResourceID, error) {
+	parse := func(s *script.State, args []string, del bool) (policytypes.PolicyEntries, ipcachetypes.ResourceID, error) {
 		if len(args) != 1 {
 			return nil, "", fmt.Errorf("expected one arg but got %d, see usage details", len(args))
 		}
@@ -38,27 +41,49 @@ func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
 		}
 
 		var (
-			rules      api.Rules
+			rules      policytypes.PolicyEntries
 			resourceID ipcachetypes.ResourceID
 		)
 		switch policy := robj.(type) {
 		case *v2.CiliumClusterwideNetworkPolicy:
-			rules, err = policy.Parse(p.log, "")
+			parsed, err := policy.Parse(p.log, "")
 			if err != nil {
 				return nil, "", fmt.Errorf("ccnp parse: %w", err)
 			}
+			rules = policyutils.RulesToPolicyEntries(parsed)
 			resourceID = ipcachetypes.NewResourceID(
 				ipcachetypes.ResourceKindCCNP,
 				policy.ObjectMeta.Namespace,
 				policy.ObjectMeta.Name,
 			)
 		case *v2.CiliumNetworkPolicy:
-			rules, err = policy.Parse(p.log, "")
+			parsed, err := policy.Parse(p.log, "")
 			if err != nil {
 				return nil, "", fmt.Errorf("cnp parse: %w", err)
 			}
+			rules = policyutils.RulesToPolicyEntries(parsed)
 			resourceID = ipcachetypes.NewResourceID(
 				ipcachetypes.ResourceKindCNP,
+				policy.ObjectMeta.Namespace,
+				policy.ObjectMeta.Name,
+			)
+		case *slim_networkingv1.NetworkPolicy:
+			rules, err = k8s.ParseNetworkPolicy(p.log, cmtypes.PolicyAnyCluster, policy)
+			if err != nil {
+				return nil, "", fmt.Errorf("network policy parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindNetpol,
+				policy.ObjectMeta.Namespace,
+				policy.ObjectMeta.Name,
+			)
+		case *policyv1alpha2.ClusterNetworkPolicy:
+			rules, err = k8s.ParseClusterNetworkPolicy(p.log, cmtypes.PolicyAnyCluster, policy)
+			if err != nil {
+				return nil, "", fmt.Errorf("cluster network policy parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindKCNP,
 				policy.ObjectMeta.Namespace,
 				policy.ObjectMeta.Name,
 			)
@@ -85,7 +110,7 @@ func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
 				}
 				dc := make(chan uint64, 1)
 				p.UpdatePolicy(&policytypes.PolicyUpdate{
-					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Rules:    rules,
 					Source:   source.CustomResource,
 					Resource: resourceID,
 					DoneChan: dc,
@@ -108,7 +133,7 @@ func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
 				}
 				dc := make(chan uint64, 1)
 				p.UpdatePolicy(&policytypes.PolicyUpdate{
-					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Rules:    rules,
 					Source:   source.CustomResource,
 					Resource: resourceID,
 					DoneChan: dc,

--- a/pkg/policy/test/testdata/namespace-label-limits.txtar
+++ b/pkg/policy/test/testdata/namespace-label-limits.txtar
@@ -1,0 +1,129 @@
+hive/start
+
+# Identities used by the four policy APIs below. The selected namespace
+# identity carries both legal extremes: a 63-character unqualified key and a
+# key with a 253-character DNS prefix plus a 63-character name.
+env long_name=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+env qualified_name=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+env namespace_labels=k8s:io.cilium.k8s.namespace.labels.${long_name}=selected,k8s:io.cilium.k8s.namespace.labels.${qualified_name}=selected
+
+env source_labels=k8s:io.kubernetes.pod.namespace=selected,k8s:app=client,${namespace_labels}
+identity/allocate ${source_labels}
+env --from-stdout source_id
+
+env selected_destination_labels=k8s:io.kubernetes.pod.namespace=selected,k8s:app=server,${namespace_labels}
+identity/allocate ${selected_destination_labels}
+env --from-stdout selected_destination_id
+
+env unselected_destination_labels=k8s:io.kubernetes.pod.namespace=unselected,k8s:app=other-server
+identity/allocate ${unselected_destination_labels}
+env --from-stdout unselected_destination_id
+
+# CNP: exercise maximum-length namespace labels in toEndpoints.
+policy/import cnp.yaml
+policy/lookup-flow --egress ${source_id} ${selected_destination_id} tcp 80
+stdout allowed
+policy/lookup-flow --egress ${source_id} ${unselected_destination_id} tcp 80
+stdout denied
+policy/remove cnp.yaml
+
+# CCNP: exercise the same labels in the policy's endpointSelector.
+policy/import ccnp.yaml
+policy/lookup-flow --egress ${source_id} ${selected_destination_id} tcp 80
+stdout allowed
+policy/lookup-flow --egress ${source_id} ${unselected_destination_id} tcp 80
+stdout denied
+policy/remove ccnp.yaml
+
+# Kubernetes NetworkPolicy: namespaceSelector keys are expanded internally by
+# Cilium and must remain valid after expansion.
+policy/import knp.yaml
+policy/lookup-flow --egress ${source_id} ${selected_destination_id} tcp 80
+stdout allowed
+policy/lookup-flow --egress ${source_id} ${unselected_destination_id} tcp 80
+stdout denied
+policy/remove knp.yaml
+
+# Kubernetes ClusterNetworkPolicy: cover both its subject namespace selector
+# and an egress namespace selector through the parser.
+policy/import kcnp.yaml
+policy/lookup-flow --egress ${source_id} ${selected_destination_id} tcp 80
+stdout allowed
+policy/lookup-flow --egress ${source_id} ${unselected_destination_id} tcp 80
+stdout denied
+
+-- cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: namespace-label-limits
+  namespace: selected
+spec:
+  endpointSelector:
+    matchLabels:
+      app: client
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: selected
+        k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+        k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+
+-- ccnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: namespace-label-limits
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: selected
+      k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+      k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: server
+        io.kubernetes.pod.namespace: selected
+        k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+        k8s:io.cilium.k8s.namespace.labels.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+
+-- knp.yaml --
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: namespace-label-limits
+  namespace: selected
+spec:
+  podSelector:
+    matchLabels:
+      app: client
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+-- kcnp.yaml --
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: namespace-label-limits
+spec:
+  tier: Admin
+  priority: 1
+  subject:
+    namespaces:
+      matchLabels:
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+  egress:
+  - action: Accept
+    to:
+    - namespaces:
+        matchLabels:
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: selected
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: selected
+  - action: Deny


### PR DESCRIPTION
This PR ensures we correctly calculate the length of label selectors when doing validation, ensuring we support all valid kubernetes labels. See commit messages for more information. Also add a test to catch a potential regression.

Fixes: #47817 

```release-note
Fix bug causing policies using label selectors of long namespace labels being dropped 
```

AIL 2/3: AI helped on the txtar test and I wrote the code and did the all the rest.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
