### PR TITLE
k8s: migrate from legacy config to ClusterInfo

### DIFF
--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -181,9 +181,7 @@ func (nc *CiliumNodeConverter) Convert(event resource.Event[*cilium_api_v2.Ciliu
 		return noneIter[store.Key], singleIter[store.NamedKey](&node)
 	}
 
-	node := k8s.ParseCiliumNode(event.Object)
-	node.Cluster = nc.cinfo.Name
-	node.ClusterID = nc.cinfo.ID
+	node := k8s.ParseCiliumNode(event.Object, nc.cinfo)
 	return singleIter[store.Key](&node), noneIter[store.NamedKey]
 }
 

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/workerpool"
 	"k8s.io/client-go/util/workqueue"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -44,6 +45,7 @@ type params struct {
 	SharedCfg    SharedConfig
 	IPSecCfg     ipsec.EnableConfig
 	WireguardCfg wgAgent.EnableConfig
+	ClusterInfo  cmtypes.ClusterInfo
 
 	Metrics                  *Metrics
 	WorkqueueMetricsProvider workqueue.MetricsProvider
@@ -52,7 +54,8 @@ type params struct {
 }
 
 type Controller struct {
-	logger *slog.Logger
+	logger      *slog.Logger
+	clusterInfo cmtypes.ClusterInfo
 
 	// Cilium kubernetes clients to access V2 and V2alpha1 resources
 	clientset           k8sClient.Clientset
@@ -153,6 +156,7 @@ func registerController(p params) error {
 
 	cesController := &Controller{
 		logger:                   p.Logger,
+		clusterInfo:              p.ClusterInfo,
 		clientset:                clientset,
 		ciliumEndpointSlice:      p.CiliumEndpointSlice,
 		ciliumNodes:              p.CiliumNodes,

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	idtu "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -41,6 +42,9 @@ func TestRegisterController(t *testing.T) {
 		k8s.ResourcesCell,
 		ipsec.OperatorCell,
 		wgAgent.OperatorCell,
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.DefaultClusterInfo
+		}),
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),
@@ -96,6 +100,9 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 		k8s.ResourcesCell,
 		ipsec.OperatorCell,
 		wgAgent.OperatorCell,
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.DefaultClusterInfo
+		}),
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),
@@ -216,6 +223,9 @@ func initHiveTest(t *testing.T, enableCES, enableCESwithoutCEPs bool) (k8sClient
 		k8s.ResourcesCell,
 		ipsec.OperatorCell,
 		wgAgent.OperatorCell,
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.DefaultClusterInfo
+		}),
 		cell.Provide(func() Config {
 			config := defaultConfig
 			if enableCESwithoutCEPs {

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -256,7 +256,7 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 	ciStore, _ := c.ciliumIdentity.Store(ctx)
 	cnodeStore, _ := c.ciliumNodes.Store(ctx)
 	namespaceStore, _ := c.namespace.Store(ctx)
-	c.reconciler = newSlimReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, cesStore, podStore, ciStore, cnodeStore, namespaceStore, c.metrics, c.ipsecEnabled, c.wgEnabled)
+	c.reconciler = newSlimReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.clusterInfo, cesStore, podStore, ciStore, cnodeStore, namespaceStore, c.metrics, c.ipsecEnabled, c.wgEnabled)
 	c.doReconciler = c.reconciler
 
 	c.initializeQueue()
@@ -484,7 +484,8 @@ func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key
 		// When pod is scheduled, we will receive a new update.
 		return "", nil, false
 	}
