### PR TITLE
clustermesh/endpointslices: explicitly limit maximum decoder memory

### DIFF
--- a/pkg/clustermesh/types/endpointslice/endpointslice.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice.go
@@ -72,6 +72,10 @@ func (eps *ClusterEndpointSlice) ToShallowSlimEndpointSlice() *slim_discovery_v1
 	}
 }
 
+// maxDecodedSize bounds decoder memory to guard against crafted payloads. The
+// selected 16MB limit provides ample margin for every legitimate EndpointSlice.
+const maxDecodeSize = 16 << 20
+
 var (
 	zstdEncoderPool sync.Pool
 	zstdDecoderPool sync.Pool
@@ -90,7 +94,7 @@ func getZstdDecoder() (*zstd.Decoder, error) {
 		return decoder.(*zstd.Decoder), nil
 	}
 
-	return zstd.NewReader(nil)
+	return zstd.NewReader(nil, zstd.WithDecoderMaxMemory(maxDecodeSize))
 }
 
 // Marshal returns the cluster EndpointSlice object as zstd-compressed protobuf


### PR DESCRIPTION
Explicitly configure a limit for the zstd decoder used to decode the ClusterEndpointSlice entries received over Cluster Mesh, to prevent the risk of unbounded memory usage in case of crafted payloads.

I've marked the PR as `release-note/misc` because the logic ingesting ClusterEndpointSlices is incomplete and disabled behind a feature flag in v1.20.

Reported-by: Secstant - Sigma Prime \<secstant@sigmaprime.io>

