### PR TITLE
policy: migrate from legacy config to ClusterInfo

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakebandwidth "github.com/cilium/cilium/pkg/datapath/linux/bandwidth/fake"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
@@ -73,7 +74,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	logger := hivetest.Logger(tb)
 
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	s := &EndpointSuite{
 		orchestrator: &fakeendpoint.FakeOrchestrator{},
 		repo:         repo,
@@ -548,7 +549,7 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 		model := newTestEndpointModel(100, StateWaitingForIdentity)
 		logger := hivetest.Logger(t)
 		idmgr := identitymanager.NewIDManager(logger)
-		repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+		repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 		fetcher := testcompute.InstantiateCellForTesting(t, logger, "endpoint", "TestInitialNamedPortsIdentityLabel", repo, idmgr)
 		p := createEndpointParams(
 			t,
@@ -1621,7 +1622,7 @@ func TestComputeCIDRLabelsAfterRestore(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{"pods"}
 
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 
 	podIP := netip.MustParseAddr("10.244.1.7")

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
@@ -28,7 +29,7 @@ func TestPolicyLog(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
@@ -73,7 +74,7 @@ func TestPolicyLog(t *testing.T) {
 
 func TestPolicyLogAfterEndpointRestore(t *testing.T) {
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 	model := newTestEndpointModel(12345, StateReady)
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -53,7 +54,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	logger := hivetest.Logger(t)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(hivetest.Logger(t))
-	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestIncrementalUpdatesDuringPolicyGeneration", repo, idManager)
 
 	addIdentity := func(labelKeys ...string) *identity.Identity {
@@ -219,7 +220,7 @@ func newPolicyTestFixture(t *testing.T) *policyTestFixture {
 	idcache := make(identity.IdentityMap)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", t.Name(), repo, idManager)
 
 	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
@@ -69,7 +70,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	}
 
 	s.do.idmgr = identitymanager.NewIDManager(logger)
-	s.do.repo = policy.NewPolicyRepository(logger, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
+	s.do.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	s.do.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupRedirectSuite", s.do.repo, s.do.idmgr)
 

--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
@@ -208,6 +209,7 @@ func newUpdatePolicyMapsTestRepo(t *testing.T, withL7Rules bool) (*policy.Reposi
 	idmgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
+		cmtypes.DefaultClusterInfo.ID,
 		nil,
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apiv1 "github.com/cilium/cilium/api/v1/models"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/completion"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -79,7 +80,7 @@ type EndpointManagerSuite struct {
 
 func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
 	s := &EndpointManagerSuite{}
-	s.repo = policy.NewPolicyRepository(hivetest.Logger(tb), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	s.repo = policy.NewPolicyRepository(hivetest.Logger(tb), cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 
 	return s
 }

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	corev1 "k8s.io/api/core/v1"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/envoy/config"
@@ -672,6 +673,7 @@ func newStandaloneTestPolicyRepo(t *testing.T, logger *slog.Logger, secretManage
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
+		cmtypes.DefaultClusterInfo.ID,
 		idCache,
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, secretManager),

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -1452,6 +1453,7 @@ func TestCNPWildcardPortListenerRedirectToEnvoy(t *testing.T) {
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
+		cmtypes.DefaultClusterInfo.ID,
 		identity.IdentityMap{localIdentity.ID: localIdentity.LabelArray},
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),
@@ -2580,6 +2582,7 @@ func newTestEndpointPolicy(t *testing.T, ep *listenerProxyUpdaterMock) (*policy.
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
+		cmtypes.DefaultClusterInfo.ID,
 		identity.IdentityMap{localIdentity.ID: localIdentity.LabelArray},
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
@@ -83,7 +84,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	s.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	s.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupDNSProxyTestSuite", s.repo, identitymanager.NewIDManager(logger))
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(tb)

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -86,7 +86,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		wg sync.WaitGroup
 	)
 
-	policyRepo := policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	policyRepo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	ipc := &mockipc.MockIPCache{}
 	nm := namemanager.New(namemanager.ManagerParams{
 		Config: namemanager.NameManagerConfig{

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -140,7 +140,7 @@ func testNewPolicyRepository(t *testing.T, initialIDs []*identity.Identity) (ide
 	}
 	logger := hivetest.Logger(t)
 	idManager := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, idmap, nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, idmap, nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	idManager.Subscribe(testpolicy.SelectorCacheObserver{Cache: repo.GetSubjectSelectorCache()})
 	return idManager, repo

--- a/pkg/policy/aggregate.go
+++ b/pkg/policy/aggregate.go
@@ -33,17 +33,14 @@
 
 package policy
 
-import (
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/option"
-)
+import "github.com/cilium/cilium/pkg/identity"
 
 // aggregateFor returns the numeric identity that aggregates the
 // given nid. If the supplied `nid` is already a wildcard,
 // then it returns itself.
 //
 // THIS MUST!!! MATCH THE IMPLEMENTATION in bpf/lib/identity.h
-func aggregateFor(nid identity.NumericIdentity) identity.NumericIdentity {
+func aggregateFor(nid identity.NumericIdentity, localClusterID uint32) identity.NumericIdentity {
 	// all aggregates must aggregate to themselves
 	switch nid {
 	case identity.IdentityUnknown, identity.ReservedIdentityAggregateCluster, identity.ReservedIdentityAggregateClusterMesh, identity.ReservedIdentityAggregateWorld, identity.ReservedIdentityAggregateRemoteNode:
@@ -66,20 +63,20 @@ func aggregateFor(nid identity.NumericIdentity) identity.NumericIdentity {
 	// NID is global scope and > 100.
 	// Determine if nid is in-cluster.
 	cid := nid.ClusterID()
-	if cid == option.Config.ClusterID {
+	if cid == localClusterID {
 		return identity.ReservedIdentityAggregateCluster
 	}
 	return identity.ReservedIdentityAggregateClusterMesh
 }
 
 // aggregates returns true if child is a child of the wildcard.
-func aggregates(agg, child identity.NumericIdentity) bool {
-	return agg != child && aggregateFor(child) == agg
+func aggregates(agg, child identity.NumericIdentity, localClusterID uint32) bool {
+	return agg != child && aggregateFor(child, localClusterID) == agg
 }
 
 // isAggregate returns true if th
-func isAggregate(nid identity.NumericIdentity) bool {
-	return nid == aggregateFor(nid)
+func isAggregate(nid identity.NumericIdentity, localClusterID uint32) bool {
+	return nid == aggregateFor(nid, localClusterID)
 }
 
 // AllAggregates is the list of all identities that do not aggregate further.

--- a/pkg/policy/aggregate_test.go
+++ b/pkg/policy/aggregate_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestAllAggregates(t *testing.T) {
 	// Validate that the aggregates evaluate to themselves:
 
 	for _, nid := range AllAggregates {
-		require.True(t, isAggregate(nid))
+		require.True(t, isAggregate(nid, 0))
 	}
 
 	c := identity.ReservedIdentityAggregateCluster
@@ -36,14 +35,14 @@ func TestAllAggregates(t *testing.T) {
 		// duplicate of AllAggregates for efficiency.
 		switch nid {
 		case 0, c, m, n, w:
-			require.True(t, isAggregate(nid))
+			require.True(t, isAggregate(nid, 0))
 		default:
-			require.False(t, isAggregate(nid))
+			require.False(t, isAggregate(nid, 0))
 		}
 
 		if writeOutput {
 			expectedIn = append(expectedIn, nid)
-			expectedOut = append(expectedOut, aggregateFor(nid))
+			expectedOut = append(expectedOut, aggregateFor(nid, 0))
 		}
 	}
 
@@ -93,12 +92,6 @@ func writeCArray(path string, nids []identity.NumericIdentity) error {
 }
 
 func TestIsAggregate(t *testing.T) {
-	oldCid := option.Config.ClusterID
-	t.Cleanup(func() {
-		option.Config.ClusterID = oldCid
-	})
-	option.Config.ClusterID = 0
-
 	// save typing
 	w := identity.ReservedIdentityAggregateWorld
 	n := identity.ReservedIdentityAggregateRemoteNode
@@ -122,10 +115,8 @@ func TestIsAggregate(t *testing.T) {
 		{identity.IdentityScopeRemoteNode, n},
 		{identity.IdentityScopeRemoteNode + 100, n},
 	} {
-		require.Equal(t, tc.out, aggregateFor(tc.in), "index %d ID %d", i, tc.in)
+		require.Equal(t, tc.out, aggregateFor(tc.in, 0), "index %d ID %d", i, tc.in)
 	}
-
-	option.Config.ClusterID = 1
 
 	for i, tc := range []struct {
 		in, out identity.NumericIdentity
@@ -146,6 +137,6 @@ func TestIsAggregate(t *testing.T) {
 		{identity.IdentityScopeRemoteNode, n},
 		{identity.IdentityScopeRemoteNode + 100, n},
 	} {
-		require.Equal(t, tc.out, aggregateFor(tc.in), "cluster ID 1, index %d ID %d", i, tc.in)
+		require.Equal(t, tc.out, aggregateFor(tc.in, 1), "cluster ID 1, index %d ID %d", i, tc.in)
 	}
 }

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -87,6 +87,7 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	// cache of label selector -> identities for policy peers.
 	policyRepo := policy.NewPolicyRepository(
 		params.Logger,
+		params.ClusterInfo.ID,
 		identity.ListReservedIdentities(), // Load SelectorCache with reserved identities
 		params.CertManager,
 		params.L7RulesTranslator,

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -97,7 +98,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "policy-cell", "TestAddReplaceRemoveRule", repo, idmgr)
 
 	pi := &Importer{

--- a/pkg/policy/commands/cell.go
+++ b/pkg/policy/commands/cell.go
@@ -39,6 +39,7 @@ type CmdParams struct {
 	Backends   statedb.Table[*loadbalancer.Backend]
 
 	ClusterMeshPolicyConfig cmtypes.PolicyConfig
+	ClusterInfo             cmtypes.ClusterInfo
 	Config                  *option.DaemonConfig
 	PMFactory               policymap.Factory
 }

--- a/pkg/policy/commands/mapstate_diff.go
+++ b/pkg/policy/commands/mapstate_diff.go
@@ -308,7 +308,7 @@ func (s *stageCmd) applyPolicy(obj *unstructured.Unstructured) error {
 }
 
 func makeCNPEntries(s *stageCmd, obj *unstructured.Unstructured) (policytypes.PolicyEntries, ipcacheTypes.ResourceKind, error) {
-	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.Config.ClusterName)
+	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.ClusterInfo.Name)
 	// parse to CNP
 	cnp := ciliumv2.CiliumNetworkPolicy{}
 	if err := convertInto(obj, &cnp); err != nil {
@@ -332,7 +332,7 @@ func makeCNPEntries(s *stageCmd, obj *unstructured.Unstructured) (policytypes.Po
 }
 
 func makeKNPEntries(s *stageCmd, obj *unstructured.Unstructured) (policytypes.PolicyEntries, ipcacheTypes.ResourceKind, error) {
-	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.Config.ClusterName)
+	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.ClusterInfo.Name)
 	knp := slim_networkingv1.NetworkPolicy{}
 	if err := convertInto(obj, &knp); err != nil {
 		return nil, "", err

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
@@ -220,7 +221,7 @@ func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomput
 
 	logger := hivetest.Logger(t)
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 
 	var (
 		db       *statedb.DB

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
 	"github.com/cilium/cilium/pkg/identity"
@@ -305,7 +306,7 @@ type policyDistillery struct {
 func newPolicyDistillery(t testing.TB, selectorCache *SelectorCache) *policyDistillery {
 	idMgr := identitymanager.NewIDManager(hivetest.Logger(t))
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(hivetest.Logger(t), nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		Repository: NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo.ID, nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idMgr:      idMgr,
 	}
 	ret.selectorCache = selectorCache

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -55,6 +55,7 @@ type PolicyWatcherParams struct {
 	ClientSet               client.Clientset
 	Config                  *option.DaemonConfig
 	ClusterMeshPolicyConfig cmtypes.PolicyConfig
+	ClusterInfo             cmtypes.ClusterInfo
 	Logger                  *slog.Logger
 
 	K8sResourceSynced *synced.Resources
@@ -89,6 +90,7 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 		log:                              params.Logger,
 		config:                           params.Config,
 		clusterMeshPolicyConfig:          params.ClusterMeshPolicyConfig,
+		clusterInfo:                      params.ClusterInfo,
 		policyImporter:                   params.PolicyImporter,
 		k8sResourceSynced:                params.K8sResourceSynced,
 		k8sAPIGroups:                     params.K8sAPIGroups,

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -137,7 +137,7 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
 	}
 
-	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName))
+	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.clusterInfo.Name))
 	if err != nil {
 		scopedLog.Warn(
 			"Unable to add CiliumNetworkPolicy",

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -32,6 +32,7 @@ import (
 type policyWatcher struct {
 	log                     *slog.Logger
 	config                  *option.DaemonConfig
+	clusterInfo             cmtypes.ClusterInfo
 	clusterMeshPolicyConfig cmtypes.PolicyConfig
 
 	k8sResourceSynced *k8sSynced.Resources
@@ -187,7 +188,7 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 				case resource.Upsert:
 					err = p.addK8sNetworkPolicyV1(
 						event.Object, k8sAPIGroupNetworkingV1Core, knpDone,
-						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName),
+						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.clusterInfo.Name),
 					)
 				case resource.Delete:
 					err = p.deleteK8sNetworkPolicyV1(event.Object, k8sAPIGroupNetworkingV1Core, knpDone)
@@ -211,7 +212,7 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 				case resource.Upsert:
 					err = p.addK8sClusterNetworkPolicy(
 						event.Object, k8sAPIGroupPolicyNetworkingV1Alpha2, kcnpDone,
-						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName),
+						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.clusterInfo.Name),
 					)
 				case resource.Delete:
 					err = p.deleteK8sClusterNetworkPolicy(event.Object, k8sAPIGroupPolicyNetworkingV1Alpha2, kcnpDone)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
@@ -79,7 +80,7 @@ func newTestData(tb testing.TB, logger *slog.Logger) *testData {
 		identityManager:   idMgr,
 		sc:                testNewSelectorCache(tb, logger, nil),
 		subjectSc:         testNewSelectorCache(tb, logger, nil),
-		repo:              NewPolicyRepository(logger, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		repo:              NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idSet:             set.NewSet[identity.NumericIdentity](),
 		testPolicyContext: &testPolicyContextType{logger: logger},
 	}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -57,7 +58,7 @@ func TestEgressNamedPortToMapStateUnion(t *testing.T) {
 	epPolicy := &EndpointPolicy{
 		SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 		PolicyOwner:    owner,
-		policyMapState: newMapState(logger, nil, namedPortRules),
+		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
 		selectors:      types.MockSelectorSnapshot(),
 	}
 	filter := &L4Filter{
@@ -113,7 +114,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules),
+			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -139,7 +140,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules),
+			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -163,7 +164,7 @@ func TestNamedPortRulesDeleteByID(t *testing.T) {
 	logger := hivetest.Logger(t)
 	epPolicy := &EndpointPolicy{
 		PolicyOwner:    DummyOwner{logger: logger},
-		policyMapState: newMapState(logger, nil, namedPortRules),
+		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
 	}
 	require.NotNil(t, epPolicy.policyMapState.byId)
 
@@ -783,7 +784,7 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 // it is released, even after all current users have been removed.
 func TestHoldPreventsDetach(t *testing.T) {
 	logger := hivetest.Logger(t)
-	repo := NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	repo.revision.Store(1)
 
 	ep := testutils.NewTestEndpoint(t)
@@ -824,7 +825,7 @@ func TestHoldPreventsDetach(t *testing.T) {
 // a policy that is being replaced.
 func TestAddHoldRejectsDetached(t *testing.T) {
 	logger := hivetest.Logger(t)
-	repo := NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	repo.revision.Store(1)
 
 	ep := testutils.NewTestEndpoint(t)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -87,7 +88,8 @@ var (
 // greatly enhances the usefuleness of the Trie and improves lookup,
 // deletion, and insertion times.
 type mapState struct {
-	logger *slog.Logger
+	logger         *slog.Logger
+	localClusterID uint32
 	// entries is the map containing the MapStateEntries
 	entries mapStateMap
 	// trie is a Trie that indexes policy Keys without their identity
@@ -195,7 +197,7 @@ func (ms *mapState) forKey(k Key, f func(Key, mapStateEntry) bool) bool {
 // forCoveredIDs calls 'f' for each covered non-aggregate ID in 'idSet' with port/proto from 'k'.
 func (ms *mapState) forCoveredIDs(agg identity.NumericIdentity, k Key, idSet IDSet, f func(Key, mapStateEntry) bool) bool {
 	for id := range idSet {
-		if aggregates(agg, id) {
+		if aggregates(agg, id, ms.localClusterID) {
 			k.Identity = id
 			if !ms.forKey(k, f) {
 				return false
@@ -220,7 +222,7 @@ func (ms *mapState) forID(k Key, idSet IDSet, f func(Key, mapStateEntry) bool) b
 //
 // All yielded keys will have either the specified ID or the aggregate ID.
 func (ms *mapState) CoveringBroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity)
+	agg := aggregateFor(key.Identity, ms.localClusterID)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -249,7 +251,7 @@ func (ms *mapState) CoveringBroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateE
 // The difference is when the aggregate key is supplied - this yields *all* keys
 // with shorter-or-equal prefix length.
 func (ms *mapState) BroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity)
+	agg := aggregateFor(key.Identity, ms.localClusterID)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -284,7 +286,7 @@ func (ms *mapState) BroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
 // If a non-aggregate key is supplied, all keys yielded will have that identity.
 // If an aggregate key is supplied, all longer-prefix keys will be yielded.
 func (ms *mapState) CoveredNarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity)
+	agg := aggregateFor(key.Identity, ms.localClusterID)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.DescendantIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -318,7 +320,7 @@ func (ms *mapState) CoveredNarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateE
 //
 // If a aggregate key is supplied, this will yield all longer-prefix keys.
 func (ms *mapState) NarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	wc := aggregateFor(key.Identity)
+	wc := aggregateFor(key.Identity, ms.localClusterID)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.DescendantIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -381,7 +383,7 @@ func (ms *mapState) SubsetKeysWithSameID(key Key) iter.Seq2[Key, mapStateEntry] 
 // LPMAncestors iterates over broader or equal port/proto entries in the trie in LPM order,
 // with most specific match with the same ID as in 'key' being returned first.
 func (ms *mapState) LPMAncestors(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity)
+	agg := aggregateFor(key.Identity, ms.localClusterID)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorLongestPrefixFirstIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -417,7 +419,7 @@ func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 	}
 
 	// The aggregate identity to retrieve
-	agg := aggregateFor(key.Identity)
+	agg := aggregateFor(key.Identity, ms.localClusterID)
 
 	// two entries: aggregate and specific.
 	// Must retrieve both.
@@ -704,12 +706,12 @@ func NewMapStateEntry(e MapStateEntry) mapStateEntry {
 }
 
 func emptyMapState(logger *slog.Logger) mapState {
-	return newMapState(logger, nil, 0)
+	return newMapState(logger, nil, 0, cmtypes.DefaultClusterInfo.ID)
 }
 
 // newMapState returns a new mapState with capacities from the given old mapState (if non-nil),
 // according to the given policy features.
-func newMapState(logger *slog.Logger, old *mapState, features policyFeatures) mapState {
+func newMapState(logger *slog.Logger, old *mapState, features policyFeatures, localClusterID uint32) mapState {
 	var nEntries int
 
 	if old != nil {
@@ -717,9 +719,10 @@ func newMapState(logger *slog.Logger, old *mapState, features policyFeatures) ma
 	}
 
 	ms := mapState{
-		logger:  logger,
-		entries: make(mapStateMap, nEntries),
-		trie:    bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
+		logger:         logger,
+		localClusterID: localClusterID,
+		entries:        make(mapStateMap, nEntries),
+		trie:           bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
 	}
 
 	if features&(passRules|namedPortRules) != 0 {
@@ -1041,7 +1044,7 @@ func (ms *mapState) pruneCoveredNarrowerKey(k Key, v mapStateEntry, key Key, ent
 
 	// If k is a direct child of key, and k's entry is equivalent to key,
 	// then delete k as it is redundant.
-	deleteEntry = deleteEntry || (key.LPMKey == k.LPMKey && aggregates(key.Identity, k.Identity) && v.equivalent(entry))
+	deleteEntry = deleteEntry || (key.LPMKey == k.LPMKey && aggregates(key.Identity, k.Identity, ms.localClusterID) && v.equivalent(entry))
 
 	// Delete whole entry?
 	if deletePassMeta && deleteEntry {
@@ -1079,9 +1082,9 @@ func (sp *keySlice) addNewKeys(l34Keys, doneKeys *Keys) {
 
 // collectNarrowerPasses adds the narrower key 'k' (with identity from 'key' if narrower) to 'm' if
 // 'v' has a higher precedence pass.
-func (sp *keySlice) collectNarrowerPasses(tierMaxPrecedence types.Precedence, k Key, v mapStateEntry, key Key, doneKeys *Keys) {
+func (sp *keySlice) collectNarrowerPasses(tierMaxPrecedence types.Precedence, k Key, v mapStateEntry, key Key, doneKeys *Keys, localClusterID uint32) {
 	// k has narrower L4, but the narrower identity may be on 'key'
-	if k.Identity == aggregateFor(key.Identity) {
+	if k.Identity == aggregateFor(key.Identity, localClusterID) {
 		k.Identity = key.Identity
 	}
 	if k != key {
@@ -1214,7 +1217,7 @@ func (ms *mapState) insertWithPasses(tierMaxPrecedence types.Precedence, key Key
 	var l34Keys, doneKeys Keys
 	var bailPrecedence types.Precedence
 	var keys keySlice
-	aggregateID := aggregateFor(key.Identity)
+	aggregateID := aggregateFor(key.Identity, ms.localClusterID)
 
 	// Find the covering pass and bail entries and pass if the found
 	// passPrecedence is higher than the bailPrecedence, else bail if found.
@@ -1280,7 +1283,7 @@ func (ms *mapState) insertWithPasses(tierMaxPrecedence types.Precedence, key Key
 		if !bail && isCoveringKey {
 			ms.pruneCoveredNarrowerKey(k, v, key, entry, entry.Precedence, changes)
 		}
-		keys.collectNarrowerPasses(tierMaxPrecedence, k, v, key, &doneKeys)
+		keys.collectNarrowerPasses(tierMaxPrecedence, k, v, key, &doneKeys, ms.localClusterID)
 	}
 
 	// Pass to a higher tier?
@@ -1486,7 +1489,7 @@ func (ms *mapState) insertWithChanges(tierMaxPrecedence types.Precedence, newKey
 // aggregateIsEquivalent returns true if an entry has an aggregate (wildcard)
 // on the same level. If so, inserting `newKey` can be skipped entirely.
 func (ms *mapState) aggregateIsEquivalent(newKey Key, newEntry mapStateEntry) bool {
-	agg := aggregateFor(newKey.Identity)
+	agg := aggregateFor(newKey.Identity, ms.localClusterID)
 	// if newKey is already aggregate, then we can bail.
 	if agg == newKey.Identity {
 		return false
@@ -1509,7 +1512,7 @@ func (ms *mapState) aggregateIsEquivalent(newKey Key, newEntry mapStateEntry) bo
 // of another entry appearing between the aggregated and specific entry.
 func (ms *mapState) pruneAggregated(newKey Key, newEntry mapStateEntry, changes ChangeState) {
 	// newKey must be capable of aggregating.
-	if !isAggregate(newKey.Identity) {
+	if !isAggregate(newKey.Identity, ms.localClusterID) {
 		return
 	}
 
@@ -1520,7 +1523,7 @@ func (ms *mapState) pruneAggregated(newKey Key, newEntry mapStateEntry, changes 
 	}
 
 	for id := range idSet {
-		if !aggregates(newKey.Identity, id) {
+		if !aggregates(newKey.Identity, id, ms.localClusterID) {
 			// skip if this ID is not aggregated by newKey
 			continue
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -68,7 +68,8 @@ type PolicyRepository interface {
 // Repository is a list of policy rules which in combination form the security
 // policy. A policy repository can be
 type Repository struct {
-	logger *slog.Logger
+	logger         *slog.Logger
+	localClusterID uint32
 	// mutex protects the whole policy tree
 	mutex lock.RWMutex
 
@@ -119,6 +120,7 @@ func (p *Repository) GetSubjectSelectorCache() *SelectorCache {
 // NewPolicyRepository creates a new policy repository.
 func NewPolicyRepository(
 	logger *slog.Logger,
+	localClusterID uint32,
 	initialIDs identity.IdentityMap,
 	certManager certificatemanager.CertificateManager,
 	l7RulesTranslator envoypolicy.EnvoyL7RulesTranslator,
@@ -130,6 +132,7 @@ func NewPolicyRepository(
 	repo := &Repository{
 		logger:               logger,
 		rules:                make(map[ruleKey]*rule),
+		localClusterID:       localClusterID,
 		rulesByNamespace:     make(map[string]sets.Set[ruleKey]),
 		rulesByResource:      make(map[ipcachetypes.ResourceID]map[ruleKey]*rule),
 		selectorCache:        selectorCache,
@@ -339,6 +342,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	calculatedPolicy := &selectorPolicy{
 		Revision:             p.GetRevision(),
+		localClusterID:       p.localClusterID,
 		SelectorCache:        sc,
 		namedPortsGetter:     p.namedPortsGetter,
 		L4Policy:             NewL4Policy(p.GetRevision()),
@@ -715,6 +719,7 @@ func (p *Repository) Snapshot(logger *slog.Logger, cm certificatemanager.Certifi
 
 	out := NewPolicyRepository(
 		logger,
+		p.localClusterID,
 		ids,
 		cm,
 		rt,

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -1333,7 +1334,7 @@ func TestDefaultAllow(t *testing.T) {
 func TestReplaceByResource(t *testing.T) {
 	// don't use the full testdata() here, since we want to watch
 	// selectorcache changes carefully
-	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	sc := testNewSelectorCache(t, hivetest.Logger(t), nil)
 	assert.True(t, sc.selectors.Empty())
 	repo.subjectSelectorCache = sc

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -189,6 +189,8 @@ type NamedPortsGetter interface {
 // particular Identity across all layers (L3, L4, and L7), with the policy
 // still determined in terms of EndpointSelectors.
 type selectorPolicy struct {
+	localClusterID uint32
+
 	// Revision is the revision of the policy repository used to generate
 	// this selectorPolicy.
 	Revision uint64
@@ -416,7 +418,7 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 		calculatedPolicy = &EndpointPolicy{
 			SelectorPolicy: p,
 			selectors:      selectors,
-			policyMapState: newMapState(logger, policyOwner.PreviousMapState(), features),
+			policyMapState: newMapState(logger, policyOwner.PreviousMapState(), features, p.localClusterID),
 			policyMapChanges: MapChanges{
 				logger:   logger,
 				firstRev: selectors.Revision,


### PR DESCRIPTION
Start using the ClusterInfo struct instead of the ClusterName/ClusterID from the legacy config within the policy package.

This commit was prepared with AIL-2
