### PR TITLE
bpf: Reduce stack usage of send_trace_notify

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -202,62 +202,71 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 	return true;
 }
 
+struct trace_notify_vars {
+	__u64 cap_len;
+	cls_flags_t flags;
+	struct ratelimit_key key;
+	struct ratelimit_settings settings;
+	struct trace_notify msg;
+};
+
+DEFINE_AUX(struct trace_notify_vars, trace_notify_vars);
+
 static __always_inline void
 __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src, __u32 dst, void *orig_addr, __u16 dst_id, __u32 ifindex,
 		    enum trace_reason reason, __u32 monitor,
 		    __be16 proto, __u16 line, __u8 file)
 {
-	__u64 ip_trace_id = load_ip_trace_id();
-	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
-	struct trace_notify msg = {};
-	cls_flags_t flags = CLS_FLAG_NONE;
+	struct trace_notify_vars *vars = AUX(trace_notify_vars);
+
+	memset(vars, 0, sizeof(*vars));
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
 
 	if (!emit_trace_notify(obs_point, monitor))
 		return;
 
+	vars->key.usage = RATELIMIT_USAGE_EVENTS_MAP;
+	vars->settings.topup_interval_ns = NSEC_PER_SEC;
 	if (CONFIG(events_map_rate_limit) > 0) {
-		settings.bucket_size = CONFIG(events_map_burst_limit);
-		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
-		if (!ratelimit_check_and_take(&rkey, &settings))
+		vars->settings.bucket_size = CONFIG(events_map_burst_limit);
+		vars->settings.tokens_per_topup = CONFIG(events_map_rate_limit);
+		if (!ratelimit_check_and_take(&vars->key, &vars->settings))
 			return;
 	}
 
-	flags = ctx_classify(ctx, proto, obs_point);
-	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
-
-	msg = (typeof(msg)) {
+	vars->flags = ctx_classify(ctx, proto, obs_point);
+	vars->cap_len = compute_capture_len(ctx, monitor, vars->flags, obs_point);
+	vars->msg = (typeof(vars->msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
+		__notify_pktcap_hdr((__u32)ctx_full_len(ctx),
+				    (__u16)vars->cap_len,
+				    NOTIFY_TRACE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
 		.reason		= reason,
-		.flags		= flags,
+		.flags		= vars->flags,
 		.ifindex	= ifindex,
-		.ip_trace_id	= ip_trace_id,
+		.ip_trace_id	= load_ip_trace_id(),
 	};
-	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
-	if (orig_addr) {
-		if (proto == bpf_htons(ETH_P_IP))
-			memcpy(&msg.orig_ip4.be32, orig_addr, sizeof(__be32));
-		else
-			ipv6_addr_copy(&msg.orig_ip6, orig_addr);
-	}
 
-	trace_extension_hook(ctx, msg);
-	ctx_event_output(ctx, &cilium_events,
-			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+	{
+		struct trace_notify *msg = &vars->msg;
+
+		if (orig_addr) {
+			if (proto == bpf_htons(ETH_P_IP))
+				memcpy(&msg->orig_ip4.be32, orig_addr, sizeof(__be32));
+			else
+				ipv6_addr_copy(&msg->orig_ip6, orig_addr);
+		}
+
+		trace_extension_hook(ctx, *msg);
+		ctx_event_output(ctx, &cilium_events,
+				 (vars->cap_len << 32) | BPF_F_CURRENT_CPU,
+				 msg, sizeof(*msg));
+	}
 }
 
 static __always_inline void


### PR DESCRIPTION
__send_trace_notify kept multiple large variables in the stack (e.g. struct trace_notify) which got us close to the stack limit in some programs, especially when BPF-to-BPF function calls were involved (256 byte stack limit).

Reduce the stack usage by moving the local variables of __send_tarce_notify into an AUX struct.

Few stackwhere numbers for bpf_host.o that improved significantly:

```
320 bytes -> 288 bytes - tail_handle_ipv6_from_netdev 
296 bytes -> 264 bytes - tail_ipv6_host_policy_ingress 
288 bytes -> 112 bytes - tail_handle_snat_fwd_ipv4 
168 bytes -> 112 bytes - tail_handle_snat_fwd_ipv6 
256 bytes -> 240 bytes - tail_nodeport_rev_dnat_ipv4 
144 bytes -> 120 bytes - tail_srv6_encap
192 bytes -> 136 bytes - tail_nat_ipv64
```