### PR TITLE
ipam/multi-pool: Allow regaining ownership of removed CIDRs

### DIFF
--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -35,6 +35,9 @@ import (
 // its allocator is kept around. But no new IPs will be allocated from this
 // CIDR. By keeping removed CIDRs in the CiliumNode CRD status, we indicate
 // to the operator that we would like to re-gain ownership over that CIDR.
+// Once the operator advertises the CIDR in the CiliumNode CRD spec again, we
+// have regained ownership and the CIDR is removed from the removed map, making
+// its IPs allocatable once more.
 type cidrPool struct {
 	logger       *slog.Logger
 	mutex        lock.Mutex
@@ -196,8 +199,15 @@ func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
+	// Only count CIDRs we are allowed to allocate from. IPs in removed CIDRs
+	// are not handed out by allocateNext, so counting them here would report
+	// free IPs that can never be allocated, which in turn would suppress the
+	// reclaim below and leave the pool permanently exhausted.
 	totalFree := 0
 	for _, ipAllocator := range p.ipAllocators {
+		if _, removed := p.removed[ipAllocator.CIDR()]; removed {
+			continue
+		}
 		totalFree += ipAllocator.Free()
 	}
 
@@ -241,6 +251,17 @@ func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	retainedAllocators := []*ipallocator.Range{}
 	for _, ipAllocator := range slices.Backward(p.ipAllocators) {
 		cidr := ipAllocator.CIDR()
+
+		// Removed CIDRs are not ours to release: they are no longer
+		// advertised, and their free IPs are excluded from totalFree above.
+		// Keep their allocator around to hold on to the in-use IPs and to
+		// signal to the operator that we want the CIDR back. Once the last
+		// IP is released, updatePool drops the allocator and the removed
+		// mark along with it.
+		if _, removed := p.removed[cidr]; removed {
+			retainedAllocators = append(retainedAllocators, ipAllocator)
+			continue
+		}
 
 		// If the CIDR is not used and releasing it would
 		// not take us below the release threshold, then release it immediately
@@ -321,6 +342,16 @@ func (p *cidrPool) updatePool(prefixes []netip.Prefix) {
 				logfields.CIDR, cidr,
 			)
 			p.removed[cidr] = struct{}{}
+		} else if _, removed := p.removed[cidr]; removed {
+			// The operator advertises the CIDR again, meaning we regained
+			// ownership over it and may allocate from it once more. Without
+			// this, the CIDR stays unallocatable for the lifetime of the
+			// agent, even though its IPs are attached and routable.
+			p.logger.Info(
+				"regained ownership of previously removed CIDR",
+				logfields.CIDR, cidr,
+			)
+			delete(p.removed, cidr)
 		}
 		newIPAllocators = append(newIPAllocators, ipAllocator)
 		existingAllocators[cidr] = struct{}{}
@@ -350,6 +381,15 @@ func (p *cidrPool) updatePool(prefixes []netip.Prefix) {
 		)
 		newIPAllocators = append(newIPAllocators, ipAllocator)
 		existingAllocators[prefix] = struct{}{} // Protect against duplicate CIDRs.
+	}
+
+	// Forget any removed CIDRs which no longer have an allocator, i.e. those
+	// whose last IP has been released above. Otherwise the mark would outlive
+	// the allocator and wrongly apply to a future allocator for the same CIDR.
+	for prefix := range p.removed {
+		if _, ok := existingAllocators[prefix]; !ok {
+			delete(p.removed, prefix)
+		}
 	}
 
 	if len(p.ipAllocators) > 0 && len(newIPAllocators) == 0 {

--- a/pkg/ipam/pool_test.go
+++ b/pkg/ipam/pool_test.go
@@ -119,3 +119,135 @@ func TestCIDRPoolReclaimsStillAdvertisedReleasedCIDR(t *testing.T) {
 	require.Len(t, pool.inUseCIDRs(), 2)
 	require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.16")))
 }
+
+// TestCIDRPoolRegainsOwnershipOfRemovedCIDR is a regression test for
+// cilium/cilium#47910. A CIDR which briefly disappears from the CiliumNode CRD
+// spec while in use is marked as removed. Once the operator advertises it
+// again, we have regained ownership and must allocate from it again, instead of
+// keeping it unallocatable for the lifetime of the agent.
+func TestCIDRPoolRegainsOwnershipOfRemovedCIDR(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	// Delegated prefixes: first and last IPs of each /28 are allocatable.
+	pool := newCIDRPool(logger, true, true)
+
+	p1 := netip.MustParsePrefix("10.0.0.0/28")
+	p2 := netip.MustParsePrefix("10.0.0.16/28")
+
+	pool.updatePool([]netip.Prefix{p1, p2})
+	require.Equal(t, 32, pool.capacity())
+
+	// Fill up p1 and take a single IP out of p2, so that p2 is in use.
+	for range 16 {
+		_, err := pool.allocateNext()
+		require.NoError(t, err)
+	}
+	addr, err := pool.allocateNext()
+	require.NoError(t, err)
+	require.True(t, p2.Contains(addr))
+
+	// The operator transiently stops advertising p2. As p2 is in use,
+	// we hold on to its allocator, but stop allocating from it.
+	pool.updatePool([]netip.Prefix{p1})
+	require.Contains(t, pool.removed, p2, "in-use p2 should be marked as removed")
+	require.Equal(t, 0, pool.capacity(), "no IP of p2 is allocatable")
+	require.False(t, pool.hasAvailableIPs())
+	_, err = pool.allocateNext()
+	require.Error(t, err)
+
+	// A removed CIDR must not be reported as free either, otherwise the
+	// reclaim logic considers the pool sufficiently provisioned and neither
+	// reclaims nor requests any additional CIDR.
+	pool.releaseExcessCIDRsMultiPool(8)
+	require.Contains(t, pool.removed, p2, "p2 is not ours to release")
+	require.Empty(t, pool.released)
+	require.Len(t, pool.inUseCIDRs(), 2, "p2 stays advertised to reclaim ownership")
+
+	// The operator advertises p2 again: we regained ownership and its
+	// remaining IPs become allocatable.
+	pool.updatePool([]netip.Prefix{p1, p2})
+	require.NotContains(t, pool.removed, p2, "ownership of p2 should be regained")
+	require.Equal(t, 15, pool.capacity())
+	addr, err = pool.allocateNext()
+	require.NoError(t, err)
+	require.True(t, p2.Contains(addr))
+}
+
+// TestCIDRPoolRemovedCIDRDoesNotSuppressReclaim asserts that the free IPs of a
+// removed CIDR are not counted as available when deciding whether a released
+// CIDR must be reclaimed. Counting them reports free IPs which allocateNext
+// never hands out, leaving the pool exhausted until the agent restarts.
+func TestCIDRPoolRemovedCIDRDoesNotSuppressReclaim(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	// Delegated prefixes: first and last IPs of each /28 are allocatable.
+	pool := newCIDRPool(logger, true, true)
+
+	p1 := netip.MustParsePrefix("10.0.0.0/28")
+	p2 := netip.MustParsePrefix("10.0.0.16/28")
+	p3 := netip.MustParsePrefix("10.0.0.32/28")
+
+	pool.updatePool([]netip.Prefix{p1, p2, p3})
+	require.Equal(t, 48, pool.capacity())
+
+	// Fill up p1 and take a single IP out of p2.
+	for range 17 {
+		_, err := pool.allocateNext()
+		require.NoError(t, err)
+	}
+
+	// Demand drops, so the unused p3 is released. The operator keeps
+	// advertising it, e.g. because release-excess-ips is disabled.
+	pool.releaseExcessCIDRsMultiPool(0)
+	require.Contains(t, pool.released, p3, "unused p3 should be released")
+
+	// The operator then transiently stops advertising the in-use p2, which is
+	// therefore marked as removed. Its 15 free IPs are no longer allocatable.
+	pool.updatePool([]netip.Prefix{p1, p3})
+	require.Contains(t, pool.removed, p2)
+	require.Contains(t, pool.released, p3, "p3 stays released while advertised")
+	require.Equal(t, 0, pool.capacity())
+
+	// Demand grows back. The still-advertised p3 must be reclaimed: the free
+	// IPs of the removed p2 do not count towards the needed IPs.
+	pool.releaseExcessCIDRsMultiPool(8)
+	require.NotContains(t, pool.released, p3, "p3 should be reclaimed")
+	require.Contains(t, pool.removed, p2, "p2 is still not ours to allocate from")
+	require.Equal(t, 16, pool.capacity())
+
+	addr, err := pool.allocateNext()
+	require.NoError(t, err)
+	require.True(t, p3.Contains(addr))
+}
+
+// TestCIDRPoolForgetsRemovedCIDRWithoutAllocator asserts that the removed mark
+// does not outlive the allocator it refers to. Otherwise a later allocator for
+// the same CIDR would inherit the mark and never hand out any IP.
+func TestCIDRPoolForgetsRemovedCIDRWithoutAllocator(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	pool := newCIDRPool(logger, true, true)
+
+	p1 := netip.MustParsePrefix("10.0.0.0/28")
+	p2 := netip.MustParsePrefix("10.0.0.16/28")
+
+	pool.updatePool([]netip.Prefix{p1, p2})
+	addr := netip.MustParseAddr("10.0.0.16")
+	require.NoError(t, pool.allocate(addr))
+
+	// p2 is dropped from the spec while in use, and so marked as removed.
+	pool.updatePool([]netip.Prefix{p1})
+	require.Contains(t, pool.removed, p2)
+
+	// The last IP of p2 is released, so its allocator is dropped on the next
+	// update, and the removed mark must be dropped with it.
+	pool.release(addr)
+	pool.updatePool([]netip.Prefix{p1})
+	require.Empty(t, pool.removed, "removed mark should not outlive the allocator")
+	require.Len(t, pool.inUseCIDRs(), 1)
+
+	// p2 is advertised again and is immediately usable.
+	pool.updatePool([]netip.Prefix{p1, p2})
+	require.Equal(t, 32, pool.capacity())
+	require.NoError(t, pool.allocate(addr))
+}


### PR DESCRIPTION
A CIDR which disappears from the CiliumNode CRD spec while IPs are allocated from it is marked as removed: we keep its allocator to hold on to the in-use IPs, stop allocating from it, and keep advertising it as allocated to signal to the operator that we want the CIDR back. But nothing ever cleared that mark, so the CIDR stayed unallocatable for the lifetime of the agent, even after the operator advertised it again.

Worse, `releaseExcessCIDRsMultiPool` counted the free IPs of removed CIDRs towards the free IPs of the pool, unlike `allocateNext`, `capacity` and `hasAvailableIPs`. this means it reported free IPs which were never handed out, which in turn suppressed the reclaim of released-but-still-advertised CIDRs added in https://github.com/cilium/cilium/commit/0e4e076b6da1a149fe4d2c3690a2fd5fea3f95bf. The pool then reported free IPs while failing every allocation with "all CIDR ranges are exhausted" until the agent was restarted.

This PR clears the removed mark when the operator starts to advertise the CIDR again, and drops marks whose allocator is gone, and counts only allocatable CIDRs when deciding whether CIDRs must be reclaimed or released.

Related: https://github.com/cilium/cilium/issues/47910