### PR TITLE
fix(gateway): fail closed on invalid ExternalAuth

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -398,19 +398,13 @@ func extractRoutes(logger *slog.Logger,
 			}
 		}
 
-		var dr *model.DirectResponse
-		if len(bes) == 0 {
-			dr = &model.DirectResponse{
-				StatusCode: 500,
-			}
-		}
-
 		var requestHeaderFilter *model.HTTPHeaderFilter
 		var responseHeaderFilter *model.HTTPHeaderFilter
 		var requestRedirectFilter *model.HTTPRequestRedirectFilter
 		var rewriteFilter *model.HTTPURLRewriteFilter
 		var requestMirrors []*model.HTTPRequestMirror
 		var externalAuth *model.HTTPExternalAuthFilter
+		var externalAuthInvalid bool
 		var requestCORS *model.HTTPCORSFilter
 
 		for _, f := range rule.Filters {
@@ -462,13 +456,20 @@ func extractRoutes(logger *slog.Logger,
 					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, mirror, hr.Namespace))
 				}
 			case gatewayv1.HTTPRouteFilterExternalAuth:
-				if f.ExternalAuth != nil {
-					beRef := gatewayv1.BackendRef{BackendObjectReference: f.ExternalAuth.BackendRef}
-					if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(), beRef, helpers.GatewayV1GVK("HTTPRoute"), grants) {
-						break
-					}
+				if f.ExternalAuth == nil {
+					continue
 				}
+
+				beRef := gatewayv1.BackendRef{BackendObjectReference: f.ExternalAuth.BackendRef}
+				if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(), beRef, helpers.GatewayV1GVK("HTTPRoute"), grants) {
+					externalAuthInvalid = true
+					continue
+				}
+
 				externalAuth = toHTTPExternalAuthFilter(logger, f.ExternalAuth, hr.Namespace, services, serviceImports, btlspMap)
+				if externalAuth == nil {
+					externalAuthInvalid = true
+				}
 			case gatewayv1.HTTPRouteFilterCORS:
 				ac := false
 				if f.CORS.AllowCredentials != nil {
@@ -484,6 +485,19 @@ func extractRoutes(logger *slog.Logger,
 					// Local tests can bypass this, ensuring we always get a default.
 					MaxAge: cmp.Or(f.CORS.MaxAge, int32(5)),
 				}
+			}
+		}
+		var dr *model.DirectResponse
+
+		if len(bes) == 0 && requestRedirectFilter == nil {
+			dr = &model.DirectResponse{
+				StatusCode: 500,
+			}
+		}
+
+		if externalAuthInvalid {
+			dr = &model.DirectResponse{
+				StatusCode: 500,
 			}
 		}
 

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1262,6 +1262,148 @@ func TestHTTPRequestMirrorServiceImportIsResolved(t *testing.T) {
 	assert.Equal(t, "default", routes[0].RequestMirrors[0].Backend.Namespace)
 }
 
