### PR TITLE
bpf: preserve original source in NodePort tunnel traces

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -15,9 +15,10 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		    const struct remote_endpoint_info *info, __u32 seclabel,
 		    __u32 dstid, __u32 vni, void *opt, __u32 opt_len,
 		    enum trace_reason ct_reason, __u32 monitor, int *ifindex,
-		    __be16 proto)
+		    __be16 proto, const void *orig_addr)
 {
-	/* When encapsulating, a packet originating from the local host is
+	/* orig_addr only annotates the source-node trace; it is not tunnel data.
+	 * When encapsulating, a packet originating from the local host is
 	 * being considered as a packet from a remote node as it is being
 	 * received.
 	 */
@@ -30,8 +31,17 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	*ifindex = 0;
 #endif
 
-	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
-			  *ifindex, ct_reason, monitor, proto);
+	if (orig_addr && proto == bpf_htons(ETH_P_IP))
+		send_trace_notify4(ctx, TRACE_TO_OVERLAY, seclabel, dstid,
+				   *(const __be32 *)orig_addr,
+				   TRACE_EP_ID_UNKNOWN, *ifindex, ct_reason, monitor);
+	else if (orig_addr && proto == bpf_htons(ETH_P_IPV6))
+		send_trace_notify6(ctx, TRACE_TO_OVERLAY, seclabel, dstid,
+				   (const union v6addr *)orig_addr,
+				   TRACE_EP_ID_UNKNOWN, *ifindex, ct_reason, monitor);
+	else
+		send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid,
+				  TRACE_EP_ID_UNKNOWN, *ifindex, ct_reason, monitor, proto);
 
 	if (info->flag_ipv6_tunnel_ep)
 		return ctx_set_encap_info6(ctx, &info->tunnel_endpoint.ip6,
@@ -55,7 +65,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
 
 	ret = __encap_with_nodeid(ctx, 0, 0, info, seclabel,
 				  dstid, vni, NULL, 0, trace->reason,
-				  trace->monitor, &ifindex, proto);
+				  trace->monitor, &ifindex, proto, NULL);
 	if (ret != CTX_ACT_REDIRECT)
 		return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -165,7 +165,7 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 			      const struct remote_endpoint_info *info,
 			      __u32 src_sec_identity, void *opt, __u32 opt_len,
 			      enum trace_reason ct_reason, __u32 monitor,
-			      int *ifindex, __be16 proto)
+			      int *ifindex, __be16 proto, const void *orig_addr)
 {
 	/* Let kernel choose the outer source ip */
 	if (ctx_is_skb())
@@ -190,7 +190,8 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 
 	return __encap_with_nodeid(ctx, src_ip, src_port, info,
 				   src_sec_identity, info->sec_identity, NOT_VTEP_DST,
-				   opt, opt_len, ct_reason, monitor, ifindex, proto);
+				   opt, opt_len, ct_reason, monitor, ifindex, proto,
+				   orig_addr);
 }
 
 static __always_inline int
@@ -198,12 +199,12 @@ nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			  const struct remote_endpoint_info *info,
 			  __u32 src_sec_identity,
 			  enum trace_reason ct_reason, __u32 monitor,
-			  int *ifindex, __be16 proto)
+			  int *ifindex, __be16 proto, const void *orig_addr)
 {
 	return nodeport_add_tunnel_encap_opt(ctx, src_ip, src_port, info,
 					     src_sec_identity, NULL, 0,
 					     ct_reason, monitor, ifindex,
-					     proto);
+					     proto, orig_addr);
 }
 #endif /* HAVE_ENCAP */
 
@@ -479,7 +480,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						     (enum trace_reason)CT_NEW,
 						     TRACE_PAYLOAD_LEN,
 						     ifindex,
-						     bpf_htons(ETH_P_IPV6));
+						     bpf_htons(ETH_P_IPV6), NULL);
 
 	return nodeport_add_tunnel_encap(ctx,
 					 IPV4_DIRECT_ROUTING,
@@ -489,7 +490,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 					 (enum trace_reason)CT_NEW,
 					 TRACE_PAYLOAD_LEN,
 					 ifindex,
-					 bpf_htons(ETH_P_IPV6));
+					 bpf_htons(ETH_P_IPV6), NULL);
 }
 # endif /* DSR_ENCAP_MODE */
 
@@ -1041,7 +1042,7 @@ encap_redirect:
 
 	ret = nodeport_add_tunnel_encap(ctx, IPV4_DIRECT_ROUTING, src_port,
 					info, src_sec_identity, trace->reason,
-					trace->monitor, &ifindex, bpf_htons(ETH_P_IPV6));
+					trace->monitor, &ifindex, bpf_htons(ETH_P_IPV6), NULL);
 	if (IS_ERR(ret))
 		return ret;
 
