### PR TITLE
bpf: don't enforce ingress policy twice on netkit with endpoint routes

### DIFF
--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -163,23 +163,15 @@ local_delivery(struct __ctx_buff *ctx, __u32 seclabel, __u32 magic,
 			return ret;
 	}
 
-	/* When BPF host routing is enabled we need to check policies at source, as in
-	 * this case the skb is delivered directly to pod's namespace and the ingress
-	 * policy (the cil_to_container BPF program) is bypassed.
+	/* Exactly one program enforces ingress policy per delivery. With
+	 * endpoint routes a plain redirect() runs cil_to_container, which
+	 * enforces, so don't evaluate here - only set the identity mark it
+	 * reads. redirect_peer() skips cil_to_container, so those fall through
+	 * to the tail-call. Keep this the exact inverse of
+	 * should_redirect_peer().
 	 */
 	use_redirect_peer = should_redirect_peer(ctx, from_host);
-	if (CONFIG(enable_endpoint_routes) && !use_redirect_peer &&
-	    /* We need to enforce policies at the source in case of netkit
-	     * devices because we can't redirect to proxy from bpf_lxc. That
-	     * needs a fix upstream. This must stay in sync with the predicate
-	     * in should_redirect_peer(): whenever we fall through to the policy
-	     * tail-call below and then do a plain redirect() into the lxc device
-	     * (should_redirect_peer() == false), endpoint routes would enforce
-	     * ingress policy a second time. On netkit that case is phys/host
-	     * ingress (ingress_ifindex > 0); there we must enforce at the source
-	     * here instead.
-	     */
-	    (!CONFIG(enable_netkit) || ctx_get_ingress_ifindex(ctx) > 0)) {
+	if (CONFIG(enable_endpoint_routes) && !use_redirect_peer) {
 		set_identity_mark(ctx, seclabel, magic);
 
 # if !defined(ENABLE_NODEPORT)

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -142,6 +142,44 @@ ASSIGN_CONFIG(bool, enable_netkit, true)
 ASSIGN_CONFIG(bool, enable_netkit, false)
 #endif
 
+/* Deal with testing endpoint routes on or off. */
+#ifdef __CONFIG_ENABLE_ENDPOINT_ROUTES
+#define TEST_EPROUTES_NAME "+epr"
+ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
+#else
+#define TEST_EPROUTES_NAME ""
+ASSIGN_CONFIG(bool, enable_endpoint_routes, false)
+#endif
+
+/* These tests target a ClusterIP, so bpf_lxc has to do the translation. */
+#ifndef ENABLE_PER_PACKET_LB
+#error "tc_redirect_lxc tests target a ClusterIP and require per-packet LB"
+#endif
+
+#ifdef ENABLE_SOCKET_LB_HOST_ONLY
+#define TEST_PPLB_NAME "+hostlb"
+#else
+#define TEST_PPLB_NAME "+pplb"
+#endif
+
+#define TEST_CONFIG_NAME TEST_DRIVER_NAME TEST_EPROUTES_NAME TEST_PPLB_NAME
+
+/* Expected {tailcall, redirect, redirect_peer}. Whichever program is reached
+ * enforces ingress policy, and it must be reached exactly once.
+ */
+#if defined(__CONFIG_ENABLE_NETKIT) && defined(__CONFIG_ENABLE_ENDPOINT_ROUTES)
+/* netkit runs at TC egress and cannot redirect_peer() for pod -> pod, so the
+ * plain redirect() reaches cil_to_container. No tail-call.
+ */
+#define TEST_EXPECTED_CALLS {0, 1, 0}
+#elif defined(__CONFIG_ENABLE_NETKIT)
+/* No cil_to_container on the device, so the tail-call enforces. */
+#define TEST_EXPECTED_CALLS {1, 1, 0}
+#else
+/* redirect_peer() skips cil_to_container, so the tail-call enforces. */
+#define TEST_EXPECTED_CALLS {1, 0, 1}
+#endif
+
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
@@ -208,11 +246,7 @@ int tc_redirect_lxc_ipv4_setup(struct __ctx_buff *ctx)
 CHECK(PROG_TYPE, "tc_redirect_lxc_ipv4")
 int tc_redirect_lxc_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
-#ifdef __CONFIG_ENABLE_NETKIT
-	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
-#else
-	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
-#endif
+	const unsigned int expected[RECORD__MAX] = TEST_EXPECTED_CALLS;
 	void *data;
 	void *data_end;
 	__u32 *status_code;
@@ -232,17 +266,17 @@ int tc_redirect_lxc_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(*status_code == CTX_ACT_REDIRECT);
 
 	/* Test redirect usage */
-	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+	test_log(TEST_CONFIG_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
 		 num_calls[RECORD_TAILCALL],
 		 num_calls[RECORD_REDIRECT],
 		 num_calls[RECORD_REDIRECT_PEER]);
 
 	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+		test_fatal(TEST_CONFIG_NAME ": Incorrect number of tail calls");
 	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+		test_fatal(TEST_CONFIG_NAME ": Incorrect number of bpf_redirect() calls")
 	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+		test_fatal(TEST_CONFIG_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
 
 	/* Check the packet. */
 	ASSERT_CTX_BUF_OFF("tc_redirect_lxc_ipv4_post",
@@ -318,11 +352,7 @@ int tc_redirect_lxc_ipv6_setup(struct __ctx_buff *ctx)
 CHECK(PROG_TYPE, "tc_redirect_lxc_ipv6")
 int tc_redirect_lxc_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
-#ifdef __CONFIG_ENABLE_NETKIT
-	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
-#else
-	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
-#endif
+	const unsigned int expected[RECORD__MAX] = TEST_EXPECTED_CALLS;
 	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
 	void *data;
 	void *data_end;
@@ -343,17 +373,17 @@ int tc_redirect_lxc_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(*status_code == CTX_ACT_REDIRECT);
 
 	/* Test redirect usage */
-	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+	test_log(TEST_CONFIG_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
 		 num_calls[RECORD_TAILCALL],
 		 num_calls[RECORD_REDIRECT],
 		 num_calls[RECORD_REDIRECT_PEER]);
 
 	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+		test_fatal(TEST_CONFIG_NAME ": Incorrect number of tail calls");
 	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+		test_fatal(TEST_CONFIG_NAME ": Incorrect number of bpf_redirect() calls")
 	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
-		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+		test_fatal(TEST_CONFIG_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
 
 	/* Check the packet. */
 	ASSERT_CTX_BUF_OFF("tc_redirect_lxc_ipv6_post",

--- a/bpf/tests/tc_redirect_lxc_netkit_eproutes.c
+++ b/bpf/tests/tc_redirect_lxc_netkit_eproutes.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define __CONFIG_ENABLE_ENDPOINT_ROUTES
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_netkit_eproutes_hostlb.c
+++ b/bpf/tests/tc_redirect_lxc_netkit_eproutes_hostlb.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define __CONFIG_ENABLE_ENDPOINT_ROUTES
+/* bpf-lb-sock-hostns-only=true: Pod traffic still needs per-packet LB. */
+#define ENABLE_SOCKET_LB_FULL 1
+#define ENABLE_SOCKET_LB_HOST_ONLY 1
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_netkit_hostlb.c
+++ b/bpf/tests/tc_redirect_lxc_netkit_hostlb.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+/* bpf-lb-sock-hostns-only=true: Pod traffic still needs per-packet LB. */
+#define ENABLE_SOCKET_LB_FULL 1
+#define ENABLE_SOCKET_LB_HOST_ONLY 1
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_veth_eproutes.c
+++ b/bpf/tests/tc_redirect_lxc_veth_eproutes.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define __CONFIG_ENABLE_ENDPOINT_ROUTES
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_veth_eproutes_hostlb.c
+++ b/bpf/tests/tc_redirect_lxc_veth_eproutes_hostlb.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define __CONFIG_ENABLE_ENDPOINT_ROUTES
+/* bpf-lb-sock-hostns-only=true: Pod traffic still needs per-packet LB. */
+#define ENABLE_SOCKET_LB_FULL 1
+#define ENABLE_SOCKET_LB_HOST_ONLY 1
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_veth_hostlb.c
+++ b/bpf/tests/tc_redirect_lxc_veth_hostlb.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+/* bpf-lb-sock-hostns-only=true: Pod traffic still needs per-packet LB. */
+#define ENABLE_SOCKET_LB_FULL 1
+#define ENABLE_SOCKET_LB_HOST_ONLY 1
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -177,6 +177,19 @@ func canUseNetkit(p connectorParams) error {
 		return fmt.Errorf("netkit devices cannot be used with --%s=true", option.EnableBPFTProxy)
 	}
 
+	// With per-endpoint routes, cil_to_container enforces ingress policy for
+	// pod-to-pod traffic, and it cannot reach the L7 proxy: netkit_xmit()
+	// reassigns skb->dev to the peer before running BPF, so skb_do_redirect()
+	// resolves cilium_net's ifindex in the Pod's netns, where it does not
+	// exist, and frees the skb. Punting to the stack lands in the same netns,
+	// where the TPROXY rules are absent.
+	//
+	// Refuse rather than drop L7 replies silently.
+	if p.DaemonConfig.EnableEndpointRoutes && p.DaemonConfig.EnableL7Proxy {
+		return fmt.Errorf("netkit devices cannot be used with --%s=true and --%s=true",
+			option.EnableEndpointRoutes, option.EnableL7Proxy)
+	}
+
 	return nil
 }
 

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -94,6 +94,13 @@ var (
 		EnableIPv6:           true,
 		EnableEndpointRoutes: true,
 	}
+	daemonConfigNetkitEndpointRoutesL7 = option.DaemonConfig{
+		DatapathMode:         datapathOption.DatapathModeNetkit,
+		EnableIPv4:           true,
+		EnableIPv6:           true,
+		EnableEndpointRoutes: true,
+		EnableL7Proxy:        true,
+	}
 	daemonConfigNetkitL2 = option.DaemonConfig{
 		DatapathMode:    datapathOption.DatapathModeNetkitL2,
 		EnableIPv4:      true,
@@ -305,6 +312,17 @@ func TestNewConfig(t *testing.T) {
 			tunnelConfig:   tunnelConfigNative,
 			expectedConfig: &connectorConfigNetkit,
 			shouldError:    !hostSupportsNetkitScrub(),
+			shouldSkip:     false,
+		},
+		{
+			// Refused regardless of scrub support: cil_to_container cannot
+			// reach the L7 proxy from the Pod's netns.
+			name:           "datapath-netkit+endpoint-routes+l7-proxy",
+			daemonConfig:   &daemonConfigNetkitEndpointRoutesL7,
+			wgAgent:        fakewireguard.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkit,
+			shouldError:    true,
 			shouldSkip:     false,
 		},
 		{


### PR DESCRIPTION
- [X] For first time contributors, read [Submitting a pull request]
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [X] Thanks for contributing!

<!-- Description of change -->
- Drop the netkit clause from local_delivery()'s enforce-at-source condition.
- Reject netkit + endpoint routes + L7 proxy as unsupported pending kernel support.
- Add missing test cases for tc_redirect_lxc: now covers driver x endpoint routes x socket LB mode combinations.
    
WARNING: This is a breaking change. netkit + endpoint routes + L7 proxy is not supported after this change and will be rejected.
    
Background:
    
With endpoint routes, local_delivery() has two ways to hand a packet to a local pod, differing in who enforces ingress policy:

- redirect_peer() delivers straight into the pod's netns and never runs cil_to_container, so policy must be enforced at the source.
- a plain redirect() into the lxc device does run cil_to_container, which enforces policy itself.

The enforce-at-source condition must therefore be the exact inverse of should_redirect_peer().

854473726b added a netkit clause to the enforce-at-source condition, to work
around bpf_lxc being unable to redirect to the L7 proxy. That clause is
false for netkit pod-to-pod. should_redirect_peer() is also false, where they
must be opposites.

Delivery falls through to the policy tail-call and then redirects into the
lxc device, so policy is unnecessarily enforced twice: once by the tail-call,
once by cil_to_container.

With per-packet LB, service replies carry reverse NAT state, so the second pass
runs after lb{4,6}_rev_nat() has rewritten the reply's source, which no longer
matches the backend-keyed CT entry. The connection is looked up as CT_NEW,
giving false Hubble flows and "Policy denied" drops for service replies.

Fixes: #47913
Fixes: 854473726b ("bpf: Workaround for netkit + L7 policy redirect failure")

This PR was prepared with AIL:4. I personally validated the resulting network flows with and without policies, both visually via Hubble and by testing the affected applications.