### PR TITLE
operator/endpointslice: fix processing of pods without an identity

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -5,6 +5,7 @@ package ciliumendpointslice
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strconv"
 	"time"
@@ -452,29 +453,29 @@ func (c *SlimController) onIdentityDelete(cid *cilium_api_v2.CiliumIdentity) {
 	c.enqueueCESReconciliation(touchedCESs)
 }
 
-// On Pod Update, verify all the necessary fields are set.
-// We recalculate the relevant fields when updating the CES instead of
-// saving them here in case of any changes in value, to minimize the
-// number of CES updates.
-// Returns error if requires retry without pod update.
+// errSkipPodEvent is a sentinel error used by [resolvePodPlacement] when the
+// given pod event should be skipped, waiting for a subsequent update event.
+var errSkipPodEvent = errors.New("pod event skipped")
+
 // resolvePodPlacement gathers the state needed to place a pod into a CES.
-// Returns (node, cidKey, true) if the pod is placeable, or ("", nil, false)
-// if it should be skipped (empty name/namespace, host-network, no IPs,
-// unscheduled, or unresolvable labels). Errors are logged at debug level.
-func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key.GlobalIdentity, bool) {
+// Returns a [errSkipPodEvent] error if the event should be skipped without
+// further processing (empty name/namespace, host-network, no IPs, unscheduled),
+// and a real error in case it is not possible to resolve the pod placement
+// (e.g., unresolvable labels).
+func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key.GlobalIdentity, error) {
 	if pod.GetName() == "" || pod.GetNamespace() == "" {
-		return "", nil, false
+		return "", nil, errSkipPodEvent
 	}
 	if pod.Spec.HostNetwork {
 		// no CEP for host networking pods
-		return "", nil, false
+		return "", nil, errSkipPodEvent
 	}
 	if _, err := GetPodEndpointNetworking(pod); err != nil {
 		c.logger.Debug("could not get endpointnetworking for pod",
 			logfields.K8sPodName, pod.Name,
 			logfields.Error, err)
 		// When pod is assigned IPs or scheduled, we will receive a new update.
-		return "", nil, false
+		return "", nil, errSkipPodEvent
 	}
 	node, err := getNodeNameForPod(pod)
 	if err != nil {
@@ -482,23 +483,33 @@ func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key
 			logfields.K8sPodName, pod.Name,
 			logfields.Error, err)
 		// When pod is scheduled, we will receive a new update.
-		return "", nil, false
+		return "", nil, errSkipPodEvent
 	}
 	cidKey, err := getPodCIDKey(pod, c.logger, c.reconciler.namespaceStore)
 	if err != nil {
 		c.logger.Debug("could not get labels for pod",
 			logfields.K8sPodName, pod.Name,
 			logfields.Error, err)
-		return "", nil, false
+		return "", nil, err
 	}
-	return node, cidKey, true
+	return node, cidKey, nil
 }
 
+// On Pod Update, verify all the necessary fields are set.
+// We recalculate the relevant fields when updating the CES instead of
+// saving them here in case of any changes in value, to minimize the
+// number of CES updates.
+// Returns error if requires retry without pod update.
 func (c *SlimController) onPodUpdate(pod *slim_corev1.Pod) error {
-	node, cidKey, ok := c.resolvePodPlacement(pod)
-	if !ok {
-		return nil
+	node, cidKey, err := c.resolvePodPlacement(pod)
+	if err != nil {
+		if errors.Is(err, errSkipPodEvent) {
+			return nil
+		}
+
+		return err
 	}
+
 	touchedCESs := c.manager.AddPodMapping(pod, node, cidKey)
 	c.enqueueCESReconciliation(touchedCESs)
 	return nil
@@ -646,7 +657,7 @@ podLoop:
 		switch event.Kind {
 		case resource.Upsert:
 			pod := event.Object
-			if _, _, ok := c.resolvePodPlacement(pod); ok {
+			if _, _, err := c.resolvePodPlacement(pod); err == nil {
 				livepods[GetCEPNameFromPod(pod)] = pod
 			}
 		case resource.Delete:


### PR DESCRIPTION
The blamed commit modified, among others, the [SlimController.onPodUpdate] logic, causing it to now never return an error in any case. Eventually, an error would cause the event to be enqueued in the workqueue once more, and processed again. While it is correct to not return an error (and hence retry) if the pod information is incomplete (e.g., due to missing IP addresses), as we are guaranteed to receive a fresh event once populated, it is not when we failed to resolve the pod identity, as in that case the pod would simply be ignored forever, and never added to a CiliumEndpointSlice. This issue is also showcased by the flakiness of the TestRegisterControllerNoCEPs test. Let's get it fixed by restoring the previous behavior, and returning an actual error when appropriate.

Labeled as release-note/misc as the regressions only affects the main branch.
Fixes: ce13af2a6df3 ("controller/endpointslice: Fix bootstrap races on slim controller")
Fixes: #47228

/cc @mauriciovasquezbernal FYI

AIL: 0