### PR TITLE
operator: Emit startup logs in the configured log format

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -413,9 +413,7 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 		Short: "Run " + binaryName,
 		Run: func(cobraCmd *cobra.Command, args []string) {
 			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
-			logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, binaryName)
-
-			initEnv(logger, h.Viper())
+			initEnv(logging.DefaultSlogLogger, h.Viper())
 
 			// Pass the DefaultSlogLogger to the hive after being initialized
 			// with the initEnv which sets up the logging.DefaultSlogLogger with
@@ -496,6 +494,13 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 
 	// add hooks after setting up metrics in the option.Config
 	logging.AddHandlers(metrics.NewLoggingHook())
+
+	// Derive the subsystem logger only now that the logging setup is complete.
+	// slog.Logger.With() snapshots the handlers of the logger it is derived
+	// from, hence a logger derived any earlier would keep emitting through the
+	// default text handler, ignoring the user-provided --log-opt format.
+	// slogloggercheck: the logger has been initialized by SetupLogging above
+	logger = logging.DefaultSlogLogger.With(logfields.LogSubsys, binaryName)
 
 	// Register the user options in the logs
 	option.LogRegisteredSlogOptions(vp, logger)


### PR DESCRIPTION
The operator derives its subsystem logger from `logging.DefaultSlogLogger` before `initEnv()` ran, i.e. before `SetupLogging()` applies the user's `--log-opt` format. `slog.Logger.With()` snapshots the handler it derives from, and `multiSlogHandler.WithAttrs()` copies the current handler list, so the later `SetHandler()` call does not reach the derived logger: the registered-options dump and the version line get emitted in the default text format while everything else respects the user supplied logging config. The derived logger also misses the metrics logging hook registered by `AddHandlers()`.

With this change, we derive the logger once the logging setup is complete, like the agent already does.



How the operator behaves today when started with `--log-opt='format=json-ts'"`: We can see that the flags dump as well as the "Cilium Operator" logs are emitted as plain text (default logger) before the logger gets properly configured and following logs get properly JSON formatted.
<img width="1512" height="312" alt="image" src="https://github.com/user-attachments/assets/33ebac03-dc8d-41ee-b0cf-78fe2be0ec45" />

And with this patch: 
<img width="1512" height="312" alt="image" src="https://github.com/user-attachments/assets/773e20b8-319c-4e12-a458-98d715659985" />


Note: I checked the other binaries in the repo and only the operator one looked to have this log config ordering issue