### PR TITLE
ipam: Accept native routing CIDR overlapping a secondary VPC CIDR

### DIFF
--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -123,14 +123,14 @@ func startENINativeRoutingCIDRSync(
 				// Status.ENI.ENIs[].VPC.PrimaryCIDR with a valid value.
 				// An invalid PrimaryCIDR (operator hasn't written yet) is
 				// treated as a transient absence.
-				primaryCIDR := deriveENIVpcCIDR(ev.Object)
+				primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(ev.Object)
 				if !primaryCIDR.IsValid() {
 					return nil
 				}
 
 				var err error
 				once.Do(func() {
-					err = autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+					err = autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf)
 					close(ready)
 				})
 				return err
@@ -143,9 +143,9 @@ func startENINativeRoutingCIDRSync(
 }
 
 // waitForENINativeRoutingCIDR blocks until the eni-native-routing-cidr-sync
-// observer has populated Local.IPv4NativeRoutingCIDR in the local node store.
-// Aborts the agent with a fatal log if the operator has not reported the VPC
-// CIDR within waitForENINativeRoutingCIDRTimeout.
+// observer has determined the native routing CIDR. Aborts the agent with a
+// fatal log if the operator has not reported the VPC CIDR within
+// waitForENINativeRoutingCIDRTimeout.
 func waitForENINativeRoutingCIDR(logger *slog.Logger, ready <-chan struct{}) {
 	deadline := time.After(waitForENINativeRoutingCIDRTimeout)
 	for {
@@ -166,7 +166,7 @@ func waitForENINativeRoutingCIDR(logger *slog.Logger, ready <-chan struct{}) {
 const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
 
 // autoDetectENINativeRoutingCIDR either validates an existing native routing
-// CIDR configuration against the given VPC primary CIDR, or uses the VPC CIDR
+// CIDR configuration against the given VPC CIDRs, or uses the VPC primary CIDR
 // as the autodetected native routing CIDR.
 //
 // Returns an error if the configured native routing CIDR overlaps no VPC CIDR:
@@ -174,17 +174,19 @@ const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
 func autoDetectENINativeRoutingCIDR(
 	logger *slog.Logger,
 	primaryCIDR netip.Prefix,
+	secondaryCIDRs []netip.Prefix,
 	localNodeStore *node.LocalNodeStore,
 	conf *option.DaemonConfig,
 ) error {
 	if nativeCIDR := conf.IPv4NativeRoutingCIDR; nativeCIDR.IsValid() {
 		// Accept the configured native routing CIDR as long as it overlaps the
-		// VPC primary CIDR, i.e. it is the VPC CIDR, a subnet of it (e.g. a
-		// single availability-zone subnet, used to masquerade cross-subnet
-		// traffic), or a supernet of it.
-		if !iputil.LaminarCIDRsOverlap(nativeCIDR, primaryCIDR) {
-			return fmt.Errorf("configured --%s %s does not overlap the VPC primary CIDR %s",
-				option.IPv4NativeRoutingCIDR, nativeCIDR, primaryCIDR)
+		// VPC primary CIDR or one of the secondary CIDR associations, i.e. it is
+		// a VPC CIDR, a subnet of one (e.g. a single availability-zone subnet,
+		// used to masquerade cross-subnet traffic), or a supernet of one.
+		overlaps := func(c netip.Prefix) bool { return iputil.LaminarCIDRsOverlap(nativeCIDR, c) }
+		if !overlaps(primaryCIDR) && !slices.ContainsFunc(secondaryCIDRs, overlaps) {
+			return fmt.Errorf("configured --%s %s overlaps neither the VPC primary CIDR %s nor any secondary CIDR association %v",
+				option.IPv4NativeRoutingCIDR, nativeCIDR, primaryCIDR, secondaryCIDRs)
 		}
 
 		logger.Info(
@@ -205,20 +207,26 @@ func autoDetectENINativeRoutingCIDR(
 	return nil
 }
 
-// deriveENIVpcCIDR extracts the VPC primary CIDR from the first ENI in the
-// CiliumNode status. All ENIs on a node belong to the same VPC, so any ENI
-// can be used.
+// deriveENIVpcCIDRs extracts the VPC primary CIDR and the secondary CIDR
+// associations from the first ENI in the CiliumNode status. All ENIs on a node
+// belong to the same VPC, so any ENI can be used.
 //
 // Returns the zero netip.Prefix when no ENI has populated PrimaryCIDR yet
 // (transient startup state).
-func deriveENIVpcCIDR(node *ciliumv2.CiliumNode) netip.Prefix {
+func deriveENIVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR netip.Prefix, secondaryCIDRs []netip.Prefix) {
 	for _, eni := range node.Status.ENI.ENIs {
 		if !eni.VPC.PrimaryCIDR.IsValid() {
 			continue
 		}
-		return eni.VPC.PrimaryCIDR.Masked()
+		primaryCIDR = eni.VPC.PrimaryCIDR.Masked()
+		for _, c := range eni.VPC.CIDRs {
+			if c.IsValid() {
+				secondaryCIDRs = append(secondaryCIDRs, c.Masked())
+			}
+		}
+		return primaryCIDR, secondaryCIDRs
 	}
-	return netip.Prefix{}
+	return netip.Prefix{}, nil
 }
 
 // validateENIConfig validates the ENI configuration in the CiliumNode resource

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -84,10 +84,12 @@ func startENIDeviceConfigurator(
 // If the native routing CIDR is already configured (via Helm or CLI), this
 // validates that the configured value contains the VPC CIDR.
 //
-// The returned channel is closed once the native routing CIDR has been set
-// in the local node store. Callers must wait on it before programming the
-// datapath, otherwise masquerade exclusion may be configured against an
-// empty CIDR.
+// The returned channel is closed once the native routing CIDR has been
+// determined. Callers must wait on it before programming the datapath,
+// otherwise masquerade exclusion may be configured against an empty CIDR.
+//
+// An unusable configuration is reported by the observer, registered with
+// job.WithObserverShutdown so that it shuts the hive down cleanly.
 func startENINativeRoutingCIDRSync(
 	logger *slog.Logger,
 	jg job.Group,
@@ -126,13 +128,15 @@ func startENINativeRoutingCIDRSync(
 					return nil
 				}
 
+				var err error
 				once.Do(func() {
-					autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+					err = autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
 					close(ready)
 				})
-				return nil
+				return err
 			},
 			nodeResource,
+			job.WithObserverShutdown[resource.Event[*ciliumv2.CiliumNode]](),
 		),
 	)
 	return ready
@@ -164,30 +168,31 @@ const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
 // autoDetectENINativeRoutingCIDR either validates an existing native routing
 // CIDR configuration against the given VPC primary CIDR, or uses the VPC CIDR
 // as the autodetected native routing CIDR.
+//
+// Returns an error if the configured native routing CIDR overlaps no VPC CIDR:
+// see the masquerading note on startENINativeRoutingCIDRSync.
 func autoDetectENINativeRoutingCIDR(
 	logger *slog.Logger,
 	primaryCIDR netip.Prefix,
 	localNodeStore *node.LocalNodeStore,
 	conf *option.DaemonConfig,
-) {
+) error {
 	if nativeCIDR := conf.IPv4NativeRoutingCIDR; nativeCIDR.IsValid() {
 		// Accept the configured native routing CIDR as long as it overlaps the
 		// VPC primary CIDR, i.e. it is the VPC CIDR, a subnet of it (e.g. a
 		// single availability-zone subnet, used to masquerade cross-subnet
 		// traffic), or a supernet of it.
-		if iputil.LaminarCIDRsOverlap(nativeCIDR, primaryCIDR) {
-			logger.Info(
-				"Native routing CIDR overlaps VPC CIDR, ignoring autodetected VPC CIDR.",
-				logfields.VPCCIDR, primaryCIDR,
-				option.IPv4NativeRoutingCIDR, nativeCIDR,
-			)
-		} else {
-			logging.Fatal(logger, "Configured native routing CIDR does not overlap VPC CIDR",
-				logfields.VPCCIDR, primaryCIDR,
-				option.IPv4NativeRoutingCIDR, nativeCIDR,
-			)
+		if !iputil.LaminarCIDRsOverlap(nativeCIDR, primaryCIDR) {
+			return fmt.Errorf("configured --%s %s does not overlap the VPC primary CIDR %s",
+				option.IPv4NativeRoutingCIDR, nativeCIDR, primaryCIDR)
 		}
-		return
+
+		logger.Info(
+			"Native routing CIDR overlaps VPC CIDR, ignoring autodetected VPC CIDR.",
+			logfields.VPCCIDR, primaryCIDR,
+			option.IPv4NativeRoutingCIDR, nativeCIDR,
+		)
+		return nil
 	}
 
 	logger.Info(
@@ -197,6 +202,7 @@ func autoDetectENINativeRoutingCIDR(
 	localNodeStore.Update(func(n *node.LocalNode) {
 		n.Local.IPv4NativeRoutingCIDR = cidr.NewCIDR(netipx.PrefixIPNet(primaryCIDR))
 	})
+	return nil
 }
 
 // deriveENIVpcCIDR extracts the VPC primary CIDR from the first ENI in the

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -775,7 +775,7 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 
 		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
 		conf := &option.DaemonConfig{}
-		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -791,7 +791,7 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("10.0.0.0/8"),
 		}
-		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -802,8 +802,7 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 	t.Run("accepts a native routing CIDR that is a subnet of the VPC CIDR", func(t *testing.T) {
 		// Regression test: a native routing CIDR that is a subset of the VPC
 		// CIDR (e.g. a single availability-zone subnet) is a valid, supported
-		// configuration. It must not be rejected (which would call
-		// logging.Fatal and crash the agent on startup).
+		// configuration. It must not be rejected.
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
@@ -811,11 +810,22 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.64.0/19"),
 		}
-		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
 		// Should NOT have been written since the config already has a value.
 		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
+	})
+
+	t.Run("rejects a native routing CIDR that overlaps no VPC CIDR", func(t *testing.T) {
+		logger := hivetest.Logger(t)
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+
+		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
+		conf := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.0.0/16"),
+		}
+		require.Error(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
 	})
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -739,7 +739,7 @@ func TestENIMultiPoolAllocator(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-func TestDeriveENIVpcCIDR(t *testing.T) {
+func TestDeriveENIVpcCIDRs(t *testing.T) {
 	t.Run("returns primary VPC CIDR from first ENI", func(t *testing.T) {
 		node := &ciliumv2.CiliumNode{}
 		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
@@ -749,12 +749,30 @@ func TestDeriveENIVpcCIDR(t *testing.T) {
 				},
 			},
 		}
-		require.Equal(t, netip.MustParsePrefix("10.0.0.0/16"), deriveENIVpcCIDR(node))
+		primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(node)
+		require.Equal(t, netip.MustParsePrefix("10.0.0.0/16"), primaryCIDR)
+		require.Empty(t, secondaryCIDRs)
+	})
+
+	t.Run("returns the secondary VPC CIDR associations", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
+			"eni-1": {
+				VPC: awsTypes.AwsVPC{
+					PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.128.0/19")),
+					CIDRs:       prefixes("100.64.0.0/16"),
+				},
+			},
+		}
+		primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(node)
+		require.Equal(t, netip.MustParsePrefix("10.1.128.0/19"), primaryCIDR)
+		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}, secondaryCIDRs)
 	})
 
 	t.Run("returns zero when no ENIs", func(t *testing.T) {
 		node := &ciliumv2.CiliumNode{}
-		require.False(t, deriveENIVpcCIDR(node).IsValid())
+		primaryCIDR, _ := deriveENIVpcCIDRs(node)
+		require.False(t, primaryCIDR.IsValid())
 	})
 
 	t.Run("returns zero when VPC CIDR is empty", func(t *testing.T) {
@@ -764,7 +782,8 @@ func TestDeriveENIVpcCIDR(t *testing.T) {
 				VPC: awsTypes.AwsVPC{},
 			},
 		}
-		require.False(t, deriveENIVpcCIDR(node).IsValid())
+		primaryCIDR, _ := deriveENIVpcCIDRs(node)
+		require.False(t, primaryCIDR.IsValid())
 	})
 }
 
@@ -775,7 +794,7 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 
 		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
 		conf := &option.DaemonConfig{}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -791,7 +810,7 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("10.0.0.0/8"),
 		}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -810,7 +829,26 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.64.0/19"),
 		}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
