### PR TITLE
Fixes #47918: Handle label filters as regex when loading from file

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -287,6 +287,16 @@ func readLabelPrefixCfgFrom(fileName string) (*labelPrefixCfg, error) {
 		if lp.Source == "" {
 			return nil, fmt.Errorf("invalid label prefix file: source was empty")
 		}
+		// Compile the prefix into a regular expression so that file-loaded
+		// prefixes are matched with the same regexp semantics as prefixes
+		// provided on the command line (see parseLabelPrefix). Without this,
+		// the unexported expr field stays nil and matches() falls back to
+		// literal strings.HasPrefix matching.
+		r, err := regexp.Compile(lp.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label prefix file: unable to compile regexp %q: %w", lp.Prefix, err)
+		}
+		lp.expr = r
 		if !lp.Ignore {
 			lpc.whitelist = true
 		}

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -4,6 +4,8 @@
 package labelsfilter
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -187,6 +189,62 @@ func TestFilterLabelsDocExample(t *testing.T) {
 
 	require.Len(t, filtered, 10)
 	require.Equal(t, wanted, filtered)
+}
+
+func TestFilterLabelsFromFileRegex(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	fileContents := `{
+		"version": 1,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "kind$"},
+			{"source": "k8s", "prefix": "foo.bar"}
+		]
+	}`
+	file := filepath.Join(t.TempDir(), "label-prefix.json")
+	require.NoError(t, os.WriteFile(file, []byte(fileContents), 0o644))
+
+	err := ParseLabelPrefixCfg(logger, []string{}, []string{}, file)
+	require.NoError(t, err)
+	dlpcfg := validLabelPrefixes
+
+	allNormalLabels := map[string]string{
+		"kind":    "foo", // matches "kind$" (anchored) as a regexp
+		"fooXbar": "foo", // matches "foo.bar"
+		"kindly":  "foo", // does NOT match "kind$" because it is anchored to the end
+		"other":   "foo", // does NOT match anything
+	}
+	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceK8s)
+	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
+
+	wanted := labels.Labels{
+		"kind":    labels.NewLabel("kind", "foo", labels.LabelSourceK8s),
+		"fooXbar": labels.NewLabel("fooXbar", "foo", labels.LabelSourceK8s),
+		"host":    labels.NewLabel("host", "", labels.LabelSourceReserved),
+	}
+
+	filtered, _ := dlpcfg.filterLabels(allLabels)
+	require.Equal(t, wanted, filtered)
+}
+
+func TestReadLabelPrefixCfgInvalidRegex(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	// An unparseable regexp in the prefix field must surface as an error
+	// rather than silently falling back to literal matching.
+	fileContents := `{
+		"version": 1,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "foo["}
+		]
+	}`
+	file := filepath.Join(t.TempDir(), "label-prefix.json")
+	require.NoError(t, os.WriteFile(file, []byte(fileContents), 0o644))
+
+	err := ParseLabelPrefixCfg(logger, []string{}, []string{}, file)
+	require.Error(t, err)
 }
 
 func TestFilterLabelsByRegex(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!


Updates the code that loads in label filters from a file via the `label-prefix-file` configuration flag to attempt to parse each prefix as a regex to align with passing them in via CLI flags.

Claude Code was used to identify the problem and suggest where needed updating. I personally checked and updated all the code in this PR.

Fixes: #47918

```release-note
Fix how label filters are handled when loading from a file so they are parsed as regex
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
