### PR TITLE
clustermesh: transition service exports to observer

### DIFF
--- a/pkg/clustermesh/endpointslice/observer.go
+++ b/pkg/clustermesh/endpointslice/observer.go
@@ -20,7 +20,7 @@ func newFactory(params params) observer.Factory {
 	return func(cluster string, onSync func()) observer.Observer {
 		obs := &endpointSliceObserver{
 			logger:        params.Logger.With(logfields.ClusterName, cluster),
-			name:          cluster,
+			cluster:       cluster,
 			serviceModeV2: params.ServiceModeV2,
 			onSync:        onSync,
 		}
@@ -48,7 +48,7 @@ func newFactory(params params) observer.Factory {
 
 type endpointSliceObserver struct {
 	logger        *slog.Logger
-	name          string
+	cluster       string
 	clusterID     uint32
 	serviceModeV2 types.ServiceModeV2
 	store         store.WatchStore
@@ -77,7 +77,7 @@ func (o *endpointSliceObserver) Register(mgr store.WatchStoreManager, backend kv
 	if o.serviceModeV2.ShouldWatchEndpointSlices() && cfg.Capabilities.EndpointSlicesExportMode != types.EndpointSlicesExportModeServicesOnly {
 		o.enabled.Store(true)
 		mgr.Register(prefix, func(ctx context.Context) {
-			o.store.Watch(ctx, backend, kvstore.JoinKey(prefix, o.name))
+			o.store.Watch(ctx, backend, kvstore.JoinKey(prefix, o.cluster))
 		})
 		return
 	}
@@ -86,7 +86,7 @@ func (o *endpointSliceObserver) Register(mgr store.WatchStoreManager, backend kv
 	if o.serviceModeV2.ShouldWatchEndpointSlices() {
 		o.logger.Error("Remote cluster does not support endpoint slice resources while Cilium is configured to watch them. "+
 			"Global Services and MCS-API will not take into account any backends from this cluster!",
-			logfields.ClusterName, o.name)
+			logfields.ClusterName, o.cluster)
 	}
 
 	// Drain any existing endpoint slices in case the remote cluster no longer supports them.

--- a/pkg/clustermesh/endpointslice/observer.go
+++ b/pkg/clustermesh/endpointslice/observer.go
@@ -84,9 +84,8 @@ func (o *endpointSliceObserver) Register(mgr store.WatchStoreManager, backend kv
 
 	o.enabled.Store(false)
 	if o.serviceModeV2.ShouldWatchEndpointSlices() {
-		o.logger.Error("Remote cluster does not support endpoint slice resources while Cilium is configured to watch them. "+
-			"Global Services and MCS-API will not take into account any backends from this cluster!",
-			logfields.ClusterName, o.cluster)
+		o.logger.Error("Remote cluster does not support endpoint slice resources while Cilium is configured to watch them. " +
+			"Global Services and MCS-API will not take into account any backends from this cluster!")
 	}
 
 	// Drain any existing endpoint slices in case the remote cluster no longer supports them.

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -18,6 +18,7 @@ import (
 
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
+	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s/apis"
@@ -30,6 +31,13 @@ import (
 var Cell = cell.Module(
 	"mcsapi",
 	"Multi-Cluster Services API",
+
+	cell.Provide(func(params paramsObserver) observer.FactoryOut {
+		return observer.NewFactoryOut(newFactory(params))
+	}),
+	cell.ProvidePrivate(newGlobalServiceExportCache),
+	cell.ProvidePrivate(newRemoteClusterServiceExportSource),
+	metrics.Metric(NewMetrics),
 	cell.Invoke(registerMCSAPIController),
 
 	cell.Provide(newMCSAPICRDs),
@@ -53,6 +61,8 @@ type mcsAPIParams struct {
 	Logger          *slog.Logger
 	JobGroup        job.Group
 	MetricsRegistry *metrics.Registry
+	Cache           *globalServiceExportCache
+	Source          *remoteClusterServiceExportSource
 
 	NamespaceConfig cmnamespace.Config
 }
@@ -106,12 +116,9 @@ func registerMCSAPIController(params mcsAPIParams) error {
 
 	registerMCSAPICollector(params.MetricsRegistry, params.Logger, params.CtrlRuntimeManager.GetClient())
 
-	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: params.Logger}
-	params.ClusterMesh.RegisterClusterServiceExportUpdateHook(remoteClusterServiceSource.onClusterServiceExportEvent)
-	params.ClusterMesh.RegisterClusterServiceExportDeleteHook(remoteClusterServiceSource.onClusterServiceExportEvent)
 	svcImportReconciler := newMCSAPIServiceImportReconciler(
 		params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name,
-		params.ClusterMesh.GlobalServiceExports(), remoteClusterServiceSource,
+		params.Cache, params.Source,
 		params.AgentConfig.EnableIPv4, params.AgentConfig.EnableIPv6,
 		params.NamespaceConfig,
 	)
@@ -119,7 +126,7 @@ func registerMCSAPIController(params mcsAPIParams) error {
 	params.JobGroup.Add(job.OneShot("mcsapi-main", func(ctx context.Context, health cell.Health) error {
 		params.Logger.Info("Bootstrap Multi-Cluster Services API support")
 
-		if err := params.ClusterMesh.ServiceExportsSynced(ctx); err != nil {
+		if err := params.ClusterMesh.ObserverSynced(ctx, mcsapitypes.Name); err != nil {
 			return nil // The parent context expired, and we are already terminating
 		}
 

--- a/pkg/clustermesh/mcsapi/metrics.go
+++ b/pkg/clustermesh/mcsapi/metrics.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 const subsystem = "mcsapi"
@@ -142,5 +143,21 @@ func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			ch <- metric
 		}
+	}
+}
+
+type Metrics struct {
+	// TotalServiceExports tracks the number of total MCS-API service exports per remote cluster.
+	TotalServiceExports metric.Vec[metric.Gauge]
+}
+
+func NewMetrics() Metrics {
+	return Metrics{
+		TotalServiceExports: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Subsystem: metrics.SubsystemClusterMesh,
+			Name:      "remote_cluster_service_exports",
+			Help:      "The total number of MCS-API service exports in the remote cluster",
+		}, []string{metrics.LabelTargetCluster}),
 	}
 }

--- a/pkg/clustermesh/mcsapi/observer.go
+++ b/pkg/clustermesh/mcsapi/observer.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/cilium/hive/cell"
+
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/observer"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type paramsObserver struct {
+	cell.In
+
+	Logger       *slog.Logger
+	StoreFactory store.Factory
+	Metrics      Metrics
+	CfgMCSAPI    mcsapitypes.MCSAPIConfig
+	Cache        *globalServiceExportCache
+	Source       *remoteClusterServiceExportSource
+}
+
+func newFactory(params paramsObserver) observer.Factory {
+	return func(cluster string, onSync func()) observer.Observer {
+		obs := &serviceExportObserver{
+			logger:       params.Logger.With(logfields.ClusterName, cluster),
+			cluster:      cluster,
+			onSync:       onSync,
+			enableMCSAPI: params.CfgMCSAPI.EnableMCSAPI,
+		}
+		obs.store = params.StoreFactory.NewWatchStore(
+			cluster,
+			mcsapitypes.KeyCreator(
+				mcsapitypes.ClusterNameValidator(cluster),
+				mcsapitypes.NamespacedNameValidator(),
+			),
+			newServiceExportsObserver(
+				params.Cache,
+				params.Source.onClusterServiceExportEvent,
+				params.Source.onClusterServiceExportEvent,
+			),
+			store.RWSWithOnSyncCallback(func(context.Context) { onSync() }),
+			store.RWSWithEntriesMetric(params.Metrics.TotalServiceExports.WithLabelValues(cluster)),
+		)
+
+		return obs
+	}
+}
+
+type serviceExportObserver struct {
+	logger  *slog.Logger
+	cluster string
+	store   store.WatchStore
+	onSync  func()
+	enabled atomic.Bool
+
+	enableMCSAPI bool
+}
+
+func (o *serviceExportObserver) Name() observer.Name { return mcsapitypes.Name }
+
+func (o *serviceExportObserver) Status() observer.Status {
+	return observer.Status{
+		Enabled: o.enabled.Load(),
+		Synced:  o.store.Synced(),
+		Entries: o.store.NumEntries(),
+	}
+}
+
+func (o *serviceExportObserver) Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig) {
+	prefix := mcsapitypes.ServiceExportStorePrefix
+	if cfg.Capabilities.Cached {
+		prefix = kvstore.StateToCachePrefix(prefix)
+	}
+
+	if o.enableMCSAPI && cfg.Capabilities.ServiceExportsEnabled != nil {
+		o.enabled.Store(true)
+		mgr.Register(prefix, func(ctx context.Context) {
+			o.store.Watch(ctx, backend, kvstore.JoinKey(prefix, o.cluster))
+		})
+		return
+	}
+
+	o.enabled.Store(false)
+	if o.enableMCSAPI {
+		o.logger.Warn("Remote cluster does not support MCS-API service export resources")
+	}
+
+	// Drain any existing service exports in case the remote cluster no longer supports them.
+	o.store.Drain()
+	// Mimic that service exports are synced if not enabled.
+	o.onSync()
+}
+
+func (o *serviceExportObserver) Drain()  { o.store.Drain() }
+func (o *serviceExportObserver) Revoke() { o.store.Drain() }

--- a/pkg/clustermesh/mcsapi/service_exports.go
+++ b/pkg/clustermesh/mcsapi/service_exports.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package operator
+package mcsapi
 
 import (
 	"maps"
@@ -20,7 +20,7 @@ type (
 	ServiceExportsByCluster   map[string]*mcsapitypes.MCSAPIServiceSpec
 )
 
-type GlobalServiceExportCache struct {
+type globalServiceExportCache struct {
 	mutex lock.RWMutex
 	cache ServiceExportsByNamespace
 
@@ -29,15 +29,15 @@ type GlobalServiceExportCache struct {
 	size uint64
 }
 
-func NewGlobalServiceExportCache() *GlobalServiceExportCache {
-	return &GlobalServiceExportCache{
+func newGlobalServiceExportCache() *globalServiceExportCache {
+	return &globalServiceExportCache{
 		cache: ServiceExportsByNamespace{},
 	}
 }
 
 // GetServiceExportsName returns all the service exports for a specific namespace
 // that have at least one service export in one of the remote cluster in the mesh.
-func (c *GlobalServiceExportCache) GetServiceExportsName(namespace string) []string {
+func (c *globalServiceExportCache) GetServiceExportsName(namespace string) []string {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -46,7 +46,7 @@ func (c *GlobalServiceExportCache) GetServiceExportsName(namespace string) []str
 
 // GetServiceExportByCluster returns a shallow copy of the GlobalServiceExport
 // object, thus the MCSAPIServiceSpec objects should not be mutated.
-func (c *GlobalServiceExportCache) GetServiceExportByCluster(serviceExportNN types.NamespacedName) ServiceExportsByCluster {
+func (c *globalServiceExportCache) GetServiceExportByCluster(serviceExportNN types.NamespacedName) ServiceExportsByCluster {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -61,7 +61,7 @@ func (c *GlobalServiceExportCache) GetServiceExportByCluster(serviceExportNN typ
 	return maps.Clone(svcExportsByCluster)
 }
 
-func (c *GlobalServiceExportCache) OnUpdate(svcExport *mcsapitypes.MCSAPIServiceSpec) {
+func (c *globalServiceExportCache) OnUpdate(svcExport *mcsapitypes.MCSAPIServiceSpec) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -80,7 +80,7 @@ func (c *GlobalServiceExportCache) OnUpdate(svcExport *mcsapitypes.MCSAPIService
 	svcExportsByCluster[svcExport.Cluster] = svcExport
 }
 
-func (c *GlobalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIServiceSpec) bool {
+func (c *globalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIServiceSpec) bool {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -114,22 +114,22 @@ func (c *GlobalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIService
 	return true
 }
 
-func (c *GlobalServiceExportCache) Size() uint64 {
+func (c *globalServiceExportCache) Size() uint64 {
 	return c.size
 }
 
 type remoteServiceExportObserver struct {
-	cache *GlobalServiceExportCache
+	cache *globalServiceExportCache
 
 	onUpdate func(*mcsapitypes.MCSAPIServiceSpec)
 	onDelete func(*mcsapitypes.MCSAPIServiceSpec)
 }
 
-// NewServiceExportsObserver returns an observer implementing the logic to convert
+// newServiceExportsObserver returns an observer implementing the logic to convert
 // and filter export notifications, update the global service export cache and
 // call the upstream handlers when appropriate.
-func NewServiceExportsObserver(
-	cache *GlobalServiceExportCache, onUpdate, onDelete func(*mcsapitypes.MCSAPIServiceSpec),
+func newServiceExportsObserver(
+	cache *globalServiceExportCache, onUpdate, onDelete func(*mcsapitypes.MCSAPIServiceSpec),
 ) store.Observer {
 	return &remoteServiceExportObserver{
 		cache: cache,

--- a/pkg/clustermesh/mcsapi/service_exports_test.go
+++ b/pkg/clustermesh/mcsapi/service_exports_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package operator
+package mcsapi
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGlobalServiceExportCache(t *testing.T) {
-	globalServiceExports := NewGlobalServiceExportCache()
+	globalServiceExports := newGlobalServiceExportCache()
 
 	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
 		Cluster:   "cluster1",

--- a/pkg/clustermesh/mcsapi/serviceimport_controller.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
-	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -53,7 +52,7 @@ type mcsAPIServiceImportReconciler struct {
 	Logger *slog.Logger
 
 	cluster                    string
-	globalServiceExports       *operator.GlobalServiceExportCache
+	globalServiceExports       *globalServiceExportCache
 	remoteClusterServiceSource *remoteClusterServiceExportSource
 
 	enableIPv4 bool
@@ -62,7 +61,7 @@ type mcsAPIServiceImportReconciler struct {
 	namespaceConfig cmnamespace.Config
 }
 
-func newMCSAPIServiceImportReconciler(mgr ctrl.Manager, logger *slog.Logger, cluster string, globalServiceExports *operator.GlobalServiceExportCache, remoteClusterServiceSource *remoteClusterServiceExportSource, enableIPv4, enableIPv6 bool, namespaceConfig cmnamespace.Config) *mcsAPIServiceImportReconciler {
+func newMCSAPIServiceImportReconciler(mgr ctrl.Manager, logger *slog.Logger, cluster string, globalServiceExports *globalServiceExportCache, remoteClusterServiceSource *remoteClusterServiceExportSource, enableIPv4, enableIPv6 bool, namespaceConfig cmnamespace.Config) *mcsAPIServiceImportReconciler {
 	return &mcsAPIServiceImportReconciler{
 		Client:                     mgr.GetClient(),
 		Logger:                     logger,
@@ -167,7 +166,7 @@ type portMerge struct {
 // orderSvcExportByPriority order the service export by priority (oldest to newest
 // service exports). If export times of two service exports are equal
 // it also sort by cluster name.
-func orderSvcExportByPriority(svcExportByCluster operator.ServiceExportsByCluster) []*mcsapitypes.MCSAPIServiceSpec {
+func orderSvcExportByPriority(svcExportByCluster ServiceExportsByCluster) []*mcsapitypes.MCSAPIServiceSpec {
 	return slices.SortedFunc(maps.Values(svcExportByCluster), func(a, b *mcsapitypes.MCSAPIServiceSpec) int {
 		if a.ExportCreationTimestamp.Equal(&b.ExportCreationTimestamp) {
 			return strings.Compare(a.Cluster, b.Cluster)
@@ -355,7 +354,7 @@ func (r mcsAPIServiceImportReconciler) filterSupportedIPFamilies(ipfamilies []co
 	return supportedIPFamilies
 }
 
-func getClustersStatus(svcExportByCluster operator.ServiceExportsByCluster) []mcsapiv1beta1.ClusterStatus {
+func getClustersStatus(svcExportByCluster ServiceExportsByCluster) []mcsapiv1beta1.ClusterStatus {
 	clusters := make([]mcsapiv1beta1.ClusterStatus, 0, len(svcExportByCluster))
 	for _, cluster := range slices.Sorted(maps.Keys(svcExportByCluster)) {
 		clusters = append(clusters, mcsapiv1beta1.ClusterStatus{
@@ -592,7 +591,7 @@ func (r *mcsAPIServiceImportReconciler) Reconcile(ctx context.Context, req ctrl.
 
 		localSvcSpec := fromServiceToMCSAPIServiceSpec(localSvc, r.cluster, svcExport)
 		if svcExportByCluster == nil {
-			svcExportByCluster = operator.ServiceExportsByCluster{}
+			svcExportByCluster = ServiceExportsByCluster{}
 		}
 		svcExportByCluster[r.cluster] = localSvcSpec
 	}
@@ -821,6 +820,10 @@ type remoteClusterServiceExportSource struct {
 
 	ctx   context.Context
 	queue workqueue.TypedRateLimitingInterface[ctrl.Request]
+}
+
+func newRemoteClusterServiceExportSource(logger *slog.Logger) *remoteClusterServiceExportSource {
+	return &remoteClusterServiceExportSource{Logger: logger}
 }
 
 func (s *remoteClusterServiceExportSource) onClusterServiceExportEvent(svcExport *mcsapitypes.MCSAPIServiceSpec) {

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
-	"github.com/cilium/cilium/pkg/clustermesh/operator"
 )
 
 const (
@@ -674,7 +673,7 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 		WithStatusSubresource(&mcsapiv1beta1.ServiceImport{}).
 		WithScheme(testScheme()).
 		Build()
-	globalServiceExports := operator.NewGlobalServiceExportCache()
+	globalServiceExports := newGlobalServiceExportCache()
 	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: hivetest.Logger(t)}
 	for _, svcExport := range remoteSvcImportTestFixtures {
 		globalServiceExports.OnUpdate(svcExport)

--- a/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
+++ b/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
@@ -15,10 +15,13 @@ import (
 	"k8s.io/utils/ptr"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
+	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 )
+
+const Name observer.Name = "service exports"
 
 var (
 	// ServiceExportStorePrefix is the kvstore prefix of the shared store

--- a/pkg/clustermesh/operator/clustermesh.go
+++ b/pkg/clustermesh/operator/clustermesh.go
@@ -41,22 +41,16 @@ type clusterMesh struct {
 	// is protected by its own mutex inside the structure.
 	globalServices *common.GlobalServiceCache
 
-	// globalServiceExports is a list of all global service exports. The datastructure
-	// is protected by its own mutex inside the structure.
-	globalServiceExports *GlobalServiceExportCache
-
 	// ObserverFactories is the list of factories to instantiate additional observers.
 	observerFactories []observer.Factory
 
 	storeFactory store.Factory
 
-	started                         atomic.Bool
-	clusterAddHooks                 []func(string)
-	clusterDeleteHooks              []func(string)
-	clusterServiceUpdateHooks       []func(*serviceStore.ClusterService)
-	clusterServiceDeleteHooks       []func(*serviceStore.ClusterService)
-	clusterServiceExportUpdateHooks []func(*mcsapitypes.MCSAPIServiceSpec)
-	clusterServiceExportDeleteHooks []func(*mcsapitypes.MCSAPIServiceSpec)
+	started                   atomic.Bool
+	clusterAddHooks           []func(string)
+	clusterDeleteHooks        []func(string)
+	clusterServiceUpdateHooks []func(*serviceStore.ClusterService)
+	clusterServiceDeleteHooks []func(*serviceStore.ClusterService)
 
 	syncTimeoutConfig  wait.TimeoutConfig
 	syncTimeoutLogOnce sync.Once
@@ -77,18 +71,9 @@ type ClusterMesh interface {
 	// RegisterClusterServiceDeleteHook register a hook when a service in the mesh is deleted.
 	// This should NOT be called after the Start hook.
 	RegisterClusterServiceDeleteHook(clusterServiceDeleteHook func(*serviceStore.ClusterService))
-	// RegisterClusterServiceExportUpdateHook register a hook when a service export in the mesh is updated.
-	// This should NOT be called after the Start hook.
-	RegisterClusterServiceExportUpdateHook(clusterServiceExportUpdateHook func(*mcsapitypes.MCSAPIServiceSpec))
-	// RegisterClusterServiceExportDeleteHook register a hook when a service export in the mesh is deleted.
-	// This should NOT be called after the Start hook.
-	RegisterClusterServiceExportDeleteHook(clusterServiceExportDeleteHook func(*mcsapitypes.MCSAPIServiceSpec))
 
 	ServicesSynced(ctx context.Context) error
 	GlobalServices() *common.GlobalServiceCache
-
-	ServiceExportsSynced(ctx context.Context) error
-	GlobalServiceExports() *GlobalServiceExportCache
 
 	ObserverSynced(ctx context.Context, name observer.Name) error
 }
@@ -105,16 +90,15 @@ func newClusterMesh(lc cell.Lifecycle, params clusterMeshParams) (*clusterMesh, 
 	params.Logger.Info("Operator ClusterMesh component enabled")
 
 	cm := clusterMesh{
-		cfg:                  params.Cfg,
-		serviceModeV2:        params.ServiceModeV2,
-		cfgMCSAPI:            params.CfgMCSAPI,
-		logger:               params.Logger,
-		metrics:              params.Metrics,
-		globalServices:       common.NewGlobalServiceCache(params.Logger),
-		globalServiceExports: NewGlobalServiceExportCache(),
-		observerFactories:    params.ObserverFactories,
-		storeFactory:         params.StoreFactory,
-		syncTimeoutConfig:    params.TimeoutConfig,
+		cfg:               params.Cfg,
+		serviceModeV2:     params.ServiceModeV2,
+		cfgMCSAPI:         params.CfgMCSAPI,
+		logger:            params.Logger,
+		metrics:           params.Metrics,
+		globalServices:    common.NewGlobalServiceCache(params.Logger),
+		observerFactories: params.ObserverFactories,
+		storeFactory:      params.StoreFactory,
+		syncTimeoutConfig: params.TimeoutConfig,
 	}
 	cm.common = common.NewClusterMesh(common.Configuration{
 		Logger:              params.Logger,
@@ -172,30 +156,8 @@ func (cm *clusterMesh) RegisterClusterServiceDeleteHook(clusterServiceDeleteHook
 	cm.clusterServiceDeleteHooks = append(cm.clusterServiceDeleteHooks, clusterServiceDeleteHook)
 }
 
-// RegisterClusterServiceExportUpdateHook register a hook when a service export in the mesh is updated.
-// This should NOT be called after the Start hook.
-func (cm *clusterMesh) RegisterClusterServiceExportUpdateHook(clusterServiceExportUpdateHook func(*mcsapitypes.MCSAPIServiceSpec)) {
-	if cm.started.Load() {
-		panic(fmt.Errorf("can't call RegisterClusterServiceExportUpdateHook after the Start hook"))
-	}
-	cm.clusterServiceExportUpdateHooks = append(cm.clusterServiceExportUpdateHooks, clusterServiceExportUpdateHook)
-}
-
-// RegisterClusterServiceExportDeleteHook register a hook when a service export in the mesh is deleted.
-// This should NOT be called after the Start hook.
-func (cm *clusterMesh) RegisterClusterServiceExportDeleteHook(clusterServiceExportDeleteHook func(*mcsapitypes.MCSAPIServiceSpec)) {
-	if cm.started.Load() {
-		panic(fmt.Errorf("can't call RegisterClusterServiceExportDeleteHook after the Start hook"))
-	}
-	cm.clusterServiceExportDeleteHooks = append(cm.clusterServiceExportDeleteHooks, clusterServiceExportDeleteHook)
-}
-
 func (cm *clusterMesh) GlobalServices() *common.GlobalServiceCache {
 	return cm.globalServices
-}
-
-func (cm *clusterMesh) GlobalServiceExports() *GlobalServiceExportCache {
-	return cm.globalServiceExports
 }
 
 func (cm *clusterMesh) newRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
@@ -236,29 +198,6 @@ func (cm *clusterMesh) newRemoteCluster(name string, status common.StatusFunc) c
 		store.RWSWithEntriesMetric(cm.metrics.TotalServices.WithLabelValues(rc.name)),
 	)
 
-	rc.remoteServiceExports = cm.storeFactory.NewWatchStore(
-		name,
-		mcsapitypes.KeyCreator(
-			mcsapitypes.ClusterNameValidator(name),
-			mcsapitypes.NamespacedNameValidator(),
-		),
-		NewServiceExportsObserver(
-			cm.globalServiceExports,
-			func(svcExport *mcsapitypes.MCSAPIServiceSpec) {
-				for _, hook := range cm.clusterServiceExportUpdateHooks {
-					hook(svcExport)
-				}
-			},
-			func(svcExport *mcsapitypes.MCSAPIServiceSpec) {
-				for _, hook := range cm.clusterServiceExportDeleteHooks {
-					hook(svcExport)
-				}
-			},
-		),
-		store.RWSWithOnSyncCallback(func(ctx context.Context) { rc.synced.serviceExports.Stop() }),
-		store.RWSWithEntriesMetric(cm.metrics.TotalServiceExports.WithLabelValues(name)),
-	)
-
 	rc.observers = make(map[observer.Name]observer.Observer, len(cm.observerFactories))
 	for _, factory := range cm.observerFactories {
 		var (
@@ -288,13 +227,6 @@ func (cm *clusterMesh) Stop(cell.HookContext) error {
 // clustermesh-sync-timeout flag elapsed. It returns an error if the given context expired.
 func (cm *clusterMesh) ServicesSynced(ctx context.Context) error {
 	return cm.synced(ctx, func(rc *remoteCluster) wait.Fn { return rc.synced.Services })
-}
-
-// ServiceExportsSynced returns after that either the initial list of service exports has
-// been received from all remote clusters, or the maximum wait period controlled by the
-// clustermesh-sync-timeout flag elapsed. It returns an error if the given context expired.
-func (cm *clusterMesh) ServiceExportsSynced(ctx context.Context) error {
-	return cm.synced(ctx, func(rc *remoteCluster) wait.Fn { return rc.synced.ServiceExports })
 }
 
 // ObserverSynced returns after that either the given named observer has received

--- a/pkg/clustermesh/operator/metrics.go
+++ b/pkg/clustermesh/operator/metrics.go
@@ -11,8 +11,6 @@ import (
 type Metrics struct {
 	// TotalServices tracks the number of total global services per remote cluster.
 	TotalServices metric.Vec[metric.Gauge]
-	// TotalServiceExports tracks the number of total MCS-API service exports per remote cluster.
-	TotalServiceExports metric.Vec[metric.Gauge]
 }
 
 func NewMetrics() Metrics {
@@ -22,12 +20,6 @@ func NewMetrics() Metrics {
 			Subsystem: metrics.SubsystemClusterMesh,
 			Name:      "remote_cluster_services",
 			Help:      "The total number of services in the remote cluster",
-		}, []string{metrics.LabelTargetCluster}),
-		TotalServiceExports: metric.NewGaugeVec(metric.GaugeOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Subsystem: metrics.SubsystemClusterMesh,
-			Name:      "remote_cluster_service_exports",
-			Help:      "The total number of MCS-API service exports in the remote cluster",
 		}, []string{metrics.LabelTargetCluster}),
 	}
 }

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -9,8 +9,6 @@ import (
 	"log/slog"
 	"sync/atomic"
 
-	"k8s.io/utils/ptr"
-
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslice"
@@ -44,8 +42,6 @@ type remoteCluster struct {
 
 	// remoteServices is the shared store representing services in remote clusters
 	remoteServices store.WatchStore
-	// remoteServiceExports is the shared store representing service exports in remote clusters
-	remoteServiceExports store.WatchStore
 
 	// observers are observers watching additional prefixes.
 	observers map[observer.Name]observer.Observer
@@ -97,17 +93,6 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		}
 	}
 
-	if rc.clusterMeshEnableMCSAPI && config.Capabilities.ServiceExportsEnabled != nil {
-		mgr.Register(adapter(mcsapitypes.ServiceExportStorePrefix), func(ctx context.Context) {
-			rc.remoteServiceExports.Watch(ctx, backend, kvstore.JoinKey(adapter(mcsapitypes.ServiceExportStorePrefix), rc.name))
-		})
-	} else {
-		// Drain the remote service exports in case the remote cluster no longer supports them
-		rc.remoteServiceExports.Drain()
-		// Mimic that service exports are synced if not enabled
-		rc.synced.serviceExports.Stop()
-	}
-
 	for _, obs := range rc.observers {
 		obs.Register(mgr, backend, config)
 	}
@@ -131,7 +116,6 @@ func (rc *remoteCluster) Stop() {
 // prevents the operator from maintaining state for potentially stale information.
 func (rc *remoteCluster) RevokeCache(ctx context.Context) {
 	rc.remoteServices.Drain()
-	rc.remoteServiceExports.Drain()
 
 	for _, obs := range rc.observers {
 		obs.Revoke()
@@ -146,7 +130,6 @@ func (rc *remoteCluster) Remove(context.Context) {
 	// is removed, and not in case the operator is shutting down, otherwise we
 	// would break existing connections on restart.
 	rc.remoteServices.Drain()
-	rc.remoteServiceExports.Drain()
 
 	for _, obs := range rc.observers {
 		obs.Drain()
@@ -155,17 +138,15 @@ func (rc *remoteCluster) Remove(context.Context) {
 
 type synced struct {
 	wait.SyncedCommon
-	services       *lock.StoppableWaitGroup
-	serviceExports *lock.StoppableWaitGroup
-	observers      map[observer.Name]chan struct{}
+	services  *lock.StoppableWaitGroup
+	observers map[observer.Name]chan struct{}
 }
 
 func newSynced() synced {
 	return synced{
-		SyncedCommon:   wait.NewSyncedCommon(),
-		services:       lock.NewStoppableWaitGroup(),
-		serviceExports: lock.NewStoppableWaitGroup(),
-		observers:      make(map[observer.Name]chan struct{}),
+		SyncedCommon: wait.NewSyncedCommon(),
+		services:     lock.NewStoppableWaitGroup(),
+		observers:    make(map[observer.Name]chan struct{}),
 	}
 }
 
@@ -174,13 +155,6 @@ func newSynced() synced {
 // or the given context is canceled.
 func (s *synced) Services(ctx context.Context) error {
 	return s.Wait(ctx, s.services.WaitChannel())
-}
-
-// ServiceExports returns after that the initial list of service exports has been
-// received from the remote cluster, the remote cluster is disconnected,
-// or the given context is canceled.
-func (s *synced) ServiceExports(ctx context.Context) error {
-	return s.Wait(ctx, s.serviceExports.WaitChannel())
 }
 
 // ObserverSynced returns after that either the given named observer has
@@ -208,7 +182,7 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 	}
 
 	status.NumSharedServices = int64(rc.remoteServices.NumEntries())
-	status.NumServiceExports = int64(rc.remoteServiceExports.NumEntries())
+	status.NumServiceExports = int64(get(mcsapitypes.Name).Entries)
 	isServicesWatched := rc.clusterMeshEnableEndpointSync && rc.clusterMeshServiceModeV2.ShouldWatchLegacyServices()
 
 	status.Synced = &models.RemoteClusterSynced{
@@ -219,17 +193,15 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 		Endpoints:  true,
 		Identities: true,
 	}
-	if status.Config != nil && status.Config.ServiceExportsEnabled != nil &&
-		rc.clusterMeshEnableMCSAPI {
-		status.Synced.ServiceExports = ptr.To(rc.remoteServiceExports.Synced())
-	}
 	if get(endpointslice.Name).Enabled {
 		status.Synced.EndpointSlices = new(get(endpointslice.Name).Synced)
+	}
+	if get(mcsapitypes.Name).Enabled {
+		status.Synced.ServiceExports = new(get(mcsapitypes.Name).Synced)
 	}
 
 	status.Ready = status.Ready &&
 		status.Synced.Nodes && status.Synced.Services &&
-		(status.Synced.ServiceExports == nil || *status.Synced.ServiceExports) &&
 		status.Synced.Identities && status.Synced.Endpoints
 
 	// We mark the status as ready only after being sure that all observers

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -42,9 +42,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 	kvsService := map[string]string{
 		"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 1}`,
 	}
-	kvsServiceExport := map[string]string{
-		"cilium/state/serviceexports/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "exportCreationTimestamp": "2024-07-07T15:55:07.627472784+02:00", "type": "ClusterSetIP", "sessionAffinity": "None"}`,
-	}
 
 	tests := []struct {
 		name                            string
@@ -53,7 +50,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 		clusterMeshEnableMCSAPI         bool
 		capabilityServiceExportsEnabled *bool
 		expectedServiceSync             bool
-		expectedMCSAPISync              bool
 	}{
 		{
 			name:                            "Everything disabled",
@@ -62,7 +58,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 			clusterMeshEnableMCSAPI:         false,
 			capabilityServiceExportsEnabled: nil,
 			expectedServiceSync:             false,
-			expectedMCSAPISync:              false,
 		},
 		{
 			name:                            "Both config enabled but remote doesn't support service exports",
@@ -71,7 +66,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 			clusterMeshEnableMCSAPI:         true,
 			capabilityServiceExportsEnabled: nil,
 			expectedServiceSync:             true,
-			expectedMCSAPISync:              false,
 		},
 		{
 			name:                            "Both config enabled and remote supports service exports",
@@ -80,7 +74,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 			clusterMeshEnableMCSAPI:         true,
 			capabilityServiceExportsEnabled: ptr.To(false),
 			expectedServiceSync:             true,
-			expectedMCSAPISync:              true,
 		},
 		{
 			name:                          "Endpoint sync enabled but services disabled by mode",
@@ -104,26 +97,19 @@ func TestRemoteClusterStatus(t *testing.T) {
 			logger := hivetest.Logger(t)
 			metrics := NewMetrics()
 			cm := clusterMesh{
-				logger:               logger,
-				metrics:              metrics,
-				storeFactory:         st,
-				globalServices:       common.NewGlobalServiceCache(logger),
-				globalServiceExports: NewGlobalServiceExportCache(),
-				cfg:                  ClusterMeshConfig{ClusterMeshEnableEndpointSync: tt.clusterMeshEnableEndpointSync},
-				cfgMCSAPI:            mcsapitypes.MCSAPIConfig{EnableMCSAPI: tt.clusterMeshEnableMCSAPI},
-				serviceModeV2:        tt.serviceModeV2,
+				logger:         logger,
+				metrics:        metrics,
+				storeFactory:   st,
+				globalServices: common.NewGlobalServiceCache(logger),
+				cfg:            ClusterMeshConfig{ClusterMeshEnableEndpointSync: tt.clusterMeshEnableEndpointSync},
+				cfgMCSAPI:      mcsapitypes.MCSAPIConfig{EnableMCSAPI: tt.clusterMeshEnableMCSAPI},
+				serviceModeV2:  tt.serviceModeV2,
 			}
 
 			// Populate the kvstore with the appropriate KV pairs
 			for key, value := range kvsService {
 				require.NoErrorf(t, client.Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
 			}
-			if tt.capabilityServiceExportsEnabled != nil {
-				for key, value := range kvsServiceExport {
-					require.NoErrorf(t, client.Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
-				}
-			}
-
 			rc := cm.newRemoteCluster("foo", func() *models.RemoteCluster {
 				return &models.RemoteCluster{Ready: true, Config: &models.RemoteClusterConfig{
 					ServiceExportsEnabled: tt.capabilityServiceExportsEnabled,
@@ -132,7 +118,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 			// Validate the status before watching the remote cluster.
 			status := rc.(*remoteCluster).Status()
-			if tt.expectedServiceSync || tt.expectedMCSAPISync {
+			if tt.expectedServiceSync {
 				require.False(t, status.Ready, "Status should not be ready")
 			}
 
@@ -141,14 +127,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 			} else {
 				require.True(t, status.Synced.Services, "Services should be marked as synced")
 			}
-			if tt.expectedMCSAPISync {
-				require.False(t, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should not be synced")
-			} else {
-				require.Nil(t, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
-			}
-
 			require.EqualValues(t, 0, status.NumSharedServices, "Incorrect number of services")
-			require.EqualValues(t, 0, status.NumServiceExports, "Incorrect number of service exports")
 
 			cfg := types.CiliumClusterConfig{
 				ID: 10, Capabilities: types.CiliumClusterConfigCapabilities{
@@ -171,21 +150,10 @@ func TestRemoteClusterStatus(t *testing.T) {
 				} else {
 					assert.True(c, status.Synced.Services, "Disabled services should be considered synced")
 				}
-				if tt.expectedMCSAPISync {
-					assert.True(c, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should be synced")
-				} else {
-					assert.Nil(c, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
-				}
-
 				if tt.expectedServiceSync {
 					assert.EqualValues(c, 1, status.NumSharedServices, "Incorrect number of services")
 				} else {
 					assert.EqualValues(c, 0, status.NumSharedServices, "Incorrect number of services")
-				}
-				if tt.expectedMCSAPISync {
-					assert.EqualValues(c, 1, status.NumServiceExports, "Incorrect number of service exports")
-				} else {
-					assert.EqualValues(c, 0, status.NumServiceExports, "Incorrect number of service exports")
 				}
 			}, timeout, tick, "Reported status is not correct")
 		})
@@ -205,11 +173,10 @@ func TestRemoteClusterHooks(t *testing.T) {
 	metrics := NewMetrics()
 	st := store.NewFactory(logger, store.MetricsProvider())
 	cm := clusterMesh{
-		logger:               logger,
-		metrics:              metrics,
-		storeFactory:         st,
-		globalServices:       common.NewGlobalServiceCache(logger),
-		globalServiceExports: NewGlobalServiceExportCache(),
+		logger:         logger,
+		metrics:        metrics,
+		storeFactory:   st,
+		globalServices: common.NewGlobalServiceCache(logger),
 	}
 
 	clusterAddCalledCount := atomic.Uint32{}


### PR DESCRIPTION
Benefit from the new observer pattern to delegate more of the service export logic within the mcsapi package.

Also fix a small logger issue in the endpointslice package.

Used AIL-1 here