### PR TITLE
hubble/relay: stop gRPC health server on shutdown

### DIFF
--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -190,6 +190,7 @@ func (s *Server) Serve() error {
 func (s *Server) Stop() {
 	s.opts.log.Info("Stopping server...")
 	s.server.Stop()
+	s.grpcHealthServer.Stop()
 	if s.metricsServer != nil {
 		if err := s.metricsServer.Shutdown(context.Background()); err != nil {
 			s.opts.log.Info("Failed to gracefully stop metrics server", logfields.Error, err)

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -92,6 +92,56 @@ func getRandomEndpoint() *testutils.FakeEndpointInfo {
 	return nil
 }
 
+func TestServerStopReturnsServe(t *testing.T) {
+	freeTCPAddress := func() string {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer l.Close()
+		return l.Addr().String()
+	}
+
+	listenAddress := freeTCPAddress()
+	healthListenAddress := freeTCPAddress()
+
+	srv, err := New(
+		WithInsecureClient(),
+		WithInsecureServer(),
+		WithPeerTarget("unix://"+filepath.Join(t.TempDir(), "peer.sock")),
+		WithListenAddress(listenAddress),
+		WithHealthListenAddress(healthListenAddress),
+		WithRetryTimeout(10*time.Millisecond),
+		WithLogger(log),
+	)
+	require.NoError(t, err)
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.Serve()
+	}()
+
+	canDial := func(address string) bool {
+		conn, err := net.DialTimeout("tcp", address, 10*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}
+
+	require.Eventually(t, func() bool {
+		return canDial(listenAddress) && canDial(healthListenAddress)
+	}, time.Second, 10*time.Millisecond)
+
+	srv.Stop()
+
+	select {
+	case err := <-serveDone:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Serve did not return after Stop")
+	}
+}
+
 func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.LocalObserverServer {
 	queueSize := numFlows
 


### PR DESCRIPTION
The gRPC health server is started as part of Server.Serve(), but Server.Stop() only stops the main gRPC server. This leaves the health listener running and keeps Serve() blocked in errgroup.Wait().

## What this PR solves
Stop the gRPC health server during shutdown

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy].

This PR was prepared with AIL:3 I used AI to assist with investigatingthe shutdown behavior, reviewing the relevant source code, and developing thetest approach.

<!-- Description of change -->

Fixes: #47941

```release-note
Fix Hubble Relay remains running during termination
```

[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
