### PR TITLE
test: Forbid `reflect.DeepEqual` in test code

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -102,6 +102,10 @@ linters:
         - pattern: ^sync\.(Mutex|RWMutex|Map)$
           pkg: ^sync$
           msg: Use pkg/lock instead to improve deadlock detection.
+        # Only reported in test files, see the forbidigo exclusion rule below.
+        - pattern: ^reflect\.DeepEqual$
+          pkg: ^reflect$
+          msg: Use assert.Equal from github.com/stretchr/testify/assert instead, which reports the differing fields on failure. See https://github.com/cilium/cilium/issues/40562.
       analyze-types: true
     goheader:
       values:
@@ -272,6 +276,13 @@ linters:
           - forbidigo
         path: (pkg|cilium-cli/utils)/lock/.+\.go
         text: sync\.
+      # reflect.DeepEqual is discouraged in test code only: it reports that two
+      # values differ without saying which fields, making failures hard to
+      # debug. Non-test code may use it freely.
+      - linters:
+          - forbidigo
+        path-except: _test\.go$
+        text: reflect\.DeepEqual
     paths:
       - third_party$
       - builtin$

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -6,7 +6,6 @@ package xds
 import (
 	"context"
 	"log/slog"
-	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -74,7 +73,7 @@ func responseCheck(response *envoy_service_discovery.DiscoveryResponse,
 			sort.Slice(resourcesAny, func(i, j int) bool {
 				return resourcesAny[i].String() < resourcesAny[j].String()
 			})
-			result = reflect.DeepEqual(response.Resources, resourcesAny)
+			result = assert.ObjectsAreEqual(response.Resources, resourcesAny)
 		}
 
 		return result

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -669,8 +669,10 @@ func BenchmarkSpecEquals(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
-			reflect.DeepEqual(r.Spec, o.Spec)
-			reflect.DeepEqual(r.Specs, o.Specs)
+			// This benchmark deliberately measures reflect.DeepEqual in order
+			// to compare it against the generated DeepEqual below.
+			reflect.DeepEqual(r.Spec, o.Spec)   //nolint:forbidigo
+			reflect.DeepEqual(r.Specs, o.Specs) //nolint:forbidigo
 		}
 	})
 	b.Run("Generated SpecEquals", func(b *testing.B) {

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -430,7 +430,9 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 				UpdateFunc: func(oldObj, newObj any) {
 					if oldK8sNP := informer.CastInformerEvent[slim_corev1.Node](hivetest.Logger(b), oldObj); oldK8sNP != nil {
 						if newK8sNP := informer.CastInformerEvent[slim_corev1.Node](hivetest.Logger(b), newObj); newK8sNP != nil {
-							if reflect.DeepEqual(oldK8sNP, newK8sNP) {
+							// Not a test assertion: this mirrors the event
+							// deduplication that real informer handlers do.
+							if reflect.DeepEqual(oldK8sNP, newK8sNP) { //nolint:forbidigo
 								return
 							}
 						}


### PR DESCRIPTION
`reflect.DeepEqual` reports only that two values differ, not which fields, which makes test failures hard to debug. The remaining test-code uses have been converted to testify, so this PR adds a forbidigo rule to stop new ones from being introduced.

The rule is scoped to `_test.go` files via a path-except exclusion, since `reflect.DeepEqual` remains legitimate in non-test code.

Notes about the remaining 3 `reflect.DeepEqual` being addressed by this PR:
* `pkg/envoy/xds` moves to `assert.ObjectsAreEqual` rather than `assert.Equal`, as the comparison happens inside a bool-returning `assert.Comparison` with no `*testing.T` in scope.
* `pkg/k8s/apis/cilium.io/v2` benchmarks `reflect.DeepEqual` deliberately, to compare it against the generated DeepEqual so it gets a `nolint` exception.
* `pkg/k8s/informer/benchmarks` mirrors informer event deduplication so it also keeps DeepEqual with a `nolint` exception.

Closes #40562