### PR TITLE
[v1.20] bpf: dsr: various fixes

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -205,6 +205,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif /* ENABLE_NODEPORT */
 
 	if (svc) {
+		bool new_backend __maybe_unused = false;
 		const struct lb4_backend *backend;
 
 #if defined(ENABLE_L7_LB)
@@ -231,7 +232,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 
 		ret = lb4_local(get_ct_map4(&tuple), ctx, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				&backend, ext_err, NULL);
+				&backend, &new_backend, ext_err, NULL);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
@@ -383,6 +384,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 #endif /* ENABLE_NODEPORT */
 
 	if (svc) {
+		bool new_backend __maybe_unused = false;
 		const struct lb6_backend *backend;
 
 #if defined(ENABLE_L7_LB)
@@ -401,7 +403,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 
 		ret = lb6_local(get_ct_map6(&tuple), ctx, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				&backend, ext_err, NULL);
+				&backend, &new_backend, ext_err, NULL);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -133,7 +133,7 @@ static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags
 	if (unlikely(flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
 		return ACTION_CLOSE;
 
-	if (unlikely((flags.value & TCP_FLAG_SYN) && !(flags.value & TCP_FLAG_ACK)))
+	if (unlikely(tcp_is_syn(flags)))
 		return ACTION_CREATE;
 
 	return ACTION_UNSPEC;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -263,12 +263,11 @@ static __always_inline __u32 ct_update_timeout(struct ct_entry *entry,
 
 static __always_inline void
 ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
-		     enum ct_dir dir, bool syn)
+		     enum ct_dir dir)
 {
 	state->rev_nat_index = entry->rev_nat_index;
 	if (dir == CT_SERVICE) {
 		state->backend_id = (__u32)entry->backend_id;
-		state->syn = syn;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
 #ifdef USE_LOOPBACK_LB
 		state->loopback = entry->lb_loopback;
@@ -435,7 +434,7 @@ __ct_lookup(const void *map, const struct __ctx_buff *ctx, const void *tuple,
 
 		/* Fill ct_state after all potential CT_NEW returns. */
 		if (ct_state)
-			ct_lookup_fill_state(ct_state, entry, dir, syn);
+			ct_lookup_fill_state(ct_state, entry, dir);
 
 		return CT_ESTABLISHED;
 	}
@@ -681,6 +680,9 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
+
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}
@@ -939,6 +941,9 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
+
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -52,8 +52,9 @@ struct ct_state {
 	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
-		  closing:1,
-	      reserved:7;
+	      closing:1,
+	      new_backend:1,	/* Service connection was assigned a new backend */
+	      reserved:6;
 	__u32 src_sec_id;
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -53,8 +53,7 @@ struct ct_state {
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
 	      closing:1,
-	      new_backend:1,	/* Service connection was assigned a new backend */
-	      reserved:6;
+	      reserved:7;
 	__u32 src_sec_id;
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -29,6 +29,12 @@ static __always_inline __u8 tcp_flags_to_u8(__be32 value)
 	return ((union tcp_flags)value).lower_bits;
 }
 
+static __always_inline bool tcp_is_syn(union tcp_flags flags)
+{
+	/* Match SYN, but not SYN-ACK. */
+	return (flags.value & (TCP_FLAG_SYN | TCP_FLAG_ACK)) == TCP_FLAG_SYN;
+}
+
 static __always_inline int
 l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
 {

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1381,6 +1381,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     const struct lb6_service *svc,
 				     struct ct_state *state,
 				     const struct lb6_backend **selected_backend,
+				     bool *new_backend,
 				     __s8 *ext_err,
 				     const struct lb6_backend *forced_backend)
 {
@@ -1442,7 +1443,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (backend == NULL)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -1490,7 +1491,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}
@@ -2207,6 +2208,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     const struct lb4_service *svc,
 				     struct ct_state *state,
 				     const struct lb4_backend **selected_backend,
+				     bool *new_backend,
 				     __s8 *ext_err,
 				     const struct lb4_backend *forced_backend)
 {
@@ -2272,7 +2274,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (backend == NULL)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -2320,7 +2322,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
-			state->new_backend = true;
+			*new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1441,6 +1441,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			backend = lb6_lookup_backend(ctx, backend_id);
 			if (backend == NULL)
 				goto no_service;
+
+			state->new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -1488,6 +1490,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
+			state->new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}
@@ -2268,6 +2271,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			backend = lb4_lookup_backend(ctx, backend_id);
 			if (backend == NULL)
 				goto no_service;
+
+			state->new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -2315,6 +2320,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
+			state->new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -522,7 +522,8 @@ static __always_inline int
 nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			struct ipv6hdr *ip6 __maybe_unused,
 			const struct ipv6_ct_tuple *tuple, int l4_off,
-			union v6addr *addr, __be16 *port, bool *dsr)
+			fraginfo_t fraginfo, union v6addr *addr, __be16 *port,
+			bool *dsr)
 {
 #if defined(IS_BPF_OVERLAY)
 	{
@@ -561,8 +562,10 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		struct ipv6_ct_tuple tmp = *tuple;
 		union tcp_flags tcp_flags = {};
 
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
+		if (ipfrag_has_l4_header(fraginfo)) {
+			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+				return DROP_CT_INVALID_HDR;
+		}
 
 		tmp.flags = TUPLE_F_OUT;
 		__ipv6_ct_tuple_reverse(&tmp);
@@ -1608,7 +1611,7 @@ skip_service_lookup:
      (DSR_ENCAP_MODE == DSR_ENCAP_NONE))
 	if (is_svc_proto) {
 		ret = nodeport_extract_dsr_v6(ctx, ip6, &tuple, l4_off,
-					      &key.address,
+					      fraginfo, &key.address,
 					      &key.dport, dsr);
 		if (IS_ERR(ret))
 			return ret;
@@ -1879,7 +1882,8 @@ static __always_inline int
 nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			const struct iphdr *ip4 __maybe_unused,
 			const struct ipv4_ct_tuple *tuple, int l4_off,
-			__be32 *addr, __be16 *port, bool *dsr)
+			fraginfo_t fraginfo,  __be32 *addr, __be16 *port,
+			bool *dsr)
 {
 	/* Parse DSR info from the packet, to get the addr/port of the
 	 * addressed service. We need this for RevDNATing the backend's replies.
@@ -1935,8 +1939,10 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 		struct ipv4_ct_tuple tmp = *tuple;
 		union tcp_flags tcp_flags = {};
 
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
+		if (ipfrag_has_l4_header(fraginfo)) {
+			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+				return DROP_CT_INVALID_HDR;
+		}
 
 		/* tuple direction only gets initialized on the first CT lookup */
 		tmp.flags = TUPLE_F_OUT;
@@ -2970,8 +2976,8 @@ skip_service_lookup:
 		/* Check if packet has embedded DSR info, or belongs to
 		 * an established DSR connection:
 		 */
-		ret = nodeport_extract_dsr_v4(ctx, ip4, &tuple,
-					      l4_off, &key.address,
+		ret = nodeport_extract_dsr_v4(ctx, ip4, &tuple, l4_off,
+					      fraginfo, &key.address,
 					      &key.dport, dsr);
 		if (IS_ERR(ret))
 			return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -117,6 +117,18 @@ static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused)
 #endif
 }
 
