### PR TITLE
hubble: add optional protocol and port labels to policy metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -1386,12 +1386,12 @@ Name                             Labels                                   Defaul
 Options
 """""""
 
-================== ============= ====================================================================================
-Option Key         Option Value  Description
-================== ============= ====================================================================================
-``protocol``       N/A           Include the L4 protocol as label ``protocol``.
-``destination_port`` N/A         Include the destination port as label ``destination_port``. This may result in high cardinality. L7 reply flows are not counted.
-================== ============= ====================================================================================
+==================== ============= ====================================================================================
+Option Key           Option Value  Description
+==================== ============= ====================================================================================
+``protocol``         N/A           Include the L4 protocol as label ``protocol``.
+``destination_port`` N/A           Include the destination port as label ``destination_port``. This may result in high cardinality. L7 reply flows are not counted.
+==================== ============= ====================================================================================
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
 

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -1374,6 +1374,27 @@ Options
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
 
+``policy``
+~~~~~~~~~~
+
+================================ ======================================== ========== =============================================
+Name                             Labels                                   Default    Description
+================================ ======================================== ========== =============================================
+``policy_verdicts_total``        ``direction``, ``match``, ``action``     Disabled   Total number of Cilium network policy verdicts
+================================ ======================================== ========== =============================================
+
+Options
+"""""""
+
+================== ============= ====================================================================================
+Option Key         Option Value  Description
+================== ============= ====================================================================================
+``protocol``       N/A           Include the L4 protocol as label ``protocol``.
+``destination_port`` N/A         Include the destination port as label ``destination_port``. This may result in high cardinality. L7 reply flows are not counted.
+================== ============= ====================================================================================
+
+This metric supports :ref:`Context Options<hubble_context_options>`.
+
 ``port-distribution``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -130,6 +130,24 @@ one stable release to a later stable release.
 
 .. include:: upgrade-warning.rst
 
