### PR TITLE
bpf: srv6: move SRv6 map structs to srv6.h

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -91,10 +91,12 @@ add_type(struct egress_gw_policy_entry6);
 add_type(struct vtep_key);
 add_type(struct vtep_value);
 
+#include "lib/srv6.h"
 add_type(struct srv6_vrf_key4);
 add_type(struct srv6_vrf_key6);
 add_type(struct srv6_policy_key4);
 add_type(struct srv6_policy_key6);
+
 add_type(struct trace_sock_notify);
 add_type(struct auth_key);
 add_type(struct auth_info);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -155,30 +155,6 @@ struct auth_info {
 	__u64       expiration;
 };
 
-struct srv6_vrf_key4 {
-	struct bpf_lpm_trie_key lpm;
-	__u32 src_ip;
-	__u32 dst_cidr;
-};
-
-struct srv6_vrf_key6 {
-	struct bpf_lpm_trie_key lpm;
-	union v6addr src_ip;
-	union v6addr dst_cidr;
-};
-
-struct srv6_policy_key4 {
-	struct bpf_lpm_trie_key lpm;
-	__u32 vrf_id;
-	__u32 dst_cidr;
-};
-
-struct srv6_policy_key6 {
-	struct bpf_lpm_trie_key lpm;
-	__u32 vrf_id;
-	union v6addr dst_cidr;
-};
-
 #ifndef BPF_F_PSEUDO_HDR
 # define BPF_F_PSEUDO_HDR                (1ULL << 4)
 #endif

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -6,7 +6,32 @@
 #include "lib/common.h"
 #include "lib/drop.h"
 #include "lib/identity.h"
+#include "lib/ipv6_core.h"
 #include "lib/tailcall.h"
+
+struct srv6_vrf_key4 {
+	struct bpf_lpm_trie_key lpm;
+	__u32 src_ip;
+	__u32 dst_cidr;
+};
+
+struct srv6_vrf_key6 {
+	struct bpf_lpm_trie_key lpm;
+	union v6addr src_ip;
+	union v6addr dst_cidr;
+};
+
+struct srv6_policy_key4 {
+	struct bpf_lpm_trie_key lpm;
+	__u32 vrf_id;
+	__u32 dst_cidr;
+};
+
+struct srv6_policy_key6 {
+	struct bpf_lpm_trie_key lpm;
+	__u32 vrf_id;
+	union v6addr dst_cidr;
+};
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LPM_TRIE);


### PR DESCRIPTION
A bit more untangling of the big common.h header.