@@ -1239,6 +1240,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	struct ipv6hdr *ip6;
 	__s8 ext_err = 0;
 #ifdef TUNNEL_MODE
+	union v6addr orig_saddr __align_stack_8;
 	const struct remote_endpoint_info *info;
 	union v6addr *dst;
 #endif
@@ -1297,6 +1299,9 @@ skip_source_lookup:
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
+#ifdef TUNNEL_MODE
+	ipv6_addr_copy(&orig_saddr, &tuple.saddr);
+#endif
 	ret = __snat_v6_nat(ctx, &tuple, state, fraginfo, l4_off, true,
 			    &target, TCP_SPORT_OFF, &trace, &ext_err);
 	if (IS_ERR(ret))
@@ -1318,7 +1323,9 @@ skip_source_lookup:
 						trace.reason,
 						trace.monitor,
 						&oif,
-						bpf_htons(ETH_P_IPV6));
+						bpf_htons(ETH_P_IPV6),
+						ipv6_addr_equals(&orig_saddr, &tuple.saddr) ?
+							NULL : &orig_saddr);
 		if (IS_ERR(ret))
 			goto drop_err;
 
@@ -1879,7 +1886,7 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct 
 						     (enum trace_reason)CT_NEW,
 						     TRACE_PAYLOAD_LEN,
 						     ifindex,
-						     bpf_htons(ETH_P_IP));
+						     bpf_htons(ETH_P_IP), NULL);
 
 	return nodeport_add_tunnel_encap(ctx,
 					 IPV4_DIRECT_ROUTING,
@@ -1889,7 +1896,7 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct 
 					 (enum trace_reason)CT_NEW,
 					 TRACE_PAYLOAD_LEN,
 					 ifindex,
-					 bpf_htons(ETH_P_IP));
+					 bpf_htons(ETH_P_IP), NULL);
 }
 # endif /* DSR_ENCAP_MODE */
 
@@ -2406,7 +2413,7 @@ redirect:
 		ret = nodeport_add_tunnel_encap(ctx, IPV4_DIRECT_ROUTING, src_port,
 						&fake_info, src_sec_identity,
 						trace->reason, trace->monitor, &ifindex,
-						bpf_htons(ETH_P_IP));
+						bpf_htons(ETH_P_IP), NULL);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -2581,6 +2588,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	__u32 dst_sec_identity __maybe_unused = 0;
 #ifdef TUNNEL_MODE
+	__be32 orig_saddr;
 	__u32 src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__u8 cluster_id __maybe_unused = (__u8)ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
 	const struct remote_endpoint_info *info;
@@ -2642,6 +2650,9 @@ skip_source_lookup:
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
+#ifdef TUNNEL_MODE
+	orig_saddr = tuple.saddr;
+#endif
 	ret = __snat_v4_nat(ctx, &tuple, state, fraginfo, l4_off, true,
 			    &target, TCP_SPORT_OFF, &trace, &ext_err);
 	if (IS_ERR(ret))
@@ -2673,7 +2684,8 @@ skip_source_lookup:
 						trace.reason,
 						trace.monitor,
 						&oif,
-						bpf_htons(ETH_P_IP));
+						bpf_htons(ETH_P_IP),
+						orig_saddr != tuple.saddr ? &orig_saddr : NULL);
 		if (IS_ERR(ret))
 			goto drop_err;
 

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -325,7 +325,7 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 static __always_inline void
 _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src __maybe_unused, __u32 dst __maybe_unused,
-		    union v6addr *orig_addr __maybe_unused,
+		    const union v6addr *orig_addr __maybe_unused,
 		    __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
 		    enum trace_reason reason, __u32 monitor __maybe_unused,
 		    __u16 line, __u8 file)

--- a/bpf/tests/nodeport_overlay_nat_lb.c
+++ b/bpf/tests/nodeport_overlay_nat_lb.c
@@ -7,23 +7,29 @@
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 
 #define ENCAP_IFINDEX		42
 #define TUNNEL_MODE
 
 #define CLIENT_IP		v4_pod_one
+#define CLIENT_IP6		{ .addr = v6_pod_one_addr }
 #define CLIENT_PORT		__bpf_htons(111)
 #define CLIENT_SEC_IDENTITY	112233
 #define CLIENT_NODE_IP		v4_node_one
 
 #define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IP6		{ .addr = v6_svc_one_addr }
 #define FRONTEND_PORT		tcp_svc_one
 
 #define LB_IP			v4_node_two
+#define LB_IP6			{ .addr = v6_node_two_addr }
 #define IPV4_DIRECT_ROUTING	LB_IP
+#define IPV6_DIRECT_ROUTING	LB_IP6
 
 #define BACKEND_IP		v4_pod_three
