### PR TITLE
bpf: use ipv6_addr_copy() to fill map keys

### DIFF
--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -49,9 +49,6 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 {
 	union macaddr mac = CONFIG(interface_mac);
 	union macaddr smac;
-	__be32 __maybe_unused sip;
-	__be32 __maybe_unused tip;
-	union v6addr __maybe_unused tip6;
 	struct l2_responder_stats *stats;
 	int ret;
 	__u64 time;
@@ -73,6 +70,7 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 
 	if (!ip6) {
 		struct l2_responder_v4_key key;
+		__be32 sip, tip;
 
 		if (!arp_validate(ctx, &mac, &smac, &sip, &tip))
 			return CTX_ACT_OK;
@@ -87,6 +85,7 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 	} else {
 #ifdef ENABLE_IPV6
 		struct l2_responder_v6_key key6;
+		union v6addr tip6;
 		int l3_off;
 
 		if (!icmp6_ndisc_validate(ctx, ip6, &mac, &tip6))


### PR DESCRIPTION
Clean up a few open-coded occurrences.