+Hubble policy verdict metric labels
+-----------------------------------
+
+The ``hubble_policy_verdicts_total`` metric supports optional ``protocol`` and
+``destination_port`` labels. Existing metric configurations retain their
+current label set. To enable the additional labels, configure the Hubble policy
+metric with the ``protocol`` and ``destination_port`` options:
+
+.. code-block:: yaml
+
+    hubble:
+      metrics:
+        enabled:
+          - "policy:protocol;destination_port"
+
+The ``destination_port`` label may increase metric cardinality depending on
+traffic patterns. L7 reply flows are not counted when this option is enabled.
+
 Step 1: Upgrade to latest patch version
 ---------------------------------------
 

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,10 +24,12 @@ import (
 )
 
 type policyHandler struct {
-	verdicts  *prometheus.CounterVec
-	context   *api.ContextOptions
-	AllowList filters.FilterFuncs
-	DenyList  filters.FilterFuncs
+	verdicts        *prometheus.CounterVec
+	context         *api.ContextOptions
+	AllowList       filters.FilterFuncs
+	DenyList        filters.FilterFuncs
+	protocol        bool
+	destinationPort bool
 }
 
 func (h *policyHandler) Init(registry *prometheus.Registry, options *api.MetricConfig) error {
@@ -41,6 +44,20 @@ func (h *policyHandler) Init(registry *prometheus.Registry, options *api.MetricC
 	}
 
 	labels := []string{"direction", "match", "action"}
+	for _, option := range options.ContextOptionConfigs {
+		switch strings.ToLower(option.Name) {
+		case "protocol":
+			h.protocol = true
+		case "destination_port":
+			h.destinationPort = true
+		}
+	}
+	if h.protocol {
+		labels = append(labels, "protocol")
+	}
+	if h.destinationPort {
+		labels = append(labels, "destination_port")
+	}
 	labels = append(labels, h.context.GetLabelNames()...)
 
 	h.verdicts = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -54,7 +71,17 @@ func (h *policyHandler) Init(registry *prometheus.Registry, options *api.MetricC
 }
 
 func (h *policyHandler) Status() string {
-	return h.context.Status()
+	var status []string
+	if h.protocol {
+		status = append(status, "protocol")
+	}
+	if h.destinationPort {
+		status = append(status, "destination_port")
+	}
+	if contextStatus := h.context.Status(); contextStatus != "" {
+		status = append(status, contextStatus)
+	}
+	return strings.Join(status, ",")
 }
 
 func (h *policyHandler) Context() *api.ContextOptions {
@@ -66,6 +93,13 @@ func (h *policyHandler) ListMetricVec() []*prometheus.MetricVec {
 }
 
 func (h *policyHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	// L7 response flows can have a client ephemeral port as their destination port.
+	if h.destinationPort &&
+		flow.GetEventType().GetType() == monitorAPI.MessageTypeAccessLog &&
+		flow.GetIsReply().GetValue() {
+		return nil
+	}
+
 	if !filters.Apply(h.AllowList, h.DenyList, &v1.Event{Event: flow, Timestamp: &timestamppb.Timestamp{}}) {
 		return nil
 	}
@@ -94,7 +128,7 @@ func (h *policyHandler) ProcessFlowL3L4(ctx context.Context, flow *flowpb.Flow) 
 	direction := strings.ToLower(flow.GetTrafficDirection().String())
 	match := strings.ToLower(monitorAPI.PolicyMatchType(flow.GetPolicyMatchType()).String())
 	action := strings.ToLower(flow.Verdict.String())
-	labels := []string{direction, match, action}
+	labels := h.labels(direction, match, action, flow)
 	labels = append(labels, labelValues...)
 
 	h.verdicts.WithLabelValues(labels...).Inc()
@@ -119,11 +153,56 @@ func (h *policyHandler) ProcessFlowL7(ctx context.Context, flow *flowpb.Flow) er
 	}
 	match := fmt.Sprintf("l7/%s", subType)
 	action := strings.ToLower(flow.Verdict.String())
-	labels := []string{direction, match, action}
+	labels := h.labels(direction, match, action, flow)
 	labels = append(labels, labelValues...)
 
 	h.verdicts.WithLabelValues(labels...).Inc()
 	return nil
+}
+
+func (h *policyHandler) labels(direction, match, action string, flow *flowpb.Flow) []string {
+	labels := []string{direction, match, action}
+	if h.protocol {
+		labels = append(labels, l4Protocol(flow))
+	}
+	if h.destinationPort {
+		labels = append(labels, destinationPort(flow))
+	}
+	return labels
+}
+
+func l4Protocol(flow *flowpb.Flow) string {
+	switch flow.GetL4().GetProtocol().(type) {
+	case *flowpb.Layer4_TCP:
+		return "TCP"
+	case *flowpb.Layer4_UDP:
+		return "UDP"
+	case *flowpb.Layer4_SCTP:
+		return "SCTP"
+	case *flowpb.Layer4_ICMPv4:
+		return "ICMPv4"
+	case *flowpb.Layer4_ICMPv6:
+		return "ICMPv6"
+	case *flowpb.Layer4_VRRP:
+		return "VRRP"
+	case *flowpb.Layer4_IGMP:
+		return "IGMP"
+	default:
+		return "Unknown L4"
+	}
+}
+
+func destinationPort(flow *flowpb.Flow) string {
+	switch l4 := flow.GetL4().GetProtocol().(type) {
+	case *flowpb.Layer4_TCP:
+		return strconv.Itoa(int(l4.TCP.GetDestinationPort()))
+	case *flowpb.Layer4_UDP:
+		return strconv.Itoa(int(l4.UDP.GetDestinationPort()))
+	case *flowpb.Layer4_SCTP:
+		return strconv.Itoa(int(l4.SCTP.GetDestinationPort()))
+	default:
+		return ""
+	}
 }
 
 func (h *policyHandler) Deinit(registry *prometheus.Registry) error {

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
@@ -59,4 +60,78 @@ hubble_policy_verdicts_total{action="redirected",direction="ingress",match="l3-l
 hubble_policy_verdicts_total{action="dropped",direction="ingress",match="l7/http"} 1
 `)
 	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
+}
+
+func TestPolicyHandlerWithProtocolAndPort(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	h := &policyHandler{}
+	assert.NoError(t, h.Init(registry, &api.MetricConfig{
+		ContextOptionConfigs: []*api.ContextOptionConfig{
+			{Name: "protocol"},
+			{Name: "destination_port"},
+		},
+	}))
+
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		PolicyMatchType:  monitorAPI.PolicyMatchL3L4,
+		Verdict:          flowpb.Verdict_DROPPED,
+		L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+			DestinationPort: 443,
+		}}},
+	}
+	h.ProcessFlow(t.Context(), flow)
+
+	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
+# TYPE hubble_policy_verdicts_total counter
+hubble_policy_verdicts_total{action="dropped",destination_port="443",direction="egress",match="l3-l4",protocol="TCP"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
+	assert.Equal(t, "protocol,destination_port", h.Status())
+}
+
+func TestPolicyHandlerUsesL4ProtocolForL7Flows(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	h := &policyHandler{}
+	assert.NoError(t, h.Init(registry, &api.MetricConfig{
+		ContextOptionConfigs: []*api.ContextOptionConfig{{Name: "protocol"}},
+	}))
+
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+		TrafficDirection: flowpb.TrafficDirection_INGRESS,
+		Verdict:          flowpb.Verdict_DROPPED,
+		L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{}}},
+		L7:               &flowpb.Layer7{Record: &flowpb.Layer7_Http{Http: &flowpb.HTTP{}}},
+	}
+	h.ProcessFlow(t.Context(), flow)
+
+	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
+# TYPE hubble_policy_verdicts_total counter
+hubble_policy_verdicts_total{action="dropped",direction="ingress",match="l7/http",protocol="TCP"} 1
+`)
+	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, expected))
+}
+
+func TestPolicyHandlerWithDestinationPortSkipsL7ReplyFlows(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	h := &policyHandler{}
+	assert.NoError(t, h.Init(registry, &api.MetricConfig{
+		ContextOptionConfigs: []*api.ContextOptionConfig{{Name: "destination_port"}},
+	}))
+
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+		TrafficDirection: flowpb.TrafficDirection_INGRESS,
+		Verdict:          flowpb.Verdict_FORWARDED,
+		IsReply:          wrapperspb.Bool(true),
+		L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+			DestinationPort: 49152,
+		}}},
+		L7: &flowpb.Layer7{Record: &flowpb.Layer7_Http{Http: &flowpb.HTTP{}}},
+	}
+	h.ProcessFlow(t.Context(), flow)
+
+	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, strings.NewReader("")))
 }

--- a/pkg/hubble/metrics/policy/plugin.go
+++ b/pkg/hubble/metrics/policy/plugin.go
@@ -20,7 +20,11 @@ Reports metrics related to Cilium network policies.
 Metrics:
   hubble_policy_verdicts_total Total number of policy verdict events
 
-Options:` +
+Options:
+ protocol - Include the L4 protocol as label "protocol".
+ destination_port - Include the destination port as label "destination_port".
+                    This may result in high cardinality depending on the traffic
+                    pattern. L7 reply flows are not counted.` +
 		api.ContextOptionsHelp
 }
 


### PR DESCRIPTION
Add opt-in protocol and destination port labels to hubble_policy_verdicts_total.

Both labels are disabled by default to preserve the existing metric label set. The destination port label may increase metric cardinality depending on the traffic pattern.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Related: #34304 

```release-note
Add opt-in `protocol` and destination `port` labels to `hubble_policy_verdicts_total`.

Enable the additional labels with:

```yaml
hubble:
  metrics:
    enabled:
      - "policy:protocol;destination_port"

Both options are disabled by default to preserve the existing metric label set. The port option may increase metric cardinality depending on traffic patterns.

```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