+#define BACKEND_IP6		{ .addr = v6_pod_three_addr }
 #define BACKEND_PORT		__bpf_htons(8080)
 #define BACKEND_SEC_IDENTITY	223344
 #define BACKEND_NODE_IP		v4_node_three
@@ -32,6 +38,9 @@ static volatile const __u8 *zero_mac = mac_zero;
 
 struct mock_settings {
 	__be16 nat_source_port;
+	bool trace_seen;
+	__be32 trace_orig_ip4;
+	union v6addr trace_orig_ip6;
 };
 
 struct {
@@ -40,6 +49,20 @@ struct {
 	__uint(value_size, sizeof(struct mock_settings));
 	__uint(max_entries, 1);
 } settings_map __section_maps_btf;
+
+#define TRACE_NOTIFY
+#define TRACE_EXTENSION
+#define trace_extension_hook(ctx, msg) do { \
+	__u32 __key = 0; \
+	struct mock_settings *__settings = map_lookup_elem(&settings_map, &__key); \
+	if (__settings && (msg).subtype == TRACE_TO_OVERLAY) { \
+		__settings->trace_seen = true; \
+		if ((msg).flags & CLS_FLAG_IPV6) \
+			ipv6_addr_copy(&__settings->trace_orig_ip6, &(msg).orig_ip6); \
+		else \
+			__settings->trace_orig_ip4 = (msg).orig_ip4.be32; \
+	} \
+} while (0)
 
 /* Set port ranges to have deterministic source port selection */
 #include "nodeport_defaults.h"
@@ -101,6 +124,7 @@ int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
 #include "lib/lb.h"
 
 ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_VXLAN)
