### PR TITLE
ci: resolve renovate PR metadata in base image workflows

### DIFF
--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -360,10 +360,20 @@ jobs:
           GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
           pr_number: ${{ github.event.pull_request.number }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ]; then
+            # workflow_call runs invoked from renovate branch pushes do not have
+            # github.event.pull_request populated. Resolve the matching PR from
+            # the branch name so follow-up pushes can still temporarily draft it.
+            pr_number=$(gh -R ${repository} pr list --head "${ref}" --json number --jq '.[0].number // empty')
+            pr_author=$(gh -R ${repository} pr list --head "${ref}" --json author --jq '.[0].author.login // empty')
+          fi
+
+          # PR webhook payloads report the app as cilium-renovate[bot], while
+          # gh pr list returns the GraphQL app identity app/cilium-renovate.
+          if [ -n "${pr_number}" ] && { [ "${pr_author}" = "cilium-renovate[bot]" ] || [ "${pr_author}" = "app/cilium-renovate" ]; }; then
             is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
             if [ "${is_draft}" = "false" ]; then
               # Follow-up image updates should not trigger CODEOWNERS while the

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -332,10 +332,20 @@ jobs:
           GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
           pr_number: ${{ github.event.pull_request.number }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ]; then
+            # workflow_call runs invoked from renovate branch pushes do not have
+            # github.event.pull_request populated. Resolve the matching PR from
+            # the branch name so follow-up pushes can still temporarily draft it.
+            pr_number=$(gh -R ${repository} pr list --head "${ref}" --json number --jq '.[0].number // empty')
+            pr_author=$(gh -R ${repository} pr list --head "${ref}" --json author --jq '.[0].author.login // empty')
+          fi
+
+          # PR webhook payloads report the app as cilium-renovate[bot], while
+          # gh pr list returns the GraphQL app identity app/cilium-renovate.
+          if [ -n "${pr_number}" ] && { [ "${pr_author}" = "cilium-renovate[bot]" ] || [ "${pr_author}" = "app/cilium-renovate" ]; }; then
             is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
             if [ "${is_draft}" = "false" ]; then
               # Follow-up image updates should not trigger CODEOWNERS while the

--- a/.github/workflows/build-images-base-v1.19.yaml
+++ b/.github/workflows/build-images-base-v1.19.yaml
@@ -305,10 +305,20 @@ jobs:
           GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
           pr_number: ${{ github.event.pull_request.number }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ]; then
+            # workflow_call runs invoked from renovate branch pushes do not have
+            # github.event.pull_request populated. Resolve the matching PR from
+            # the branch name so follow-up pushes can still temporarily draft it.
+            pr_number=$(gh -R ${repository} pr list --head "${ref}" --json number --jq '.[0].number // empty')
+            pr_author=$(gh -R ${repository} pr list --head "${ref}" --json author --jq '.[0].author.login // empty')
+          fi
+
+          # PR webhook payloads report the app as cilium-renovate[bot], while
+          # gh pr list returns the GraphQL app identity app/cilium-renovate.
+          if [ -n "${pr_number}" ] && { [ "${pr_author}" = "cilium-renovate[bot]" ] || [ "${pr_author}" = "app/cilium-renovate" ]; }; then
             is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
             if [ "${is_draft}" = "false" ]; then
               # Follow-up image updates should not trigger CODEOWNERS while the

--- a/.github/workflows/build-images-base-v1.20.yaml
+++ b/.github/workflows/build-images-base-v1.20.yaml
@@ -305,10 +305,20 @@ jobs:
           GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
           pr_number: ${{ github.event.pull_request.number }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ]; then
+            # workflow_call runs invoked from renovate branch pushes do not have
+            # github.event.pull_request populated. Resolve the matching PR from
+            # the branch name so follow-up pushes can still temporarily draft it.
+            pr_number=$(gh -R ${repository} pr list --head "${ref}" --json number --jq '.[0].number // empty')
+            pr_author=$(gh -R ${repository} pr list --head "${ref}" --json author --jq '.[0].author.login // empty')
+          fi
+
+          # PR webhook payloads report the app as cilium-renovate[bot], while
+          # gh pr list returns the GraphQL app identity app/cilium-renovate.
+          if [ -n "${pr_number}" ] && { [ "${pr_author}" = "cilium-renovate[bot]" ] || [ "${pr_author}" = "app/cilium-renovate" ]; }; then
             is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
             if [ "${is_draft}" = "false" ]; then
               # Follow-up image updates should not trigger CODEOWNERS while the

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -321,10 +321,20 @@ jobs:
           GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
           pr_number: ${{ github.event.pull_request.number }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ]; then
+            # workflow_call runs invoked from renovate branch pushes do not have
+            # github.event.pull_request populated. Resolve the matching PR from
+            # the branch name so follow-up pushes can still temporarily draft it.
+            pr_number=$(gh -R ${repository} pr list --head "${ref}" --json number --jq '.[0].number // empty')
+            pr_author=$(gh -R ${repository} pr list --head "${ref}" --json author --jq '.[0].author.login // empty')
+          fi
+
+          # PR webhook payloads report the app as cilium-renovate[bot], while
+          # gh pr list returns the GraphQL app identity app/cilium-renovate.
+          if [ -n "${pr_number}" ] && { [ "${pr_author}" = "cilium-renovate[bot]" ] || [ "${pr_author}" = "app/cilium-renovate" ]; }; then
             is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
             if [ "${is_draft}" = "false" ]; then
               # Follow-up image updates should not trigger CODEOWNERS while the


### PR DESCRIPTION
The base image push step relied on github.event.pull_request metadata to detect Renovate-authored PRs and temporarily re-draft them before pushing follow-up image updates.

The reason behind this is to prevent unnecessary notifications / reviews from users. These reviews should already be handled by `ciliumbot`.

That works for pull_request_target runs, but not for the workflow_call path used by the Renovate branch workflows, where github.event.pull_request is unset. In that case pr_number and pr_author were empty, so the workflow skipped the re-draft logic.

Since this usecase is the relevant one, this commit fixes this by falling back to resolving the PR from the branch name with `gh pr list --head` when PR metadata is missing. Use the short ref name for the non-PR path so the branch lookup matches correctly.

Note: we need to accept both Renovate author formats:
- `cilium-renovate[bot]` from PR webhook payloads
- `app/cilium-renovate` from `gh pr list` GraphQL output

See PR: https://github.com/cilium/cilium/pull/47950 and related [workflow run](https://github.com/cilium/cilium/actions/runs/31743959287/job/94593874945) that didn't draft the PR as intended.

Fixes: https://github.com/cilium/cilium/pull/47364