### PR TITLE
cilium-cli/connectivity: detect Cilium version in connectivity perf setup

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -409,6 +409,14 @@ func (ct *ConnectivityTest) setupAndValidatePerf(ctx context.Context, _ SetupHoo
 		return err
 	}
 
+	if err := ct.initCiliumPods(ctx); err != nil {
+		return err
+	}
+
+	if err := ct.detectCiliumVersion(ctx); err != nil {
+		return err
+	}
+
 	if err := ct.deployPerf(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
`cilium connectivity perf` always reports "Cilium version: 0.0.0" in its info banner, regardless of the actual Cilium version running in the cluster.

`setupAndValidatePerf()`, the setup path used by the `perf` subcommand, never calls `initCiliumPods()`/`detectCiliumVersion()`, unlike `setupAndValidate()` (used by `connectivity test`).
`CiliumVersion` is therefore left at its Go zero value, which prints as `0.0.0`.

This calls the same two steps `setupAndValidate()` already uses, in the same order, so `CiliumVersion` is populated before it's printed in `connectivity.Run()`.

Tested manually against an RKE2 cluster (Cilium v1.19.4):
- before the fix, `cilium connectivity perf` reported "Cilium version: 0.0.0"
- after the fix, it correctly reports "Cilium version: 1.19.4"

```release-note
Fixed `cilium connectivity perf` always reporting `Cilium version: 0.0.0` instead of the actual detected Cilium version.