+ASSIGN_CONFIG(union v6addr, router_ipv6, LB_IP6)
 
 /* Test that a SVC request to an intermediate LB node gets DNATed and SNATed,
  * and flows back out on the overlay interface to a remote backend
@@ -193,8 +217,10 @@ int nodeport_overlay_nat_1_fwd_check(const struct __ctx_buff *ctx)
 
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
 
-	if (settings)
-		settings->nat_source_port = l4->source;
+	if (!settings)
+		test_fatal("no test settings found");
+
+	settings->nat_source_port = l4->source;
 
 	struct bpf_tunnel_key *tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
 
@@ -202,6 +228,9 @@ int nodeport_overlay_nat_1_fwd_check(const struct __ctx_buff *ctx)
 		test_fatal("no tunnel key set");
 
 	assert(tunnel_key->tunnel_id == WORLD_ID);
+
+	assert(settings->trace_seen);
+	assert(settings->trace_orig_ip4 == CLIENT_IP);
 
 	test_finish();
 }
@@ -305,6 +334,239 @@ int nodeport_overlay_nat_2_reply_check(const struct __ctx_buff *ctx)
 		test_fatal("no tunnel key set");
 
 	assert(identity_is_remote_node(tunnel_key->tunnel_id));
+
+	test_finish();
+}
+
+/* Test that tunneling a packet whose source already matches the selected SNAT
+ * address does not report a source-address translation.
+ */
+PKTGEN(PROG_TYPE, "nodeport_overlay_nat_3_same_source")
+int nodeport_overlay_nat_3_same_source_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)zero_mac, (__u8 *)zero_mac,
+					  IPV4_GATEWAY, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "nodeport_overlay_nat_3_same_source")
+int nodeport_overlay_nat_3_same_source_setup(struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->trace_seen = false;
+	settings->trace_orig_ip4 = 0;
+
+	return overlay_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "nodeport_overlay_nat_3_same_source")
+int nodeport_overlay_nat_3_same_source_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct mock_settings *settings;
+
+	test_init();
+
+	settings = map_lookup_elem(&settings_map, &key);
+	if (!settings)
+		test_fatal("no test settings found");
+
+	assert(settings->trace_seen);
+	assert(settings->trace_orig_ip4 == 0);
+
+	test_finish();
+}
+
+/* Test that an IPv6 SVC request to an intermediate LB node gets DNATed and
+ * SNATed, and that the overlay trace reports the pre-SNAT source address.
+ */
+PKTGEN(PROG_TYPE, "nodeport_overlay_nat_4_fwd_v6")
+int nodeport_overlay_nat_4_fwd_v6_pktgen(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = CLIENT_IP6;
+	union v6addr frontend_ip = FRONTEND_IP6;
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)zero_mac, (__u8 *)zero_mac,
+					  client_ip.addr, frontend_ip.addr,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "nodeport_overlay_nat_4_fwd_v6")
+int nodeport_overlay_nat_4_fwd_v6_setup(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IP6;
+	union v6addr backend_ip = BACKEND_IP6;
+	__u16 revnat_id = 2;
+
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_UDP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 125,
+			  &backend_ip, BACKEND_PORT, IPPROTO_UDP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, BACKEND_SEC_IDENTITY,
+			     BACKEND_NODE_IP, 0);
+
+	return overlay_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "nodeport_overlay_nat_4_fwd_v6")
+int nodeport_overlay_nat_4_fwd_v6_check(const struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = CLIENT_IP6;
+	union v6addr backend_ip = BACKEND_IP6;
+	union v6addr lb_ip = LB_IP6;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ipv6hdr *l3;
+	struct ethhdr *l2;
+	__u32 key = 0;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("L2 header out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("IPv6 header out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("UDP header out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &lb_ip))
+		test_fatal("source IP hasn't been SNATed to router IP");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &backend_ip))
+		test_fatal("destination IP hasn't been DNATed to backend IP");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("destination port hasn't been DNATed to backend port");
+
+	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
+
+	if (!settings)
+		test_fatal("no test settings found");
+
+	struct bpf_tunnel_key *tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+
+	if (!tunnel_key)
+		test_fatal("no tunnel key set");
+
+	assert(settings->trace_seen);
+	assert(ipv6_addr_equals(&settings->trace_orig_ip6, &client_ip));
+
+	test_finish();
+}
+
+/* Test that tunneling an IPv6 packet whose source already matches the selected
+ * SNAT address does not report a source-address translation.
+ */
+PKTGEN(PROG_TYPE, "nodeport_overlay_nat_5_same_source_v6")
+int nodeport_overlay_nat_5_same_source_v6_pktgen(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IP6;
+	union v6addr lb_ip = LB_IP6;
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)zero_mac, (__u8 *)zero_mac,
+					  lb_ip.addr, frontend_ip.addr,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "nodeport_overlay_nat_5_same_source_v6")
+int nodeport_overlay_nat_5_same_source_v6_setup(struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->trace_seen = false;
+	memset(&settings->trace_orig_ip6, 0, sizeof(settings->trace_orig_ip6));
+
+	return overlay_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "nodeport_overlay_nat_5_same_source_v6")
+int nodeport_overlay_nat_5_same_source_v6_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	union v6addr zero_addr = {};
+	__u32 key = 0;
+	struct mock_settings *settings;
+
+	test_init();
+
+	settings = map_lookup_elem(&settings_map, &key);
+	if (!settings)
+		test_fatal("no test settings found");
+
+	assert(settings->trace_seen);
+	assert(ipv6_addr_equals(&settings->trace_orig_ip6, &zero_addr));
 
 	test_finish();
 }

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1566,6 +1566,32 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
+
+	eth.EthernetType = layers.EthernetTypeIPv6
+	ip6 := layers.IPv6{
+		SrcIP: net.ParseIP("2001:db8::2"),
+		DstIP: net.ParseIP("2001:db8::3"),
+	}
+	v1 = monitor.TraceNotify{
+		Type:    byte(monitorAPI.MessageTypeTrace),
+		Version: monitor.TraceNotifyVersion1,
+		Flags:   monitor.TraceNotifyFlagIsIPv6,
+		OrigIP:  [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+	}
+	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip6, &layers.TCP{})
+	require.NoError(t, err)
+	err = parser.Decode(data, f)
+	require.NoError(t, err)
+	assert.Equal(t, "2001:db8::1", f.IP.Source)
+	assert.Equal(t, "2001:db8::2", f.IP.SourceXlated)
+
+	v1.OrigIP = [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip6, &layers.TCP{})
+	require.NoError(t, err)
+	err = parser.Decode(data, f)
+	require.NoError(t, err)
+	assert.Equal(t, "2001:db8::2", f.IP.Source)
+	assert.Empty(t, f.IP.SourceXlated)
 }
 
 func TestICMP(t *testing.T) {


### PR DESCRIPTION
## Summary

Preserve the original IPv4 or IPv6 client address in `TRACE_TO_OVERLAY` when tunneled NodePort or LoadBalancer traffic is SNATed. Hubble can then show the client address in `source` and the SNAT address in `source_xlated`.

Flows without SNAT and other encapsulation paths are unchanged.

The result is:

```
{"ip_version":"IPv4","source":"10.89.1.8","source_xlated":"10.244.1.115","destination":"10.244.2.148","observation":"TO_OVERLAY","interface":"cilium_vxlan"}
{"ip_version":"IPv6","source":"fc00:c111::8","source_xlated":"fd00:10:244:1::ce8d","destination":"fd00:10:244:2::557f","observation":"TO_OVERLAY","interface":"cilium_vxlan"}
```

## Testing

- Overlay NodePort BPF runtime tests
- Hubble parser tests
- Full BPF build matrix