### PR TITLE
helm: let user annotations override the Prometheus scrape annotations

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -55,9 +55,9 @@ The ports can be configured via ``prometheus.port``,
 ``envoy.prometheus.port``, or ``operator.prometheus.port`` respectively.
 
 
-When metrics are enabled and ServiceMonitor is not enabled (``hubble.metrics.serviceMonitor.enabled: false``), all Cilium components will have the following annotations. These annotations can be used to signal Prometheus whether to scrape metrics.
+When metrics are enabled and ServiceMonitor is not enabled (``prometheus.serviceMonitor.enabled: false``), all Cilium components will have the following annotations. These annotations can be used to signal Prometheus whether to scrape metrics.
 
-If ServiceMonitor is enabled (``hubble.metrics.serviceMonitor.enabled: true``), these annotations are omitted and Prometheus discovers metrics via the ServiceMonitor resource.
+If ServiceMonitor is enabled (``prometheus.serviceMonitor.enabled: true``), these annotations are omitted and Prometheus discovers metrics via the ServiceMonitor resource.
 
 .. code-block:: yaml
 
@@ -93,6 +93,54 @@ option is set in the ``scrape_configs`` section:
           regex: ([^:]+)(?::\d+)?;(\d+)
           replacement: ${1}:${2}
           target_label: __address__
+
+.. _prometheus_annotation_override:
+
+Overriding the Prometheus Annotations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The chart renders these annotations alongside the annotations you set yourself,
+and your values take precedence. Set ``prometheus.io/scrape`` to ``false`` to
+keep the metrics port exposed while opting out of annotation-based scraping,
+for example when your collector reads the port from its own configuration
+rather than from the annotations:
+
+.. code-block:: yaml
+
+    prometheus:
+      enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "false"
+    operator:
+      podAnnotations:
+        prometheus.io/scrape: "false"
+    envoy:
+      annotations:
+        prometheus.io/scrape: "false"
+
+Kubernetes annotation values are strings, hence the quotes around ``"false"``.
+On the command line, use ``--set-string``. Plain ``--set`` infers the type and
+renders an unquoted boolean, which the API server rejects:
+
+.. code-block:: shell-session
+
+    $ helm upgrade cilium cilium/cilium --namespace kube-system --reuse-values \
+        --set-string 'podAnnotations.prometheus\.io/scrape=false'
+
+The annotations of each component are taken from a different Helm value:
+
+===================================  ==================================================
+Component                            Helm value
+===================================  ==================================================
+``cilium-agent`` pods                ``podAnnotations``
+``cilium-operator`` pods             ``operator.podAnnotations``
+``cilium-envoy`` service             ``envoy.annotations``
+``cilium-agent`` service             ``annotations``
+===================================  ==================================================
+
+The ``cilium-agent`` service only carries the Envoy annotations, and only when
+Envoy runs inside the agent rather than as its own DaemonSet. See
+:ref:`hubble_metrics` for the Hubble equivalents.
 
 Prometheus Operator ServiceMonitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -292,6 +340,19 @@ have it scrape all Hubble metrics from the endpoints automatically:
             target_label: __address__
             regex: (.+)(?::\d+);(\d+)
             replacement: $1:$2
