### PR TITLE
cilium-cli: Skip HostToWorld if no external IPv6

### DIFF
--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -239,6 +239,10 @@ func (s *hostToWorld) Run(ctx context.Context, t *check.Test) {
 		}
 
 		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			if ipFam == features.IPFamilyV6 && !t.Context().Params().ExternalTargetIPv6Capable {
+				return
+			}
+
 			// With http, over port 80.
 			t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &src, http, ipFam).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ct.CurlCommand(http, ipFam, true, nil))


### PR DESCRIPTION
As with PodToWorld() we need to skip the IPv6
actions if ExternalTargetIPv6Capable parameter
is not set.