+
+		localNode, err := localNodeStore.Get(context.Background())
+		require.NoError(t, err)
+		// Should NOT have been written since the config already has a value.
+		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
+	})
+
+	t.Run("accepts a native routing CIDR matching a secondary VPC CIDR association", func(t *testing.T) {
+		// Regression test: pod subnets are commonly carved out of a secondary
+		// VPC CIDR association rather than the primary CIDR.
+		logger := hivetest.Logger(t)
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+
+		primaryCIDR := netip.MustParsePrefix("10.1.128.0/19")
+		secondaryCIDRs := []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}
+		conf := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: netip.MustParsePrefix("100.64.0.0/16"),
+		}
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -822,10 +860,11 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
+		primaryCIDR := netip.MustParsePrefix("10.1.128.0/19")
+		secondaryCIDRs := []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.0.0/16"),
 		}
-		require.Error(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf))
+		require.Error(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf))
 	})
 }


### PR DESCRIPTION
ENI IPAM checks ipv4NativeRoutingCIDR against the VPC primary CIDR only. Pod subnets in a secondary CIDR association are rejected and every agent crash-loops on startup, with no way to disable the check.

- Derive the secondary CIDR associations alongside the primary CIDR
- Accept if the configured CIDR overlaps any of them; fatal only when none match
- Subnets and supernets of a VPC CIDR stay accepted
- Add the test coverage this validation never had

This PR was prepared with `AIL:2`. Claude Code was used to debug initial failure condition and assistance in understanding existing conventions within the repo. It assisted in writing tests and once I completed initial code changes, I used the `/simplify` skill to assist in finding examples where I could simplify logic or re-use existing patterns.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #47811

```release-note
Fix agent crash on startup in ENI IPAM mode when ipv4NativeRoutingCIDR is set to a secondary VPC CIDR association
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
