### PR TITLE
install: detect GKE from kubelet path

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -32,9 +32,12 @@ rm -f /tmp/node-init.cilium.io
 touch /tmp/node-deinit.cilium.io
 
 {{- if .Values.nodeinit.reconfigureKubelet }}
-# Check if we're running on a GKE containerd flavor.
+# Check if we're running on GKE, identified by the
+# presence of the kubelet binary at GKE_KUBERNETES_BIN_DIR. This also matches
+# after startup.bash has replaced the real kubelet with the Cilium wrapper,
+# since the wrapper is installed at the same path.
 GKE_KUBERNETES_BIN_DIR="/home/kubernetes/bin"
-if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && command -v containerd &>/dev/null; then
+if [[ -f "${GKE_KUBERNETES_BIN_DIR}/kubelet" ]]; then
   CONTAINERD_CONFIG="/etc/containerd/config.toml"
   echo "Reverting changes to the containerd configuration"
   sed -Ei "s/^\#(\s+conf_template)/\1/g" "${CONTAINERD_CONFIG}"

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -24,11 +24,11 @@ fi
 {{- end }}
 
 {{- if .Values.nodeinit.reconfigureKubelet }}
-# Check if we're running on a GKE containerd flavor as indicated by the presence
-# of the '--container-runtime-endpoint' flag in '/etc/default/kubelet'.
+# Check if we're running on GKE, identified by the
+# presence of the kubelet binary at GKE_KUBERNETES_BIN_DIR.
 GKE_KUBERNETES_BIN_DIR="/home/kubernetes/bin"
 KUBELET_DEFAULTS_FILE="/etc/default/kubelet"
-if [[ -f "${GKE_KUBERNETES_BIN_DIR}/gke" ]] && [[ $(grep -cF -- '--container-runtime-endpoint' "${KUBELET_DEFAULTS_FILE}") == "1" ]]; then
+if [[ -f "${GKE_KUBERNETES_BIN_DIR}/kubelet" ]]; then
   echo "GKE *_containerd flavor detected..."
 
   # (GKE *_containerd) Upon node restarts, GKE's containerd images seem to reset


### PR DESCRIPTION
GKE `1.36.2-gke.2064000` no longer exposes the container runtime endpoint through the `--container-runtime-endpoint` flag in `/etc/default/kubelet`. This causes the existing node-init GKE detection to miss the GKE-specific path and fall through to generic kubelet handling.

Instead of detecting individual GKE node layouts through container runtime configuration, this change uses the presence of `/home/kubernetes/bin/kubelet`, which is shared by both the legacy and current GKE layouts.

The same detection is used by startup and prestop, so the kubelet wrapper installed during startup can also be detected and reverted correctly.

Testing performed:

* `helm lint`
* Helm template rendering with GKE/node-init values
* `bash -n` on rendered startup and prestop scripts
* sandboxed scenarios covering legacy GKE, the GKE 1.36.2 layout, generic non-GKE nodes, and an already-installed kubelet wrapper
* live GKE `1.36.2-gke.2064000` COS/containerd node verification:
  * `/home/kubernetes/bin/kubelet` exists as a regular executable file
  * `/home/kubernetes/kubelet-config.yaml` contains `containerRuntimeEndpoint: unix:///run/containerd/containerd.sock`
  * `/etc/default/kubelet` does not contain `--container-runtime-endpoint`
* `git diff --check`

Claude was used to suggest the implementation. I manually reviewed the changes and validated the resulting behavior with the tests above.

AIL:4

Fixes: #47884

```release-note
Fix node-init startup on GKE 1.36.2-gke.2064000 nodes by detecting GKE from the kubelet path instead of container runtime configuration.
```