### PR TITLE
bpf: use memset() to 0-initialize IPv6 CT tuple

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -321,7 +321,7 @@ lb6_ctx_store_state(struct __ctx_buff *ctx, const struct ct_state *state,
 static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr *ip6,
 						       __s8 *ext_err)
 {
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct ct_state ct_state_new = {};
 	const struct lb6_service *svc;
 	fraginfo_t fraginfo = 0;
@@ -329,6 +329,8 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 	__u16 proxy_port = 0;
 	int l4_off;
 	int ret;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	tuple.nexthdr = ip6->nexthdr;
 	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
@@ -2008,7 +2010,7 @@ __declare_tail(CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY)
 static __always_inline
 int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
@@ -2018,6 +2020,8 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	struct ipv6hdr *ip6;
 	__s8 ext_err = 0;
 	int ret;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_HOST)
 		from_host = true;

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -497,13 +497,15 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 	struct iphdr *ip4;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct ipv4_ct_tuple tuple4 = {};
-	struct ipv6_ct_tuple __maybe_unused tuple6 = {};
+	struct ipv6_ct_tuple __maybe_unused tuple6 __align_stack_8;
 	int l4_off;
 	const struct remote_endpoint_info *info;
 	const struct endpoint_info *src_ep;
 	fraginfo_t fraginfo = 0;
 	bool is_reply;
 	int ret;
+
+	memset(&tuple6, 0, sizeof(tuple6));
 
 	if (src_sec_identity == HOST_ID)
 		return CTX_ACT_OK;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1554,8 +1554,10 @@ snat_v6_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
 	if (*state) {
 		struct ipv6_nat_entry *lookup_result;
 		struct ipv6_nat_entry ostate;
-		struct ipv6_ct_tuple otuple = {};
+		struct ipv6_ct_tuple otuple __align_stack_8;
 		int ret;
+
+		memset(&otuple, 0, sizeof(otuple));
 
 		/* Check for the original SNAT entry. If it is missing (e.g. due to LRU
 		 * eviction), it must be restored before returning.
@@ -1840,12 +1842,14 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			      struct ipv6_nat_entry **state)
 {
 	__u32 inner_l3_off = (__u32)(off + sizeof(struct icmp6hdr));
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct ipv6hdr ip6;
 	__u16 port_off;
 	__u32 icmpoff;
 	int hdrlen;
 	__u8 type;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	/* According to the RFC 5508, any networking equipment that is
 	 * responding with an ICMP Error packet should embed the original
@@ -2058,12 +2062,14 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 				       __u32 inner_l3_off,
 				       struct ipv6_nat_entry **state)
 {
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct ipv6hdr iphdr;
 	__u16 port_off;
 	__u32 icmpoff;
 	__u8 type;
 	int hdrlen;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	/* According to the RFC 5508, any networking
 	 * equipment that is responding with an ICMP Error
@@ -2145,7 +2151,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct ipv6_nat_entry *state = NULL;
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	__u32 off, inner_l3_off;
 	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
@@ -2155,6 +2161,8 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 	int ret, hdrlen;
 
 	build_bug_on(sizeof(struct ipv6_nat_entry) > 64);
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -425,7 +425,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 int *ifindex, int *ohead)
 {
 	const struct remote_endpoint_info *info;
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct geneve_dsr_opt6 gopt;
 	union v6addr *dst;
 	__u16 encap_len = sizeof(struct ipv6hdr) + sizeof(struct udphdr) +
@@ -437,6 +437,8 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 	int l4_off, ret;
 
 	build_bug_on((sizeof(gopt) % 4) != 0);
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	dst = (union v6addr *)&ip6->daddr;
 	info = lookup_ip6_remote_endpoint(dst, 0);
@@ -956,7 +958,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 	};
 	int ret, l4_off;
 	const struct remote_endpoint_info *info __maybe_unused;
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct ct_state ct_state = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -966,6 +968,8 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 	fraginfo_t fraginfo = 0;
 	int ifindex = 0;
 	__u32 monitor = 0;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -1227,7 +1231,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MAX_NAT,
 		.addr = IPV6_DIRECT_ROUTING,
 	};
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	struct trace_ctx trace = {
 		.reason = (enum trace_reason)CT_NEW,
 		.monitor = TRACE_PAYLOAD_LEN,
@@ -1242,6 +1246,8 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	const struct remote_endpoint_info *info;
 	union v6addr *dst;
 #endif
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	if (nat_46x64)
 		build_v4_in_v6(&target.addr, IPV4_DIRECT_ROUTING);
@@ -1569,10 +1575,12 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 {
 	bool is_svc_proto __maybe_unused = true;
 	int ret, l3_off = ETH_HLEN, l4_off;
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	const struct lb6_service *svc;
 	fraginfo_t fraginfo = 0;
 	struct lb6_key key = {};
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	tuple.nexthdr = ip6->nexthdr;
 	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -162,12 +162,14 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 {
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
 	struct lb6_reverse_nat nat_info __align_stack_8;
-	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	struct ipv6_ct_tuple tuple __align_stack_8;
 	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u32 monitor = 0;
 	int ret, l4_off;
+
+	memset(&tuple, 0, sizeof(tuple));
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;


### PR DESCRIPTION
This should produce slightly better code.