### PR TITLE
Improve canned responses for contributors

### DIFF
--- a/.github/workflows/reusable-greetings.yml
+++ b/.github/workflows/reusable-greetings.yml
@@ -11,8 +11,9 @@ on:
           👋 Welcome to the Cilium community! 🐝 Thanks and congrats for opening your first PR here. We're excited to have you contributing!
 
           **Before we can merge, please ensure:**
-          - ✅ **You've Gone Through** every step of the [pull request template](https://github.com/cilium/cilium/blob/main/.github/pull_request_template.md) and have it in your PR
-          - ✅ **You've Read** [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
+          - **You've Read** [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
+          - **You understand and agree to follow** the [Generative AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md).
+          - **Your PR description includes** the full [pull request template](https://github.com/cilium/cilium/blob/main/.github/pull_request_template.md) and you complete each checkbox, and it is not written by Generative AI tools.
 
           📬 If you're using Cilium in your organization, please [add your name to our Adopters list](https://github.com/cilium/cilium/blob/main/USERS.md). 🙏 It really helps the project gain momentum and credibility.
 
@@ -38,6 +39,7 @@ on:
           - If you are new to Cilium, we have great [getting started guides](https://docs.cilium.io/en/stable/#getting-started)
           - Subscribe to eCHO News for your bi-weekly [Cilium and eBPF update](https://cilium.io/newsletter/)
           - [Slack](https://docs.cilium.io/en/stable/community/community/#slack) is the best place to start conversation.
+          - This community is for humans to connect, so please [avoid sending Generative AI text](https://github.com/cilium/community/blob/main/AI-POLICY.md#unacceptable-use) to others.
           - Get hands on learning with interactive [courses and labs](https://cilium.io/labs/categories/getting-started/)
           - To get Cilium enterprise support or for other matters, see the [enterprise page](https://cilium.io/enterprise/)
 

--- a/contrib/replies/README.md
+++ b/contrib/replies/README.md
@@ -6,6 +6,7 @@ community members who are engaging with the project:
 - [Let's build this together](./build-together.txt)
 - [Mark as draft to address feedback](./address-feedback.txt)
 - [Disclose motivation and generative AI use](./why-implement-like-this.txt)
+- [Complete the PR template](./complete-template.md)
 
 To use these, browse to [your saved replies] and add a new saved reply using
 the form at the bottom. When responding to an issue or PR, there is an icon in

--- a/contrib/replies/complete-template.md
+++ b/contrib/replies/complete-template.md
@@ -1,0 +1,8 @@
+Hi, please make sure to review the [Guide for Submitting a Pull Request] and
+the [Generative AI Policy], and ensure you include the [Pull Request Template]
+in the PR description. Additionally, please complete the checkboxes in the
+template so that reviewers understand the steps you took.
+
+[Guide for Submitting a Pull Request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
+[Generative AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
+[Pull Request Template]: https://github.com/cilium/cilium/blob/main/.github/pull_request_template.md


### PR DESCRIPTION
Improve the canned responses we have for contributors to the project:

- **contrib: Add reply for filling out the template**
- **.github: Improve reusable greetings**

The biggest change proposed here is to explicitly refer to the generative AI
policy in the posts that the bots automatically post towards contributons
from brand new community members.

There's also a new "saved reply" that reviewers can use to communicate
expectations with contributors.

See individual commits for more details.
