### PR TITLE
fix: stale CEC owner UID lets GC delete the in-use Envoy config

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -380,6 +380,7 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, gw *gatewayv1
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
 		cec.Spec = desired.Spec
+		cec.OwnerReferences = desired.OwnerReferences
 		setMergedLabelsAndAnnotations(cec, desired)
 		return nil
 	})

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -928,6 +928,70 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 	})
 }
 
+// Test_gatewayReconciler_ensureEnvoyConfig_refreshesOwnerReferences verifies
+// that when a Gateway is deleted and recreated with the same name (new UID)
+// while its old CiliumEnvoyConfig still exists, patching the CEC refreshes
+// the owner reference to the new Gateway UID. Otherwise the garbage collector
+// could delete the in-use CEC because it is still owned by the old UID.
+func Test_gatewayReconciler_ensureEnvoyConfig_refreshesOwnerReferences(t *testing.T) {
+	t.Parallel()
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreated-gateway",
+			Namespace: "default",
+			UID:       types.UID("new-gateway-uid"),
+		},
+	}
+
+	cecKey := types.NamespacedName{
+		Namespace: gw.Namespace,
+		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
+	}
+
+	ownerRef := func(uid types.UID) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: gatewayv1.GroupVersion.String(),
+			Kind:       "Gateway",
+			Name:       gw.Name,
+			UID:        uid,
+			Controller: ptr.To(true),
+		}
+	}
+
+	staleCEC := &ciliumv2.CiliumEnvoyConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            cecKey.Name,
+			Namespace:       cecKey.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef("old-gateway-uid")},
+		},
+	}
+	desiredCEC := &ciliumv2.CiliumEnvoyConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            cecKey.Name,
+			Namespace:       cecKey.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef(gw.UID)},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(staleCEC).
+		Build()
+	r := &gatewayReconciler{
+		Client: c,
+		logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+	}
+
+	require.NoError(t, r.ensureEnvoyConfig(t.Context(), gw, desiredCEC))
+
+	actual := &ciliumv2.CiliumEnvoyConfig{}
+	require.NoError(t, c.Get(t.Context(), cecKey, actual))
+	require.Len(t, actual.OwnerReferences, 1)
+	assert.Equal(t, string(gw.UID), string(actual.OwnerReferences[0].UID))
+	assert.True(t, metav1.IsControlledBy(actual, gw))
+}
+
 func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
The name of a CiliumEnvoyConfig is derived from the Gateway name ·cilium-gateway-<name>·, so a recreated Gateway with the same name necessarily maps to the same CiliumEnvoyConfig object.

Since Gateway has no finalizer, deleting a Gateway relies entirely on Kubernetes garbage collection for cleanup, which is asynchronous and may take seconds or longer.

When a user recreates a Gateway with the same name `kubectl delete gateway same-namespace && kubectl apply -f gateway.yaml`, the Cilium operator may adopt and update the old CiliumEnvoyConfig in place, refreshing its spec but keeping the owner reference that still points to the old Gateway UID, the owner UID is not updated.

Eventually, the Kubernetes garbage collector finds that the owner UID no longer exists and deletes that CiliumEnvoyConfig. This defeats the Cilium in-place adoption mechanism.

<!-- Description of change -->

Fixes: #issue-number

```release-note
fix: stale CEC owner UID lets GC delete the in-use Envoy config
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
