### PR TITLE
bpf: trace: turn trace_notify msg into auxvar

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include "auxvars.h"
 #include "dbg.h"
 #include "events.h"
 #include "common.h"
@@ -202,12 +203,15 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 	return true;
 }
 
+DEFINE_AUX(struct trace_notify, trace_msg);
+
 static __always_inline void
 __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src, __u32 dst, void *orig_addr, __u16 dst_id, __u32 ifindex,
 		    enum trace_reason reason, __u32 monitor,
 		    __be16 proto, __u16 line, __u8 file)
 {
+	struct trace_notify *msg = AUX(trace_msg);
 	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len;
@@ -217,8 +221,9 @@ __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	struct ratelimit_settings settings = {
 		.topup_interval_ns = NSEC_PER_SEC,
 	};
-	struct trace_notify msg = {};
 	cls_flags_t flags = CLS_FLAG_NONE;
+
+	memset(msg, 0, sizeof(*msg));
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
 
@@ -235,29 +240,38 @@ __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	flags = ctx_classify(ctx, proto, obs_point);
 	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
-	msg = (typeof(msg)) {
-		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
-		.src_label	= src,
-		.dst_label	= dst,
-		.dst_id		= dst_id,
-		.reason		= reason,
-		.flags		= flags,
-		.ifindex	= ifindex,
-		.ip_trace_id	= ip_trace_id,
-	};
-	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
+	/* open-coded __notify_common_hdr() */
+	msg->type		= CILIUM_NOTIFY_TRACE;
+	msg->subtype		= obs_point;
+	msg->source		= EVENT_SOURCE;
+	msg->hash		= get_hash(ctx);
+
+	/* open-coded __notify_pktcap_hdr() */
+	msg->len_orig		= (__u32)ctx_len;
+	msg->len_cap		= (__u16)cap_len;
+	msg->version		= NOTIFY_TRACE_VER;
+	msg->ext_version	= 0;
+
+	msg->src_label = src;
+	msg->dst_label = dst;
+	msg->dst_id = dst_id;
+	msg->reason = reason;
+	msg->flags = flags;
+	msg->ifindex = ifindex;
+	msg->ip_trace_id = ip_trace_id;
+
+	memset(&msg->orig_ip6, 0, sizeof(union v6addr));
 	if (orig_addr) {
 		if (proto == bpf_htons(ETH_P_IP))
-			memcpy(&msg.orig_ip4.be32, orig_addr, sizeof(__be32));
+			memcpy(&msg->orig_ip4.be32, orig_addr, sizeof(__be32));
 		else
-			ipv6_addr_copy(&msg.orig_ip6, orig_addr);
+			ipv6_addr_copy(&msg->orig_ip6, orig_addr);
 	}
 
 	trace_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+			 msg, sizeof(*msg));
 }
 
 static __always_inline void


### PR DESCRIPTION
This is taking up a non-trivial amount of stack space.

<img width="902" height="683" alt="image" src="https://github.com/user-attachments/assets/b70077d6-8bd7-4ee6-8b40-580f54853f73" />
