### PR TITLE
ci: update k8s matrixes for 1.36

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,14 +1,12 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.32"
-    region: us-west-1
-  - version: "1.33"
-    region: us-east-2
   - version: "1.34"
+    region: us-east-2
+  - version: "1.35"
     region: us-east-1
     kpr: true
-  - version: "1.35"
+  - version: "1.36"
     region: us-west-2
     default: true
     wireguard: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,20 +1,14 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.31"
-    location: westus3
-    index: 1
-  - version: "1.32"
-    location: westus2
-    index: 2
-  - version: "1.33"
-    location: westus
-    index: 3
   - version: "1.34"
-    location: eastus2
-    index: 4
+    location: westus
+    index: 1
   - version: "1.35"
+    location: eastus2
+    index: 2
+  - version: "1.36"
     location: eastus
     default: true
     preview: true
-    index: 5
+    index: 3

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -8,11 +8,11 @@
 # the second to last version, so that only that one enables prefix delegation.
 ---
 include:
-  - version: "1.33"
-    region: us-east-2
   - version: "1.34"
+    region: us-east-2
+  - version: "1.35"
     region: us-east-1
     aws-eni-pd: true
-  - version: "1.35"
+  - version: "1.36"
     region: us-west-2
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.31"
-    zone: us-west2-c
-    vmIndex: 1
-  - version: "1.32"
-    zone: us-west3-a
-    vmIndex: 2
   - version: "1.33"
-    zone: us-east4-b
-    vmIndex: 3
+    zone: us-west3-a
+    vmIndex: 1
   - version: "1.34"
-    zone: us-west1-c
-    vmIndex: 4
+    zone: us-east4-b
+    vmIndex: 2
   - version: "1.35"
+    zone: us-west1-c
+    vmIndex: 3
+  - version: "1.36"
     zone: us-east1-c
-    vmIndex: 5
+    vmIndex: 4
     default: true


### PR DESCRIPTION
1.36 is now available on AKS / GKE / EKS, updating matrixes accordingly and removing older versions that are not under standard platform support anymore, as per our usual policy (they are still supported by Cilium, just not by AKS / GKE / EKS outside of their LTS / Extended programs).