+#define NEED_DSR_INFO	(1 << 16)
+
+static __always_inline bool
+nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
+{
+	/* We only need to embed the DSR info into the first packet of a connection
+	 * (since it will then be cached on the backend node).
+	 * Doing so for the TCP-SYN avoids MTU troubles.
+	 */
+	return (nexthdr != IPPROTO_TCP) || ct_state->syn;
+}
+
 #if defined(ENABLE_IPV4)
 static __always_inline struct ipv4_nat_entry *
 nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
@@ -352,31 +364,18 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					const union v6addr *svc_addr,
-					__be16 svc_port, int *ohead)
+					__be16 svc_port, bool need_dsr_info,
+					int *ohead)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(opt);
 	__u16 total_len = bpf_ntohs(ip6->payload_len) + sizeof(struct ipv6hdr) + sizeof(opt);
-	__u8 nexthdr = ip6->nexthdr;
-	int hdrlen;
 
 	/* The IPv6 extension should be 8-bytes aligned */
 	build_bug_on((sizeof(struct dsr_opt_v6) % 8) != 0);
 
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
-
-	/* See dsr_set_opt4(): */
-	if (nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, ETH_HLEN + hdrlen, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			return 0;
-	}
+	if (!need_dsr_info)
+		return 0;
 
 	if (dsr_is_too_big(ctx, total_len)) {
 		*ohead = sizeof(opt);
@@ -406,13 +405,13 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 struct ipv6hdr *ip6,
 						 const union v6addr *svc_addr,
 						 __be16 svc_port,
+						 bool need_opt,
 						 int *ifindex, int *ohead)
 {
 	const struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	struct geneve_dsr_opt6 gopt;
 	union v6addr *dst;
-	bool need_opt = true;
 	__u16 encap_len = sizeof(struct ipv6hdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(*ip6);
@@ -440,17 +439,6 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 		return ret;
 
 	src_port = tunnel_gen_src_port_v6(&tuple);
-
-	/* See encap_geneve_dsr_opt4(): */
-	if (tuple.nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			need_opt = false;
-	}
 
 	if (need_opt) {
 		encap_len += sizeof(struct geneve_dsr_opt6);
@@ -704,12 +692,14 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
+	__u32 tmp = ctx_load_meta(ctx, CB_PORT);
+	bool need_dsr_info __maybe_unused = tmp & NEED_DSR_INFO;
+	__be16 port = tmp & 0xffff;
 	int ret, oif = 0, ohead = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr addr __align_stack_8 = {};
 	__s8 ext_err = 0;
-	__be16 port;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -718,15 +708,14 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 
 	ctx_load_meta_ipv6(ctx, &addr, CB_ADDR_V6_1);
 
-	port = (__be16)ctx_load_meta(ctx, CB_PORT);
-
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip6(ctx, ip6, &addr,
 			    ctx_load_meta(ctx, CB_HINT), &oif, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-	ret = dsr_set_ext6(ctx, ip6, &addr, port, &ohead);
+	ret = dsr_set_ext6(ctx, ip6, &addr, port, need_dsr_info, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, need_dsr_info,
+				    &oif, &ohead);
 	if (!IS_ERR(ret))
 		fib_params.l.family = AF_INET;
 #else
@@ -1525,7 +1514,12 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		__u32 port = key->dport;
+
+		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+			port |= NEED_DSR_INFO;
+
+		ctx_store_meta(ctx, CB_PORT, port);
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR, ext_err);
@@ -1758,27 +1752,16 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 # elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
 static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4, __be32 svc_addr,
-					__be16 svc_port, __be16 *ohead)
+					__be16 svc_port, bool need_dsr_info,
+					__be16 *ohead)
 {
 	__u32 iph_old, iph_new;
 	struct dsr_opt_v4 opt;
 	__u16 tot_len = bpf_ntohs(ip4->tot_len) + sizeof(opt);
 	__be32 sum;
 
-	if (ip4->protocol == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, ETH_HLEN + ipv4_hdrlen(ip4), &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		/* Setting the option is required only for the first packet
-		 * (SYN), in the case of TCP, as for further packets of the
-		 * same connection a remote node will use a NAT entry to
-		 * reverse xlate a reply.
-		 */
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			return 0;
-	}
+	if (!need_dsr_info)
+		return 0;
 
 	if (ipv4_hdrlen(ip4) + sizeof(opt) > sizeof(struct iphdr) + MAX_IPOPTLEN)
 		return DROP_CT_INVALID_HDR;
@@ -1816,19 +1799,18 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 # elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
 static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct iphdr *ip4,
 						 __be32 svc_addr, __be16 svc_port,
-						 int *ifindex, __be16 *ohead)
+						 bool need_opt, int *ifindex, __be16 *ohead)
 {
 	const struct remote_endpoint_info *info;
 	struct geneve_dsr_opt4 gopt __align_stack_8 = { };
-	bool need_opt = true;
 	__u16 encap_len = sizeof(struct iphdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 total_len = bpf_ntohs(ip4->tot_len);
 	__u32 src_sec_identity = WORLD_IPV4_ID;
 	__be16 src_port = 0;
-	int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 #  if __ctx_is == __ctx_xdp
 	fraginfo_t fraginfo = ipfrag_encode_ipv4(ip4);
+	int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 	struct ipv4_ct_tuple tuple = {};
 	int ret;
 
@@ -1844,21 +1826,6 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct 
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (!info || !info->flag_has_tunnel_ep)
 		return DROP_NO_TUNNEL_ENDPOINT;
-
-	if (ip4->protocol == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		/* The GENEVE option is required only for the first packet
-		 * (SYN), in the case of TCP, as for further packets of the
-		 * same connection a remote node will use a NAT entry to
-		 * reverse xlate a reply.
-		 */
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			need_opt = false;
-	}
 
 	if (need_opt) {
 		encap_len += sizeof(struct geneve_dsr_opt4);
@@ -2094,31 +2061,31 @@ drop_err:
 __declare_tail(CILIUM_CALL_IPV4_NODEPORT_DSR)
 int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 {
+	__u32 tmp = ctx_load_meta(ctx, CB_PORT);
+	bool need_dsr_info __maybe_unused = tmp & NEED_DSR_INFO;
+	__be16 port = tmp & 0xffff;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int ret, oif = 0;
 	__be16 ohead = 0;
 	__s8 ext_err = 0;
 	__be32 addr;
-	__be16 port;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
 	addr = ctx_load_meta(ctx, CB_ADDR_V4);
-	port = (__be16)ctx_load_meta(ctx, CB_PORT);
 
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip4(ctx, ip4,
 			    addr,
 			    ctx_load_meta(ctx, CB_HINT), &oif, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-	ret = dsr_set_opt4(ctx, ip4,
-			   addr,
-			   port, &ohead);
+	ret = dsr_set_opt4(ctx, ip4, addr, port, need_dsr_info, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, need_dsr_info,
+				    &oif, &ohead);
 #else
 # error "Invalid load balancer DSR encapsulation mode!"
 #endif
@@ -2905,7 +2872,12 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta(ctx, CB_ADDR_V4, backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		__u32 port = key->dport;
+
+		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+			port |= NEED_DSR_INFO;
+
+		ctx_store_meta(ctx, CB_PORT, port);
 		ctx_store_meta(ctx, CB_ADDR_V4, key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR, ext_err);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -570,7 +570,7 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		tmp.flags = TUPLE_F_OUT;
 		__ipv6_ct_tuple_reverse(&tmp);
 
-		if (tcp_flags.value & TCP_FLAG_SYN) {
+		if (tcp_is_syn(tcp_flags)) {
 			/* SYN for a new connection that's not / no longer DSR.
 			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
 			 */
@@ -1948,7 +1948,7 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 		tmp.flags = TUPLE_F_OUT;
 		__ipv4_ct_tuple_reverse(&tmp);
 
-		if (tcp_flags.value & TCP_FLAG_SYN) {
+		if (tcp_is_syn(tcp_flags)) {
 			/* SYN for a new connection that's not / no longer DSR.
 			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
 			 */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -564,7 +564,8 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		ipv6_ct_tuple_reverse(&tmp);
+		tmp.flags = TUPLE_F_OUT;
+		__ipv6_ct_tuple_reverse(&tmp);
 
 		if (tcp_flags.value & TCP_FLAG_SYN) {
 			/* SYN for a new connection that's not / no longer DSR.
@@ -1937,7 +1938,9 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		ipv4_ct_tuple_reverse(&tmp);
+		/* tuple direction only gets initialized on the first CT lookup */
+		tmp.flags = TUPLE_F_OUT;
+		__ipv4_ct_tuple_reverse(&tmp);
 
 		if (tcp_flags.value & TCP_FLAG_SYN) {
 			/* SYN for a new connection that's not / no longer DSR.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -125,8 +125,13 @@ nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
 	/* We only need to embed the DSR info into the first packet of a connection
 	 * (since it will then be cached on the backend node).
 	 * Doing so for the TCP-SYN avoids MTU troubles.
+	 *
+	 * We also send DSR info for the first TCP packet towards a new backend,
+	 * so that it can at least RevDNAT its RST reply.
 	 */
-	return (nexthdr != IPPROTO_TCP) || ct_state->syn;
+	return (nexthdr != IPPROTO_TCP) ||
+	       ct_state->new_backend ||
+	       ct_state->syn;
 }
 
 #if defined(ENABLE_IPV4)
@@ -1778,8 +1783,17 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 
 	opt.type = DSR_IPV4_OPT_TYPE;
 	opt.len = sizeof(opt);
+#ifdef TEST_DSR_OPT_NETWORK_BYTE_ORDER
+	/* We're annoyingly sending out the IPv4 option in host byte-order,
+	 * and this is baked into the wire-format now.
+	 * For easier testing with scapy, fix this up.
+	 */
+	opt.port = svc_port;
+	opt.addr = svc_addr;
+#else
 	opt.port = bpf_htons(svc_port);
 	opt.addr = bpf_htonl(svc_addr);
+#endif
 
 	sum = csum_diff(&iph_old, 4, &iph_new, 4, 0);
 	sum = csum_diff(NULL, 0, &opt, sizeof(opt), sum);
@@ -1926,8 +1940,13 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 
 		if (opt.type == DSR_IPV4_OPT_TYPE && opt.len == sizeof(opt)) {
 			*dsr = true;
+#ifdef TEST_DSR_OPT_NETWORK_BYTE_ORDER
+			*addr = opt.addr;
+			*port = opt.port;
+#else
 			*addr = bpf_ntohl(opt.addr);
 			*port = bpf_ntohs(opt.port);
+#endif
 			return 0;
 		}
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -120,7 +120,7 @@ static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused)
 #define NEED_DSR_INFO	(1 << 16)
 
 static __always_inline bool
-nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
+nodeport_need_dsr_info(__u8 nexthdr, bool syn, bool new_backend)
 {
 	/* We only need to embed the DSR info into the first packet of a connection
 	 * (since it will then be cached on the backend node).
@@ -129,9 +129,7 @@ nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
 	 * We also send DSR info for the first TCP packet towards a new backend,
 	 * so that it can at least RevDNAT its RST reply.
 	 */
-	return (nexthdr != IPPROTO_TCP) ||
-	       ct_state->new_backend ||
-	       ct_state->syn;
+	return (nexthdr != IPPROTO_TCP) || syn || new_backend;
 }
 
 #if defined(ENABLE_IPV4)
@@ -1370,6 +1368,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 					    bool *punt_to_stack __maybe_unused,
 					    __s8 *ext_err)
 {
+	bool new_backend __maybe_unused = false;
 	struct ct_state ct_state_svc = {};
 	const struct lb6_backend *backend;
 	const struct lb6_backend *forced_be_p __maybe_unused = NULL;
@@ -1434,7 +1433,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 		}
 	}
 	ret = lb6_local(get_ct_map6(tuple), ctx, fraginfo, l4_off,
-			key, tuple, svc, &ct_state_svc, &backend,
+			key, tuple, svc, &ct_state_svc, &backend, &new_backend,
 			ext_err, forced_be_p);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE) {
@@ -1523,7 +1522,9 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		__u32 port = key->dport;
 
-		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+		if (nodeport_need_dsr_info(tuple->nexthdr,
+					   ct_state_svc.syn,
+					   new_backend))
 			port |= NEED_DSR_INFO;
 
 		ctx_store_meta(ctx, CB_PORT, port);
@@ -2698,6 +2699,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 					    bool *punt_to_stack __maybe_unused,
 					    __s8 *ext_err)
 {
+	bool new_backend __maybe_unused = false;
 	const struct lb4_backend *backend;
 	struct ct_state ct_state_svc = {};
 	__u32 cluster_id = 0;
@@ -2784,7 +2786,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 		}
 		ret = lb4_local(get_ct_map4(tuple), ctx, fraginfo, l4_off,
 				key, tuple, svc, &ct_state_svc, &backend,
-				ext_err, tmp);
+				&new_backend, ext_err, tmp);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
 				if (!CONFIG(enable_no_service_endpoints_routable))
@@ -2899,7 +2901,9 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		__u32 port = key->dport;
 
-		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+		if (nodeport_need_dsr_info(tuple->nexthdr,
+					   ct_state_svc.syn,
+					   new_backend))
 			port |= NEED_DSR_INFO;
 
 		ctx_store_meta(ctx, CB_PORT, port);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -524,23 +524,6 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			const struct ipv6_ct_tuple *tuple, int l4_off,
 			union v6addr *addr, __be16 *port, bool *dsr)
 {
-	struct ipv6_ct_tuple tmp = *tuple;
-
-	if (tuple->nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = {};
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		ipv6_ct_tuple_reverse(&tmp);
-
-		if (!(tcp_flags.value & TCP_FLAG_SYN)) {
-			*dsr = ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp);
-			*port = 0;
-			return 0;
-		}
-	}
-
 #if defined(IS_BPF_OVERLAY)
 	{
 		struct geneve_dsr_opt6 gopt;
@@ -574,11 +557,26 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 	}
 #endif
 
-	/* SYN for a new connection that's not / no longer DSR.
-	 * If it's reopened, avoid sending subsequent traffic down the DSR path.
-	 */
-	if (tuple->nexthdr == IPPROTO_TCP)
-		ct_update_dsr(get_ct_map6(&tmp), &tmp, false);
+	if (tuple->nexthdr == IPPROTO_TCP) {
+		struct ipv6_ct_tuple tmp = *tuple;
+		union tcp_flags tcp_flags = {};
+
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		ipv6_ct_tuple_reverse(&tmp);
+
+		if (tcp_flags.value & TCP_FLAG_SYN) {
+			/* SYN for a new connection that's not / no longer DSR.
+			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+			 */
+			ct_update_dsr(get_ct_map6(&tmp), &tmp, false);
+		} else {
+			*dsr = ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp);
+			*port = 0;
+			return 0;
+		}
+	}
 
 	return 0;
 }
@@ -1882,33 +1880,9 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			const struct ipv4_ct_tuple *tuple, int l4_off,
 			__be32 *addr, __be16 *port, bool *dsr)
 {
-	struct ipv4_ct_tuple tmp = *tuple;
-
 	/* Parse DSR info from the packet, to get the addr/port of the
 	 * addressed service. We need this for RevDNATing the backend's replies.
-	 *
-	 * TCP connections have the DSR Option only in their SYN packet.
-	 * To identify that a non-SYN packet belongs to a DSR connection,
-	 * we need to check whether a corresponding CT entry with .dsr flag exists.
 	 */
-	if (tuple->nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = {};
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		ipv4_ct_tuple_reverse(&tmp);
-
-		if (!(tcp_flags.value & TCP_FLAG_SYN)) {
-			/* If the packet belongs to a tracked DSR connection,
-			 * trigger a CT update.
-			 * We don't have any DSR info to report back, and that's ok.
-			 */
-			*dsr = ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp);
-			*port = 0;
-			return 0;
-		}
-	}
 
 #if defined(IS_BPF_OVERLAY)
 	{
@@ -1952,11 +1926,34 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 	}
 #endif
 
-	/* SYN for a new connection that's not / no longer DSR.
-	 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+	/* TCP connections typically have the DSR info only in their SYN packet.
+	 * To identify that a packet without DSR info belongs to a DSR connection,
+	 * we need to check whether a corresponding CT entry with .dsr flag exists.
 	 */
-	if (tuple->nexthdr == IPPROTO_TCP)
-		ct_update_dsr(get_ct_map4(&tmp), &tmp, false);
+	if (tuple->nexthdr == IPPROTO_TCP) {
+		struct ipv4_ct_tuple tmp = *tuple;
+		union tcp_flags tcp_flags = {};
+
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		ipv4_ct_tuple_reverse(&tmp);
+
+		if (tcp_flags.value & TCP_FLAG_SYN) {
+			/* SYN for a new connection that's not / no longer DSR.
+			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+			 */
+			ct_update_dsr(get_ct_map4(&tmp), &tmp, false);
+		} else {
+			/* If the packet belongs to a tracked DSR connection,
+			 * trigger a CT update.
+			 * We don't have any DSR info to report back, and that's ok.
+			 */
+			*dsr = ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp);
+			*port = 0;
+			return 0;
+		}
+	}
 
 	return 0;
 }

