### PR TITLE
operator/ipam: Remove the per-node pool-maintainer retry trigger

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -53,6 +53,10 @@ const (
 	fieldName = "name"
 )
 
+// errInstancesAPIUnstable is returned by MaintainIPPool while the instances
+// API is unstable, in which case pool maintenance is skipped entirely.
+var errInstancesAPIUnstable = errors.New("instances API is unstable, blocking mutating operations")
+
 func (n *Node) SetOpts(ops NodeOperations) {
 	n.ops = ops
 }
@@ -138,10 +142,6 @@ type Node struct {
 
 	// ops is the IPAM implementation to use for this node
 	ops NodeOperations
-
-	// retry is the trigger used to retry pool maintenance while the
-	// instances API is unstable
-	retry *trigger.Trigger
 
 	// logLimiter rate limits potentially repeating warning logs
 	logLimiter logging.Limiter
@@ -660,7 +660,6 @@ func (n *Node) UpdatedResource(resource *v2.CiliumNode) bool {
 	allocationNeeded := n.allocationNeeded()
 	releaseNeeded := n.releaseNeeded()
 	if allocationNeeded || releaseNeeded {
-		n.requirePoolMaintenance()
 		n.poolMaintainer.Trigger()
 	}
 
@@ -1394,14 +1393,21 @@ func (n *Node) updateLastResync(syncTime time.Time) {
 
 // MaintainIPPool attempts to allocate or release all required IPs to fulfill
 // the needed gap. If required, interfaces are created.
+//
+// It owns waitingForPoolMaintenance, taken on entry and released on every
+// return path: the flag makes allocationNeeded() and releaseNeeded() false, and
+// those gate the only two sites that enqueue this, so a pass returning with it
+// set would strand the node for good. It is released before the pass triggers
+// any further asynchronous work, so that a resync racing with the tail of the
+// pass still observes the deficit and can enqueue the next one.
 func (n *Node) MaintainIPPool(ctx context.Context) error {
+	n.requirePoolMaintenance()
+	defer n.poolMaintenanceComplete()
+
 	// As long as the instances API is unstable, don't perform any
 	// operation that can mutate state.
 	if !n.manager.InstancesAPIIsReady() {
-		if n.retry != nil {
-			n.retry.Trigger()
-		}
-		return fmt.Errorf("instances API is unstable. Blocking mutating operations. See logs for details.")
+		return errInstancesAPIUnstable
 	}
 
 	// If the instance has stopped running for less than a minute, don't attempt any deficit
@@ -1416,6 +1422,12 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 		n.logger.Load().Debug("Setting resync needed")
 		n.requireResync()
 	}
+
+	// The mutating part of the pass is over. Release the flag before the
+	// instance syncs below: those run asynchronously, and the resync they
+	// end up driving reads allocationNeeded() for this node, which the flag
+	// would make false, dropping the enqueue of the next pass. The deferred
+	// release stays as the guarantee for the early returns above.
 	n.poolMaintenanceComplete()
 
 	n.recalculate(ctx)

--- a/operator/pkg/ipam/nodemanager/node_manager.go
+++ b/operator/pkg/ipam/nodemanager/node_manager.go
@@ -355,7 +355,13 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 			MetricsObserver: n.metricsAPI.PoolMaintainerTrigger(),
 			TriggerFunc: func(reasons []string) {
 				if err := node.MaintainIPPool(ctx); err != nil {
-					node.logger.Load().Warn("Unable to maintain ip pool of node", logfields.Error, err)
+					// An unstable instances API is a cluster wide failure
+					// that every node hits on every attempt, and it is
+					// already reported by the instances API resync itself,
+					// so don't log it once more per node.
+					if !errors.Is(err, errInstancesAPIUnstable) {
+						node.logger.Load().Warn("Unable to maintain ip pool of node", logfields.Error, err)
+					}
 					backoff.Wait(ctx)
 				}
 			},
@@ -365,17 +371,6 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 			node.logger.Load().Error("Unable to create pool-maintainer trigger", logfields.Error, err)
 			return
 		}
-
-		retry, err := trigger.NewTrigger(trigger.Parameters{
-			Name:        fmt.Sprintf("ipam-pool-maintainer-%s-retry", resource.Name),
-			MinInterval: time.Minute, // large minimal interval to not retry too often
-			TriggerFunc: func(reasons []string) { poolMaintainer.Trigger() },
-		})
-		if err != nil {
-			node.logger.Load().Error("Unable to create pool-maintainer-retry trigger", logfields.Error, err)
-			return
-		}
-		node.retry = retry
 
 		k8sSync, err := trigger.NewTrigger(trigger.Parameters{
 			Name:            fmt.Sprintf("ipam-node-k8s-sync-%s", resource.Name),
@@ -442,9 +437,6 @@ func (n *NodeManager) Delete(resource *v2.CiliumNode) {
 		}
 		if node.k8sSync != nil {
 			node.k8sSync.Shutdown()
-		}
-		if node.retry != nil {
-			node.retry.Shutdown()
 		}
 		if node.instanceSync != nil {
 			node.instanceSync.Shutdown()
@@ -528,7 +520,6 @@ func (n *NodeManager) resyncNode(ctx context.Context, node *Node, stats *resyncS
 	allocationNeeded := node.allocationNeeded()
 	releaseNeeded := node.releaseNeeded()
 	if allocationNeeded || releaseNeeded {
-		node.requirePoolMaintenance()
 		node.poolMaintainer.Trigger()
 	}
 

--- a/operator/pkg/ipam/nodemanager/node_test.go
+++ b/operator/pkg/ipam/nodemanager/node_test.go
@@ -156,6 +156,86 @@ func TestSyncToAPIServerForNonExistingNode(t *testing.T) {
 	require.NoError(t, node.syncToAPIServer())
 }
 
+func waitingForPoolMaintenance(n *Node) bool {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+	return n.waitingForPoolMaintenance
+}
+
+// newMaintenanceTestNode returns a node in deficit, wired with the bare
+// minimum for MaintainIPPool's early returns. It deliberately has no triggers
+// so that nothing runs pool maintenance concurrently with the test.
+func newMaintenanceTestNode(t *testing.T, instancesAPIReady bool) *Node {
+	t.Helper()
+
+	node := &Node{
+		rootLogger: hivetest.Logger(t),
+		name:       "test-node",
+		manager: &NodeManager{
+			k8sAPI:             &k8sMockNode{},
+			stableInstancesAPI: instancesAPIReady,
+		},
+		logLimiter: logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
+		resource:   newCiliumNode("test-node", 0, 0, 0),
+		ops:        &nodeOperationsMock{},
+	}
+	node.updateLogger()
+	node.stats.IPv4.NeededIPs = 1
+
+	return node
+}
+
+// TestMaintainIPPoolReleasesPoolMaintenance covers the invariant documented on
+// MaintainIPPool: it owns waitingForPoolMaintenance and releases it on every
+// return path, including the early ones. The flag gates allocationNeeded() and
+// releaseNeeded(), which in turn gate the only two places that ever enqueue the
+// pool maintainer, so a pass that returns with the flag still set strands the
+// node for good.
+func TestMaintainIPPoolReleasesPoolMaintenance(t *testing.T) {
+	t.Run("instances API is unstable", func(t *testing.T) {
+		node := newMaintenanceTestNode(t, false)
+
+		err := node.MaintainIPPool(context.Background())
+		require.ErrorIs(t, err, errInstancesAPIUnstable)
+		require.False(t, waitingForPoolMaintenance(node), "the pass must release the flag it took")
+		require.True(t, node.allocationNeeded(), "node must report its deficit again so the background resync re-drives it")
+	})
+
+	t.Run("instance stopped running", func(t *testing.T) {
+		node := newMaintenanceTestNode(t, true)
+		node.SetRunning(false)
+
+		require.NoError(t, node.MaintainIPPool(context.Background()))
+		require.False(t, waitingForPoolMaintenance(node), "the pass must release the flag it took")
+		require.True(t, node.allocationNeeded(), "node must report its deficit again so the sign of life can re-drive it")
+	})
+}
+
+// TestUpdatedResourceDoesNotSetPoolMaintenance pins the other half of that
+// ownership: enqueue sites only enqueue. If they set the flag themselves, they
+// reintroduce the skew where setting and clearing live in different layers and
+// a return path can leak it.
+func TestUpdatedResourceDoesNotSetPoolMaintenance(t *testing.T) {
+	node := newMaintenanceTestNode(t, true)
+	maintainer := &countingPoolMaintainer{}
+	node.poolMaintainer = maintainer
+
+	require.True(t, node.UpdatedResource(newCiliumNode("test-node", 0, 4, 0)))
+	require.Equal(t, 1, maintainer.triggered, "a node in deficit must enqueue a maintenance pass")
+	require.False(t, waitingForPoolMaintenance(node), "the flag belongs to the pass, not to the enqueue")
+}
+
+// countingPoolMaintainer counts enqueues without running any maintenance, so
+// that the flag is only ever touched by the code under test. Unlike
+// poolMaintainerMock, which only silences the maintainer, the count is the
+// assertion here, so it is used from a single goroutine and left unsynchronized.
+type countingPoolMaintainer struct {
+	triggered int
+}
+
+func (p *countingPoolMaintainer) Trigger()  { p.triggered++ }
+func (p *countingPoolMaintainer) Shutdown() {}
+
 func TestPoolRequestedIPv4(t *testing.T) {
 	t.Run("returns IPv4 demand from default pool", func(t *testing.T) {
 		cn := &v2.CiliumNode{}


### PR DESCRIPTION
Each CiliumNode creates 4 triggers today, and one of them exists only to call another one: the "-retry" trigger's entire body is `poolMaintainer.Trigger()`, rate limited to one call per minute. That is one goroutine and one timer per node, which on a large enough production cluster where the majority of goroutine count is driven by node count, amounts to a quarter of the operator's parked trigger waiters.

It exists only because of a skewed invariant. The two halves of `waitingForPoolMaintenance` live in different layers: the enqueue sites set it, and `MaintainIPPool` clears it on the one return path. Its early return for an unstable instances API returns with the flag still set, and the flag makes both `allocationNeeded()` and `releaseNeeded()` false, which gate the only two places that ever enqueue the maintainer. Nothing can re-drive the node, hence the retry trigger.

This commit gives the flag a single owner instead. `MaintainIPPool` takes it on entry and releases it with a defer, so it is held for exactly the duration of a pass and released on every return path, and the enqueue sites only enqueue. The node reports its deficit again, so the interval based background resync re-drives it, and since that resync only reaches `Resync()` after a successful instances API resync, the node is picked up in the very iteration that observes the API recovering. While it is down the maintainer is re-triggered by node events rather than once per minute, but each of those is an early return that mutates nothing and is bounded by the backoff already applied to failed maintenance.

This also fixes a latent strand on the second early return, taken while the instance has been stopped for less than a minute. Its comment says to wait for the custom resource to be updated as a sign of life, but that wait could never complete: `UpdatedResource()` marks the instance running and then consults `allocationNeeded()`, which was false because the flag was still set. A node that briefly stopped while in deficit stayed stranded until the operator restarted.