### PR TITLE
golangci-lint: Forbid stdlib `net.Interface*` functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,6 +47,12 @@ linters:
         - pattern: ^netlink\.(Handle\.)?("AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList|NeighProxyList|NeighListExecute|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFiltered|RouteListFilteredIter|RouteSubscribeWithOptions|RuleList|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|SocketXDPGetInfo|SocketDiagXDP|VDPAGetDevList|VDPAGetDevConfigList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
           pkg: ^github.com/vishvananda/netlink$
           msg: Found netlink function which can return ErrDumpInterrupted. Use safenetlink package instead.
+        # The stdlib net.Interface* functions query the kernel over a netlink
+        # socket without a timeout, so they can block forever. See
+        # https://github.com/cilium/cilium/issues/15051
+        - pattern: ^net\.(Interfaces|InterfaceAddrs|InterfaceByIndex|InterfaceByName|Interface\.Addrs)$
+          pkg: ^net$
+          msg: 'Found stdlib net.Interface* function which can block forever, see https://github.com/cilium/cilium/issues/15051. Use the netlink or safenetlink package instead.'
       analyze-types: true
     goheader:
       values:

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 
 	"github.com/cilium/cilium/pkg/components"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/mountinfo"
 )
@@ -314,18 +314,19 @@ func loadConfigFile(path string) (*BugtoolConfiguration, error) {
 // Listing tc filter/chain/classes requires specific interface names.
 // Commands are generated per-interface.
 func tcInterfaceCommands() []string {
-	ifaces, err := net.Interfaces()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate per interface tc commands: %s\n", fmt.Errorf("could not list network interfaces: %w", err))
 		return nil
 	}
 	commands := []string{}
-	for _, iface := range ifaces {
+	for _, link := range links {
+		name := link.Attrs().Name
 		commands = append(commands,
-			fmt.Sprintf("tc filter show dev %s ingress", iface.Name),
-			fmt.Sprintf("tc filter show dev %s egress", iface.Name),
-			fmt.Sprintf("tc chain show dev %s", iface.Name),
-			fmt.Sprintf("tc class show dev %s", iface.Name))
+			fmt.Sprintf("tc filter show dev %s ingress", name),
+			fmt.Sprintf("tc filter show dev %s egress", name),
+			fmt.Sprintf("tc chain show dev %s", name),
+			fmt.Sprintf("tc class show dev %s", name))
 	}
 	return commands
 }

--- a/pkg/auth/mutual_authhandler_test.go
+++ b/pkg/auth/mutual_authhandler_test.go
@@ -444,7 +444,11 @@ func getRandomOpenPort(t *testing.T) int {
 }
 
 func GetLoopBackIP(t *testing.T) string {
-	addrs, err := net.InterfaceAddrs()
+	// Test-only helper, so blocking forever on the stdlib netlink socket is not
+	// a concern here. Retrieving addresses of all interfaces at once has no
+	// netlink equivalent, and the netlink package is Linux-only while this test
+	// is not.
+	addrs, err := net.InterfaceAddrs() //nolint:forbidigo
 	if err != nil {
 		t.Fatalf("failed to get interface addresses: %v", err)
 	}

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 
 	"github.com/cilium/hive/cell"
@@ -101,7 +100,7 @@ func NewL2ResponderReconciler(params params) *l2ResponderReconciler {
 	if params.AddRemMcMACFunc == nil {
 		log := params.Logger
 		params.AddRemMcMACFunc = func(ifindex int, m mac.MAC, add bool) error {
-			ifi, err := net.InterfaceByIndex(ifindex)
+			link, err := netlink.LinkByIndex(ifindex)
 			if err != nil {
 				return fmt.Errorf("interface by index %d: %w", ifindex, err)
 			}
@@ -113,10 +112,10 @@ func NewL2ResponderReconciler(params params) *l2ResponderReconciler {
 			solAddr := netip.AddrFrom16(raw)
 
 			if add {
-				return multicast.JoinGroup(log, ifi.Name, solAddr)
+				return multicast.JoinGroup(log, link.Attrs().Name, solAddr)
 			}
 
-			return multicast.LeaveGroup(log, ifi.Name, solAddr)
+			return multicast.LeaveGroup(log, link.Attrs().Name, solAddr)
 		}
 	}
 


### PR DESCRIPTION
The Go stdlib `net.Interface*` family talks to the kernel over a netlink socket with no timeout, so it can block forever. This PR converts the two remaining offenders to `netlink/safenetlink` and add a forbidigo rule so new ones don't creep back in.

Fixes: #15051