### PR TITLE
gh: run BPF tests in parallel

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Run BPF tests
         id: run-tests
         run: |
-          make run_bpf_tests \
+          make -j "$(nproc)" run_bpf_tests \
               LOG_CODEOWNERS=1 \
               JUNIT_PATH="test/${{ env.job_name }}.xml" \
           || (echo "Run 'make run_bpf_tests' locally to investigate failures"; exit 1)


### PR DESCRIPTION
Wire up the -j parameter to speed up compilation.