### PR TITLE
hubble: Add Kubernetes Pod UID to flow endpoints

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -226,6 +226,7 @@ Emitter identifies the source that emits a Hubble flow.
 | labels | [string](#string) | repeated | labels in `foo=bar` format. |
 | pod_name | [string](#string) |  |  |
 | workloads | [Workload](#flow-Workload) | repeated |  |
+| pod_uid | [string](#string) |  | pod_uid is the Kubernetes UID of the Pod represented by this endpoint. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -2494,9 +2494,11 @@ type Endpoint struct {
 	ClusterName string                 `protobuf:"bytes,7,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
 	Namespace   string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// labels in `foo=bar` format.
-	Labels        []string    `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty"`
-	PodName       string      `protobuf:"bytes,5,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
-	Workloads     []*Workload `protobuf:"bytes,6,rep,name=workloads,proto3" json:"workloads,omitempty"`
+	Labels    []string    `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty"`
+	PodName   string      `protobuf:"bytes,5,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
+	Workloads []*Workload `protobuf:"bytes,6,rep,name=workloads,proto3" json:"workloads,omitempty"`
+	// pod_uid is the Kubernetes UID of the Pod represented by this endpoint.
+	PodUid        string `protobuf:"bytes,8,opt,name=pod_uid,json=podUid,proto3" json:"pod_uid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2578,6 +2580,13 @@ func (x *Endpoint) GetWorkloads() []*Workload {
 		return x.Workloads
 	}
 	return nil
+}
+
+func (x *Endpoint) GetPodUid() string {
+	if x != nil {
+		return x.PodUid
+	}
+	return ""
 }
 
 type Workload struct {
@@ -5625,7 +5634,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\fTraceContext\x12)\n" +
 	"\x06parent\x18\x01 \x01(\v2\x11.flow.TraceParentR\x06parent\"(\n" +
 	"\vTraceParent\x12\x19\n" +
-	"\btrace_id\x18\x01 \x01(\tR\atraceId\"\xd8\x01\n" +
+	"\btrace_id\x18\x01 \x01(\tR\atraceId\"\xf1\x01\n" +
 	"\bEndpoint\x12\x0e\n" +
 	"\x02ID\x18\x01 \x01(\rR\x02ID\x12\x1a\n" +
 	"\bidentity\x18\x02 \x01(\rR\bidentity\x12!\n" +
@@ -5633,7 +5642,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x16\n" +
 	"\x06labels\x18\x04 \x03(\tR\x06labels\x12\x19\n" +
 	"\bpod_name\x18\x05 \x01(\tR\apodName\x12,\n" +
-	"\tworkloads\x18\x06 \x03(\v2\x0e.flow.WorkloadR\tworkloads\"2\n" +
+	"\tworkloads\x18\x06 \x03(\v2\x0e.flow.WorkloadR\tworkloads\x12\x17\n" +
+	"\apod_uid\x18\b \x01(\tR\x06podUid\"2\n" +
 	"\bWorkload\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\"w\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -319,6 +319,8 @@ message Endpoint {
     repeated string labels = 4;
     string pod_name = 5;
     repeated Workload workloads = 6;
+    // pod_uid is the Kubernetes UID of the Pod represented by this endpoint.
+    string pod_uid = 8;
 }
 
 message Workload {

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -265,6 +265,7 @@ func ciliumEndpointMapper(endpoint *types.CiliumEndpoint) iter.Seq[store.Key] {
 						HostIP:            net.ParseIP(n.NodeIP),
 						K8sNamespace:      endpoint.Namespace,
 						K8sPodName:        endpoint.Name,
+						K8sPodUID:         endpoint.GetPodUID(),
 						K8sServiceAccount: endpoint.ServiceAccount,
 						NamedPorts:        namedPortsToIPIdentity(endpoint.NamedPorts),
 					}
@@ -315,6 +316,7 @@ func ciliumEndpointSliceMapper(endpointslice *cilium_api_v2a1.CiliumEndpointSlic
 							HostIP:            net.ParseIP(n.NodeIP),
 							K8sNamespace:      endpointslice.Namespace,
 							K8sPodName:        endpoint.Name,
+							K8sPodUID:         endpoint.PodUID,
 							ID:                identity.NumericIdentity(endpoint.IdentityID),
 							Key:               uint8(endpoint.Encryption.Key),
 							K8sServiceAccount: endpoint.ServiceAccount,

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -157,6 +157,11 @@ kind: CiliumEndpoint
 metadata:
   name: cep-002
   namespace: bar
+  ownerReferences:
+  - apiVersion: v1
+    kind: Pod
+    name: cep-002
+    uid: cep-pod-uid
 status:
   encryption:
     key: 5
@@ -241,6 +246,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {
@@ -275,6 +281,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {
@@ -310,6 +317,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {
@@ -333,6 +341,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {
@@ -368,6 +377,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {
@@ -402,6 +412,7 @@ status:
   "Metadata": "",
   "K8sNamespace": "bar",
   "K8sPodName": "cep-002",
+  "K8sPodUID": "cep-pod-uid",
   "K8sServiceAccount": "default",
   "NamedPorts": [
     {

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
@@ -107,6 +107,7 @@ endpoints:
     key: 5
   id: 199475
   name: foo-002
+  pod-uid: ces-pod-uid
   service-account: default
   networking:
     addressing:
@@ -215,6 +216,7 @@ namespace: fred
   "Metadata": "",
   "K8sNamespace": "qux",
   "K8sPodName": "foo-002",
+  "K8sPodUID": "ces-pod-uid",
   "K8sServiceAccount": "default"
 }
 # cilium/state/ip/v1/default/10.244.2.78
@@ -294,6 +296,7 @@ namespace: fred
   "Metadata": "",
   "K8sNamespace": "qux",
   "K8sPodName": "foo-002",
+  "K8sPodUID": "ces-pod-uid",
   "K8sServiceAccount": "default"
 }
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4

--- a/pkg/cgroups/manager/manager.go
+++ b/pkg/cgroups/manager/manager.go
@@ -103,7 +103,12 @@ func (m *cgroupManager) OnAddPod(pod *v1.Pod) {
 }
 
 func (m *cgroupManager) OnUpdatePod(oldPod, newPod *v1.Pod) {
-	if newPod.Spec.NodeName != nodetypes.GetName() {
+	localNodeName := nodetypes.GetName()
+	if oldPod.UID != newPod.UID {
+		if oldPod.Spec.NodeName != localNodeName && newPod.Spec.NodeName != localNodeName {
+			return
+		}
+	} else if newPod.Spec.NodeName != localNodeName {
 		return
 	}
 	m.podEvents <- podEvent{
@@ -214,7 +219,11 @@ func (m *cgroupManager) processPodEvents(ctx context.Context, _ cell.Health) err
 		case ev := <-m.podEvents:
 			switch ev.eventType {
 			case podAddEvent, podUpdateEvent:
-				m.updatePodMetadata(ev.pod, ev.oldPod)
+				if ev.oldPod != nil && ev.oldPod.UID != ev.pod.UID {
+					m.replacePodMetadata(ev.oldPod, ev.pod)
+				} else {
+					m.updatePodMetadata(ev.pod, ev.oldPod)
+				}
 				if m.podEventsDone != nil {
 					m.podEventsDone <- podEventStatus{
 						name:      ev.pod.Name,
@@ -348,6 +357,16 @@ func (m *cgroupManager) updatePodMetadata(pod, oldPod *v1.Pod) {
 			}
 		}
 		m.metadataCacheLock.Unlock()
+	}
+}
+
+func (m *cgroupManager) replacePodMetadata(oldPod, newPod *v1.Pod) {
+	localNodeName := nodetypes.GetName()
+	if oldPod.Spec.NodeName == localNodeName {
+		m.deletePodMetadata(oldPod)
+	}
+	if newPod.Spec.NodeName == localNodeName {
+		m.updatePodMetadata(newPod, nil)
 	}
 }
 

--- a/pkg/cgroups/manager/manager_test.go
+++ b/pkg/cgroups/manager/manager_test.go
@@ -227,7 +227,7 @@ func TestGetPodMetadataOnPodUpdate(t *testing.T) {
 	require.Equal(t, &PodMetadata{Name: pod3.Name, Namespace: pod3.Namespace, IPs: pod3Ipstrs}, got)
 
 	// Update pod, and check for pod metadata for their containers.
-	mm.OnUpdatePod(pod1, newPod)
+	mm.OnUpdatePod(pod3, newPod)
 
 	got1 := mm.GetPodMetadataForContainer(c3CId)
 	got2 := mm.GetPodMetadataForContainer(c1CId)
@@ -246,6 +246,84 @@ func TestGetPodMetadataOnPodUpdate(t *testing.T) {
 
 	got = mm.GetPodMetadataForContainer(c3CId)
 	require.Nil(t, got)
+}
+
+func TestGetPodMetadataOnPodUIDReplacement(t *testing.T) {
+	setup()
+
+	const cgroupID = uint64(1234)
+	cgMock := cgroupMock{cgroupIds: map[string]uint64{
+		pod1C1CgrpPath: cgroupID,
+	}}
+	provMock := providerMock{paths: map[string]string{
+		c1Id: pod1C1CgrpPath,
+	}}
+	manager := newCgroupManagerTest(t, provMock, cgMock, nil)
+	oldPod := pod1.DeepCopy()
+	newPod := oldPod.DeepCopy()
+	newPod.UID = "replacement-pod-uid"
+
+	manager.OnAddPod(oldPod)
+	require.NotNil(t, manager.GetPodMetadataForContainer(cgroupID))
+
+	manager.OnUpdatePod(oldPod, newPod)
+	manager.DumpPodMetadata() // Wait for the replacement event to be processed.
+
+	impl := manager.(*cgroupManager)
+	require.NotContains(t, impl.podMetadataById, string(oldPod.UID))
+	require.Contains(t, impl.podMetadataById, string(newPod.UID))
+	require.Equal(t, string(newPod.UID), impl.containerMetadataByCgrpId[cgroupID].podId)
+	require.Equal(t, pod1Ipstrs, impl.podMetadataById[string(newPod.UID)].ips)
+}
+
+func TestPodUIDReplacementNodeTransitions(t *testing.T) {
+	setup()
+
+	tests := []struct {
+		name        string
+		oldNodeName string
+		newNodeName string
+		wantNew     bool
+		wantOld     bool
+	}{
+		{name: "local to local", oldNodeName: "n1", newNodeName: "n1", wantNew: true},
+		{name: "local to remote", oldNodeName: "n1", newNodeName: "n2"},
+		{name: "remote to local", oldNodeName: "n2", newNodeName: "n1", wantNew: true},
+		{name: "remote to remote", oldNodeName: "n2", newNodeName: "n3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const cgroupID = uint64(1234)
+			cgMock := cgroupMock{cgroupIds: map[string]uint64{
+				pod1C1CgrpPath: cgroupID,
+			}}
+			provMock := providerMock{paths: map[string]string{
+				c1Id: pod1C1CgrpPath,
+			}}
+			manager := newCgroupManagerTest(t, provMock, cgMock, nil)
+			oldPod := pod1.DeepCopy()
+			oldPod.Spec.NodeName = tt.oldNodeName
+			newPod := oldPod.DeepCopy()
+			newPod.UID = "replacement-pod-uid"
+			newPod.Spec.NodeName = tt.newNodeName
+
+			manager.OnAddPod(oldPod)
+			manager.OnUpdatePod(oldPod, newPod)
+			manager.DumpPodMetadata() // Wait for any replacement event to be processed.
+
+			impl := manager.(*cgroupManager)
+			_, gotOld := impl.podMetadataById[string(oldPod.UID)]
+			_, gotNew := impl.podMetadataById[string(newPod.UID)]
+			require.Equal(t, tt.wantOld, gotOld)
+			require.Equal(t, tt.wantNew, gotNew)
+			if tt.wantNew {
+				require.Equal(t, string(newPod.UID), impl.containerMetadataByCgrpId[cgroupID].podId)
+			} else {
+				require.NotContains(t, impl.containerMetadataByCgrpId, cgroupID)
+			}
+		})
+	}
 }
 
 func TestGetPodMetadataOnManagerDisabled(t *testing.T) {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -2297,7 +2297,12 @@ func groupL4AddrsByProto(ports []lb.L4Addr) map[lb.L4Type][]uint16 {
 	return result
 }
 
-// replaceNoTrackHostPortRules replaces noTrackHostPort rules on a state change. the new ruleset is added, and the previous one is removed.
+// replaceNoTrackHostPortRules replaces noTrackHostPort rules on a state change.
+// Install all changed protocols before removing old rules so a cross-protocol
+// update does not leave a gap in which neither ruleset is installed. This
+// deliberately allows a short overlap where both rulesets match. If
+// installation fails, the old rules remain and full reconciliation retries
+// the desired state.
 func (m *manager) replaceNoTrackHostPortRules(oldPorts, newPorts map[lb.L4Type][]uint16) error {
 	for _, proto := range noTrackSupportedProtos {
 		oldP := set.NewSet(oldPorts[proto]...)
@@ -2311,6 +2316,15 @@ func (m *manager) replaceNoTrackHostPortRules(oldPorts, newPorts map[lb.L4Type][
 			if err := m.installHostNoTrackRules(proto, newP.AsSlice()); err != nil {
 				return err
 			}
+		}
+	}
+
+	for _, proto := range noTrackSupportedProtos {
+		oldP := set.NewSet(oldPorts[proto]...)
+		newP := set.NewSet(newPorts[proto]...)
+
+		if newP.Equal(oldP) {
+			continue
 		}
 
 		if !oldP.Empty() {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -4,6 +4,7 @@
 package iptables
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -999,27 +1001,27 @@ func TestNoTrackHostPorts(t *testing.T) {
 		assert.NoError(t, mockIp6tables.checkExpectations())
 	})
 
-	t.Run("test changing the port", func(t *testing.T) {
+	t.Run("test changing the protocol installs before deleting", func(t *testing.T) {
 		mockIp4tables.expectations = []expectation{
 			{args: "-t raw -A CILIUM_PRE_raw -p tcp --match multiport --dports 443 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
 			{args: "-t raw -A CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
 
-			{args: "-t raw -D CILIUM_PRE_raw -p tcp --match multiport --dports 443,999 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
-			{args: "-t raw -D CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443,999 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
-
 			{args: "-t raw -A CILIUM_PRE_raw -p udp --match multiport --dports 443 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
 			{args: "-t raw -A CILIUM_OUTPUT_raw -p udp --match multiport --sports 443 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
+
+			{args: "-t raw -D CILIUM_PRE_raw -p tcp --match multiport --dports 443,999 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
+			{args: "-t raw -D CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443,999 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
 		}
 
 		mockIp6tables.expectations = []expectation{
 			{args: "-t raw -A CILIUM_PRE_raw -p tcp --match multiport --dports 443 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
 			{args: "-t raw -A CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
 
-			{args: "-t raw -D CILIUM_PRE_raw -p tcp --match multiport --dports 443,999 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
-			{args: "-t raw -D CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443,999 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
-
 			{args: "-t raw -A CILIUM_PRE_raw -p udp --match multiport --dports 443 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
 			{args: "-t raw -A CILIUM_OUTPUT_raw -p udp --match multiport --sports 443 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
+
+			{args: "-t raw -D CILIUM_PRE_raw -p tcp --match multiport --dports 443,999 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
+			{args: "-t raw -D CILIUM_OUTPUT_raw -p tcp --match multiport --sports 443,999 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack"},
 		}
 
 		assert.NoError(t, testMgr.setNoTrackHostPorts(testState, testPod2, []string{"443/udp"}))
@@ -1100,6 +1102,34 @@ func TestNoTrackHostPorts(t *testing.T) {
 		assert.NoError(t, mockIp6tables.checkExpectations())
 		assert.Empty(t, testState)
 	})
+}
+
+func TestReplaceNoTrackHostPortRulesDoesNotCleanupOnInstallFailure(t *testing.T) {
+	installErr := errors.New("install failed")
+	mockIp4tables := &mockIptables{
+		t:    t,
+		prog: "iptables",
+		expectations: []expectation{
+			{args: "-t raw -A CILIUM_PRE_raw -p udp --match multiport --dports 53 -m comment --comment cilium no-track-host-ports -j CT --notrack"},
+			{
+				args: "-t raw -A CILIUM_OUTPUT_raw -p udp --match multiport --sports 53 -m comment --comment cilium no-track-host-ports return traffic -j CT --notrack",
+				err:  installErr,
+			},
+		},
+	}
+	testMgr := &manager{
+		sharedCfg: SharedConfig{EnableIPv4: true},
+		ip4tables: mockIp4tables,
+	}
+
+	// No delete commands are expected: failed installation must leave the old
+	// TCP rules in place for full reconciliation.
+	err := testMgr.replaceNoTrackHostPortRules(
+		map[loadbalancer.L4Type][]uint16{loadbalancer.TCP: {80}},
+		map[loadbalancer.L4Type][]uint16{loadbalancer.UDP: {53}},
+	)
+	require.ErrorIs(t, err, installErr)
+	require.NoError(t, mockIp4tables.checkExpectations())
 }
 
 func TestEncryptionRules(t *testing.T) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1344,12 +1344,16 @@ func (e *Endpoint) GetK8sNamespace() string {
 	return ns
 }
 
-// GetK8sUID returns the UID of the pod if the endpoint represents a Kubernetes
-// pod.
-func (e *Endpoint) GetK8sUID() string {
-	// const after creation
-	uid := e.K8sUID
-	return uid
+// GetK8sPodUID returns the UID of the Pod represented by the endpoint.
+func (e *Endpoint) GetK8sPodUID() string {
+	// K8sUID is immutable and identifies the Pod generation supplied by CNI.
+	if e.K8sUID != "" {
+		return e.K8sUID
+	}
+	if pod := e.GetPod(); pod != nil {
+		return string(pod.UID)
+	}
+	return ""
 }
 
 // SetPod sets the pod related to this endpoint.

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -1257,6 +1257,42 @@ func TestK8sPodNameIsSet(t *testing.T) {
 	require.True(t, e.K8sNamespaceAndPodNameIsSet())
 }
 
+func TestGetK8sPodUID(t *testing.T) {
+	tests := []struct {
+		name   string
+		cniUID string
+		podUID string
+		want   string
+	}{
+		{
+			name:   "CNI UID takes precedence",
+			cniUID: "cni-pod-uid",
+			podUID: "cached-pod-uid",
+			want:   "cni-pod-uid",
+		},
+		{
+			name:   "cached Pod UID fallback",
+			podUID: "cached-pod-uid",
+			want:   "cached-pod-uid",
+		},
+		{
+			name: "unknown Pod UID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Endpoint{K8sUID: tt.cniUID}
+			if tt.podUID != "" {
+				e.SetPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+					UID: k8sTypes.UID(tt.podUID),
+				}})
+			}
+			require.Equal(t, tt.want, e.GetK8sPodUID())
+		})
+	}
+}
+
 type EndpointDeadlockEvent struct {
 	ep           *Endpoint
 	deadlockChan chan struct{}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1207,6 +1207,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName
+				k8sPodUID := e.GetK8sPodUID()
 
 				k8sServiceAccount := ""
 				if pod := e.GetPod(); pod != nil {
@@ -1225,6 +1226,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					Metadata:          metadata,
 					K8sNamespace:      k8sNamespace,
 					K8sPodName:        k8sPodName,
+					K8sPodUID:         k8sPodUID,
 					K8sServiceAccount: k8sServiceAccount,
 					NPM:               e.GetK8sPorts(),
 				}

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -14,7 +14,6 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -95,8 +94,7 @@ type params struct {
 
 	Lifecycle cell.Lifecycle
 
-	Clientset  k8sClient.Clientset
-	K8sWatcher *watchers.K8sWatcher
+	Clientset k8sClient.Clientset
 
 	Config config
 
@@ -119,7 +117,7 @@ func newDropEventEmitter(p params) FlowProcessor {
 		logfields.RateLimit, p.Config.K8sDropEventsRateLimit,
 	)
 
-	flowProcessor := new(p.Logger, p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Config.EnableK8sDropEventsExtended, p.Config.K8sDropEventsRateLimit, p.Clientset, p.K8sWatcher, p.EndpointsLookup)
+	flowProcessor := new(p.Logger, p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Config.EnableK8sDropEventsExtended, p.Config.K8sDropEventsRateLimit, p.Clientset, p.EndpointsLookup)
 	p.Lifecycle.Append(cell.Hook{
 		OnStop: func(hc cell.HookContext) error {
 			flowProcessor.Shutdown()

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 
@@ -24,7 +25,6 @@ import (
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	metaslimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	slimscheme "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/scheme"
-	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
@@ -41,14 +41,13 @@ type endpointInterface interface {
 type dropEventEmitter struct {
 	broadcaster     record.EventBroadcaster
 	recorder        record.EventRecorder
-	k8sWatcher      watchers.CacheAccessK8SWatcher
 	showPolicies    bool
 	rateLimiter     *rate.Limiter
 	reasons         []flowpb.DropReason
 	endpointsLookup endpointsLookup
 }
 
-func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicies bool, rateLimit int64, k8s client.Clientset, watcher watchers.CacheAccessK8SWatcher, endpointsLookup endpointsLookup) *dropEventEmitter {
+func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicies bool, rateLimit int64, k8s client.Clientset, endpointsLookup endpointsLookup) *dropEventEmitter {
 	broadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
 		BurstSize:            1,
 		QPS:                  1 / float32(interval.Seconds()),
@@ -73,7 +72,6 @@ func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicie
 	return &dropEventEmitter{
 		broadcaster:     broadcaster,
 		recorder:        broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
-		k8sWatcher:      watcher,
 		reasons:         rs,
 		showPolicies:    showPolicies,
 		endpointsLookup: endpointsLookup,
@@ -123,13 +121,7 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 			}
 		}
 
-		e.recorder.Event(&slimv1.Pod{
-			TypeMeta: typeMeta,
-			ObjectMeta: metaslimv1.ObjectMeta{
-				Name:      flow.Destination.PodName,
-				Namespace: flow.Destination.Namespace,
-			},
-		}, v1.EventTypeWarning, "PacketDrop", message)
+		e.recorder.Event(podFromEndpoint(typeMeta, flow.Destination), v1.EventTypeWarning, "PacketDrop", message)
 	} else {
 		message := "Outgoing packet dropped (" + reason + ") to " +
 			endpointToString(flow.IP.Destination, flow.Destination) + " " +
@@ -145,21 +137,7 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 			}
 		}
 
-		objMeta := metaslimv1.ObjectMeta{
-			Name:      flow.Source.PodName,
-			Namespace: flow.Source.Namespace,
-		}
-		if e.k8sWatcher != nil {
-			pod, err := e.k8sWatcher.GetCachedPod(flow.Source.Namespace, flow.Source.PodName)
-			if err == nil {
-				objMeta.UID = pod.UID
-			}
-		}
-		podObj := slimv1.Pod{
-			TypeMeta:   typeMeta,
-			ObjectMeta: objMeta,
-		}
-		e.recorder.Event(&podObj, v1.EventTypeWarning, "PacketDrop", message)
+		e.recorder.Event(podFromEndpoint(typeMeta, flow.Source), v1.EventTypeWarning, "PacketDrop", message)
 	}
 
 	return nil
@@ -167,6 +145,19 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 
 func (e *dropEventEmitter) Shutdown() {
 	e.broadcaster.Shutdown()
+}
+
+func podFromEndpoint(typeMeta metaslimv1.TypeMeta, endpoint *flowpb.Endpoint) *slimv1.Pod {
+	// Leave UID empty when the flow does not include it. Looking up a Pod by its
+	// current name could associate a delayed flow with a replacement Pod.
+	return &slimv1.Pod{
+		TypeMeta: typeMeta,
+		ObjectMeta: metaslimv1.ObjectMeta{
+			Name:      endpoint.PodName,
+			Namespace: endpoint.Namespace,
+			UID:       types.UID(endpoint.PodUid),
+		},
+	}
 }
 
 func endpointToString(ip string, endpoint *flowpb.Endpoint) string {

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -15,15 +15,13 @@ import (
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 const (
 	fakePodName = "pod"
-	fakePodUid  = "79f04581-a0e7-4a42-a020-db51cf21a605"
+	fakePodUID  = "79f04581-a0e7-4a42-a020-db51cf21a605"
 )
 
 func TestEndpointToString(t *testing.T) {
@@ -107,12 +105,41 @@ func TestProcessFlowRateLimitChargedOnlyToEvents(t *testing.T) {
 
 func TestProcessFlow(t *testing.T) {
 	tests := []struct {
-		name   string
-		flow   *flowpb.Flow
-		expect string
+		name         string
+		flow         *flowpb.Flow
+		expect       string
+		expectPodUID string
 	}{
 		{
-			name: "valid ingress drop event",
+			name: "valid ingress drop event with pod UID",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{},
+				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUid: fakePodUID},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			},
+			expect:       "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
+			expectPodUID: fakePodUID,
+		},
+		{
+			name: "valid egress drop event with pod UID",
+			flow: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUid: fakePodUID},
+				Destination:      &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+			},
+			expect:       "Outgoing packet dropped (policy_denied) to remote-node (5.6.7.8) UDP/512",
+			expectPodUID: fakePodUID,
+		},
+		{
+			name: "valid ingress drop event without pod UID",
 			flow: &flowpb.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
@@ -125,7 +152,7 @@ func TestProcessFlow(t *testing.T) {
 			expect: "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
 		},
 		{
-			name: "valid egress drop event to node",
+			name: "valid egress drop event without pod UID",
 			flow: &flowpb.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
@@ -197,9 +224,8 @@ func TestProcessFlow(t *testing.T) {
 				IncludeObject: true,
 			}
 			e := &dropEventEmitter{
-				reasons:    []flowpb.DropReason{flowpb.DropReason_POLICY_DENIED},
-				recorder:   fakeRecorder,
-				k8sWatcher: &fakeK8SWatcher{},
+				reasons:  []flowpb.DropReason{flowpb.DropReason_POLICY_DENIED},
+				recorder: fakeRecorder,
 			}
 			if err := e.ProcessFlow(t.Context(), tt.flow); err != nil {
 				t.Errorf("DropEventEmitter.ProcessFlow() error = %v", err)
@@ -210,9 +236,7 @@ func TestProcessFlow(t *testing.T) {
 				assert.Len(t, fakeRecorder.Events, 1)
 				event := <-fakeRecorder.Events
 				assert.Contains(t, event, tt.expect)
-				if tt.flow.Destination.PodName == fakePodName && tt.flow.TrafficDirection == flowpb.TrafficDirection_EGRESS {
-					assert.Contains(t, event, fakePodUid)
-				}
+				assert.Contains(t, event, "uid="+tt.expectPodUID+"}")
 			}
 		})
 	}
@@ -451,23 +475,6 @@ func TestParsePolicyCorrelation(t *testing.T) {
 			assert.Equal(t, tt.expectClusterPolicies, actualClusterPolicies)
 		})
 	}
-}
-
-type fakeK8SWatcher struct{}
-
-func (k *fakeK8SWatcher) GetCachedNamespace(namespace string) (*slim_corev1.Namespace, error) {
-	return nil, nil
-}
-func (k *fakeK8SWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
-	if name == fakePodName {
-		return &slim_corev1.Pod{
-			ObjectMeta: slim_metav1.ObjectMeta{
-				Name: fakePodName,
-				UID:  fakePodUid,
-			},
-		}, nil
-	}
-	return nil, fmt.Errorf("pod not found in cache : %s", name)
 }
 
 type fakeEndpointsLookup struct{}

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -147,6 +147,7 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 				Namespace:   ep.GetK8sNamespace(),
 				Labels:      SortAndFilterLabels(r.log, labels.GetModel(), identity.NumericIdentity(epIdentity)),
 				PodName:     ep.GetK8sPodName(),
+				PodUid:      ep.GetK8sPodUID(),
 			}
 			if pod := ep.GetPod(); pod != nil {
 				workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
@@ -160,13 +161,13 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 
 	// for remote endpoints, assemble the information via ip and identity
 	numericIdentity := datapathSecurityIdentity
-	var namespace, podName string
+	var namespace, podName, podUID string
 	if r.ipGetter != nil {
 		if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
 			numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
 		}
 		if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
-			namespace, podName = meta.Namespace, meta.PodName
+			namespace, podName, podUID = meta.Namespace, meta.PodName, meta.PodUID
 		}
 	}
 	var labels []string
@@ -190,5 +191,6 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
+		PodUid:      podUID,
 	}
 }

--- a/pkg/hubble/parser/common/endpoint_test.go
+++ b/pkg/hubble/parser/common/endpoint_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/ipcache"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestResolveEndpointPodUID(t *testing.T) {
+	ip := netip.MustParseAddr("10.0.0.1")
+
+	t.Run("local endpoint", func(t *testing.T) {
+		endpointGetter := &testutils.FakeEndpointGetter{
+			OnGetEndpointInfo: func(netip.Addr) (getters.EndpointInfo, bool) {
+				return &testutils.FakeEndpointInfo{PodUID: "local-pod-uid"}, true
+			},
+		}
+		resolver := NewEndpointResolver(hivetest.Logger(t), endpointGetter, nil, nil)
+
+		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
+
+		assert.Equal(t, "local-pod-uid", endpoint.GetPodUid())
+	})
+
+	t.Run("local endpoint Pod fallback", func(t *testing.T) {
+		endpointGetter := &testutils.FakeEndpointGetter{
+			OnGetEndpointInfo: func(netip.Addr) (getters.EndpointInfo, bool) {
+				return &testutils.FakeEndpointInfo{Pod: &slim_corev1.Pod{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						UID: k8sTypes.UID("cached-pod-uid"),
+					},
+				}}, true
+			},
+		}
+		resolver := NewEndpointResolver(hivetest.Logger(t), endpointGetter, nil, nil)
+
+		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
+
+		assert.Equal(t, "cached-pod-uid", endpoint.GetPodUid())
+	})
+
+	t.Run("remote endpoint", func(t *testing.T) {
+		ipGetter := &testutils.FakeIPGetter{
+			OnGetK8sMetadata: func(netip.Addr) *ipcache.K8sMetadata {
+				return &ipcache.K8sMetadata{PodUID: "remote-pod-uid"}
+			},
+			OnLookupSecIDByIP: func(netip.Addr) (ipcache.Identity, bool) {
+				return ipcache.Identity{}, false
+			},
+		}
+		resolver := NewEndpointResolver(hivetest.Logger(t), nil, nil, ipGetter)
+
+		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
+
+		assert.Equal(t, "remote-pod-uid", endpoint.GetPodUid())
+	})
+
+	t.Run("unknown UID", func(t *testing.T) {
+		resolver := NewEndpointResolver(hivetest.Logger(t), nil, nil, nil)
+
+		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
+
+		assert.Empty(t, endpoint.GetPodUid())
+	})
+}

--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -93,6 +93,7 @@ func (p *Parser) decodeEndpoint(id uint16) *flowpb.Endpoint {
 				Namespace:   ep.GetK8sNamespace(),
 				Labels:      common.SortAndFilterLabels(p.log, labels.GetModel(), ep.GetIdentity()),
 				PodName:     ep.GetK8sPodName(),
+				PodUid:      ep.GetK8sPodUID(),
 			}
 		}
 	}

--- a/pkg/hubble/parser/debug/parser_test.go
+++ b/pkg/hubble/parser/debug/parser_test.go
@@ -38,6 +38,7 @@ func TestDecodeDebugEvent(t *testing.T) {
 					Identity:     5678,
 					PodName:      "hubble-ui",
 					PodNamespace: "kube-system",
+					PodUID:       "hubble-ui-uid",
 					Labels: []string{
 						"k8s:io.cilium.k8s.policy.cluster=default",
 						"k8s:io.kubernetes.pod.namespace=kube-system",
@@ -98,6 +99,7 @@ func TestDecodeDebugEvent(t *testing.T) {
 					ID:          1234,
 					Identity:    5678,
 					PodName:     "hubble-ui",
+					PodUid:      "hubble-ui-uid",
 					ClusterName: "default",
 					Namespace:   "kube-system",
 					Labels: []string{
@@ -133,6 +135,7 @@ func TestDecodeDebugEvent(t *testing.T) {
 					ID:          1234,
 					Identity:    5678,
 					PodName:     "hubble-ui",
+					PodUid:      "hubble-ui-uid",
 					ClusterName: "default",
 					Namespace:   "kube-system",
 					Labels: []string{

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -76,6 +76,7 @@ type EndpointInfo interface {
 	GetIdentity() identity.NumericIdentity
 	GetK8sPodName() string
 	GetK8sNamespace() string
+	GetK8sPodUID() string
 	GetLabels() labels.Labels
 	GetPod() *slim_corev1.Pod
 	GetPolicyCorrelationInfoForKey(key policyTypes.Key) (policyTypes.PolicyCorrelationInfo, bool)

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -72,6 +72,7 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 				return &ipcache.K8sMetadata{
 					Namespace: "default",
 					PodName:   "pod-1234",
+					PodUID:    "pod-1234-uid",
 				}
 			}
 			return nil
@@ -90,14 +91,10 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
 		OnGetEndpointInfo: func(ip netip.Addr) (endpoint getters.EndpointInfo, ok bool) {
-			switch {
-			case ip == netip.MustParseAddr(fakeSourceEndpoint.IPv4):
+			if ip == netip.MustParseAddr(fakeSourceEndpoint.IPv4) {
 				return &testutils.FakeEndpointInfo{
-					ID: fakeSourceEndpoint.ID,
-				}, true
-			case ip == netip.MustParseAddr(fakeDestinationEndpoint.IPv4):
-				return &testutils.FakeEndpointInfo{
-					ID: fakeDestinationEndpoint.ID,
+					ID:     fakeSourceEndpoint.ID,
+					PodUID: "source-pod-uid",
 				}, true
 			}
 			return nil, false
@@ -117,6 +114,7 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
 	assert.Empty(t, f.GetSource().GetNamespace())
 	assert.Empty(t, f.GetSource().GetPodName())
+	assert.Equal(t, "source-pod-uid", f.GetSource().GetPodUid())
 	assert.Empty(t, f.GetSourceService().GetNamespace())
 	assert.Empty(t, f.GetSourceService().GetName())
 
@@ -126,6 +124,7 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
 	assert.Equal(t, "default", f.GetDestination().GetNamespace())
 	assert.Equal(t, "pod-1234", f.GetDestination().GetPodName())
+	assert.Equal(t, "pod-1234-uid", f.GetDestination().GetPodUid())
 	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
 	assert.Equal(t, "service-1234", f.GetDestinationService().GetName())
 
@@ -187,6 +186,7 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 				return &ipcache.K8sMetadata{
 					Namespace: "default",
 					PodName:   "pod-1234",
+					PodUID:    "pod-1234-uid",
 				}
 			}
 			return nil
@@ -205,14 +205,10 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
 		OnGetEndpointInfo: func(ip netip.Addr) (endpoint getters.EndpointInfo, ok bool) {
-			switch {
-			case ip.String() == fakeSourceEndpoint.IPv4:
+			if ip.String() == fakeSourceEndpoint.IPv4 {
 				return &testutils.FakeEndpointInfo{
-					ID: fakeSourceEndpoint.ID,
-				}, true
-			case ip.String() == fakeDestinationEndpoint.IPv4:
-				return &testutils.FakeEndpointInfo{
-					ID: fakeDestinationEndpoint.ID,
+					ID:     fakeSourceEndpoint.ID,
+					PodUID: "source-pod-uid",
 				}, true
 			}
 			return nil, false
@@ -232,6 +228,7 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
 	assert.Empty(t, f.GetDestination().GetNamespace())
 	assert.Empty(t, f.GetDestination().GetPodName())
+	assert.Equal(t, "source-pod-uid", f.GetDestination().GetPodUid())
 	assert.Empty(t, f.GetDestinationService().GetNamespace())
 	assert.Empty(t, f.GetDestinationService().GetName())
 
@@ -241,6 +238,7 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
 	assert.Equal(t, "default", f.GetSource().GetNamespace())
 	assert.Equal(t, "pod-1234", f.GetSource().GetPodName())
+	assert.Equal(t, "pod-1234-uid", f.GetSource().GetPodUid())
 	assert.Equal(t, "default", f.GetSourceService().GetNamespace())
 	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
 

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -109,25 +109,25 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	sourceIP, _ := netip.ParseAddr(ip.Source)
 	destinationIP, _ := netip.ParseAddr(ip.Destination)
 	var sourceNames, destinationNames []string
-	var sourceNamespace, sourcePod, destinationNamespace, destinationPod string
+	var sourceNamespace, sourcePod, sourcePodUID, destinationNamespace, destinationPod, destinationPodUID string
 	if p.dnsGetter != nil {
 		sourceNames = p.dnsGetter.GetNamesOf(uint32(r.DestinationEndpoint.ID), sourceIP)
 		destinationNames = p.dnsGetter.GetNamesOf(uint32(r.SourceEndpoint.ID), destinationIP)
 	}
 	if p.ipGetter != nil {
 		if meta := p.ipGetter.GetK8sMetadata(sourceIP); meta != nil {
-			sourceNamespace, sourcePod = meta.Namespace, meta.PodName
+			sourceNamespace, sourcePod, sourcePodUID = meta.Namespace, meta.PodName, meta.PodUID
 		}
 		if meta := p.ipGetter.GetK8sMetadata(destinationIP); meta != nil {
-			destinationNamespace, destinationPod = meta.Namespace, meta.PodName
+			destinationNamespace, destinationPod, destinationPodUID = meta.Namespace, meta.PodName, meta.PodUID
 		}
 	}
-	srcEndpoint := decodeEndpoint(r.SourceEndpoint, sourceNamespace, sourcePod)
-	dstEndpoint := decodeEndpoint(r.DestinationEndpoint, destinationNamespace, destinationPod)
+	srcEndpoint := decodeEndpoint(r.SourceEndpoint, sourceNamespace, sourcePod, sourcePodUID)
+	dstEndpoint := decodeEndpoint(r.DestinationEndpoint, destinationNamespace, destinationPod, destinationPodUID)
 
 	if p.endpointGetter != nil {
-		p.updateEndpointWorkloads(sourceIP, srcEndpoint)
-		p.updateEndpointWorkloads(destinationIP, dstEndpoint)
+		p.updateEndpointFromLocal(sourceIP, srcEndpoint)
+		p.updateEndpointFromLocal(destinationIP, dstEndpoint)
 	}
 
 	l4, sourcePort, destinationPort := decodeLayer4(r.TransportProtocol, r.SourceEndpoint, r.DestinationEndpoint)
@@ -223,8 +223,18 @@ func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time
 	return 0
 }
 
-func (p *Parser) updateEndpointWorkloads(ip netip.Addr, endpoint *flowpb.Endpoint) {
+func (p *Parser) updateEndpointFromLocal(ip netip.Addr, endpoint *flowpb.Endpoint) {
 	if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
+		// Access logs are decoded asynchronously. The IP may now belong to a
+		// replacement endpoint, so only use Pod metadata when the IDs match.
+		if ep.GetID() != uint64(endpoint.GetID()) {
+			return
+		}
+		// Keep the Pod identity tuple tied to the ID-matched endpoint. When the
+		// UID is unknown, empty is safer than retaining metadata resolved by IP.
+		endpoint.Namespace = ep.GetK8sNamespace()
+		endpoint.PodName = ep.GetK8sPodName()
+		endpoint.PodUid = ep.GetK8sPodUID()
 		if pod := ep.GetPod(); pod != nil {
 			workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
 			if ok {
@@ -324,7 +334,7 @@ func decodeLayer4(protocol accesslog.TransportProtocol, source, destination acce
 	}
 }
 
-func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) *flowpb.Endpoint {
+func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName, podUID string) *flowpb.Endpoint {
 	labels := endpoint.Labels.GetModel()
 	slices.Sort(labels)
 	return &flowpb.Endpoint{
@@ -334,6 +344,7 @@ func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) 
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
+		PodUid:      podUID,
 	}
 }
 

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -5,15 +5,20 @@ package seven
 
 import (
 	"net/http"
+	"net/netip"
 	"net/url"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -122,7 +127,119 @@ func Test_decodeEndpoint(t *testing.T) {
 			"k8s:k8s-app=hubble-ui",
 		},
 		PodName: "hubble-ui",
+		PodUid:  "hubble-ui-uid",
 	}
-	ep := decodeEndpoint(epi, "kube-system", "hubble-ui")
+	ep := decodeEndpoint(epi, "kube-system", "hubble-ui", "hubble-ui-uid")
 	assert.Equal(t, expected, ep)
+
+	ep = decodeEndpoint(epi, "kube-system", "hubble-ui", "")
+	assert.Empty(t, ep.GetPodUid())
+}
+
+func TestUpdateEndpointFromLocalPodMetadata(t *testing.T) {
+	ip := netip.MustParseAddr("10.0.0.1")
+	controller := true
+	newLocalPod := func(uid string) *slim_corev1.Pod {
+		return &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{
+			UID:          k8sTypes.UID(uid),
+			GenerateName: "local-pod-",
+			OwnerReferences: []slim_metav1.OwnerReference{{
+				Kind:       "StatefulSet",
+				Name:       "local-workload",
+				Controller: &controller,
+			}},
+		}}
+	}
+	localWorkload := []*flowpb.Workload{{Kind: "StatefulSet", Name: "local-workload"}}
+	tests := []struct {
+		name            string
+		endpointID      uint32
+		localEndpointID uint64
+		localNamespace  string
+		localPodName    string
+		localPodUID     string
+		localPod        *slim_corev1.Pod
+		wantNamespace   string
+		wantPodName     string
+		wantPodUID      string
+		wantWorkloads   []*flowpb.Workload
+	}{
+		{
+			name:            "CNI UID overrides IPCache metadata",
+			endpointID:      1234,
+			localEndpointID: 1234,
+			localNamespace:  "local-namespace",
+			localPodName:    "local-pod",
+			localPodUID:     "cni-pod-uid",
+			localPod:        newLocalPod("attached-pod-uid"),
+			wantNamespace:   "local-namespace",
+			wantPodName:     "local-pod",
+			wantPodUID:      "cni-pod-uid",
+			wantWorkloads:   localWorkload,
+		},
+		{
+			name:            "attached Pod UID overrides IPCache metadata",
+			endpointID:      1234,
+			localEndpointID: 1234,
+			localNamespace:  "local-namespace",
+			localPodName:    "local-pod",
+			localPod:        newLocalPod("attached-pod-uid"),
+			wantNamespace:   "local-namespace",
+			wantPodName:     "local-pod",
+			wantPodUID:      "attached-pod-uid",
+			wantWorkloads:   localWorkload,
+		},
+		{
+			name:            "unknown local UID clears IPCache UID",
+			endpointID:      1234,
+			localEndpointID: 1234,
+			localNamespace:  "local-namespace",
+			localPodName:    "local-pod",
+			wantNamespace:   "local-namespace",
+			wantPodName:     "local-pod",
+		},
+		{
+			name:            "different local endpoint preserves IPCache metadata and skips workloads",
+			endpointID:      1234,
+			localEndpointID: 4321,
+			localNamespace:  "local-namespace",
+			localPodName:    "local-pod",
+			localPodUID:     "local-pod-uid",
+			localPod:        newLocalPod("local-pod-uid"),
+			wantNamespace:   "ipcache-namespace",
+			wantPodName:     "ipcache-pod",
+			wantPodUID:      "ipcache-pod-uid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Parser{
+				endpointGetter: &testutils.FakeEndpointGetter{
+					OnGetEndpointInfo: func(netip.Addr) (getters.EndpointInfo, bool) {
+						return &testutils.FakeEndpointInfo{
+							ID:           tt.localEndpointID,
+							PodNamespace: tt.localNamespace,
+							PodName:      tt.localPodName,
+							PodUID:       tt.localPodUID,
+							Pod:          tt.localPod,
+						}, true
+					},
+				},
+			}
+			endpoint := &flowpb.Endpoint{
+				ID:        tt.endpointID,
+				Namespace: "ipcache-namespace",
+				PodName:   "ipcache-pod",
+				PodUid:    "ipcache-pod-uid",
+			}
+
+			parser.updateEndpointFromLocal(ip, endpoint)
+
+			assert.Equal(t, tt.wantNamespace, endpoint.GetNamespace())
+			assert.Equal(t, tt.wantPodName, endpoint.GetPodName())
+			assert.Equal(t, tt.wantPodUID, endpoint.GetPodUid())
+			assert.Equal(t, tt.wantWorkloads, endpoint.GetWorkloads())
+		})
+	}
 }

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -422,6 +422,7 @@ type FakeEndpointInfo struct {
 	IPv6         net.IP
 	PodName      string
 	PodNamespace string
+	PodUID       string
 	Labels       []string
 	Pod          *slim_corev1.Pod
 
@@ -447,6 +448,17 @@ func (e *FakeEndpointInfo) GetK8sPodName() string {
 // GetK8sNamespace returns the pod namespace of the endpoint.
 func (e *FakeEndpointInfo) GetK8sNamespace() string {
 	return e.PodNamespace
+}
+
+// GetK8sPodUID returns the Pod UID of the endpoint.
+func (e *FakeEndpointInfo) GetK8sPodUID() string {
+	if e.PodUID != "" {
+		return e.PodUID
+	}
+	if e.Pod != nil {
+		return string(e.Pod.UID)
+	}
+	return ""
 }
 
 // GetLabels returns the labels of the endpoint.

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -52,6 +52,7 @@ type IPIdentityPair struct {
 	Metadata          string          `json:"Metadata"`
 	K8sNamespace      string          `json:"K8sNamespace,omitempty"`
 	K8sPodName        string          `json:"K8sPodName,omitempty"`
+	K8sPodUID         string          `json:"K8sPodUID,omitempty"`
 	K8sServiceAccount string          `json:"K8sServiceAccount,omitempty"`
 	NamedPorts        []NamedPort     `json:"NamedPorts,omitempty"`
 }

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -4,6 +4,8 @@
 package identity
 
 import (
+	"encoding/json"
+	"net"
 	"net/netip"
 	"testing"
 
@@ -13,6 +15,30 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 )
+
+func TestIPIdentityPairPodUIDJSONCompatibility(t *testing.T) {
+	pair := IPIdentityPair{
+		IP:           net.ParseIP("10.0.0.1"),
+		K8sNamespace: "default",
+		K8sPodName:   "echo",
+	}
+
+	withoutUID, err := pair.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(withoutUID), "K8sPodUID")
+
+	var decoded IPIdentityPair
+	require.NoError(t, json.Unmarshal(withoutUID, &decoded))
+	assert.Empty(t, decoded.K8sPodUID)
+
+	pair.K8sPodUID = "90b3d76d-3c14-42ce-b132-d2aad6789d47"
+	withUID, err := pair.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(withUID), `"K8sPodUID":"90b3d76d-3c14-42ce-b132-d2aad6789d47"`)
+
+	require.NoError(t, json.Unmarshal(withUID, &decoded))
+	assert.Equal(t, pair.K8sPodUID, decoded.K8sPodUID)
+}
 
 func TestReservedID(t *testing.T) {
 	i := GetReservedID("host")

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -96,6 +96,8 @@ type K8sMetadata struct {
 	Namespace string
 	// PodName is the Kubernetes pod name behind the IP
 	PodName string
+	// PodUID is the Kubernetes pod UID behind the IP
+	PodUID string
 	// NamedPorts is the set of named ports for the pod
 	NamedPorts types.NamedPortMap
 }
@@ -985,5 +987,5 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 			return false
 		}
 	}
-	return m.Namespace == o.Namespace && m.PodName == o.PodName
+	return m.Namespace == o.Namespace && m.PodName == o.PodName && m.PodUID == o.PodUID
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -839,12 +839,14 @@ func (ipc *IPCache) GetNamedPorts() (npm types.NamedPortMultiMap) {
 }
 
 // DeleteOnMetadataMatch removes the provided IP to security identity mapping from the IPCache
-// if the metadata cache holds the same "owner" metadata as the triggering pod event.
-func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool) {
+// if its Kubernetes metadata matches the triggering Pod event. The UIDs must match exactly:
+// two empty UIDs retain the legacy behavior, while a missing UID on only one side is treated
+// as a mismatch to avoid deleting an entry that cannot be proven to have the same owner.
+func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, namespace, name, uid string) (namedPortsChanged bool) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
 	k8sMeta := ipc.getK8sMetadata(IP)
-	if k8sMeta != nil && k8sMeta.Namespace == namespace && k8sMeta.PodName == name {
+	if k8sMeta != nil && k8sMeta.Namespace == namespace && k8sMeta.PodName == name && k8sMeta.PodUID == uid {
 		return ipc.deleteLocked(IP, source)
 	}
 	return false

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -244,6 +244,25 @@ func TestIPCache(t *testing.T) {
 	require.Empty(t, s.IPIdentityCache.identityToIPCache)
 }
 
+func TestK8sMetadataEqualIncludesPodUID(t *testing.T) {
+	metadata := &K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-uid",
+	}
+
+	require.True(t, metadata.Equal(&K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-uid",
+	}))
+	require.False(t, metadata.Equal(&K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "new-uid",
+	}))
+}
+
 func TestIPCacheNamedPorts(t *testing.T) {
 	s := setupIPCacheTestSuite(t)
 	t.Parallel()

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -263,6 +263,66 @@ func TestK8sMetadataEqualIncludesPodUID(t *testing.T) {
 	}))
 }
 
+func TestDeleteOnMetadataMatchPodUID(t *testing.T) {
+	tests := []struct {
+		name        string
+		metadataUID string
+		deleteUID   string
+		wantDeleted bool
+	}{
+		{
+			name:        "matching UID",
+			metadataUID: "pod-uid",
+			deleteUID:   "pod-uid",
+			wantDeleted: true,
+		},
+		{
+			name:        "different UID",
+			metadataUID: "new-pod-uid",
+			deleteUID:   "old-pod-uid",
+			wantDeleted: false,
+		},
+		{
+			name:        "cached UID with empty deletion UID",
+			metadataUID: "pod-uid",
+			deleteUID:   "",
+			wantDeleted: false,
+		},
+		{
+			name:        "empty metadata UID with UID deletion",
+			metadataUID: "",
+			deleteUID:   "pod-uid",
+			wantDeleted: false,
+		},
+		{
+			name:        "legacy metadata and deletion",
+			metadataUID: "",
+			deleteUID:   "",
+			wantDeleted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupIPCacheTestSuite(t)
+			const endpointIP = "10.0.0.15"
+			_, err := s.IPIdentityCache.Upsert(endpointIP, nil, 0, &K8sMetadata{
+				Namespace: "default",
+				PodName:   "echo",
+				PodUID:    tt.metadataUID,
+			}, Identity{
+				ID:     identityPkg.NumericIdentity(68),
+				Source: source.Kubernetes,
+			})
+			require.NoError(t, err)
+
+			s.IPIdentityCache.DeleteOnMetadataMatch(endpointIP, source.Kubernetes, "default", "echo", tt.deleteUID)
+			_, exists := s.IPIdentityCache.LookupByIP(endpointIP)
+			require.Equal(t, !tt.wantDeleted, exists)
+		})
+	}
+}
+
 func TestIPCacheNamedPorts(t *testing.T) {
 	s := setupIPCacheTestSuite(t)
 	t.Parallel()

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -72,6 +72,7 @@ type UpsertParams struct {
 	Metadata          string
 	K8sNamespace      string
 	K8sPodName        string
+	K8sPodUID         string
 	K8sServiceAccount string
 	NPM               types.NamedPortMap
 }
@@ -100,6 +101,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 		Key:               params.Key,
 		K8sNamespace:      params.K8sNamespace,
 		K8sPodName:        params.K8sPodName,
+		K8sPodUID:         params.K8sPodUID,
 		K8sServiceAccount: params.K8sServiceAccount,
 		NamedPorts:        namedPorts,
 	}
@@ -399,10 +401,11 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 	}
 
 	var k8sMeta *K8sMetadata
-	if ipIDPair.K8sNamespace != "" || ipIDPair.K8sPodName != "" || len(ipIDPair.NamedPorts) > 0 {
+	if ipIDPair.K8sNamespace != "" || ipIDPair.K8sPodName != "" || ipIDPair.K8sPodUID != "" || len(ipIDPair.NamedPorts) > 0 {
 		k8sMeta = &K8sMetadata{
 			Namespace:  ipIDPair.K8sNamespace,
 			PodName:    ipIDPair.K8sPodName,
+			PodUID:     ipIDPair.K8sPodUID,
 			NamedPorts: make(types.NamedPortMap, len(ipIDPair.NamedPorts)),
 		}
 		for _, np := range ipIDPair.NamedPorts {

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -5,7 +5,9 @@ package ipcache
 
 import (
 	"context"
+	"encoding/json"
 	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -30,10 +32,20 @@ type event struct {
 
 type fakeIPCache struct{ events chan event }
 type fakeBackend struct{ prefix string }
+type recordingKVStoreClient struct{ value []byte }
 
 func NewEvent(ev, ip string, source source.Source) event { return event{ev, ip, source, nil} }
 func NewFakeIPCache() *fakeIPCache                       { return &fakeIPCache{events: make(chan event)} }
 func NewFakeBackend() *fakeBackend                       { return &fakeBackend{} }
+
+func (c *recordingKVStoreClient) IsEnabled() bool { return true }
+
+func (c *recordingKVStoreClient) UpdateIfDifferent(_ context.Context, _ string, value []byte, _ bool) (bool, error) {
+	c.value = append(c.value[:0], value...)
+	return true, nil
+}
+
+func (c *recordingKVStoreClient) Delete(_ context.Context, _ string) error { return nil }
 
 func (m *fakeIPCache) Upsert(ip string, _ net.IP, _ uint8, k8sMeta *K8sMetadata, id Identity) (bool, error) {
 	m.events <- event{ev: "upsert", ip: ip, source: id.Source, k8sMeta: k8sMeta}
@@ -90,6 +102,26 @@ func eventually(in <-chan event) event {
 	case <-time.After(5 * time.Second):
 		return NewEvent("error", "timed out waiting for KV", source.Unspec)
 	}
+}
+
+func TestIPIdentitySynchronizerPodUID(t *testing.T) {
+	client := &recordingKVStoreClient{}
+	synchronizer := &IPIdentitySynchronizer{
+		logger: hivetest.Logger(t),
+		client: client,
+	}
+
+	require.NoError(t, synchronizer.Upsert(t.Context(), &UpsertParams{
+		IP:           netip.MustParseAddr("10.0.0.1"),
+		HostIP:       netip.MustParseAddr("10.0.0.2"),
+		K8sNamespace: "default",
+		K8sPodName:   "echo",
+		K8sPodUID:    "90b3d76d-3c14-42ce-b132-d2aad6789d47",
+	}))
+
+	var pair identity.IPIdentityPair
+	require.NoError(t, json.Unmarshal(client.value, &pair))
+	require.Equal(t, "90b3d76d-3c14-42ce-b132-d2aad6789d47", pair.K8sPodUID)
 }
 
 func TestIPIdentityWatcher(t *testing.T) {
@@ -218,6 +250,7 @@ func TestIPIdentityWatcherNamedPorts(t *testing.T) {
 		ID:           identity.NumericIdentity(1000),
 		K8sNamespace: "test-ns",
 		K8sPodName:   "echo-1",
+		K8sPodUID:    "90b3d76d-3c14-42ce-b132-d2aad6789d47",
 		NamedPorts: []identity.NamedPort{
 			{Name: "http", Port: 8080, Protocol: "TCP"},
 			{Name: "dns", Port: 53, Protocol: "UDP"},
@@ -231,6 +264,7 @@ func TestIPIdentityWatcherNamedPorts(t *testing.T) {
 	require.NotNil(t, event.k8sMeta)
 	require.Equal(t, "test-ns", event.k8sMeta.Namespace)
 	require.Equal(t, "echo-1", event.k8sMeta.PodName)
+	require.Equal(t, "90b3d76d-3c14-42ce-b132-d2aad6789d47", event.k8sMeta.PodUID)
 	require.Equal(t, types.NamedPortMap{
 		"http": {Proto: u8proto.TCP, Port: 8080},
 		"dns":  {Proto: u8proto.UDP, Port: 53},

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -42,8 +42,21 @@ func (in *CiliumEndpoint) DeepEqual(other *CiliumEndpoint) bool {
 	if in.Namespace != other.Namespace {
 		return false
 	}
+	if in.GetPodUID() != other.GetPodUID() {
+		return false
+	}
 
 	return in.deepEqual(other)
+}
+
+// GetPodUID returns the UID of the Pod that owns the CiliumEndpoint.
+func (in *CiliumEndpoint) GetPodUID() string {
+	for _, ref := range in.OwnerReferences {
+		if ref.Kind == "Pod" {
+			return string(ref.UID)
+		}
+	}
+	return ""
 }
 
 // +deepequal-gen=true

--- a/pkg/k8s/types/types_test.go
+++ b/pkg/k8s/types/types_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestCiliumEndpointDeepEqualIncludesPodUID(t *testing.T) {
+	endpoint := &CiliumEndpoint{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "echo",
+			Namespace: "default",
+			OwnerReferences: []slim_metav1.OwnerReference{
+				{
+					Kind: "Pod",
+					UID:  k8sTypes.UID("old-pod-uid"),
+				},
+			},
+		},
+	}
+
+	same := endpoint.DeepCopy()
+	require.True(t, endpoint.DeepEqual(same))
+	require.Equal(t, "old-pod-uid", endpoint.GetPodUID())
+
+	changed := endpoint.DeepCopy()
+	changed.OwnerReferences[0].UID = k8sTypes.UID("new-pod-uid")
+	require.False(t, endpoint.DeepEqual(changed))
+}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -163,13 +163,13 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 					}
 				}
 				if !v4Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV4, source.CustomResource, oldEndpoint.Namespace, oldEndpoint.Name, oldEndpoint.GetPodUID())
 					if portsChanged {
 						namedPortsChanged = true
 					}
 				}
 				if !v6Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV6, source.CustomResource, oldEndpoint.Namespace, oldEndpoint.Name, oldEndpoint.GetPodUID())
 					if portsChanged {
 						namedPortsChanged = true
 					}
@@ -215,6 +215,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	k8sMeta := &ipcache.K8sMetadata{
 		Namespace:  endpoint.Namespace,
 		PodName:    endpoint.Name,
+		PodUID:     endpoint.GetPodUID(),
 		NamedPorts: make(ciliumTypes.NamedPortMap, len(endpoint.NamedPorts)),
 	}
 	for _, port := range endpoint.NamedPorts {
@@ -254,14 +255,14 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
 		namedPortsChanged := false
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name, endpoint.GetPodUID())
 				if portsChanged {
 					namedPortsChanged = true
 				}
 			}
 
 			if pair.IPV6 != "" {
-				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name, endpoint.GetPodUID())
 				if portsChanged {
 					namedPortsChanged = true
 				}

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -166,6 +167,17 @@ func newEndpoint(name, namespace string, id int64, serviceAccount string) *types
 		Encryption:     &v2.EncryptionSpec{},
 		ServiceAccount: serviceAccount,
 	}
+}
+
+func newEndpointWithPodUID(name, namespace string, id int64, serviceAccount, podUID string) *types.CiliumEndpoint {
+	endpoint := newEndpoint(name, namespace, id, serviceAccount)
+	endpoint.OwnerReferences = []slim_metav1.OwnerReference{
+		{
+			Kind: "Pod",
+			UID:  k8sTypes.UID(podUID),
+		},
+	}
+	return endpoint
 }
 
 // TestCESSubscriber_CEPTransfer tests a CEP being transferred between two
@@ -731,6 +743,32 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 			expectedCurrentCES: map[string]string{
 				"default/cep1": "ces",
 				"default/cep2": "ces",
+			},
+		},
+		{
+			name: "update_pod_uid",
+			oldCES: newCES("ces", testNamespace,
+				v2alpha1.CoreCiliumEndpoint{
+					Name:           "cep1",
+					ServiceAccount: "test-service-account",
+					PodUID:         "old-pod-uid",
+				},
+			),
+			newCES: newCES("ces", testNamespace,
+				v2alpha1.CoreCiliumEndpoint{
+					Name:           "cep1",
+					ServiceAccount: "test-service-account",
+					PodUID:         "new-pod-uid",
+				},
+			),
+			expectUpdates: []endpointUpdate{
+				{
+					OldEP: newEndpointWithPodUID("cep1", testNamespace, 0, "test-service-account", "old-pod-uid"),
+					NewEP: newEndpointWithPodUID("cep1", testNamespace, 0, "test-service-account", "new-pod-uid"),
+				},
+			},
+			expectedCurrentCES: map[string]string{
+				"default/cep1": "ces",
 			},
 		},
 		{

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -172,12 +172,18 @@ func (k *K8sPodWatcher) podsInit(ctx context.Context) {
 				name := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 				if !change.Deleted {
 					oldPod := pods[name]
-					if oldPod == nil {
+					switch {
+					case oldPod == nil:
 						k.addK8sPodV1(ctx, pod)
-					} else {
-						k.updateK8sPodV1(ctx, oldPod, pod)
+					case oldPod.UID != pod.UID:
+						k.replaceK8sPodV1(ctx, oldPod, pod)
+					default:
+						k.updateExistingK8sPodV1(ctx, oldPod, pod)
 					}
 					k.k8sResourceSynced.SetEventTimestamp(podApiGroup)
+					// Track the latest observed Pod rather than the last fully
+					// reconciled transition. Handlers can partially apply an event,
+					// so retaining the old object could replay stale replacement work.
 					pods[name] = pod
 				} else {
 					k.deleteK8sPodV1(pod)
@@ -254,7 +260,7 @@ func (k *K8sPodWatcher) addK8sPodV1(ctx context.Context, pod *slim_corev1.Pod) e
 		k.hostNetworkManager.AddNoTrackHostPorts(pod.Namespace, pod.Name, strings.Split(hostPorts, ","))
 	}
 
-	if pod.Spec.HostNetwork && !option.Config.EnableLocalRedirectPolicy {
+	if shouldSkipHostNetworkPod(pod) {
 		scopedLog.Debug("Skip pod event using host networking")
 		return err
 	}
@@ -274,7 +280,86 @@ func (k *K8sPodWatcher) addK8sPodV1(ctx context.Context, pod *slim_corev1.Pod) e
 	return err
 }
 
-func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod *slim_corev1.Pod) error {
+func (k *K8sPodWatcher) replaceK8sPodV1(ctx context.Context, oldPod, newPod *slim_corev1.Pod) error {
+	scopedLog := k.logger.With(
+		logfields.K8sPodName, newPod.ObjectMeta.Name,
+		logfields.K8sNamespace, newPod.ObjectMeta.Namespace,
+	)
+	if !k8sUtils.IsPodRunning(newPod.Status) {
+		return k.deleteK8sPodV1(oldPod)
+	}
+
+	k.replaceHostNetworkState(oldPod, newPod)
+	if !shouldSkipHostNetworkPod(newPod) {
+		k.cgroupManager.OnUpdatePod(oldPod, newPod)
+	}
+
+	var ipcacheErr error
+	if newPod.Spec.HostNetwork {
+		if !oldPod.Spec.HostNetwork {
+			k.deletePodIPCacheMetadata(oldPod)
+		}
+	} else {
+		var oldPodIPs k8sTypes.IPSlice
+		if !oldPod.Spec.HostNetwork {
+			oldPodIPs = k8sUtils.ValidIPs(oldPod.Status)
+		}
+		newPodIPs := k8sUtils.ValidIPs(newPod.Status)
+		if len(oldPodIPs) != 0 || len(newPodIPs) != 0 {
+			ipcacheErr = k.replacePodHostData(ctx, oldPod, newPod, oldPodIPs, newPodIPs)
+		}
+	}
+	if ipcacheErr != nil {
+		scopedLog.Warn("Unable to replace ipcache map entry on pod replacement", logfields.Error, ipcacheErr)
+	}
+
+	var endpointErr error
+	if !shouldSkipHostNetworkPod(newPod) {
+		endpointErr = k.reconcilePodEndpoints(oldPod, newPod, true)
+	}
+	return errors.Join(ipcacheErr, endpointErr)
+}
+
+func (k *K8sPodWatcher) replaceHostNetworkState(oldPod, newPod *slim_corev1.Pod) {
+	scopedLog := k.logger.With(
+		logfields.K8sPodName, newPod.ObjectMeta.Name,
+		logfields.K8sNamespace, newPod.ObjectMeta.Namespace,
+	)
+	hostPorts, ok := annotation.Get(newPod, annotation.NoTrackHostPorts)
+	if ok && !newPod.Spec.HostNetwork {
+		scopedLog.Warn(fmt.Sprintf("%s annotation present but pod does not have hostNetwork: true. ignoring", annotation.NoTrackHostPorts))
+	}
+
+	switch {
+	case newPod.Spec.HostNetwork:
+		hostPorts = strings.ReplaceAll(hostPorts, " ", "")
+		ports := strings.Split(hostPorts, ",")
+		if oldPod.Spec.HostNetwork && !validNoTrackHostPorts(ports) {
+			// The host-network manager leaves its existing desired state in place
+			// when parsing fails. A replacement must not retain rules owned by the
+			// old Pod in that case.
+			k.hostNetworkManager.RemoveNoTrackHostPorts(oldPod.Namespace, oldPod.Name)
+		}
+		k.hostNetworkManager.AddNoTrackHostPorts(newPod.Namespace, newPod.Name, ports)
+	case oldPod.Spec.HostNetwork:
+		k.hostNetworkManager.RemoveNoTrackHostPorts(oldPod.Namespace, oldPod.Name)
+	}
+}
+
+func validNoTrackHostPorts(ports []string) bool {
+	for _, port := range ports {
+		if port == "" {
+			continue
+		}
+		parsed, err := loadbalancer.L4AddrFromString(port)
+		if err != nil || parsed.Protocol != loadbalancer.TCP && parsed.Protocol != loadbalancer.UDP {
+			return false
+		}
+	}
+	return true
+}
+
+func (k *K8sPodWatcher) updateExistingK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod *slim_corev1.Pod) error {
 	var err error
 
 	if oldK8sPod == nil || newK8sPod == nil {
@@ -291,7 +376,6 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 		logfields.OldPodIPs, oldK8sPod.Status.PodIPs,
 		logfields.OldHostIP, oldK8sPod.Status.HostIP,
 	)
-
 	// In Kubernetes Jobs, Pods can be left in Kubernetes until the Job
 	// is deleted. If the Job is never deleted, Cilium will never receive a Pod
 	// delete event, causing the IP to be left in the ipcache.
@@ -313,8 +397,7 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 		k.hostNetworkManager.AddNoTrackHostPorts(newK8sPod.Namespace, newK8sPod.Name, strings.Split(hostPorts, ","))
 	}
 
-	if newK8sPod.Spec.HostNetwork && !option.Config.EnableLocalRedirectPolicy &&
-		!option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing {
+	if shouldSkipHostNetworkPod(newK8sPod) {
 		scopedLog.Debug("Skip pod event using host networking")
 		return err
 	}
@@ -329,6 +412,17 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 			scopedLog.Warn("Unable to update ipcache map entry on pod update", logfields.Error, err)
 		}
 	}
+	if endpointErr := k.reconcilePodEndpoints(oldK8sPod, newK8sPod, false); endpointErr != nil {
+		return endpointErr
+	}
+	return err
+}
+
+func (k *K8sPodWatcher) reconcilePodEndpoints(oldK8sPod, newK8sPod *slim_corev1.Pod, forceLabels bool) error {
+	scopedLog := k.logger.With(
+		logfields.K8sPodName, newK8sPod.ObjectMeta.Name,
+		logfields.K8sNamespace, newK8sPod.ObjectMeta.Namespace,
+	)
 
 	// Check annotation updates.
 	oldAnno := oldK8sPod.ObjectMeta.Annotations
@@ -351,18 +445,17 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 	newK8sPodLabels, _ := labelsfilter.Filter(labels.Map2Labels(strippedNewLabels, labels.LabelSourceK8s))
 	newPodLabels := newK8sPodLabels.K8sStringMap()
 	labelsChanged := !maps.Equal(oldPodLabels, newPodLabels)
-	uidChanged := oldK8sPod.UID != newK8sPod.UID
 
 	// Nothing changed.
-	if !annotationsChanged && !labelsChanged {
+	if !annotationsChanged && !labelsChanged && !forceLabels {
 		scopedLog.Debug(
-			"Pod does not have any annotations nor labels changed",
+			"Pod does not have any relevant changes",
 			logfields.OldLabels, oldK8sPod.GetObjectMeta().GetLabels(),
 			logfields.OldAnnotations, oldK8sPod.GetObjectMeta().GetAnnotations(),
 			logfields.NewLabels, newK8sPod.GetObjectMeta().GetLabels(),
 			logfields.NewAnnotations, newK8sPod.GetObjectMeta().GetAnnotations(),
 		)
-		return err
+		return nil
 	}
 
 	podNSName := k8sUtils.GetObjNamespaceName(&newK8sPod.ObjectMeta)
@@ -373,14 +466,13 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 			"Endpoint not found running for the given pod",
 			logfields.Pod, podNSName,
 		)
-		return err
+		return nil
 	}
 
 	for _, podEP := range podEPs {
-		if labelsChanged || uidChanged {
-			// Consider a UID change the same as a label change in case the pod's
-			// identity needs to be updated, see GH-30409. Annotations are not
-			// checked for because annotations don't impact identities.
+		if labelsChanged || forceLabels {
+			// A replacement needs the same forced label refresh as an observed UID
+			// change, even when the old and new label maps are equal. See GH-30409.
 			err := podEP.UpdateLabelsFrom(oldPodLabels, newPodLabels, labels.LabelSourceK8s)
 			if err != nil {
 				scopedLog.Warn(
@@ -460,7 +552,12 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 		}
 	}
 
-	return err
+	return nil
+}
+
+func shouldSkipHostNetworkPod(pod *slim_corev1.Pod) bool {
+	return pod.Spec.HostNetwork && !option.Config.EnableLocalRedirectPolicy &&
+		!option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing
 }
 
 func realizePodAnnotationUpdate(podEP *endpoint.Endpoint) {
@@ -596,6 +693,14 @@ func (k *K8sPodWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 }
 
 func (k *K8sPodWatcher) updatePodHostData(ctx context.Context, oldPod, newPod *slim_corev1.Pod, oldPodIPs, newPodIPs k8sTypes.IPSlice) error {
+	return k.upsertPodHostData(ctx, oldPod, newPod, oldPodIPs, newPodIPs, false)
+}
+
+func (k *K8sPodWatcher) replacePodHostData(ctx context.Context, oldPod, newPod *slim_corev1.Pod, oldPodIPs, newPodIPs k8sTypes.IPSlice) error {
+	return k.upsertPodHostData(ctx, oldPod, newPod, oldPodIPs, newPodIPs, true)
+}
+
+func (k *K8sPodWatcher) upsertPodHostData(ctx context.Context, oldPod, newPod *slim_corev1.Pod, oldPodIPs, newPodIPs k8sTypes.IPSlice, replace bool) error {
 	if newPod.Spec.HostNetwork {
 		k.logger.Debug("Pod is using host networking",
 			logfields.K8sPodName, newPod.ObjectMeta.Name,
@@ -609,18 +714,18 @@ func (k *K8sPodWatcher) updatePodHostData(ctx context.Context, oldPod, newPod *s
 	ipSliceEqual := oldPodIPs != nil && oldPodIPs.DeepEqual(&newPodIPs)
 
 	defer func() {
-		if !ipSliceEqual {
-			// delete all IPs that were not added regardless if the insertion of the
-			// entry in the ipcache map was successful or not because we will not
-			// receive any other event with these old IP addresses.
+		if oldPod != nil && (!ipSliceEqual || replace) {
+			// Delete IPs that the old Pod no longer owns after attempting the new
+			// insertion.
 			for _, oldPodIP := range oldPodIPs {
-				var found bool
-				if slices.Contains(newPodIPs, oldPodIP) {
-					found = true
-				}
-				if !found {
-					npc := k.ipcache.Delete(oldPodIP, source.Kubernetes)
-					if npc {
+				if replace || !slices.Contains(newPodIPs, oldPodIP) {
+					if k.ipcache.DeleteOnMetadataMatch(
+						oldPodIP,
+						source.Kubernetes,
+						oldPod.Namespace,
+						oldPod.Name,
+						string(oldPod.UID),
+					) {
 						namedPortsChanged = true
 					}
 				}
@@ -629,7 +734,7 @@ func (k *K8sPodWatcher) updatePodHostData(ctx context.Context, oldPod, newPod *s
 
 		// This happens at most once due to k8sMeta being the same for all podIPs in this loop
 		if namedPortsChanged {
-			k.policyManager.TriggerPolicyUpdates("Named ports added or updated")
+			k.policyManager.TriggerPolicyUpdates("Named ports added, updated or deleted")
 		}
 	}()
 
@@ -638,7 +743,7 @@ func (k *K8sPodWatcher) updatePodHostData(ctx context.Context, oldPod, newPod *s
 
 	// if spec, host IPs, and pod IPs are the same there no need to perform the remaining
 	// operations
-	if specEqual && hostIPEqual && ipSliceEqual {
+	if specEqual && hostIPEqual && ipSliceEqual && !replace {
 		return nil
 	}
 
@@ -657,6 +762,7 @@ func (k *K8sPodWatcher) updatePodHostData(ctx context.Context, oldPod, newPod *s
 	k8sMeta := &ipcache.K8sMetadata{
 		Namespace: newPod.Namespace,
 		PodName:   newPod.Name,
+		PodUID:    string(newPod.UID),
 	}
 
 	// Store Named ports, if any.
@@ -726,8 +832,9 @@ func (k *K8sPodWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 	}
 
 	var (
-		errs    []string
-		skipped bool
+		errs              []string
+		skipped           bool
+		namedPortsChanged bool
 	)
 
 	for _, podIP := range podIPs {
@@ -747,7 +854,13 @@ func (k *K8sPodWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 			continue
 		}
 
-		k.ipcache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name)
+		if k.ipcache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name, string(pod.UID)) {
+			namedPortsChanged = true
+		}
+	}
+
+	if namedPortsChanged {
+		k.policyManager.TriggerPolicyUpdates("Named ports deleted")
 	}
 
 	if len(errs) != 0 {
@@ -755,6 +868,28 @@ func (k *K8sPodWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 	}
 
 	return skipped, nil
+}
+
+func (k *K8sPodWatcher) deletePodIPCacheMetadata(pod *slim_corev1.Pod) {
+	if pod.Spec.HostNetwork {
+		return
+	}
+
+	var namedPortsChanged bool
+	for _, podIP := range k8sUtils.ValidIPs(pod.Status) {
+		if k.ipcache.DeleteOnMetadataMatch(
+			podIP,
+			source.Kubernetes,
+			pod.Namespace,
+			pod.Name,
+			string(pod.UID),
+		) {
+			namedPortsChanged = true
+		}
+	}
+	if namedPortsChanged {
+		k.policyManager.TriggerPolicyUpdates("Named ports deleted")
+	}
 }
 
 // GetCachedPod returns a pod from the local store.

--- a/pkg/k8s/watchers/pod_test.go
+++ b/pkg/k8s/watchers/pod_test.go
@@ -1,0 +1,649 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	k8sAPITypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/source"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	ciliumTypes "github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/u8proto"
+	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
+)
+
+type fakeEndpointManager struct {
+	endpoints []*endpoint.Endpoint
+}
+
+func (*fakeEndpointManager) LookupCEPName(string) *endpoint.Endpoint { return nil }
+
+func (m *fakeEndpointManager) GetEndpoints() []*endpoint.Endpoint { return m.endpoints }
+
+func (*fakeEndpointManager) GetHostEndpoint() *endpoint.Endpoint { return nil }
+
+func (m *fakeEndpointManager) GetEndpointsByPodName(string) []*endpoint.Endpoint {
+	return m.endpoints
+}
+
+func (*fakeEndpointManager) WaitForEndpointsAtPolicyRev(context.Context, uint64) error { return nil }
+
+func (*fakeEndpointManager) UpdatePolicyMaps(context.Context) error { return nil }
+
+type fakeCgroupManager struct {
+	addedPod   *slim_corev1.Pod
+	deletedPod *slim_corev1.Pod
+	operations []string
+	updatedPod *slim_corev1.Pod
+}
+
+func (m *fakeCgroupManager) OnAddPod(pod *slim_corev1.Pod) {
+	m.operations = append(m.operations, "add:"+string(pod.UID))
+	m.addedPod = pod
+}
+
+func (m *fakeCgroupManager) OnUpdatePod(oldPod, newPod *slim_corev1.Pod) {
+	if oldPod.UID != newPod.UID {
+		m.operations = append(m.operations, "replace:"+string(oldPod.UID)+"->"+string(newPod.UID))
+	} else {
+		m.operations = append(m.operations, "update:"+string(newPod.UID))
+	}
+	m.updatedPod = newPod
+}
+
+func (m *fakeCgroupManager) OnDeletePod(pod *slim_corev1.Pod) {
+	m.operations = append(m.operations, "delete:"+string(pod.UID))
+	m.deletedPod = pod
+}
+
+type fakePolicyManager struct {
+	reasons []string
+}
+
+func (m *fakePolicyManager) TriggerPolicyUpdates(reason string) {
+	m.reasons = append(m.reasons, reason)
+}
+
+type ipcacheEvent struct {
+	modType   ipcache.CacheModification
+	oldHostIP string
+	newHostIP string
+	podUID    string
+}
+
+type recordingIPCacheListener struct {
+	events []ipcacheEvent
+}
+
+func (l *recordingIPCacheListener) OnIPIdentityCacheChange(
+	modType ipcache.CacheModification,
+	_ cmtypes.PrefixCluster,
+	oldHostIP, newHostIP net.IP,
+	_ *ipcache.Identity,
+	_ ipcache.Identity,
+	_ uint8,
+	k8sMeta *ipcache.K8sMetadata,
+	_ uint8,
+) {
+	event := ipcacheEvent{
+		modType: modType,
+	}
+	if oldHostIP != nil {
+		event.oldHostIP = oldHostIP.String()
+	}
+	if newHostIP != nil {
+		event.newHostIP = newHostIP.String()
+	}
+	if k8sMeta != nil {
+		event.podUID = k8sMeta.PodUID
+	}
+	l.events = append(l.events, event)
+}
+
+type fakeHostNetworkManager struct {
+	addedPorts  [][]string
+	addedPods   []k8sAPITypes.NamespacedName
+	removedPods []k8sAPITypes.NamespacedName
+	operations  []string
+}
+
+func (m *fakeHostNetworkManager) AddNoTrackHostPorts(namespace, name string, ports []string) {
+	m.operations = append(m.operations, "add:"+namespace+"/"+name)
+	m.addedPorts = append(m.addedPorts, slices.Clone(ports))
+	m.addedPods = append(m.addedPods, k8sAPITypes.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+func (m *fakeHostNetworkManager) RemoveNoTrackHostPorts(namespace, name string) {
+	m.operations = append(m.operations, "remove:"+namespace+"/"+name)
+	m.removedPods = append(m.removedPods, k8sAPITypes.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+func TestAddK8sPodV1TracedHostNetworkPodAddsCgroupMetadata(t *testing.T) {
+	oldTracing := option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing
+	option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing = true
+	t.Cleanup(func() {
+		option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing = oldTracing
+	})
+
+	cgroups := &fakeCgroupManager{}
+	hostNetwork := &fakeHostNetworkManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		cgroupManager:      cgroups,
+		hostNetworkManager: hostNetwork,
+	}
+	pod := podWatcherTestPod("pod-uid", slim_corev1.PodRunning, "", "")
+	pod.Spec.HostNetwork = true
+
+	require.NoError(t, watcher.addK8sPodV1(t.Context(), pod))
+	require.Equal(t, []string{"add:pod-uid"}, cgroups.operations)
+	require.Equal(t, []string{"add:default/echo"}, hostNetwork.operations)
+}
+
+func TestReplaceK8sPodV1TerminalPodDeletesOldPodMetadata(t *testing.T) {
+	const podIP = "10.0.0.1"
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	cgroups := &fakeCgroupManager{}
+	watcher := &K8sPodWatcher{
+		logger:        hivetest.Logger(t),
+		ipcache:       ipc,
+		cgroupManager: cgroups,
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodSucceeded, podIP, "10.0.0.2")
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	_, exists := ipc.LookupByIP(podIP)
+	require.False(t, exists)
+	require.Same(t, oldPod, cgroups.deletedPod)
+	require.Nil(t, cgroups.addedPod)
+	require.Equal(t, []string{"delete:old-pod-uid"}, cgroups.operations)
+}
+
+func TestReplaceK8sPodV1TracedHostNetworkPodDeletesOldPodMetadata(t *testing.T) {
+	const podIP = "10.0.0.1"
+	oldTracing := option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing
+	option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing = true
+	t.Cleanup(func() {
+		option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing = oldTracing
+	})
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	cgroups := &fakeCgroupManager{}
+	hostNetwork := &fakeHostNetworkManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		ipcache:            ipc,
+		cgroupManager:      cgroups,
+		hostNetworkManager: hostNetwork,
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod.Spec.HostNetwork = true
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	_, exists := ipc.LookupByIP(podIP)
+	require.False(t, exists)
+	require.Equal(t, []string{"replace:old-pod-uid->new-pod-uid"}, cgroups.operations)
+	require.Equal(t, []string{"add:default/echo"}, hostNetwork.operations)
+}
+
+func TestReplaceK8sPodV1RemovesOldHostNetworkState(t *testing.T) {
+	hostNetwork := &fakeHostNetworkManager{}
+	cgroups := &fakeCgroupManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		cgroupManager:      cgroups,
+		hostNetworkManager: hostNetwork,
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, "", "")
+	oldPod.Spec.HostNetwork = true
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, "", "")
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	require.Equal(t, []k8sAPITypes.NamespacedName{
+		{Namespace: "default", Name: "echo"},
+	}, hostNetwork.removedPods)
+	require.Equal(t, []string{"replace:old-pod-uid->new-pod-uid"}, cgroups.operations)
+}
+
+func TestReplaceK8sPodV1HostNetworkReplacementRefreshesState(t *testing.T) {
+	hostNetwork := &fakeHostNetworkManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: hostNetwork,
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, "", "")
+	oldPod.Spec.HostNetwork = true
+	oldPod.Annotations = map[string]string{annotation.NoTrackHostPorts: "80/tcp"}
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, "", "")
+	newPod.Spec.HostNetwork = true
+	newPod.Annotations = map[string]string{annotation.NoTrackHostPorts: "53/udp"}
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	pod := []k8sAPITypes.NamespacedName{{Namespace: "default", Name: "echo"}}
+	require.Empty(t, hostNetwork.removedPods)
+	require.Equal(t, pod, hostNetwork.addedPods)
+	require.Equal(t, []string{"add:default/echo"}, hostNetwork.operations)
+	require.Equal(t, [][]string{{"53/udp"}}, hostNetwork.addedPorts)
+}
+
+func TestValidNoTrackHostPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports []string
+		want  bool
+	}{
+		{name: "empty", ports: []string{""}, want: true},
+		{name: "TCP", ports: []string{"80/tcp"}, want: true},
+		{name: "UDP", ports: []string{"53/udp"}, want: true},
+		{name: "multiple", ports: []string{"80/tcp", "53/udp"}, want: true},
+		{name: "malformed", ports: []string{"invalid"}},
+		{name: "unsupported protocol", ports: []string{"80/sctp"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, validNoTrackHostPorts(tt.ports))
+		})
+	}
+}
+
+func TestReplaceK8sPodV1InvalidHostNetworkReplacementRemovesOldState(t *testing.T) {
+	hostNetwork := &fakeHostNetworkManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: hostNetwork,
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, "", "")
+	oldPod.Spec.HostNetwork = true
+	oldPod.Annotations = map[string]string{annotation.NoTrackHostPorts: "80/tcp"}
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, "", "")
+	newPod.Spec.HostNetwork = true
+	newPod.Annotations = map[string]string{annotation.NoTrackHostPorts: "invalid"}
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	require.Equal(t, []string{
+		"remove:default/echo",
+		"add:default/echo",
+	}, hostNetwork.operations)
+	require.Equal(t, [][]string{{"invalid"}}, hostNetwork.addedPorts)
+}
+
+func TestReplaceK8sPodV1InvalidHostIPRecoversOnPodUpdate(t *testing.T) {
+	const podIP = "10.0.0.1"
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	_, err := ipc.Upsert(podIP, nil, 0, &ipcache.K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-pod-uid",
+		NamedPorts: ciliumTypes.NamedPortMap{
+			"http": {Port: 80, Proto: u8proto.TCP},
+		},
+	}, ipcache.Identity{
+		ID:     identity.ReservedIdentityUnmanaged,
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+	ipc.GetNamedPorts()
+
+	cgroups := &fakeCgroupManager{}
+	policies := &fakePolicyManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		policyManager:      policies,
+		ipcache:            ipc,
+		cgroupManager:      cgroups,
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, "")
+
+	err = watcher.replaceK8sPodV1(t.Context(), oldPod, newPod)
+	require.ErrorContains(t, err, "no/invalid HostIP")
+	_, exists := ipc.LookupByIP(podIP)
+	require.False(t, exists)
+	require.Len(t, policies.reasons, 1)
+	require.Equal(t, []string{"replace:old-pod-uid->new-pod-uid"}, cgroups.operations)
+
+	recoveredPod := newPod.DeepCopy()
+	recoveredPod.Status.HostIP = "10.0.0.2"
+	require.NoError(t, watcher.updateExistingK8sPodV1(t.Context(), newPod, recoveredPod))
+	metadata := ipc.GetK8sMetadata(netip.MustParseAddr(podIP))
+	require.NotNil(t, metadata)
+	require.Equal(t, string(recoveredPod.UID), metadata.PodUID)
+	require.Equal(t, []string{
+		"replace:old-pod-uid->new-pod-uid",
+		"update:new-pod-uid",
+	}, cgroups.operations)
+}
+
+func TestReplaceK8sPodV1KeepsNewPodMetadata(t *testing.T) {
+	const podIP = "10.0.0.1"
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	listener := &recordingIPCacheListener{}
+	ipc.AddListener(listener)
+	// Ignore the current-state dump performed when a listener is registered.
+	listener.events = nil
+	cgroups := &fakeCgroupManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		ipcache:            ipc,
+		cgroupManager:      cgroups,
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	metadata := ipc.GetK8sMetadata(netip.MustParseAddr(podIP))
+	require.NotNil(t, metadata)
+	require.Equal(t, string(newPod.UID), metadata.PodUID)
+	require.Equal(t, []string{"replace:old-pod-uid->new-pod-uid"}, cgroups.operations)
+	require.Equal(t, []ipcacheEvent{{
+		modType:   ipcache.Upsert,
+		newHostIP: "10.0.0.2",
+		podUID:    "new-pod-uid",
+	}}, listener.events)
+}
+
+func TestReplaceK8sPodV1SameIPChangedHostUpdatesInPlace(t *testing.T) {
+	const (
+		podIP     = "10.0.0.1"
+		oldHostIP = "10.0.0.2"
+		newHostIP = "10.0.0.3"
+	)
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	_, err := ipc.Upsert(podIP, net.ParseIP(oldHostIP), 0, &ipcache.K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-pod-uid",
+	}, ipcache.Identity{
+		ID:     identity.ReservedIdentityUnmanaged,
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+	listener := &recordingIPCacheListener{}
+	ipc.AddListener(listener)
+	listener.events = nil // Ignore the listener's initial current-state dump.
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		ipcache:            ipc,
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, oldHostIP)
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, newHostIP)
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	require.Equal(t, []ipcacheEvent{{
+		modType:   ipcache.Upsert,
+		oldHostIP: oldHostIP,
+		newHostIP: newHostIP,
+		podUID:    "new-pod-uid",
+	}}, listener.events)
+}
+
+func TestReplaceK8sPodV1PublishesNewIPBeforeDeletingOldIP(t *testing.T) {
+	const (
+		oldPodIP = "10.0.0.1"
+		newPodIP = "10.0.0.2"
+	)
+
+	ipc := newPodWatcherTestIPCache(t, oldPodIP)
+	listener := &recordingIPCacheListener{}
+	ipc.AddListener(listener)
+	listener.events = nil // Ignore the listener's initial current-state dump.
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		ipcache:            ipc,
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, oldPodIP, "10.0.0.3")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, newPodIP, "10.0.0.3")
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	require.Equal(t, []ipcacheEvent{
+		{modType: ipcache.Upsert, newHostIP: "10.0.0.3", podUID: "new-pod-uid"},
+		{modType: ipcache.Delete, podUID: "old-pod-uid"},
+	}, listener.events)
+}
+
+func TestReplaceK8sPodV1CoalescesNamedPortPolicyUpdate(t *testing.T) {
+	const podIP = "10.0.0.1"
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	_, err := ipc.Upsert(podIP, nil, 0, &ipcache.K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-pod-uid",
+		NamedPorts: ciliumTypes.NamedPortMap{
+			"http": {Port: 80, Proto: u8proto.TCP},
+		},
+	}, ipcache.Identity{
+		ID:     identity.ReservedIdentityUnmanaged,
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+	ipc.GetNamedPorts()
+
+	policies := &fakePolicyManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		policyManager:      policies,
+		ipcache:            ipc,
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod.Spec.Containers = []slim_corev1.Container{{
+		Ports: []slim_corev1.ContainerPort{{
+			Name:          "http",
+			ContainerPort: 8080,
+			Protocol:      slim_corev1.ProtocolTCP,
+		}},
+	}}
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	require.Len(t, policies.reasons, 1)
+	port, err := ipc.GetNamedPorts().GetNamedPort(
+		"http",
+		u8proto.TCP,
+		slices.Values([]identity.NumericIdentity{identity.ReservedIdentityUnmanaged}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint16(8080), port)
+}
+
+func TestReplaceK8sPodV1MissingOldMetadataStillAddsNewPod(t *testing.T) {
+	const podIP = "10.0.0.1"
+
+	ipc := newPodWatcherTestIPCache(t, podIP)
+	ipc.Delete(podIP, source.Kubernetes)
+	cgroups := &fakeCgroupManager{}
+	watcher := &K8sPodWatcher{
+		logger:             hivetest.Logger(t),
+		endpointManager:    &fakeEndpointManager{},
+		ipcache:            ipc,
+		cgroupManager:      cgroups,
+		hostNetworkManager: &fakeHostNetworkManager{},
+		localNodeStore:     node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:           fakewireguard.Config{},
+		ipsecConfig:        fakeipsec.Config{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, podIP, "10.0.0.2")
+
+	require.NoError(t, watcher.replaceK8sPodV1(t.Context(), oldPod, newPod))
+	metadata := ipc.GetK8sMetadata(netip.MustParseAddr(podIP))
+	require.NotNil(t, metadata)
+	require.Equal(t, string(newPod.UID), metadata.PodUID)
+	require.Equal(t, []string{"replace:old-pod-uid->new-pod-uid"}, cgroups.operations)
+}
+
+func TestReplaceK8sPodV1ReconcilesEndpointLabels(t *testing.T) {
+	logger := hivetest.Logger(t)
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, ""))
+	repo := policy.NewPolicyRepository(
+		logger,
+		cmtypes.DefaultClusterInfo.ID,
+		nil,
+		nil,
+		nil,
+		nil,
+		testpolicy.NewPolicyMetricsNoop(),
+	)
+	state := models.EndpointStateWaitingDashForDashIdentity
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
+		Logger:     logger,
+		PolicyRepo: repo,
+	}, nil, nil, &models.EndpointChangeRequest{State: &state}, nil)
+	require.NoError(t, err)
+	require.True(t, ep.SetState(endpoint.StateDisconnecting, "test replacement reconciliation"))
+
+	watcher := &K8sPodWatcher{
+		logger:             logger,
+		endpointManager:    &fakeEndpointManager{endpoints: []*endpoint.Endpoint{ep}},
+		cgroupManager:      &fakeCgroupManager{},
+		hostNetworkManager: &fakeHostNetworkManager{},
+	}
+	oldPod := podWatcherTestPod("old-pod-uid", slim_corev1.PodRunning, "", "")
+	oldPod.Labels = map[string]string{"app": "echo"}
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, "", "")
+	newPod.Labels = map[string]string{"app": "echo"}
+
+	err = watcher.replaceK8sPodV1(t.Context(), oldPod, newPod)
+	require.ErrorIs(t, err, endpoint.ErrNotAlive)
+}
+
+func TestUpdatePodHostDataWithoutOldPodDoesNotDeleteUnownedMetadata(t *testing.T) {
+	const (
+		oldPodIP = "10.0.0.1"
+		newPodIP = "10.0.0.2"
+	)
+
+	ipc := newPodWatcherTestIPCache(t, oldPodIP)
+	watcher := &K8sPodWatcher{
+		logger:         hivetest.Logger(t),
+		policyManager:  &fakePolicyManager{},
+		ipcache:        ipc,
+		localNodeStore: node.NewTestLocalNodeStore(node.LocalNode{}),
+		wgConfig:       fakewireguard.Config{},
+		ipsecConfig:    fakeipsec.Config{},
+	}
+	newPod := podWatcherTestPod("new-pod-uid", slim_corev1.PodRunning, newPodIP, "10.0.0.3")
+
+	require.NoError(t, watcher.updatePodHostData(
+		t.Context(),
+		nil,
+		newPod,
+		k8sTypes.IPSlice{oldPodIP},
+		k8sTypes.IPSlice{newPodIP},
+	))
+	_, oldExists := ipc.LookupByIP(oldPodIP)
+	_, newExists := ipc.LookupByIP(newPodIP)
+	require.True(t, oldExists)
+	require.True(t, newExists)
+}
+
+func newPodWatcherTestIPCache(t *testing.T, podIP string) *ipcache.IPCache {
+	t.Helper()
+
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context: t.Context(),
+		Logger:  hivetest.Logger(t),
+	})
+	t.Cleanup(func() {
+		require.NoError(t, ipc.Shutdown())
+	})
+
+	_, err := ipc.Upsert(podIP, nil, 0, &ipcache.K8sMetadata{
+		Namespace: "default",
+		PodName:   "echo",
+		PodUID:    "old-pod-uid",
+	}, ipcache.Identity{
+		ID:     identity.ReservedIdentityUnmanaged,
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+
+	return ipc
+}
+
+func podWatcherTestPod(uid string, phase slim_corev1.PodPhase, podIP, hostIP string) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "echo",
+			UID:       k8sAPITypes.UID(uid),
+		},
+		Status: slim_corev1.PodStatus{
+			Phase:  phase,
+			PodIP:  podIP,
+			PodIPs: []slim_corev1.PodIP{{IP: podIP}},
+			HostIP: hostIP,
+		},
+	}
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -80,11 +80,10 @@ type ipcacheManager interface {
 	// GH-21142: Re-evaluate the need for these APIs
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)
 	LookupByIP(IP string) (ipcache.Identity, bool)
-	Delete(IP string, source source.Source) (namedPortsChanged bool)
 
 	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[cmtypes.PrefixCluster]struct{}, resource ipcacheTypes.ResourceID)
-	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
+	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name, uid string) (namedPortsChanged bool)
 }
 
 type hostNetworkManager interface {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -72,10 +72,6 @@ type cgroupManager interface {
 	OnDeletePod(pod *slim_corev1.Pod)
 }
 
-type CacheAccessK8SWatcher interface {
-	GetCachedPod(namespace, name string) (*slim_corev1.Pod, error)
-}
-
 type ipcacheManager interface {
 	// GH-21142: Re-evaluate the need for these APIs
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -38,7 +38,7 @@ func (m *MockIPCache) Delete(IP string, source source.Source) (namedPortsChanged
 func (m *MockIPCache) RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID) {
 }
 
-func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool) {
+func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, namespace, name, uid string) (namedPortsChanged bool) {
 	return false
 }
 


### PR DESCRIPTION
Hubble currently identifies a Pod mainly by cluster, namespace, and name.
Kubernetes permits a deleted object's name to be reused, while its UID
identifies that specific object lifetime. This matters especially for
StatefulSet Pods, but applies to any recreated Pod.

Adding the UID improves flow attribution. Consumers can distinguish Pod
instances and correlate flows with Kubernetes records keyed by UID.

The UID is carried through IPCache and ClusterMesh metadata, so Hubble can
expose it for remote endpoints when that metadata is available. Local
endpoints prefer the UID supplied by CNI and fall back to the Pod already
attached to the endpoint when that UID is absent.

Cilium also uses the UID internally:
- IPCache deletion checks UID, preventing a delayed Pod, CEP, or CES deletion
  from removing metadata belonging to a replacement Pod.
- Same-name Pod replacements update IPCache, cgroup, endpoint, and host-network
  state. IPCache and NOTRACK changes install new state before removing old
  state, allowing a short overlap instead of a gap.
- Kubernetes drop events use the UID captured in the flow instead of resolving
  whichever Pod currently owns that namespace/name.

The UID remains optional when metadata is unavailable or components are
running mixed versions.

This PR was prepared with AIL:4. Codex drafted the implementation and tests. I
reviewed the code and changed the replacement handling.

```release-note
Hubble flow endpoints now include the Kubernetes Pod UID.
```
