### PR TITLE
health/client: replace deprecated http.Transport.Dial with DialContext

### DIFF
--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -57,12 +58,12 @@ func configureTransport(tr *http.Transport, proto, addr string) *http.Transport 
 	if proto == "unix" {
 		// No need for compression in local communications.
 		tr.DisableCompression = true
-		tr.Dial = func(_, _ string) (net.Conn, error) {
+		tr.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial(proto, addr)
 		}
 	} else {
 		tr.Proxy = http.ProxyFromEnvironment
-		tr.Dial = (&net.Dialer{}).Dial
+		tr.DialContext = (&net.Dialer{}).DialContext
 	}
 
 	return tr


### PR DESCRIPTION
`http.Transport.Dial` has been deprecated since Go 1.7 (`SA1019`) in favor of `DialContext`, which allows the transport to cancel dials as soon as they are no longer needed. Per the Go docs, if both fields are set `DialContext` takes priority — so the current code is effectively opting out of context-aware dialing on every request the Cilium health checker's HTTP client makes.

This PR migrates the two assignments in `configureTransport` (`pkg/health/client/client.go`) to `DialContext`, preserving existing behavior exactly:
- **`unix` branch** — the existing closure is wrapped in the `DialContext` signature. The extra `context.Context` argument is intentionally ignored so the dial semantics do not change: it still targets the `proto`/`addr` values captured from the outer scope.
- **fallback branch** — `(&net.Dialer{}).Dial` is swapped for its `DialContext` method value, which is the direct, semantically equivalent replacement.

No behavior change is expected for callers of the health client.

Ref: #32274
## Testing
- `go vet ./pkg/health/client/...`
- `GOOS=linux go build ./pkg/health/...`
- `GOOS=linux go test -c ./pkg/health/client` (verifies clean cross-compilation for the deployment target)
- `go test ./pkg/health/client/...` (unit tests pass natively on darwin)

## AI usage
This PR was prepared with AIL:3. I used LLM assistance to locate the
remaining `tr.Dial` call sites in `pkg/health/client/client.go`, draft
the minimal-scope diff, and prepare this description. I personally
reviewed the diff, verified the replacement preserves existing
semantics on both branches of `configureTransport`, and ran the
validation commands above.
