### PR TITLE
bpf: clean up 0-initializing for struct csum_offset

### DIFF
--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -17,9 +17,9 @@ struct csum_offset {
 };
 
 /**
- * Determins the L4 checksum field offset and required flags
+ * Determines the L4 checksum field offset and required flags
  * @arg nexthdr	L3 nextheader field
- * @arg off	Pointer to uninitialied struct csum_offset struct
+ * @arg off	Pointer to uninitialized struct csum_offset struct
  *
  * Sets off.offset to offset from start of L4 header to L4 checksum field
  * and off.flags to the required flags, namely BPF_F_MARK_MANGLED_0 for UDP.
@@ -29,14 +29,18 @@ struct csum_offset {
 static __always_inline void csum_l4_offset_and_flags(__u8 nexthdr,
 						     struct csum_offset *off)
 {
+	off->flags = 0;
+
 	switch (nexthdr) {
 	case IPPROTO_TCP:
 		off->offset = TCP_CSUM_OFF;
 		break;
-
 	case IPPROTO_UDP:
 		off->offset = UDP_CSUM_OFF;
 		off->flags = BPF_F_MARK_MANGLED_0;
+		break;
+	case IPPROTO_ICMPV6:
+		off->offset = offsetof(struct icmp6hdr, icmp6_cksum);
 		break;
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
@@ -50,14 +54,9 @@ static __always_inline void csum_l4_offset_and_flags(__u8 nexthdr,
 		 * crc32c checksum in eBPF and will likely require
 		 * additional kernel support.
 		 */
-		off->offset = 0;
-		break;
 #endif  /* ENABLE_SCTP */
-	case IPPROTO_ICMPV6:
-		off->offset = offsetof(struct icmp6hdr, icmp6_cksum);
-		break;
-
-	case IPPROTO_ICMP:
+	default:
+		off->offset = 0;
 		break;
 	}
 }

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -801,7 +801,7 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 		ipv6_addr_copy(&tuple->daddr, &old_saddr);
 
 		if (has_l4_header) {
-			struct csum_offset csum_off = {};
+			struct csum_offset csum_off;
 
 			csum_l4_offset_and_flags(tuple->nexthdr, &csum_off);
 
@@ -818,7 +818,7 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 		return DROP_WRITE_ERROR;
 
 	if (has_l4_header) {
-		struct csum_offset csum_off = {};
+		struct csum_offset csum_off;
 
 		csum_l4_offset_and_flags(tuple->nexthdr, &csum_off);
 
@@ -1623,7 +1623,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 		return DROP_CSUM_L3;
 
 	if (has_l4_header) {
-		struct csum_offset csum_off = {};
+		struct csum_offset csum_off;
 
 		csum_l4_offset_and_flags(tuple->nexthdr, &csum_off);
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -510,7 +510,7 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 		return DROP_CSUM_L3;
 
 	if (has_l4_header) {
-		struct csum_offset csum = {};
+		struct csum_offset csum;
 
 		csum_l4_offset_and_flags(nexthdr, &csum);
 
@@ -1616,7 +1616,7 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 			const union v6addr *new_addr, __u16 addr_off,
 			__be16 old_port, __be16 new_port, __u16 port_off)
 {
-	struct csum_offset csum = {};
+	struct csum_offset csum;
 	__wsum sum;
 
 	/* No change needed: */


### PR DESCRIPTION
Let csum_l4_offset_and_flags() take care of this when needed.