### PR TITLE
operator: prevent CNPs with nodeSelector from silently enforcing nothing

### DIFF
--- a/operator/pkg/networkpolicy/validator.go
+++ b/operator/pkg/networkpolicy/validator.go
@@ -104,11 +104,13 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 	if newPol.Spec != nil {
 		errs = errors.Join(errs, newPol.Spec.Sanitize())
 		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, newPol.Spec))
+		errs = errors.Join(errs, validateCNPNodeSelector(newPol.Spec))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
 		errs = errors.Join(errs, r.Sanitize())
 		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, r))
+		errs = errors.Join(errs, validateCNPNodeSelector(r))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
 
@@ -228,6 +230,18 @@ func validateCNPEndpointSelectorNamespace(namespace string, spec *api.Rule) erro
 		return fmt.Errorf("CiliumNetworkPolicy endpointSelector matches namespace(s) %v, but the endpointSelector can only select endpoints in the policy's own namespace %q", selectedNamespaces, namespace)
 	}
 	return nil
+}
+
+// validateCNPNodeSelector rejects rules of a CiliumNetworkPolicy that use a
+// nodeSelector. Node selectors are only supported by
+// CiliumClusterwideNetworkPolicy, and the agent rejects such rules when parsing
+// a CiliumNetworkPolicy, which would otherwise leave the policy silently
+// ineffective while being reported as valid.
+func validateCNPNodeSelector(spec *api.Rule) error {
+	if spec == nil || spec.NodeSelector.LabelSelector == nil {
+		return nil
+	}
+	return errors.New("CiliumNetworkPolicy rule cannot have NodeSelector, use CiliumClusterwideNetworkPolicy instead")
 }
 
 // updateCondition creates or updates the policy validation condition in Conditions, setting

--- a/operator/pkg/networkpolicy/validator_test.go
+++ b/operator/pkg/networkpolicy/validator_test.go
@@ -4,10 +4,18 @@
 package networkpolicy
 
 import (
+	"context"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8s_client "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -98,4 +106,151 @@ func TestValidateCNPEndpointSelectorNamespace(t *testing.T) {
 		require.NoError(t, spec.Sanitize())
 		require.Error(t, validateCNPEndpointSelectorNamespace("foo", spec))
 	})