+func TestHTTPRequestExternalAuthCrossNamespaceWithoutReferenceGrantFailsClosed(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	routes := extractRoutes(logger, 80, nil, gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cross-namespace-external-auth",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName("backend"),
+									Port: ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name:      gatewayv1.ObjectName("auth-backend"),
+									Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+									Port:      ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, []corev1.Service{
+		testService("default", "backend", 8080),
+		testService("other-ns", "auth-backend", 8080),
+	}, nil, nil, nil)
+
+	require.Len(t, routes, 1)
+	require.NotNil(t, routes[0].DirectResponse)
+	assert.Equal(t, 500, routes[0].DirectResponse.StatusCode)
+	assert.Nil(t, routes[0].ExternalAuth)
+}
+
+func TestHTTPRequestExternalAuthCrossNamespaceWithReferenceGrantIsKept(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	routes := extractRoutes(logger, 80, nil, gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cross-namespace-external-auth",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName("backend"),
+									Port: ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name:      gatewayv1.ObjectName("auth-backend"),
+									Namespace: ptr.To(gatewayv1.Namespace("other-ns")),
+									Port:      ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, []corev1.Service{
+		testService("default", "backend", 8080),
+		testService("other-ns", "auth-backend", 8080),
+	}, nil, []gatewayv1.ReferenceGrant{
+		testReferenceGrant("other-ns", "default", "HTTPRoute"),
+	}, nil)
+
+	require.Len(t, routes, 1)
+	assert.Nil(t, routes[0].DirectResponse)
+	require.NotNil(t, routes[0].ExternalAuth)
+	assert.Equal(t, "auth-backend", routes[0].ExternalAuth.Backend.Name)
+	assert.Equal(t, "other-ns", routes[0].ExternalAuth.Backend.Namespace)
+}
+
+func TestHTTPRequestExternalAuthMissingBackendFailsClosed(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	routes := extractRoutes(logger, 80, nil, gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-external-auth",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName("backend"),
+									Port: ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName("missing-auth"),
+									Port: ptr.To(gatewayv1.PortNumber(8080)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, []corev1.Service{
+		testService("default", "backend", 8080),
+	}, nil, nil, nil)
+
+	require.Len(t, routes, 1)
+	require.NotNil(t, routes[0].DirectResponse)
+	assert.Equal(t, 500, routes[0].DirectResponse.StatusCode)
+	assert.Nil(t, routes[0].ExternalAuth)
+}
+
 func TestGRPCRequestMirrorNilFilterDoesNotPanic(t *testing.T) {
 	routes := extractGRPCRoutes(nil, gatewayv1.GRPCRoute{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteRequestRedirect/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteRequestRedirect/output-listeners.yaml
@@ -13,9 +13,7 @@
         hostname: example.com
         port: 80
       timeout: {}
-    - direct_response:
-        status_code: 500
-      path_match:
+    - path_match:
         prefix: /status-code-301
       request_redirect:
         port: 80

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -330,8 +330,8 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 			backends = append(backends, r.Backends...)
 		}
 
-		if len(backends) == 0 && hRoutes[0].RequestRedirect == nil {
-			noBackendRoute := envoyHTTPRouteNoBackend(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters)
+		if hRoutes[0].DirectResponse != nil {
+			noBackendRoute := envoyHTTPRouteDirectResponse(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters)
 			routes = append(routes, noBackendRoute)
 			delete(matchBackendMap, key)
 			continue
@@ -645,7 +645,7 @@ func getRouteRedirectMatch(match string) *envoy_config_route_v3.HeaderMatcher {
 	}
 }
 
-func envoyHTTPRouteNoBackend(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) *envoy_config_route_v3.Route {
+func envoyHTTPRouteDirectResponse(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) *envoy_config_route_v3.Route {
 	if route.DirectResponse == nil {
 		return nil
 	}

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -975,6 +975,26 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
 		require.Equal(t, "default:backend-v2:8080", res[1].GetRoute().GetCluster())
 	})
+	t.Run("fail closed direct response takes precedence over backend", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch: model.StringMatch{Prefix: "/"},
+				DirectResponse: &model.DirectResponse{
+					StatusCode: 500,
+				},
+				Backends: []model.Backend{
+					backend("backend", 8080),
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+
+		require.Len(t, res, 1)
+		require.NotNil(t, res[0].GetDirectResponse())
+		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
+		require.Nil(t, res[0].GetRoute())
+	})
 }
 
 // Test_envoyHTTPSRoutes_disablesExtAuthzFilters verifies that HTTPS redirect routes

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/input.yaml
@@ -13,9 +13,7 @@ http:
     request_redirect:
       hostname: example.com
     timeout: {}
-  - direct_response:
-      status_code: 500
-    path_match:
+  - path_match:
       prefix: /status-code-301
     request_redirect:
       status_code: 301

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/input.yaml
@@ -11,9 +11,7 @@ http:
     path_match:
       prefix: /request-redirect
     timeout: {}
-  - direct_response:
-      status_code: 500
-    path_match:
+  - path_match:
       prefix: /
     request_redirect:
       hostname: example.com
@@ -28,6 +26,7 @@ http:
     name: same-namespace
     namespace: gateway-conformance-infra
     version: v1
+
 - hostname: example.com
   name: https
   port: 443
@@ -40,9 +39,7 @@ http:
     path_match:
       prefix: /request-redirect
     timeout: {}
-  - direct_response:
-      status_code: 500
-    path_match:
+  - path_match:
       prefix: /
     request_redirect:
       hostname: example.com


### PR DESCRIPTION
## Description of change

Make HTTPRoute ExternalAuth fail closed when the backend reference is invalid or cannot be resolved.

Previously, an invalid ExternalAuth backend reference could cause the filter to be omitted while the route remained active, effectively allowing requests to bypass external authentication.

This change:
- Fails closed with HTTP 500 when the ExternalAuth backend reference is not permitted by a ReferenceGrant.
- Fails closed when the ExternalAuth backend cannot be resolved.
- Adds unit tests covering invalid cross-namespace references, missing backends, and valid ReferenceGrant configuration.

Fixes: #47877

```release-note
Fix HTTPRoute ExternalAuth to fail closed when its backend reference is invalid or cannot be resolved.
```

This PR was prepared with AIL:3. I personally checked the implementation and unit tests.

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI) in accordance with the [Cilium AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md), and indicate the rating using [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
- [x] Thanks for contributing!

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
