### PR TITLE
bpf: reduce scope for ratelimit_* structs

### DIFF
--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -79,15 +79,16 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 	__u8 file = (__u8)(meta4 >> 8);
 	__u8 exitcode = (__u8)meta4;
 	cls_flags_t flags = CLS_FLAG_NONE;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	struct drop_notify msg;
 
 	if (CONFIG(events_map_rate_limit) > 0) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = NSEC_PER_SEC,
+		};
+
 		settings.bucket_size = CONFIG(events_map_burst_limit);
 		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
 		if (!ratelimit_check_and_take(&rkey, &settings))

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -61,12 +61,6 @@ send_policy_verdict_notify(const struct __ctx_buff *ctx, __u32 remote_label, __u
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	struct policy_verdict_notify msg;
 
 #if defined(IS_BPF_HOST)
@@ -94,6 +88,13 @@ send_policy_verdict_notify(const struct __ctx_buff *ctx, __u32 remote_label, __u
 		verdict = (int)proxy_port;
 
 	if (CONFIG(events_map_rate_limit) > 0) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = NSEC_PER_SEC,
+		};
+
 		settings.bucket_size = CONFIG(events_map_burst_limit);
 		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
 		if (!ratelimit_check_and_take(&rkey, &settings))

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -211,12 +211,6 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	struct trace_notify msg = {};
 	cls_flags_t flags = CLS_FLAG_NONE;
 
@@ -226,6 +220,13 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		return;
 
 	if (CONFIG(events_map_rate_limit) > 0) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = NSEC_PER_SEC,
+		};
+
 		settings.bucket_size = CONFIG(events_map_burst_limit);
 		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
 		if (!ratelimit_check_and_take(&rkey, &settings))
@@ -263,12 +264,6 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	struct trace_notify msg = {};
 	cls_flags_t flags = CLS_FLAG_NONE;
 
@@ -278,6 +273,13 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		return;
 
 	if (CONFIG(events_map_rate_limit) > 0) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = NSEC_PER_SEC,
+		};
+
 		settings.bucket_size = CONFIG(events_map_burst_limit);
 		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
 		if (!ratelimit_check_and_take(&rkey, &settings))
@@ -315,12 +317,6 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	struct trace_notify msg = {};
 	cls_flags_t flags = CLS_FLAG_NONE;
 
@@ -330,6 +326,13 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		return;
 
 	if (CONFIG(events_map_rate_limit) > 0) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = NSEC_PER_SEC,
+		};
+
 		settings.bucket_size = CONFIG(events_map_burst_limit);
 		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
 		if (!ratelimit_check_and_take(&rkey, &settings))

--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -123,12 +123,6 @@ send_trace_sock_notify4(struct __ctx_sock *ctx,
 			bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8 = {};
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
-	};
 
 	if (!emit_trace_sock_notify(xlate_point, is_connect))
 		return;
@@ -138,6 +132,13 @@ send_trace_sock_notify4(struct __ctx_sock *ctx,
 	 * align with monitor aggregation timing.
 	 */
 	if (CONFIG(monitor_aggregation) != TRACE_SOCK_AGGREGATE_NONE) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
+		};
+
 		/* One token per CT_REPORT_INTERVAL with no burst to align with
 		 * monitor aggregation semantics ("~1 per interval").
 		 */
@@ -167,12 +168,6 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 			bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
-	};
 
 	if (!emit_trace_sock_notify(xlate_point, is_connect))
 		return;
@@ -182,6 +177,13 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 	 * align with monitor aggregation timing.
 	 */
 	if (CONFIG(monitor_aggregation) != TRACE_SOCK_AGGREGATE_NONE) {
+		struct ratelimit_key rkey = {
+			.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
+		};
+		struct ratelimit_settings settings = {
+			.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
+		};
+
 		/* One token per CT_REPORT_INTERVAL with no burst to align with
 		 * monitor aggregation semantics ("~1 per interval").
 		 */


### PR DESCRIPTION
Usage of these structs is usually guarded by CONFIG(events_map_rate_limit), push them down into this scope. This improves readability, and might also help the compiler to reduce stack usage.