+}
+func testValidator(t *testing.T) *policyValidator {
+	t.Helper()
+
+	logger := hivetest.Logger(t)
+	_, cs := k8s_client.NewFakeClientset(logger)
+
+	return &policyValidator{
+		params: &ValidatorParams{
+			Logger:    logger,
+			Clientset: cs,
+			Cfg:       defaultConfig,
+		},
+	}
+}
+
+// validCondition returns the status of the "Valid" condition and its message.
+func validCondition(t *testing.T, conds []cilium_api_v2.NetworkPolicyCondition) (corev1.ConditionStatus, string) {
+	t.Helper()
+
+	for _, cond := range conds {
+		if cond.Type == cilium_api_v2.PolicyConditionValid {
+			return cond.Status, cond.Message
+		}
+	}
+	t.Fatalf("no %q condition found in %v", cilium_api_v2.PolicyConditionValid, conds)
+	return "", ""
+}
+
+// runCNPValidation runs the CNP validator against the given policy and returns
+// the resulting status conditions.
+func runCNPValidation(t *testing.T, cnp *cilium_api_v2.CiliumNetworkPolicy) []cilium_api_v2.NetworkPolicyCondition {
+	t.Helper()
+
+	pv := testValidator(t)
+
+	created, err := pv.params.Clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Create(
+		t.Context(), cnp, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = pv.handleCNPEvent(t.Context(), resource.Event[*cilium_api_v2.CiliumNetworkPolicy]{
+		Kind:   resource.Upsert,
+		Object: created,
+		Done:   func(error) {},
+	})
+	require.NoError(t, err)
+
+	updated, err := pv.params.Clientset.CiliumV2().CiliumNetworkPolicies(cnp.Namespace).Get(
+		t.Context(), cnp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	return updated.Status.Conditions
+}
+
+func ingressRule() []api.IngressRule {
+	return []api.IngressRule{{
+		IngressCommonRule: api.IngressCommonRule{
+			FromEntities: api.EntitySlice{api.EntityCluster},
+		},
+	}}
+}
+
+// TestCNPNodeSelectorMarkedInvalid asserts that a CiliumNetworkPolicy using a
+// nodeSelector is reported as invalid. The agent rejects such policies in
+// CiliumNetworkPolicy.Parse ("rule cannot have NodeSelector"), so the operator
+// must not report them as valid.
+func TestCNPNodeSelectorMarkedInvalid(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cnp  *cilium_api_v2.CiliumNetworkPolicy
+	}{
+		{
+			name: "spec",
+			cnp: &cilium_api_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "host-policy", Namespace: "foo"},
+				Spec: &api.Rule{
+					NodeSelector: api.NewESFromLabels(),
+					Ingress:      ingressRule(),
+				},
+			},
+		},
+		{
+			name: "specs",
+			cnp: &cilium_api_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "host-policy", Namespace: "foo"},
+				Specs: api.Rules{{
+					NodeSelector: api.NewESFromLabels(),
+					Ingress:      ingressRule(),
+				}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, msg := validCondition(t, runCNPValidation(t, tc.cnp))
+			assert.Equal(t, corev1.ConditionFalse, status)
+			assert.Contains(t, msg, "cannot have NodeSelector")
+		})
+	}
+}
+
+// TestCNPEndpointSelectorStillValid asserts the nodeSelector check does not
+// reject regular namespaced policies.
+func TestCNPEndpointSelectorStillValid(t *testing.T) {
+	cnp := &cilium_api_v2.CiliumNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-cluster", Namespace: "foo"},
+		Spec: &api.Rule{
+			EndpointSelector: api.NewESFromLabels(),
+			Ingress:          ingressRule(),
+		},
+	}
+
+	status, msg := validCondition(t, runCNPValidation(t, cnp))
+	assert.Equal(t, corev1.ConditionTrue, status)
+	assert.Equal(t, "Policy validation succeeded", msg)
+}
+
+// TestCCNPNodeSelectorStillValid asserts that CiliumClusterwideNetworkPolicy
+// keeps supporting nodeSelector (host policies).
+func TestCCNPNodeSelectorStillValid(t *testing.T) {
+	pv := testValidator(t)
+
+	ccnp := &cilium_api_v2.CiliumClusterwideNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "host-policy"},
+		Spec: &api.Rule{
+			NodeSelector: api.NewESFromLabels(),
+			Ingress:      ingressRule(),
+		},
+	}
+
+	createdCCNP, err := pv.params.Clientset.CiliumV2().CiliumClusterwideNetworkPolicies().Create(
+		context.Background(), ccnp, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = pv.handleCCNPEvent(t.Context(), resource.Event[*cilium_api_v2.CiliumClusterwideNetworkPolicy]{
+		Kind:   resource.Upsert,
+		Object: createdCCNP,
+		Done:   func(error) {},
+	})
+	require.NoError(t, err)
+
+	updated, err := pv.params.Clientset.CiliumV2().CiliumClusterwideNetworkPolicies().Get(
+		context.Background(), ccnp.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	status, msg := validCondition(t, updated.Status.Conditions)
+	assert.Equal(t, corev1.ConditionTrue, status)
+	assert.Equal(t, "Policy validation succeeded", msg)
 }


### PR DESCRIPTION

<!-- Description of change -->

The Rule struct is shared by both CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy, and its NodeSelector field can only be used in CiliumClusterwideNetworkPolicies.

```
// https://github.com/cilium/cilium/blob/main/pkg/policy/api/rule.go#L76

type Rule struct {
    ...

    // NodeSelector selects all nodes which should be subject to this rule.
    // EndpointSelector and NodeSelector cannot be both empty and are mutually
    // exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
    //
    // +kubebuilder:validation:OneOf
    NodeSelector EndpointSelector `json:"nodeSelector,omitzero"`
}
```

When a user creates an instance like the following:

```
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
    namespace: foo
    name: host-policy
spec:
  nodeSelector:
    matchLabels:
        node-role.kubernetes.io/worker: ""
  ingress:
  - fromEntities: [cluster]
```

nodeSelector is not allowed in a CiliumNetworkPolicy, but the operator currently does not validate it, while the cilium agent rejects such an instance and refuses to enforce it.

```
// https://github.com/cilium/cilium/blob/main/pkg/k8s/apis/cilium.io/v2/cnp_types.go#L199

    if r.Spec.NodeSelector.LabelSelector != nil {
        return nil, NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
    }
```

As a result, this error is not surfaced in the status of the CiliumNetworkPolicy, so users are misled into believing the policy is in effect, even though the cilium agent has already reported an error.



Fixes: #issue-number

```release-note
operator: prevent CNPs with nodeSelector from silently enforcing nothing
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
