### PR TITLE
renovate: Bump cilium-envoy version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -900,7 +900,7 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
-      "allowedVersions": "/^v1\\.37\\.([0-9]+)-([0-9]+)-.*$/",
+      "allowedVersions": "/^v1\\.38\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "main",
       ]
@@ -917,9 +917,25 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
-      "allowedVersions": "/^v1\\.36\\.([0-9]+)-([0-9]+)-.*$/",
+      "allowedVersions": "/^v1\\.37\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.20",
+      ]
+    },
+    {
+      // cilium-envoy is referenced in both images/cilium/Dockerfile and
+      // install/kubernetes/Makefile.values. Without explicit grouping,
+      // Renovate creates separate PRs for each manager. The groupSlug ensures
+      // both updates use the same branch name and get combined into a single
+      // PR.
+      "groupName": "cilium-envoy",
+      "groupSlug": "cilium-envoy",
+      "matchDepNames": [
+        "quay.io/cilium/cilium-envoy"
+      ],
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
+      "allowedVersions": "/^v1\\.36\\.([0-9]+)-([0-9]+)-.*$/",
+      "matchBaseBranches": [
         "v1.19",
         "v1.18",
       ]


### PR DESCRIPTION
This is as part of regular upgrade, as envoy v1.36 will be EOL in coming October. The plan will be as below

- main -> 1.38.x
- v1.20 -> 1.37.x for Aug release
- v1.19 -> 1.37 for Sep release
- v1.18 -> 1.37 for Oct release

Relates: https://github.com/cilium/proxy/pull/1917
