### PR TITLE
.github: Set issue type on bug report and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug encountered while operating Cilium
+type: Bug
 labels: ["kind/community-report", "kind/bug", "needs/triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yaml
@@ -1,5 +1,6 @@
 name: Feature Proposal
 description: Suggest a feature to Cilium
+type: Enhancement
 labels: ["kind/feature", "kind/cfp"]
 body:
   - type: markdown


### PR DESCRIPTION
Populate the `type` field so newly filed issues land with the appropriate GitHub issue type. Those issue types are arguably equivalent to the current `kind/bug` and `kind/feature` labels we're already using, but since those types often end up being manually set on those issues at triage time, we might as well have them pre-set like that.

Syntax reference: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms