### PR TITLE
kvstore: let [UserEnforcePresence] additionally revoke stale roles

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1635,18 +1636,42 @@ func (e *etcdClient) expiredLockLeaseObserver(key string) {
 }
 
 // UserEnforcePresence creates a user in etcd if not already present, and grants the specified roles.
+// It additionally revokes any other roles that may have been previously granted to that user.
 func (e *etcdClient) UserEnforcePresence(ctx context.Context, name string, roles []string) error {
+	var desired = sets.New(roles...)
+
 	e.logger.Debug("Creating user", FieldUser, name)
 	_, err := e.client.Auth.UserAddWithOptions(ctx, name, "", &client.UserAddOptions{NoPassword: true})
 	if err != nil {
 		if errors.Is(err, v3rpcErrors.ErrUserAlreadyExist) {
 			e.logger.Debug("User already exists", FieldUser, name)
+			user, err := e.client.Auth.UserGet(ctx, name)
+			if err != nil {
+				return fmt.Errorf("retrieving user: %w", err)
+			}
+
+			for _, role := range user.Roles {
+				if desired.Has(role) {
+					desired.Delete(role)
+					continue
+				}
+
+				e.logger.Debug("Revoking stale role from user",
+					FieldRole, role,
+					FieldUser, name,
+				)
+
+				_, err := e.client.Auth.UserRevokeRole(ctx, name, role)
+				if err != nil {
+					return fmt.Errorf("revoking %q role: %w", role, err)
+				}
+			}
 		} else {
 			return err
 		}
 	}
 
-	for _, role := range roles {
+	for role := range desired {
 		e.logger.Debug("Granting role to user",
 			FieldRole, role,
 			FieldUser, name,

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
+	v3rpcErrors "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	etcdAPI "go.etcd.io/etcd/client/v3"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -1515,4 +1516,91 @@ func TestPaginatedList(t *testing.T) {
 				func(t *testing.T) { run(t, batchSize, parallelOps) })
 		}
 	}
+}
+
+func TestUserManagement(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	var (
+		client = SetupDummy(t, "etcd")
+		auth   = client.(*clientImpl).BackendOperations.(*etcdClient).client.Auth
+
+		assertUsers = func(t *testing.T, users ...string) {
+			got, err := auth.UserList(t.Context())
+			require.NoError(t, err, "auth.UserList")
+			require.ElementsMatch(t, got.Users, users)
+		}
+
+		assertRoles = func(t *testing.T, user string, roles ...string) {
+			got, err := auth.UserGet(t.Context(), user)
+			require.NoError(t, err, "auth.UserGet")
+			require.ElementsMatch(t, got.Roles, roles)
+		}
+	)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		ignore := func(err, ignore error) error {
+			if errors.Is(err, ignore) {
+				return nil
+			}
+
+			return err
+		}
+
+		for _, role := range []string{"foo", "bar", "baz"} {
+			_, err := auth.RoleDelete(ctx, role)
+			require.NoError(t, ignore(err, v3rpcErrors.ErrRoleNotFound), "auth.RoleDelete")
+		}
+
+		for _, user := range []string{"alpaca", "llama", "dolphin"} {
+			_, err := auth.UserDelete(ctx, user)
+			require.NoError(t, ignore(err, v3rpcErrors.ErrUserNotFound), "auth.UserDelete")
+		}
+	})
+
+	// Create a few test roles.
+	for _, role := range []string{"foo", "bar", "baz"} {
+		_, err := auth.RoleAdd(t.Context(), role)
+		require.NoError(t, err, "auth.RoleAdd")
+	}
+
+	// Enforce two users, and assert that they are present and assigned the correct roles.
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "alpaca", []string{"foo"}))
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "llama", []string{"bar", "baz"}))
+
+	assertUsers(t, "alpaca", "llama")
+	assertRoles(t, "alpaca", "foo")
+	assertRoles(t, "llama", "bar", "baz")
+
+	// Enforce the same user again, with no changes, and assert that it succeeds.
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "alpaca", []string{"foo"}))
+	assertRoles(t, "alpaca", "foo")
+
+	// Enforce the same user again, and assert that the roles are updated.
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "llama", []string{"foo", "bar"}))
+	assertRoles(t, "llama", "foo", "bar")
+
+	// Enforce the same user again with no roles, and assert that the roles are withdrawn.
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "llama", nil))
+	assertRoles(t, "llama")
+
+	// Delete a user, and assert that it gets removed. Deleting a non-existing
+	// user should also succeed.
+	require.NoError(t, client.UserEnforceAbsence(t.Context(), "alpaca"))
+	require.NoError(t, client.UserEnforceAbsence(t.Context(), "camel"))
+	assertUsers(t, "llama")
+
+	// Enforce the same user again, and assert that the roles are correct.
+	require.NoError(t, client.UserEnforcePresence(t.Context(), "alpaca", []string{"bar"}))
+	assertRoles(t, "alpaca", "bar")
+
+	// Enforcing a user and attempting to grant a non-existing role should return an error.
+	require.ErrorIs(t, client.UserEnforcePresence(t.Context(), "dolphin", []string{"other"}), v3rpcErrors.ErrRoleNotFound)
+
+	// But deleting it afterwards should succeed.
+	require.NoError(t, client.UserEnforceAbsence(t.Context(), "dolphin"))
+	assertUsers(t, "alpaca", "llama")
 }


### PR DESCRIPTION
The [UserEnforcePresence] function is responsible for creating the target user in etcd, if not present, and granting the specified roles. Let's extend it to additionally revoke any possible roles that had been previously granted to that user, and are not present in the list of roles anymore. While being there, let's also cover this logic with a dedicated unit test, to prevent possible regressions in the future.

Overall, this addresses a limitation in the clustermesh users management logic, which would not have revoked a previously granted role upon config change. While this is not deemed to manifest as an actual problem in the vast majority of scenarios, given that the only role granted with that machinery is the `remote` one \[1], it may still be problematic if users leveraged it for different purposes, and is potentially confusing.

\[1]: https://github.com/cilium/cilium/blob/6655160839b90f6c5277655a9a359dc791d89930/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml#L26-L27

AIL: 0

Reported-by: Mike Molchanov

```release-note
Fixed a bug that caused the clustermesh-apiserver etcd users managements logic to not revoke stale roles upon configuration change; users leveraging the configuration provided by the Cilium helm chart are not affected, as the target etcd role is never changed.  
```