### PR TITLE
gateway-api: compare static Gateway addresses as parsed IPs

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -811,13 +811,24 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 		// reconciliation should be triggered when the loadbalancer services gets updated.
 		return nil
 	}
-	addresses := make(map[string]struct{})
+	// Compare parsed addresses because the same IP address can have multiple
+	// textual representations.
+	addresses := make(map[netip.Addr]struct{}, len(svc.Status.LoadBalancer.Ingress))
 	for _, addr := range svc.Status.LoadBalancer.Ingress {
-		addresses[addr.IP] = struct{}{}
+		ip, err := netip.ParseAddr(addr.IP)
+		if err != nil {
+			// Ignore hostname-only ingress entries.
+			continue
+		}
+		addresses[ip] = struct{}{}
 	}
 
 	for _, addr := range gw.Spec.Addresses {
-		if _, ok := addresses[addr.Value]; !ok {
+		ip, err := netip.ParseAddr(addr.Value)
+		if err != nil {
+			return fmt.Errorf("static address %q can't be used", addr.Value)
+		}
+		if _, ok := addresses[ip]; !ok {
 			return fmt.Errorf("static address %q can't be used", addr.Value)
 		}
 	}

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1538,3 +1538,117 @@ func TestGatewayReconciler_statuses(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
 	})
 }
+
+func Test_gatewayReconciler_setStaticAddressStatus(t *testing.T) {
+	t.Parallel()
+
+	gateway := func(addr string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "static-address-gateway",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Addresses: []gatewayv1.GatewaySpecAddress{
+					{
+						Type:  ptr.To(gatewayv1.IPAddressType),
+						Value: addr,
+					},
+				},
+			},
+		}
+	}
+
+	service := func(ingress ...corev1.LoadBalancerIngress) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-gateway-static-address-gateway",
+				Namespace: "default",
+				Labels: map[string]string{
+					owningGatewayLabel: shortener.ShortenK8sResourceName("static-address-gateway"),
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: ingress,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		specAddr  string
+		ingress   []corev1.LoadBalancerIngress
+		wantError bool
+	}{
+		{
+			name:     "IPv6 spelled with :: matches the canonical status address",
+			specAddr: "2001:db8:1:2:3:4::6",
+			ingress:  []corev1.LoadBalancerIngress{{IP: "2001:db8:1:2:3:4:0:6"}},
+		},
+		{
+			name:     "IPv6 with leading zeroes matches the canonical status address",
+			specAddr: "2001:0db8::0001",
+			ingress:  []corev1.LoadBalancerIngress{{IP: "2001:db8::1"}},
+		},
+		{
+			name:     "identical IPv4 addresses match",
+			specAddr: "10.0.0.1",
+			ingress:  []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+		},
+		{
+			name:     "hostname entry is ignored when a matching IP is present",
+			specAddr: "2001:db8::1",
+			ingress: []corev1.LoadBalancerIngress{
+				{Hostname: "gateway.example.com"},
+				{IP: "2001:db8::1"},
+			},
+		},
+		{
+			name:      "a different address is still rejected",
+			specAddr:  "2001:db8::1",
+			ingress:   []corev1.LoadBalancerIngress{{IP: "2001:db8::2"}},
+			wantError: true,
+		},
+		{
+			name:      "hostname-only ingress is rejected",
+			specAddr:  "2001:db8::1",
+			ingress:   []corev1.LoadBalancerIngress{{Hostname: "gateway.example.com"}},
+			wantError: true,
+		},
+		{
+			name:      "invalid ingress IP is rejected",
+			specAddr:  "2001:db8::1",
+			ingress:   []corev1.LoadBalancerIngress{{IP: "not-an-ip"}},
+			wantError: true,
+		},
+		{
+			name:      "invalid Gateway spec address is rejected",
+			specAddr:  "not-an-ip",
+			ingress:   []corev1.LoadBalancerIngress{{IP: "2001:db8::1"}},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := gateway(tc.specAddr)
+			c := fake.NewClientBuilder().
+				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithObjects(gw, service(tc.ingress...)).
+				Build()
+			r := &gatewayReconciler{
+				Client: c,
+				logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+			}
+
+			err := r.setStaticAddressStatus(t.Context(), gw)
+			if tc.wantError {
+				require.ErrorContains(t, err, "can't be used")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
`setStaticAddressStatus` compared addresses from `Gateway.spec.addresses` with
the generated Service status as strings. Equivalent IPv6 addresses can use
different textual representations, causing an allocated and working static
address to be reported as unusable.

Parse both sides with `netip.ParseAddr` and compare the resulting addresses.
Hostname-only Service ingress entries are ignored. Add regression coverage for
equivalent IPv6 representations, IPv4 addresses, and mismatched addresses.

Tested with:

```text
go test ./operator/pkg/gateway-api -count=1
```

Fixes: #47857

```release-note
Fix Gateway API static IPv6 addresses being reported as unusable when the Gateway and Service use different textual representations of the same address.
```

AIL:2 — Generative AI was used to assist with parts of the implementation,
testing, and PR preparation. I reviewed and validated the changes.
