### PR TITLE
Documentation: document mesh security model

### DIFF
--- a/Documentation/network/clustermesh/intro.rst
+++ b/Documentation/network/clustermesh/intro.rst
@@ -61,3 +61,17 @@ Cluster Mesh reuses several concepts from :ref:`kvstore mode <kvstore>` to
 exchange state between clusters. When Cilium is already running in kvstore mode,
 Cluster Mesh extends the existing kvstore etcd instance instead of
 deploying an additional embedded etcd instance.
+
+Security
+========
+
+.. _clustermesh_security_model:
+
+All clusters connected in a Cluster Mesh form a single trust domain.
+
+While Cilium performs various sanity checks on information received from remote
+clusters, these checks cannot fully prevent a compromised cluster's Cilium
+control plane from propagating malicious information to other clusters.
+
+Only connect clusters that are mutually trusted and have equivalent security
+postures.

--- a/Documentation/security/threat-model.rst
+++ b/Documentation/security/threat-model.rst
@@ -28,6 +28,11 @@ into Cilium. For users who are concerned about supply-chain attacks,
 Cilium's `security audit`_ assessed Cilium's supply chain controls
 against `the SLSA framework`_.
 
+For simplicity, the model covers a single cluster architecture. When using
+Cluster Mesh, all connected clusters form a single trust domain. See the
+:ref:`Cluster Mesh security model <clustermesh_security_model>` for more
+details.
+
 In order to understand the following threat model, readers will need
 familiarity with basic Kubernetes concepts, as well as a high-level
 understanding of Cilium's :ref:`architecture and components<component_overview>`.


### PR DESCRIPTION
There isn't currently an explicit mention of how cluster mesh affects the threat/security model of cilium. To clarify the assumptions the code already makes, make it explicit that there isn't a security boundary between clusters once meshed.

We can think about "improving"/hardening, but fundamentally I do not believe it to be possible to fully withstand an adversarial meshed cluster any more than it is possible to withstand a compromised agent.