+
+As described in :ref:`prometheus_annotation_override`, your own annotations take
+precedence over these, so setting ``prometheus.io/scrape`` to ``false`` keeps
+the Hubble metrics port exposed without opting into annotation-based scraping.
+The Hubble annotations are taken from the following Helm values:
+
+===================================  ==================================================
+Component                            Helm value
+===================================  ==================================================
+``hubble-metrics`` service           ``hubble.metrics.serviceAnnotations`` or ``hubble.annotations``
+``hubble-relay`` pods                ``hubble.relay.podAnnotations``
+``hubble-relay`` service             ``hubble.relay.annotations``
+===================================  ==================================================
 
 Prometheus Operator ServiceMonitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -112,6 +112,32 @@ Validate duration field, return validated duration, 0s when provided duration is
 {{- end }}
 
 {{/*
+Render the Prometheus scrape annotations for the given metrics port, skipping
+the ones already set in the user annotations rendered next to them, so that
+each key stays unique and the user value wins.
+Usage:
+  include "cilium.prometheusAnnotations" (list .Values.prometheus.port .Values.podAnnotations)
+*/}}
+{{- define "cilium.prometheusAnnotations" -}}
+{{- $userKeys := list -}}
+{{- range $i, $userAnnotations := . -}}
+{{- if $i -}}
+{{- $userKeys = concat $userKeys (keys (default (dict) $userAnnotations)) -}}
+{{- end -}}
+{{- end -}}
+{{- $annotations := dict -}}
+{{- if not (has "prometheus.io/port" $userKeys) -}}
+{{- $_ := set $annotations "prometheus.io/port" (index . 0 | toString) -}}
+{{- end -}}
+{{- if not (has "prometheus.io/scrape" $userKeys) -}}
+{{- $_ := set $annotations "prometheus.io/scrape" "true" -}}
+{{- end -}}
+{{- with $annotations -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Convert a map to a comma-separated string: key1=value1,key2=value2
 */}}
 {{- define "mapToString" -}}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -54,8 +54,9 @@ spec:
     metadata:
       annotations:
         {{- if and .Values.prometheus.enabled (not .Values.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: "{{ .Values.prometheus.port }}"
-        prometheus.io/scrape: "true"
+        {{- with include "cilium.prometheusAnnotations" (list .Values.prometheus.port .Values.podAnnotations) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.rollOutCiliumPods }}
         # ensure pods roll when configmap updates

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -41,8 +41,12 @@ metadata:
   name: cilium-agent
   namespace: {{ include "cilium.namespace" . }}
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.envoy.prometheus.port | quote }}
+    {{- with include "cilium.prometheusAnnotations" (list .Values.envoy.prometheus.port .Values.annotations) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -8,8 +8,9 @@ metadata:
   {{- if or (not .Values.envoy.prometheus.serviceMonitor.enabled) .Values.envoy.annotations }}
   annotations:
   {{- if not .Values.envoy.prometheus.serviceMonitor.enabled }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.envoy.prometheus.port | quote }}
+    {{- with include "cilium.prometheusAnnotations" (list .Values.envoy.prometheus.port .Values.envoy.annotations) }}
+    {{- . | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- with .Values.envoy.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -50,8 +50,9 @@ spec:
         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
         {{- end }}
         {{- if and .Values.operator.prometheus.enabled (not .Values.operator.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: {{ .Values.operator.prometheus.port | quote }}
-        prometheus.io/scrape: "true"
+        {{- with include "cilium.prometheusAnnotations" (list .Values.operator.prometheus.port .Values.operator.podAnnotations) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- with .Values.operator.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -37,8 +37,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if and .Values.hubble.relay.prometheus.enabled (not .Values.hubble.relay.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: {{ .Values.hubble.relay.prometheus.port | quote }}
-        prometheus.io/scrape: "true"
+        {{- with include "cilium.prometheusAnnotations" (list .Values.hubble.relay.prometheus.port .Values.hubble.relay.podAnnotations) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- end }}
       labels:
         k8s-app: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -9,8 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if and .Values.hubble.relay.prometheus.enabled (not .Values.hubble.relay.prometheus.serviceMonitor.enabled) }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.hubble.relay.prometheus.port | quote }}
+    {{- with include "cilium.prometheusAnnotations" (list .Values.hubble.relay.prometheus.port .Values.hubble.relay.annotations) }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- end }}
   labels:
     k8s-app: hubble-relay

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -21,8 +21,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if not .Values.hubble.metrics.serviceMonitor.enabled }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.hubble.metrics.port | quote }}
+    {{- with include "cilium.prometheusAnnotations" (list .Values.hubble.metrics.port .Values.hubble.annotations .Values.hubble.metrics.serviceAnnotations) }}
+    {{- . | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   clusterIP: None


### PR DESCRIPTION
- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- TODO(me): add my own AI disclosure sentence and tick the box above. -->

The chart rendered `prometheus.io/scrape` and `prometheus.io/port` as literal lines next to the user's own annotation map, so setting either key produced a duplicate YAML key and precedence came down to render order. The chart default is rendered last for `hubble-metrics`, the `hubble-relay` Service and the `hubble-relay` pod, so those three silently discarded the user value, which is why annotation-based scraping could not be turned off.

Both keys now render through a helper that skips the ones the user already set. Each key appears once and the user value always wins, so `prometheus.io/scrape: "false"` keeps the metrics port exposed while opting out of annotation-based scraping. No new Helm values are added.

Verified with `helm template` across the default, metrics-enabled, override, ServiceMonitor and embedded-Envoy paths: default output is unchanged apart from key ordering, and no manifest carries a duplicate key.



```release-note
Helm: user-supplied annotations now take precedence over the chart's prometheus.io/scrape and prometheus.io/port annotations, which no longer render as duplicate keys.
```
AIL:1

Fixes: #47821