--- a/bpf/tests/host_kpr_dsr_geneve_lb.c
+++ b/bpf/tests/host_kpr_dsr_geneve_lb.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE        3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX		42
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/host_kpr_dsr_option_lb.c
+++ b/bpf/tests/host_kpr_dsr_option_lb.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_GENEVE        3
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/host_kpr_dsr_option_remote_node.c
+++ b/bpf/tests/host_kpr_dsr_option_remote_node.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_GENEVE        3
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_remote_node.h"

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -1,0 +1,1047 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifdef ATTACHMENT_XDP
+# define ATTACH "xdp"
+# include <bpf/ctx/xdp.h>
+#else
+# define ATTACH "tc"
+# include <bpf/ctx/skb.h>
+#endif
+
+#include "common.h"
+
+#include "pktgen.h"
+#include "scapy.h"
+
+#define IPV4_DIRECT_ROUTING		v4_node_one
+
+#define fib_lookup mock_fib_lookup
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = 22;
+
+	__bpf_memcpy_builtin(params->smac, (__u8 *)mac_one, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, (__u8 *)mac_two, ETH_ALEN);
+
+	return 0;
+}
+
+bool tunnel_key_set;
+bool tunnel_opt_set;
+
+#ifdef ATTACHMENT_XDP
+# include "lib/bpf_xdp.h"
+# define netdev_receive_packet  xdp_receive_packet
+#else
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct bpf_tunnel_key));
+	__uint(max_entries, 1);
+} tunnel_key_map __section_maps_btf;
+
+# define skb_set_tunnel_key mock_skb_set_tunnel_key
+int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const struct bpf_tunnel_key *from,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	__u32 map_key = 0;
+	struct bpf_tunnel_key *mock_key = map_lookup_elem(&tunnel_key_map, &map_key);
+
+	if (mock_key) {
+		memcpy(mock_key, from, sizeof(*from));
+		tunnel_key_set = true;
+	}
+
+	return 0;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct geneve_dsr_opt6));
+	__uint(max_entries, 1);
+} tunnel_opt_map __section_maps_btf;
+
+# define skb_set_tunnel_opt mock_skb_set_tunnel_opt
+int mock_skb_set_tunnel_opt(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const void *opt,
+			    __maybe_unused __u32 opt_len)
+{
+	__u32 map_key = 0;
+	void *data = map_lookup_elem(&tunnel_opt_map, &map_key);
+
+	if (!data)
+		return -1;
+
+	switch (opt_len) {
+	case sizeof(struct geneve_dsr_opt4):
+		memcpy(data, opt, sizeof(struct geneve_dsr_opt4));
+		tunnel_opt_set = true;
+		return 0;
+	case sizeof(struct geneve_dsr_opt6):
+		memcpy(data, opt, sizeof(struct geneve_dsr_opt6));
+		tunnel_opt_set = true;
+		return 0;
+	default:
+		return -1;
+	}
+}
+
+# include "lib/bpf_host.h"
+#endif /* ATTACHMENT_XDP */
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_GENEVE)
+ASSIGN_CONFIG(__u16, tunnel_port, 6081)
+#endif
+
+ASSIGN_CONFIG(__u32, hash_init4_seed, 0xcafe)
+ASSIGN_CONFIG(__u32, hash_init6_seed, 0xeb9f)
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+const __u8 kpr_v4_dsr_lb1_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_geneve_xdp)
+};
+
+#ifdef ENABLE_IPV4
+/* Client accesses a DSR service with remote backend.
+ * We expect the SYN to carry DSR-info, but the SYN-ACK to be forwarded
+ * without DSR-info.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb1_syn,
+			sizeof(kpr_v4_dsr_lb1_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
+			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(v4_pod_one, 0, 112233, v4_node_two, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_geneve,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt4 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV4_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (dsr_opt->addr != v4_svc_one)
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_one)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_option,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb1_synack,
+			sizeof(kpr_v4_dsr_lb1_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+ # ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_geneve,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("expected DSR opt");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_option,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+/* Client's TCP connection is interrupted, and switches to a different LB node.
+ * We expect the first data packet to carry DSR-info, but the second data packet
+ * to be forwarded without DSR-info.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb2_data,
+			sizeof(kpr_v4_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service(v4_svc_one, tcp_svc_two, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_two, 1, 124,
+			  v4_pod_one, tcp_dst_two, IPPROTO_TCP, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt4 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV4_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (dsr_opt->addr != v4_svc_one)
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_two)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_option,
+			   sizeof(kpr_v4_dsr_lb2_data_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb2_data,
+			sizeof(kpr_v4_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_option,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+PKTGEN(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb1_syn,
+			sizeof(kpr_v6_dsr_lb1_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	lb_v6_add_service(&frontend_ip, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, tcp_svc_one, 1, 124,
+			  &backend_ip, tcp_dst_one, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, v4_node_two, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_geneve,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_geneve));
+
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt6 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV6_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (!ipv6_addr_equals((union v6addr *)&dsr_opt->addr, &frontend_ip))
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_one)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_option,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_option));
+# endif
+#endif
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb1_synack,
+			sizeof(kpr_v6_dsr_lb1_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_geneve,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("expected DSR opt");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_option,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb2_data,
+			sizeof(kpr_v6_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	lb_v6_add_service(&frontend_ip, tcp_svc_two, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, tcp_svc_two, 1, 124,
+			  &backend_ip, tcp_dst_two, IPPROTO_TCP, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve));
+
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt6 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV6_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (!ipv6_addr_equals((union v6addr *)&dsr_opt->addr, &frontend_ip))
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_two)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_option,
+			   sizeof(kpr_v6_dsr_lb2_data_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb2_data,
+			sizeof(kpr_v6_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_option,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/kpr_dsr_remote_node.h
+++ b/bpf/tests/kpr_dsr_remote_node.h
@@ -264,6 +264,27 @@ int kpr_v4_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff 
 			   kpr_v4_dsr_remote_node_synack,
 			   sizeof(kpr_v4_dsr_remote_node_synack));
 
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (ct_entry->nat_addr.p4 != v4_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
 	test_finish();
 }
 
@@ -620,6 +641,30 @@ int kpr_v6_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff 
 			   "Ether", ctx, pkt_offset,
 			   kpr_v6_dsr_remote_node_synack,
 			   sizeof(kpr_v6_dsr_remote_node_synack));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &frontend_ip))
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
 
 	test_finish();
 }

--- a/bpf/tests/kpr_dsr_remote_node.h
+++ b/bpf/tests/kpr_dsr_remote_node.h
@@ -1,0 +1,800 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifdef ATTACHMENT_XDP
+# define ATTACH "xdp"
+# include <bpf/ctx/xdp.h>
+#else
+# define ATTACH "tc"
+# include <bpf/ctx/skb.h>
+#endif
+
+#include "common.h"
+
+#include "pktgen.h"
+#include "scapy.h"
+
+#define BACKEND_EP_ID			127
+#define NATIVE_IFINDEX			22
+
+#define fib_lookup mock_fib_lookup
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = NATIVE_IFINDEX;
+
+	return 0;
+}
+
+#ifdef ATTACHMENT_XDP
+# include "lib/bpf_xdp.h"
+# define netdev_receive_packet	xdp_receive_packet
+#else
+# define CHECK_REPLY	1
+# include "lib/bpf_host.h"
+#endif
+
+ASSIGN_CONFIG(__u32, interface_ifindex, NATIVE_IFINDEX);
+
+#include "lib/endpoint.h"
+
+const __u8 kpr_v4_dsr_remote_node_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_remote_node_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_remote_node_data_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_data_option)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply_post[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply_post)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply2_post[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply2_post)
+};
+
+const __u8 kpr_v6_dsr_remote_node_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_remote_node_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_remote_node_data_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_data_option)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply_post[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply_post)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply2_post[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply2_post)
+};
+
+#ifdef ENABLE_IPV4
+/* Backend node receives SYN with DSR-info. Reply can be RevDNATed.
+ * Then we receive a second packet without DSR-info. Replies can still be
+ * RevDNATed.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_syn,
+			sizeof(kpr_v4_dsr_remote_node_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(v4_pod_one, 123, BACKEND_EP_ID, 0, 0, 0, NULL, NULL);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_syn",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_syn,
+			   sizeof(kpr_v4_dsr_remote_node_syn));
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (ct_entry->nat_addr.p4 != v4_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_synack,
+			sizeof(kpr_v4_dsr_remote_node_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_synack",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_synack,
+			   sizeof(kpr_v4_dsr_remote_node_synack));
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+/* Now receive a non-SYN with different DSR-info.
+ * The RevDNAT follows accordingly.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_data_option,
+			sizeof(kpr_v4_dsr_remote_node_data_option));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_data_option",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_data_option,
+			   sizeof(kpr_v4_dsr_remote_node_data_option));
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (ct_entry->nat_addr.p4 != v4_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_two)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply2_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply2_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply2_post));
+
+	test_finish();
+}
+#endif
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_syn,
+			sizeof(kpr_v6_dsr_remote_node_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
+{
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	endpoint_v6_add_entry(&backend_ip, 123, BACKEND_EP_ID, 0, 0, NULL, NULL);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_syn",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_syn,
+			   sizeof(kpr_v6_dsr_remote_node_syn));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &frontend_ip))
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_synack,
+			sizeof(kpr_v6_dsr_remote_node_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_synack",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_synack,
+			   sizeof(kpr_v6_dsr_remote_node_synack));
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_data_option,
+			sizeof(kpr_v6_dsr_remote_node_data_option));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_data_option",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_data_option,
+			   sizeof(kpr_v6_dsr_remote_node_data_option));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &frontend_ip))
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_two)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply2_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply2_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply2_post));
+
+	test_finish();
+}
+#endif
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -1,0 +1,348 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+from pkt_defs_common import *
+from scapy.contrib.geneve import GENEVE, GeneveOptions
+
+class IPOption_DSR(IPOption):
+    name = "DSR IPv4 Option"
+
+    fields_desc = [
+        ByteField("option", 0x9a),
+        ByteField("length", 8),
+        ShortField("port", 0),
+        IPField("addr", "0.0.0.0"),
+    ]
+
+    # Suppress trailing layer warnings when packed in IP option arrays
+    def extract_padding(self, p):
+        return b"", p
+
+class IPv6Ext_DSR(Packet):
+    name = "DSR IPv6 Ext Header"
+    nh = 60
+
+    fields_desc = [
+        ByteField("nh", 6),
+        ByteField("len", 2),
+
+        ByteField("opt_type", 0x1b),
+        ByteField("opt_len", 20),
+        IP6Field("addr", "::"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+bind_layers(IPv6, IPv6Ext_DSR, nh=60)
+bind_layers(IPv6Ext_DSR, TCP, nh=6)
+
+class Geneve_DSR_Opt4(GeneveOptions):
+    name = "GENEVE DSR IPv4 Option"
+
+    fields_desc = [
+        ShortField("classid", 0x014b),
+        ByteField("type", 0x81),
+        BitField("reserved", 0, 3),
+        BitField("length", 2, 5),
+
+        IPField("addr", "0.0.0.0"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+class Geneve_DSR_Opt6(GeneveOptions):
+    name = "GENEVE DSR IPv6 Option"
+
+    fields_desc = [
+        ShortField("classid", 0x014b),
+        ByteField("type", 0x81),
+        BitField("reserved", 0, 3),
+        BitField("length", 5, 5),
+
+        IP6Field("addr", "::"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+kpr_v4_dsr_lb1_syn = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=56602,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_synack = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=56602, dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb2_data = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=24364,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_two)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=24364,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb1_syn = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_syn_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S", chksum=50277)
+)
+
+kpr_v6_dsr_lb1_syn_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S", chksum=50277)
+)
+
+kpr_v6_dsr_lb1_syn_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_syn_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=52625,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_synack = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
+)
+
+kpr_v6_dsr_lb1_synack_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
+)
+
+kpr_v6_dsr_lb1_synack_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=52625, dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb2_data = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=18056,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_two)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=18056,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -206,6 +206,32 @@ kpr_v4_dsr_lb2_data2_post_geneve_xdp = (
     b"foobar"
 )
 
+kpr_v4_dsr_remote_node_reply = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_pod_one, dst=v4_ext_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v4_dsr_remote_node_reply_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one) /
+    TCP(sport=tcp_svc_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v4_dsr_remote_node_data_option = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_remote_node_reply2_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one) /
+    TCP(sport=tcp_svc_two, dport=tcp_src_one, flags="R")
+)
+
 kpr_v6_dsr_lb1_syn = (
     Ether(src=host_mac_addr, dst=mac_one) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
@@ -345,4 +371,30 @@ kpr_v6_dsr_lb2_data2_post_geneve_xdp = (
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
     b"foobar"
+)
+
+kpr_v6_dsr_remote_node_reply = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_pod_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v6_dsr_remote_node_reply_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_svc_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v6_dsr_remote_node_data_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_remote_node_reply2_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_svc_two, dport=tcp_src_one, flags="R")
 )

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -19,3 +19,4 @@ from tc_redirect_pkt_defs import *
 from xdp_nodeport_lb4_nat_lb_tun_dynamic_pkt_defs import *
 from tc_nodeport_lb4_nat_lb_dynamic_pkt_defs import *
 from tc_nodeport_lb6_nat_lb_dynamic_pkt_defs import *
+from kpr_dsr_pkt_defs import *

--- a/bpf/tests/xdp_kpr_dsr_geneve_lb.c
+++ b/bpf/tests/xdp_kpr_dsr_geneve_lb.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_IPIP			2
+#define DSR_ENCAP_GENEVE		3
+#define DSR_ENCAP_MODE			DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX			42
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/xdp_kpr_dsr_option_lb.c
+++ b/bpf/tests/xdp_kpr_dsr_option_lb.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_GENEVE		3
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/xdp_kpr_dsr_option_remote_node.c
+++ b/bpf/tests/xdp_kpr_dsr_option_remote_node.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_GENEVE		3
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_remote_node.h"


### PR DESCRIPTION
Backport
* [ ] #47388
* [ ] #47529
* [ ] #47593
* [ ] #47640
* [ ] #47592
* [ ] #47841

```release-note
Fix various aspects in the DSR feature: support TCP-RST after switching to a new backend, fix processing of fragmented TCP traffic, fix accidental RevDNAT of a connection which matches an earlier DSR connection.
```

```upstream-prs
47388 47529 47593 47640 47592 47841
```