### PR TITLE
cilium-cli: disable host-firewall-egress-to-fqdns test on RHEL

### DIFF
--- a/cilium-cli/connectivity/builder/host_firewall_egress_to_fqdns.go
+++ b/cilium-cli/connectivity/builder/host_firewall_egress_to_fqdns.go
@@ -23,6 +23,7 @@ func (t hostFirewallEgressToFqdns) build(ct *check.ConnectivityTest, templates m
 		WithCondition(differentExternalTargets).
 		WithFeatureRequirements(
 			features.RequireDisabled(features.EndpointRoutes), // currently broken when proxying to in-cluster endpoints, see #45957
+			features.RequireDisabled(features.RHEL),           // currently broken, see #47921
 			features.RequireEnabled(features.L7Proxy),
 			features.RequireEnabled(features.HostFirewall)).
 		WithCiliumClusterwidePolicy(templates["hostFirewallEgressToFQDNsPolicyYAML"]).


### PR DESCRIPTION
host-firewall-egress-to-fqdns consistently fails in the kube-proxy-1 configuration (using rhel8.10 kernel) although it appears to succeed in all other cases it runs in. It is unclear why this happens. Note that other L7 tests (to-fqdns, client-egress-l7, client-egress-l7-named-port, client-egress-tls-cni) using pod-to-world scenarios are disabled on RHEL kernels, see commit message in b1d70aa. Possibly the reason this test fails on RHEL is related to that. However that may be, this PR disables the test on RHEL to make scheduled CI runs usable.

Fixes: #47921

```release-note
cilium-cli: disable host-firewall-egress-to-fqdns test on RHEL
```