### PR TITLE
golangci-lint: Fix `netlink.AddrList` escaping the forbidigo check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,7 +44,7 @@ linters:
     forbidigo:
       forbid:
         # List based on https://github.com/vishvananda/netlink/pull/1018
-        - pattern: ^netlink\.(Handle\.)?("AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList|NeighProxyList|NeighListExecute|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFiltered|RouteListFilteredIter|RouteSubscribeWithOptions|RuleList|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|SocketXDPGetInfo|SocketDiagXDP|VDPAGetDevList|VDPAGetDevConfigList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
+        - pattern: ^netlink\.(Handle\.)?(AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList|NeighProxyList|NeighListExecute|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFiltered|RouteListFilteredIter|RouteSubscribeWithOptions|RuleList|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|SocketXDPGetInfo|SocketDiagXDP|VDPAGetDevList|VDPAGetDevConfigList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
           pkg: ^github.com/vishvananda/netlink$
           msg: Found netlink function which can return ErrDumpInterrupted. Use safenetlink package instead.
       analyze-types: true

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -385,7 +385,7 @@ func TestPrivilegedRemoveOldRouterState(t *testing.T) {
 			// Assert that the old router IP (192.0.2.1) was removed because we are
 			// restoring a different one (10.0.0.1).
 			assert.NoError(t, infraIPAllocator.removeOldRouterState(false, net.ParseIP("10.0.0.1")))
-			addrs, err := netlink.AddrList(&netlink.Dummy{
+			addrs, err := safenetlink.AddrList(&netlink.Dummy{
 				LinkAttrs: netlink.LinkAttrs{
 					Name: defaults.HostDevice,
 				},

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -496,7 +496,7 @@ func TestPrivilegedAddHostDeviceAddr(t *testing.T) {
 		err = addHostDeviceAddr(dummy, testIPv4, testIPv6)
 		require.NoError(t, err)
 
-		addrs, err := netlink.AddrList(dummy, netlink.FAMILY_ALL)
+		addrs, err := safenetlink.AddrList(dummy, netlink.FAMILY_ALL)
 		require.NoError(t, err)
 
 		var foundIPv4, foundIPv6 bool

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -201,7 +201,7 @@ func initializeNetns(t *testing.T, ns *netns.NetNS, addr string) net.Conn {
 					},
 				})
 			}
-			_, err := netlink.AddrList(l, unix.AF_INET)
+			_, err := safenetlink.AddrList(l, unix.AF_INET)
 			assert.NoError(t, err)
 		}
 		conn, err = net.Dial("udp", addr)


### PR DESCRIPTION
The `ErrDumpInterrupted` pattern has been `(Handle\.)?("AddrList|BridgeVlanList|...` since it was introduced. The double quote character makes the first alternative `"AddrList`, which cannot match anything, so `netlink.AddrList` and `netlink.Handle.AddrList` have never been flagged.

Fixing this surfaces three new previously accidentally ignored findings. This PR converts them to `safenetlink.AddrList`.