### PR TITLE
datapath: Fix BPF memory leak for orphaned netdevs

### DIFF
--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -19,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/callsmap"
 )
 
 // bpfMasqAddrs returns the IPv4 and IPv6 masquerade addresses to be used for
@@ -176,6 +179,57 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 				logfields.Error, err,
 				logfields.Path, statePath,
 			)
+		}
+	}
+
+	// Clean up BPFFS pins and tail call maps for physically deleted devices.
+	// Devices that have been removed from the kernel do not appear in safenetlink.LinkList(),
+	// so their obsolete BPF maps and directories must be explicitly discovered and deleted.
+	validIfindexes := make(map[int]struct{}, len(links))
+	validDeviceNames := make(map[string]struct{}, len(links))
+	for _, l := range links {
+		validIfindexes[l.Attrs().Index] = struct{}{}
+		validDeviceNames[l.Attrs().Name] = struct{}{}
+		// Include the sanitized name used for bpffs directory mapping
+		validDeviceNames[strings.ReplaceAll(l.Attrs().Name, ".", "-")] = struct{}{}
+	}
+
+	callMapsPattern := filepath.Join(bpf.TCGlobalsPath(), callsmap.NetdevMapName+"*")
+	matches, _ := filepath.Glob(callMapsPattern)
+	for _, match := range matches {
+		parts := strings.Split(match, "_")
+		if len(parts) > 0 {
+			ifindexStr := parts[len(parts)-1]
+			ifindex, err := strconv.Atoi(ifindexStr)
+			if err == nil {
+				if _, ok := validIfindexes[ifindex]; !ok {
+					if err := os.RemoveAll(match); err != nil {
+						logger.Error("Failed to remove orphaned netdev calls map",
+							logfields.Error, err,
+							logfields.Path, match,
+						)
+					}
+				}
+			}
+		}
+	}
+
+	devicesDir := bpffsDevicesDir(bpf.CiliumPath())
+	devDirs, err := os.ReadDir(devicesDir)
+	if err == nil {
+		for _, d := range devDirs {
+			if !d.IsDir() {
+				continue
+			}
+			if _, ok := validDeviceNames[d.Name()]; !ok {
+				orphanedDir := filepath.Join(devicesDir, d.Name())
+				if err := bpf.Remove(orphanedDir); err != nil {
+					logger.Error("Failed to remove orphaned bpffs device directory",
+						logfields.Error, err,
+						logfields.Path, orphanedDir,
+					)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION


- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:0.
- [x] Thanks for contributing!

<!-- Description of change -->
### Description
This pr fixes a kernel executable memory exhaustion bug where the host datapath leaks BPF programs and `prog_array` maps each time a managed physical device is rapidly deleted mid-reload. 

Previously, `removeObsoleteNetdevPrograms` only iterated over `safenetlink.LinkList()`, which retrieves the list of *currently active* network interfaces. If an interface was physically destroyed before the cleanup routine ran, the agent skipped it entirely. This left behind the orphaned `cilium_calls_netdev_X` maps in the global BPFFS (`/sys/fs/bpf/tc/globals`) and the per-device plugin pins in `/sys/fs/bpf/cilium/devices/...`, keeping the BPF programs trapped in memory.

This patch updates `removeObsoleteNetdevPrograms` to explicitly discover and delete orphaned BPFFS map pins and directories for interfaces that no longer exist in the kernel, ensuring the kernel can successfully garbage-collect the underlying BPF programs.

### Testing
- `go vet` and `go build ./pkg/datapath/loader` compile successfully.
- Manual verification of the explicit cleanup routine leveraging standard BPFFS paths.

Fixes: #47730

```release-note
Fix a bug causing kernel memory leaks when network devices are rapidly deleted during agent datapath reloads.