-	cidKey, err := getPodCIDKey(pod, c.logger, c.reconciler.namespaceStore)
+
+	cidKey, err := getPodCIDKey(pod, c.logger, c.reconciler.namespaceStore, c.reconciler.clusterInfo)
 	if err != nil {
 		c.logger.Debug("could not get labels for pod",
 			logfields.K8sPodName, pod.Name,

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -353,7 +354,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &SlimController{
@@ -481,7 +482,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -606,7 +607,7 @@ func TestCESManagement(t *testing.T) {
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -731,7 +732,7 @@ func TestSyncCESsInLocalCacheOperatorDowntime(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &SlimController{

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/operator/pkg/ciliumidentity"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -66,6 +67,7 @@ type slimReconciler struct {
 
 	ipsecEnabled bool
 	wgEnabled    bool
+	clusterInfo  cmtypes.ClusterInfo
 }
 
 // newDefaultReconciler creates and initializes a new defaultReconciler.
@@ -97,6 +99,7 @@ func newSlimReconciler(
 	client clientset.CiliumV2alpha1Interface,
 	cesMgr *slimManager,
 	logger *slog.Logger,
+	clusterInfo cmtypes.ClusterInfo,
 	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice],
 	podStore resource.Store[*slim_corev1.Pod],
 	cidStore resource.Store[*cilium_v2.CiliumIdentity],
@@ -121,6 +124,7 @@ func newSlimReconciler(
 		manager:         cesMgr,
 		ipsecEnabled:    ipsecEnabled,
 		wgEnabled:       wgEnabled,
+		clusterInfo:     clusterInfo,
 	}
 	sReconciler.reconciler.endpointGetter = &sReconciler
 	return &sReconciler
@@ -456,8 +460,8 @@ func getNodeNameForPod(pod *slim_corev1.Pod) (string, error) {
 	return pod.Spec.NodeName, nil
 }
 
-func getPodCIDKey(pod *slim_corev1.Pod, logger *slog.Logger, nsStore resource.Store[*slim_corev1.Namespace]) (*key.GlobalIdentity, error) {
-	k8sLabels, err := ciliumidentity.GetRelevantLabelsForPod(logger, pod, nsStore)
+func getPodCIDKey(pod *slim_corev1.Pod, logger *slog.Logger, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (*key.GlobalIdentity, error) {
+	k8sLabels, err := ciliumidentity.GetRelevantLabelsForPod(logger, pod, nsStore, clusterInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get relevant labels for pod: %w", err)
 	}

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -310,7 +311,7 @@ func TestReconcileCreate(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var createdSlice *cilium_v2a1.CiliumEndpointSlice
@@ -408,7 +409,7 @@ func TestReconcileUpdate(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
@@ -506,7 +507,7 @@ func TestReconcileDelete(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var deletedSlice string
@@ -596,7 +597,7 @@ func TestReconcileNoop(t *testing.T) {
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
-	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cmtypes.DefaultClusterInfo, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	noRequest := true

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -51,6 +52,7 @@ type params struct {
 
 	Logger              *slog.Logger
 	Config              config
+	ClusterInfo         cmtypes.ClusterInfo
 	Lifecycle           cell.Lifecycle
 	Clientset           k8sClient.Clientset
 	SharedCfg           SharedConfig
@@ -66,6 +68,7 @@ type params struct {
 
 type Controller struct {
 	logger              *slog.Logger
+	clusterInfo         cmtypes.ClusterInfo
 	clientset           k8sClient.Clientset
 	reconciler          *reconciler
 	jobGroup            job.Group
@@ -109,6 +112,7 @@ func registerController(p params) {
 
 	cidController := &Controller{
 		logger:                   p.Logger,
+		clusterInfo:              p.ClusterInfo,
 		clientset:                p.Clientset,
 		namespace:                p.Namespace,
 		pod:                      p.Pod,
@@ -216,7 +220,7 @@ func (c *Controller) startEventProcessing() {
 
 func (c *Controller) initReconciler(ctx context.Context) error {
 	var err error
-	c.reconciler, err = newReconciler(ctx, c.logger, c.clientset, c.namespace, c.pod, c.ciliumIdentity, c.ciliumEndpoint, c.ciliumEndpointSlice, c.cesEnabled, c)
+	c.reconciler, err = newReconciler(ctx, c.logger, c.clusterInfo, c.clientset, c.namespace, c.pod, c.ciliumIdentity, c.ciliumEndpoint, c.ciliumEndpointSlice, c.cesEnabled, c)
 	if err != nil {
 		return fmt.Errorf("cid reconciler failed to init: %w", err)
 	}

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -113,6 +114,9 @@ func initHiveTest(t *testing.T, operatorManagingCID bool) (*resource.Resource[*c
 		k8sClient.FakeClientCell(),
 		k8s.ResourcesCell,
 		metrics.Metric(NewMetrics),
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.DefaultClusterInfo
+		}),
 		cell.Provide(func() config {
 			if operatorManagingCID {
 				return config{

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	operator_k8s "github.com/cilium/cilium/operator/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/basicallocator"
 	"github.com/cilium/cilium/pkg/identity/key"
@@ -28,12 +29,12 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type reconciler struct {
 	logger          *slog.Logger
 	ctx             context.Context
+	clusterInfo     cmtypes.ClusterInfo
 	clientset       k8sClient.Clientset
 	idAllocator     *basicallocator.BasicIDAllocator
 	desiredCIDState *CIDState
@@ -55,6 +56,7 @@ type reconciler struct {
 func newReconciler(
 	ctx context.Context,
 	logger *slog.Logger,
+	clusterInfo cmtypes.ClusterInfo,
 	clientset k8sClient.Clientset,
 	namespace resource.Resource[*slim_corev1.Namespace],
 	pod resource.Resource[*slim_corev1.Pod],
@@ -66,8 +68,8 @@ func newReconciler(
 ) (*reconciler, error) {
 	logger.InfoContext(ctx, "Creating CID controller Operator reconciler")
 
-	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(clusterInfo.ID))
+	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(clusterInfo.ID))
 	idAllocator := basicallocator.NewBasicIDAllocator(minIDValue, maxIDValue)
 
 	nsStore, err := namespace.Store(ctx)
@@ -98,6 +100,7 @@ func newReconciler(
 	r := &reconciler{
 		logger:          logger,
 		ctx:             ctx,
+		clusterInfo:     clusterInfo,
 		clientset:       clientset,
 		idAllocator:     idAllocator,
 		desiredCIDState: NewCIDState(logger),
@@ -279,7 +282,7 @@ func (r *reconciler) cidIsUsedInCEPOrCES(cidName string) bool {
 // 1. CID exists: No action.
 // 2. CID doesn't exist: Create CID.
 func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
-	k8sLabels, err := GetRelevantLabelsForPod(r.logger, pod, r.nsStore)
+	k8sLabels, err := GetRelevantLabelsForPod(r.logger, pod, r.nsStore, r.clusterInfo)
 	if err != nil {
 		return fmt.Errorf("failed to get relevant labels for pod: %w", err)
 	}
@@ -346,13 +349,13 @@ func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, erro
 }
 
 // GetRelevantLabelsForPod returns the pod and namespace labels for a given pod
-func GetRelevantLabelsForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace]) (map[string]string, error) {
+func GetRelevantLabelsForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (map[string]string, error) {
 	ns, err := getNamespace(pod.Namespace, nsStore)
 	if err != nil {
 		return nil, err
 	}
 
-	_, labelsMap := k8s.GetPodMetadata(logger, ns, pod)
+	_, labelsMap := k8s.GetPodMetadata(logger, clusterInfo, ns, pod)
 	return labelsMap, nil
 }
 

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity/key"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -84,6 +85,7 @@ func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reco
 	reconciler, _ := newReconciler(
 		ctx,
 		tlog,
+		cmtypes.DefaultClusterInfo,
 		fakeClient.Clientset,
 		namespace,
 		pod,
@@ -402,7 +404,7 @@ func TestReconcilePod(t *testing.T) {
 				}
 
 				expectedLbs := key.GetCIDKeyFromLabels(
-					k8sUtils.SanitizePodLabels(tc.newPod.ObjectMeta.Labels, ns1, "", ""),
+					k8sUtils.SanitizePodLabels(tc.newPod.ObjectMeta.Labels, ns1, "", cmtypes.DefaultClusterInfo.Name),
 					labels.LabelSourceK8s,
 				).GetAsMap()
 
@@ -495,7 +497,7 @@ func TestGetRelevantLabelsForPodDoesNotIncludeGeneratedNamedPorts(t *testing.T) 
 		}},
 	}}
 
-	k8sLabels, err := GetRelevantLabelsForPod(hivetest.Logger(t), pod, reconciler.nsStore)
+	k8sLabels, err := GetRelevantLabelsForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo)
 	require.NoError(t, err)
 	require.NotContains(t, k8sLabels, ciliumio.NamedPortsIdentityLabelName)
 }

--- a/operator/pkg/ciliumidentity/testutils/test_utils.go
+++ b/operator/pkg/ciliumidentity/testutils/test_utils.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity/key"
 	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	idbackend "github.com/cilium/cilium/pkg/k8s/identitybackend"
@@ -31,7 +32,7 @@ func NewCID(id string, lbs map[string]string) *capi_v2.CiliumIdentity {
 }
 
 func NewCIDWithNamespace(id string, pod *slim_corev1.Pod, namespace *slim_corev1.Namespace) *capi_v2.CiliumIdentity {
-	lbs := k8sUtils.SanitizePodLabels(pod.ObjectMeta.Labels, namespace, "", "")
+	lbs := k8sUtils.SanitizePodLabels(pod.ObjectMeta.Labels, namespace, "", cmtypes.DefaultClusterInfo.Name)
 	return NewCID(id, lbs)
 }
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -90,6 +91,8 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type Manager struct {
 	logger *slog.Logger
 
+	clusterInfo cmtypes.ClusterInfo
+
 	lock.Mutex
 
 	// allCachesSynced is true when all k8s objects we depend on have had
@@ -158,6 +161,7 @@ type Params struct {
 
 	Config            Config
 	DaemonConfig      *option.DaemonConfig
+	ClusterInfo       cmtypes.ClusterInfo
 	TunnelConfig      tunnel.Config
 	IdentityAllocator identityCache.IdentityAllocator
 	PolicyMap4V2      egressmap.PolicyMap4V2
@@ -223,6 +227,7 @@ func NewEgressGatewayManager(p Params) (out struct {
 func newEgressGatewayManager(p Params) (*Manager, error) {
 	manager := &Manager{
 		logger:                        p.Logger,
+		clusterInfo:                   p.ClusterInfo,
 		policyConfigs:                 make(map[policyID]*PolicyConfig),
 		epDataStore:                   make(map[endpointID]*endpointMetadata),
 		identityAllocator:             p.IdentityAllocator,
@@ -555,7 +560,7 @@ func (manager *Manager) handleEndpointEvent(event resource.Event[*k8sTypes.Ciliu
 func (manager *Manager) handleNodeEvent(event resource.Event[*cilium_api_v2.CiliumNode]) {
 	defer event.Done(nil)
 
-	node := k8s.ParseCiliumNode(event.Object)
+	node := k8s.ParseCiliumNode(event.Object, manager.clusterInfo)
 
 	manager.Lock()
 	defer manager.Unlock()

--- a/pkg/egressgateway/script_test.go
+++ b/pkg/egressgateway/script_test.go
@@ -134,6 +134,11 @@ func TestPrivilegedScripts(t *testing.T) {
 				),
 
 				cell.Invoke(func(*Manager) {}),
+				cell.Invoke(func(clusterInfo cmtypes.ClusterInfo) {
+					// Set ClusterName for [nodeTypes.Node.IsLocal] to work properly
+					// since it still depends on the legacy global config.
+					option.Config.ClusterName = clusterInfo.Name
+				}),
 			)
 
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/pkg/endpoint/metadata/k8s_metadatafetcher.go
+++ b/pkg/endpoint/metadata/k8s_metadatafetcher.go
@@ -12,6 +12,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -30,20 +31,22 @@ type EndpointMetadataFetcher interface {
 }
 
 type cachedEndpointMetadataFetcher struct {
-	logger     *slog.Logger
-	config     *option.DaemonConfig
-	db         *statedb.DB
-	pods       statedb.Table[k8sTables.LocalPod]
-	namespaces statedb.Table[k8sTables.Namespace]
+	logger      *slog.Logger
+	config      *option.DaemonConfig
+	clusterInfo cmtypes.ClusterInfo
+	db          *statedb.DB
+	pods        statedb.Table[k8sTables.LocalPod]
+	namespaces  statedb.Table[k8sTables.Namespace]
 }
 
-func NewEndpointMetadataFetcher(logger *slog.Logger, config *option.DaemonConfig, db *statedb.DB, pods statedb.Table[k8sTables.LocalPod], namespaces statedb.Table[k8sTables.Namespace]) EndpointMetadataFetcher {
+func NewEndpointMetadataFetcher(logger *slog.Logger, config *option.DaemonConfig, clusterInfo cmtypes.ClusterInfo, db *statedb.DB, pods statedb.Table[k8sTables.LocalPod], namespaces statedb.Table[k8sTables.Namespace]) EndpointMetadataFetcher {
 	return &cachedEndpointMetadataFetcher{
-		logger:     logger,
-		config:     config,
-		db:         db,
-		pods:       pods,
-		namespaces: namespaces,
+		logger:      logger,
+		config:      config,
+		clusterInfo: clusterInfo,
+		db:          db,
+		pods:        pods,
+		namespaces:  namespaces,
 	}
 }
 
@@ -85,7 +88,7 @@ func (cemf *cachedEndpointMetadataFetcher) FetchK8sMetadataForEndpointFromPod(p 
 		return nil, err
 	}
 
-	namedPorts, lbls := k8s.GetPodMetadata(cemf.logger, ns, p)
+	namedPorts, lbls := k8s.GetPodMetadata(cemf.logger, cemf.clusterInfo, ns, p)
 	k8sLbls := labels.Map2Labels(lbls, labels.LabelSourceK8s)
 	identityLabels, infoLabels := labelsfilter.Filter(k8sLbls)
 	return &endpoint.K8sMetadata{

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -15,6 +15,7 @@ import (
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipam/podippool"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -255,7 +256,12 @@ func startLocalNodeAllocCIDRsSync(
 					return nil
 				}
 
-				no := k8s.ParseCiliumNode(ev.Object)
+				no := k8s.ParseCiliumNode(
+					ev.Object,
+					// The rest of the function does not use the cluster name/id, so let's
+					// just pass a dummy value to avoid having to propagate a ClusterInfo
+					cmtypes.ClusterInfo{ID: 0, Name: "should-not-be-used"},
+				)
 				localNodeStore.Update(func(n *node.LocalNode) {
 					if enableIPv4 && no.IPv4AllocCIDR.IsValid() {
 						n.IPv4AllocCIDR = no.IPv4AllocCIDR

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -12,12 +12,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/validate/content"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	ciliumLabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 )
 
@@ -35,7 +35,7 @@ type nameLabelsGetter interface {
 
 // GetPodMetadata returns the named ports, labels and annotations of the pod
 // with the given namespace / name.
-func GetPodMetadata(logger *slog.Logger, k8sNs nameLabelsGetter, pod *slim_corev1.Pod) (namedPorts ciliumTypes.NamedPortMap, lbls map[string]string) {
+func GetPodMetadata(logger *slog.Logger, clusterInfo cmtypes.ClusterInfo, k8sNs nameLabelsGetter, pod *slim_corev1.Pod) (namedPorts ciliumTypes.NamedPortMap, lbls map[string]string) {
 	namespace := pod.Namespace
 	logger.Debug(
 		"Connecting to k8s local stores to retrieve labels for pod",
@@ -44,7 +44,7 @@ func GetPodMetadata(logger *slog.Logger, k8sNs nameLabelsGetter, pod *slim_corev
 	)
 
 	objMetaCpy := pod.ObjectMeta.DeepCopy()
-	labels := k8sUtils.SanitizePodLabels(objMetaCpy.Labels, k8sNs, pod.Spec.ServiceAccountName, option.Config.ClusterName)
+	labels := k8sUtils.SanitizePodLabels(objMetaCpy.Labels, k8sNs, pod.Spec.ServiceAccountName, clusterInfo.Name)
 
 	namedPorts = make(ciliumTypes.NamedPortMap)
 	for _, containers := range pod.Spec.Containers {

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -41,7 +42,7 @@ func TestGetPodMetadata(t *testing.T) {
 
 	expectedLabels := map[string]string{
 		"app":                          "test",
-		"io.cilium.k8s.policy.cluster": "",
+		"io.cilium.k8s.policy.cluster": "default",
 		"io.kubernetes.pod.namespace":  "default",
 		"io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "default",
 		"io.cilium.k8s.namespace.labels.namespace-level-key":         "namespace-level-value",
@@ -50,7 +51,7 @@ func TestGetPodMetadata(t *testing.T) {
 	t.Run("normal scenario", func(t *testing.T) {
 		pod := pod.DeepCopy()
 
-		_, labels := GetPodMetadata(hivetest.Logger(t), ns, pod)
+		_, labels := GetPodMetadata(hivetest.Logger(t), cmtypes.DefaultClusterInfo, ns, pod)
 		require.Equal(t, expectedLabels, labels)
 	})
 
@@ -59,7 +60,7 @@ func TestGetPodMetadata(t *testing.T) {
 			pod := pod.DeepCopy()
 			pod.Labels["io.cilium.k8s.namespace.labels.namespace-level-key"] = "override-namespace-level-value"
 
-			_, labels := GetPodMetadata(hivetest.Logger(t), ns, pod)
+			_, labels := GetPodMetadata(hivetest.Logger(t), cmtypes.DefaultClusterInfo, ns, pod)
 			require.Equal(t, expectedLabels, labels)
 		})
 
@@ -67,7 +68,7 @@ func TestGetPodMetadata(t *testing.T) {
 			pod := pod.DeepCopy()
 			pod.Labels["io.cilium.k8s.namespace.labels.another-namespace-key"] = "another-namespace-level-value"
 
-			_, labels := GetPodMetadata(hivetest.Logger(t), ns, pod)
+			_, labels := GetPodMetadata(hivetest.Logger(t), cmtypes.DefaultClusterInfo, ns, pod)
 			require.Equal(t, expectedLabels, labels)
 		})
 	})
@@ -85,7 +86,7 @@ func TestGetPodMetadata(t *testing.T) {
 			},
 		}}
 
-		namedPorts, labels := GetPodMetadata(hivetest.Logger(t), ns, pod)
+		namedPorts, labels := GetPodMetadata(hivetest.Logger(t), cmtypes.DefaultClusterInfo, ns, pod)
 		require.Equal(t, ciliumTypes.NamedPortMap{
 			"dns":   {Port: 53, Proto: u8proto.UDP},
 			"http":  {Port: 80, Proto: u8proto.TCP},

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -44,7 +45,7 @@ type nodeAddressGroup struct {
 }
 
 // ParseNode parses a kubernetes node to a cilium node
-func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node {
+func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Source, clusterInfo cmtypes.ClusterInfo) *nodeTypes.Node {
 	addrGroups := make(map[nodeAddressGroup]struct{})
 	scopedLog := logger.With(
 		logfields.NodeName, k8sNode.Name,
@@ -107,7 +108,8 @@ func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Sou
 	}
 	newNode := &nodeTypes.Node{
 		Name:        k8sNode.Name,
-		Cluster:     option.Config.ClusterName,
+		Cluster:     clusterInfo.Name,
+		ClusterID:   clusterInfo.ID,
 		IPAddresses: addrs,
 		Source:      source,
 	}
@@ -311,7 +313,7 @@ func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Sou
 
 // ParseCiliumNode parses a CiliumNode custom resource and returns a Node
 // instance. Invalid IP and CIDRs are silently ignored
-func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
+func ParseCiliumNode(n *ciliumv2.CiliumNode, clusterInfo cmtypes.ClusterInfo) (node nodeTypes.Node) {
 	var appendAllocCIDR = func(node *nodeTypes.Node, podCIDR netip.Prefix) {
 		prefix := nodeTypes.PrefixFrom(podCIDR)
 		if podCIDR.Addr().Is4() {
@@ -333,8 +335,8 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
 	node = nodeTypes.Node{
 		Name:            n.Name,
 		EncryptionKey:   uint8(n.Spec.Encryption.Key),
-		Cluster:         option.Config.ClusterName,
-		ClusterID:       option.Config.ClusterID,
+		Cluster:         clusterInfo.Name,
+		ClusterID:       clusterInfo.ID,
 		Source:          source.CustomResource,
 		Labels:          n.ObjectMeta.Labels,
 		Annotations:     n.ObjectMeta.Annotations,

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -56,7 +57,7 @@ func TestParseNode(t *testing.T) {
 		},
 	}
 
-	n := ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n := ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node1", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n.IPv4AllocCIDR.String())
@@ -87,7 +88,7 @@ func TestParseNode(t *testing.T) {
 		},
 	}
 
-	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node2", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n.IPv4AllocCIDR.String())
@@ -106,7 +107,7 @@ func TestParseNode(t *testing.T) {
 		},
 	}
 
-	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node2", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.254.0.0/16", n.IPv4AllocCIDR.String())
@@ -127,7 +128,7 @@ func TestParseNode(t *testing.T) {
 		},
 	}
 
-	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node2", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n.IPv4AllocCIDR.String())
@@ -183,7 +184,7 @@ func TestParseNode(t *testing.T) {
 		},
 	}
 
-	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node2", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n.IPv4AllocCIDR.String())
@@ -227,7 +228,7 @@ func TestParseNodeWithoutAnnotations(t *testing.T) {
 		},
 	}
 
-	n := ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n := ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node1", n.Name)
 	require.True(t, n.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n.IPv4AllocCIDR.String())
@@ -252,7 +253,7 @@ func TestParseNodeWithoutAnnotations(t *testing.T) {
 		},
 	}
 
-	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n = ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node2", n.Name)
 	require.False(t, n.IPv4AllocCIDR.IsValid())
 	require.True(t, n.IPv6AllocCIDR.IsValid())
@@ -371,7 +372,7 @@ func TestParseNodeWithService(t *testing.T) {
 		},
 	}
 
-	n1 := ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	n1 := ParseNode(hivetest.Logger(t), k8sNode, source.Local, cmtypes.DefaultClusterInfo)
 	require.Equal(t, "node1", n1.Name)
 	require.True(t, n1.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.1.0.0/16", n1.IPv4AllocCIDR.String())
@@ -386,8 +387,11 @@ func TestParseNodeWithService(t *testing.T) {
 		},
 	}
 
-	n2 := ParseNode(hivetest.Logger(t), k8sNode, source.Local)
+	clusterInfo := cmtypes.ClusterInfo{ID: 42, Name: "remote"}
+	n2 := ParseNode(hivetest.Logger(t), k8sNode, source.Local, clusterInfo)
 	require.Equal(t, "node2", n2.Name)
+	require.Equal(t, clusterInfo.Name, n2.Cluster)
+	require.Equal(t, clusterInfo.ID, n2.ClusterID)
 	require.True(t, n2.IPv4AllocCIDR.IsValid())
 	require.Equal(t, "10.2.0.0/16", n2.IPv4AllocCIDR.String())
 	require.Empty(t, n2.Labels[annotation.ServiceNodeExposure])
@@ -425,10 +429,13 @@ func TestParseCiliumNode(t *testing.T) {
 		},
 	}
 
-	n := ParseCiliumNode(nodeResource)
+	clusterInfo := cmtypes.ClusterInfo{ID: 42, Name: "remote"}
+	n := ParseCiliumNode(nodeResource, clusterInfo)
 	require.Equal(t, nodeTypes.Node{
-		Name:   "foo",
-		Source: source.CustomResource,
+		Name:      "foo",
+		Cluster:   clusterInfo.Name,
+		ClusterID: clusterInfo.ID,
+		Source:    source.CustomResource,
 		IPAddresses: []nodeTypes.Address{
 			{Type: addressing.NodeInternalIP, IP: net.ParseIP("2.2.2.2")},
 			{Type: addressing.NodeExternalIP, IP: net.ParseIP("3.3.3.3")},

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -16,6 +16,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -36,6 +37,7 @@ type k8sCiliumNodeWatcherParams struct {
 	K8sAPIGroups      *k8sSynced.APIGroups
 
 	NodeManager nm.NodeManager
+	ClusterInfo cmtypes.ClusterInfo
 }
 
 func newK8sCiliumNodeWatcher(params k8sCiliumNodeWatcherParams) *K8sCiliumNodeWatcher {
@@ -46,6 +48,7 @@ func newK8sCiliumNodeWatcher(params k8sCiliumNodeWatcherParams) *K8sCiliumNodeWa
 		k8sAPIGroups:      params.K8sAPIGroups,
 		ciliumNode:        params.CiliumNode,
 		nodeManager:       params.NodeManager,
+		clusterInfo:       params.ClusterInfo,
 	}
 }
 
@@ -64,6 +67,7 @@ type K8sCiliumNodeWatcher struct {
 	ciliumNode   resource.Resource[*cilium_v2.CiliumNode]
 
 	nodeManager nodeManager
+	clusterInfo cmtypes.ClusterInfo
 
 	ciliumNodeStore atomic.Pointer[resource.Store[*cilium_v2.CiliumNode]]
 }
@@ -122,7 +126,7 @@ func (k *K8sCiliumNodeWatcher) onCiliumNodeInsert(ciliumNode *cilium_v2.CiliumNo
 	if k8s.IsLocalCiliumNode(ciliumNode) {
 		return false
 	}
-	n := k8s.ParseCiliumNode(ciliumNode)
+	n := k8s.ParseCiliumNode(ciliumNode, k.clusterInfo)
 	k.nodeManager.NodeUpdated(n)
 	return true
 }
@@ -141,7 +145,7 @@ func (k *K8sCiliumNodeWatcher) onCiliumNodeDelete(ciliumNode *cilium_v2.CiliumNo
 	if k8s.IsLocalCiliumNode(ciliumNode) {
 		return
 	}
-	n := k8s.ParseCiliumNode(ciliumNode)
+	n := k8s.ParseCiliumNode(ciliumNode, k.clusterInfo)
 	k.nodeManager.NodeDeleted(n)
 }
 

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -16,6 +16,7 @@ import (
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/cidr"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	iputil "github.com/cilium/cilium/pkg/ip"
@@ -52,6 +53,7 @@ type localNodeSynchronizerParams struct {
 
 	Logger             *slog.Logger
 	Config             *option.DaemonConfig
+	ClusterInfo        cmtypes.ClusterInfo
 	TunnelConfig       tunnel.Config
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
@@ -110,7 +112,7 @@ func (ini *localNodeSynchronizer) SyncLocalNode(ctx context.Context, store *node
 					ln.Local.IsBeingDeleted = true
 				})
 			}
-			new := parseNode(ini.Logger, ev.Object)
+			new := parseNode(ini.Logger, ev.Object, ini.ClusterInfo)
 			if !ini.mutableFieldsEqual(new) {
 				store.Update(func(ln *node.LocalNode) {
 					ini.syncFromK8s(ln, new)
@@ -136,8 +138,8 @@ func newLocalNodeSynchronizer(p localNodeSynchronizerParams) node.LocalNodeSynch
 }
 
 func (ini *localNodeSynchronizer) initFromConfig(n *node.LocalNode) error {
-	n.Cluster = ini.Config.ClusterName
-	n.ClusterID = ini.Config.ClusterID
+	n.Cluster = ini.ClusterInfo.Name
+	n.ClusterID = ini.ClusterInfo.ID
 	n.Name = nodeTypes.GetName()
 
 	if ini.Config.IPv4NativeRoutingCIDR.IsValid() {
@@ -211,7 +213,7 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 	if err != nil {
 		return err
 	}
-	parsedNode := parseNode(ini.Logger, k8sNode)
+	parsedNode := parseNode(ini.Logger, k8sNode, ini.ClusterInfo)
 
 	// Initialize the fields in local node where the source of truth is in Kubernetes.
 	// Later stages will deal with updating rest of the fields depending on configuration.
@@ -313,9 +315,9 @@ func (ini *localNodeSynchronizer) syncFromK8s(ln, new *node.LocalNode) {
 	)
 }
 
-func parseNode(logger *slog.Logger, k8sNode *slim_corev1.Node) *node.LocalNode {
+func parseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, clusterInfo cmtypes.ClusterInfo) *node.LocalNode {
 	return &node.LocalNode{
-		Node: *k8s.ParseNode(logger, k8sNode, source.Kubernetes),
+		Node: *k8s.ParseNode(logger, k8sNode, source.Kubernetes, clusterInfo),
 		Local: &node.LocalNodeInfo{
 			UID:        k8sNode.GetUID(),
 			ProviderID: k8sNode.Spec.ProviderID,

--- a/pkg/node/sync/local_node_sync_wait.go
+++ b/pkg/node/sync/local_node_sync_wait.go
@@ -40,7 +40,7 @@ func (ini *localNodeSynchronizer) retrieveNodeInformation(ctx context.Context) *
 				break
 			}
 			if event.Kind == resource.Upsert {
-				no := k8s.ParseCiliumNode(event.Object)
+				no := k8s.ParseCiliumNode(event.Object, ini.ClusterInfo)
 				n = &no
 				ini.Logger.Info("Retrieved node information from cilium node", logfields.NodeName, n.Name)
 				if err := waitForCIDR(); err != nil {
@@ -59,7 +59,7 @@ func (ini *localNodeSynchronizer) retrieveNodeInformation(ctx context.Context) *
 				break
 			}
 			if event.Kind == resource.Upsert {
-				n = k8s.ParseNode(ini.Logger, event.Object, source.Unspec)
+				n = k8s.ParseNode(ini.Logger, event.Object, source.Unspec, ini.ClusterInfo)
 				ini.Logger.Info("Retrieved node information from kubernetes node", logfields.NodeName, n.Name)
 				if err := waitForCIDR(); err != nil {
 					ini.Logger.Warn("Waiting for k8s node information", logfields.Error, err)

--- a/pkg/nodediscovery/k8s_node_annotate_test.go
+++ b/pkg/nodediscovery/k8s_node_annotate_test.go
@@ -19,6 +19,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -69,7 +70,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 			return true, n1copy, nil
 		})
 
-	node1Cilium := k8s.ParseNode(logger, toSlimNode(node1.DeepCopy()), source.Unspec)
+	node1Cilium := k8s.ParseNode(logger, toSlimNode(node1.DeepCopy()), source.Unspec, cmtypes.DefaultClusterInfo)
 	node1Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
 
 	n := &NodeDiscovery{logger: logger}
@@ -121,7 +122,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 			return true, n2Copy, nil
 		})
 
-	node2Cilium := k8s.ParseNode(hivetest.Logger(t), toSlimNode(node2.DeepCopy()), source.Unspec)
+	node2Cilium := k8s.ParseNode(hivetest.Logger(t), toSlimNode(node2.DeepCopy()), source.Unspec, cmtypes.DefaultClusterInfo)
 	node2Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
 
 	n.annotateK8sNode(t.Context(), fakeK8sClient, *node2Cilium)

--- a/test/controlplane/node/localnode.go
+++ b/test/controlplane/node/localnode.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
@@ -117,7 +118,7 @@ func validateLocalNodeAgent(cs client.Clientset, lns *node.LocalNodeStore) error
 		assert.Equal(errs, localNodeObject.UID, ciliumNode.OwnerReferences[0].UID)
 	}
 
-	parsedCiliumNode := k8s.ParseCiliumNode(&ciliumNode)
+	parsedCiliumNode := k8s.ParseCiliumNode(&ciliumNode, cmtypes.DefaultClusterInfo)
 	assert.Equal(errs, node.IPv4HealthIP, parsedCiliumNode.IPv4HealthIP, "CiliumNode HealthIP")
 	assert.Equal(errs, node.IPAddresses, parsedCiliumNode.IPAddresses, "CiliumNode IPAddresses")
 	assert.Equal(errs, node.Labels, parsedCiliumNode.Labels, "CiliumNode Labels")


### PR DESCRIPTION
Migrate the functions exposed from the k8s package to use the ClusterInfo struct to depends less on the legacy config.

Sorry for the many codeowners involved, those k8s functions are called in a bunch of places unfortunately :sweat_smile:.

I prepared this commit using AIL-2