### PR TITLE
fix(bgp): only auto-discover the default gateway from the main table

### DIFF
--- a/pkg/bgp/manager/reconciler/default_gateway.go
+++ b/pkg/bgp/manager/reconciler/default_gateway.go
@@ -168,6 +168,16 @@ func (r *DefaultGatewayReconciler) getDefaultGateway(defaultGateway *v2.DefaultG
 		if !route.Gw.IsValid() || route.Dst != defaultRoute {
 			continue
 		}
+		// Only the main table holds the node's default gateway. Other tables
+		// routinely hold their own default routes - Cilium itself installs a
+		// "default via <cilium_host>" one, and a local table can hold a metric-0
+		// "default dev lo" - which are not the way off the node and would
+		// outrank the real default route, as they are usually installed with a
+		// lower metric. Non-unicast types (local, blackhole, unreachable,
+		// prohibit) do not forward anything either.
+		if route.Table != tables.RT_TABLE_MAIN || route.Type != tables.RTN_UNICAST {
+			continue
+		}
 		dev, _, found := r.deviceTable.Get(txn, tables.DeviceByIndex(route.LinkIndex))
 		// ignore routes if the link through which it is reachable is not up
 		if !found || dev.OperStatus != "up" {

--- a/pkg/bgp/manager/reconciler/default_gateway_test.go
+++ b/pkg/bgp/manager/reconciler/default_gateway_test.go
@@ -47,24 +47,9 @@ func TestDefaultGatewayReconciler_Reconcile(t *testing.T) {
 
 	// Test data
 	defaultRouteTable := []*tables.Route{
-		{
-			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-			Gw:        netip.MustParseAddr("192.168.0.3"),
-			LinkIndex: 123,
-			Priority:  100,
-		},
-		{
-			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-			Gw:        netip.MustParseAddr("192.168.0.4"),
-			LinkIndex: 124,
-			Priority:  200,
-		},
-		{
-			Dst:       netip.MustParsePrefix("::/0"),
-			Gw:        netip.MustParseAddr("fd00:10:0:1::1"),
-			LinkIndex: 124,
-			Priority:  200,
-		},
+		defaultRouteEntry("192.168.0.3", 123, 100),
+		defaultRouteEntry("192.168.0.4", 124, 200),
+		defaultRouteEntry("fd00:10:0:1::1", 124, 200),
 	}
 
 	table := []struct {
@@ -249,18 +234,8 @@ func TestDefaultGatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			newRoutes: []*tables.Route{
-				{
-					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-					Gw:        netip.MustParseAddr("192.168.0.3"),
-					LinkIndex: 123,
-					Priority:  200,
-				},
-				{
-					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-					Gw:        netip.MustParseAddr("192.168.0.4"),
-					LinkIndex: 124,
-					Priority:  100,
-				},
+				defaultRouteEntry("192.168.0.3", 123, 200),
+				defaultRouteEntry("192.168.0.4", 124, 100),
 			},
 			newPeers: []v2.CiliumBGPNodePeer{
 				{
@@ -278,6 +253,115 @@ func TestDefaultGatewayReconciler_Reconcile(t *testing.T) {
 				{
 					Name:        "peer-3",
 					PeerAddress: ptr.To[string]("192.168.0.4"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+		{
+			// A real default route in the main table is not beaten by a route in
+			// another table, however good the other one's metric. The main-table route
+			// deliberately carries the worse metric here, so what decides the outcome
+			// is the filter and not the ordering by metric.
+			name: "prefers the main-table default route over one in another table",
+			routes: []*tables.Route{
+				{
+					// local table: a metric-0 "local default" over the wrong device
+					Table:     2004,
+					Type:      tables.RTN_LOCAL,
+					Scope:     tables.RT_SCOPE_HOST,
+					Dst:       ipv4Default,
+					Gw:        netip.MustParseAddr("192.168.0.9"),
+					LinkIndex: 123,
+					Priority:  0,
+				},
+				{
+					// Cilium's own table: a default route by way of cilium_host
+					Table:     2005,
+					Type:      tables.RTN_UNICAST,
+					Dst:       ipv4Default,
+					Gw:        netip.MustParseAddr("10.0.5.160"),
+					LinkIndex: 124,
+					Priority:  0,
+				},
+				defaultRouteEntry("192.168.0.3", 123, 1024),
+			},
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-tables-pref",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-tables-pref",
+					PeerAddress: ptr.To[string]("192.168.0.3"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+		{
+			// A node runs default routes in tables other than main - Cilium installs one
+			// by way of cilium_host, and a local table holds a metric-0 "default dev lo".
+			// Neither is the way off the node, so with no main-table unicast default
+			// route there is nothing to discover at all.
+			name: "ignores default routes outside the main table",
+			routes: []*tables.Route{
+				{
+					// local table: "local default dev lo" with the best metric
+					Table:     2004,
+					Type:      tables.RTN_LOCAL,
+					Scope:     tables.RT_SCOPE_HOST,
+					Dst:       ipv4Default,
+					Gw:        netip.MustParseAddr("192.168.0.9"),
+					LinkIndex: 123,
+					Priority:  0,
+				},
+				{
+					// Cilium's own table: a default route by way of cilium_host
+					Table:     2005,
+					Type:      tables.RTN_UNICAST,
+					Dst:       ipv4Default,
+					Gw:        netip.MustParseAddr("10.0.5.160"),
+					LinkIndex: 124,
+					Priority:  0,
+				},
+			},
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-tables",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			// A nil PeerAddress: no gateway was discovered.
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-tables",
 					AutoDiscovery: &v2.BGPAutoDiscovery{
 						Mode: v2.BGPDefaultGatewayMode,
 						DefaultGateway: &v2.DefaultGateway{
@@ -524,6 +608,24 @@ func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
 	return testInstance, err
 }
 
+// defaultRouteEntry builds a main-table unicast default route, the shape the reconciler
+// selects from. The default route it covers follows the family of the gateway.
+func defaultRouteEntry(gw string, linkIndex, priority int) *tables.Route {
+	addr := netip.MustParseAddr(gw)
+	dst := ipv6Default
+	if addr.Is4() {
+		dst = ipv4Default
+	}
+	return &tables.Route{
+		Table:     tables.RT_TABLE_MAIN,
+		Type:      tables.RTN_UNICAST,
+		Dst:       dst,
+		Gw:        addr,
+		LinkIndex: linkIndex,
+		Priority:  priority,
+	}
+}
+
 func setupStateDB(routes []*tables.Route) (*statedb.DB, error) {
 	// create a test statedb
 	db := statedb.New()
@@ -570,6 +672,8 @@ func validatePeers(req *require.Assertions, expected, actual []v2.CiliumBGPNodeP
 				if expPeer.PeerAddress != nil {
 					req.NotNil(actPeer.PeerAddress)
 					req.Equal(*expPeer.PeerAddress, *actPeer.PeerAddress)
+				} else {
+					req.Nil(actPeer.PeerAddress)
 				}
 				if expPeer.PeerASN != nil {
 					req.NotNil(actPeer.PeerASN)

--- a/pkg/bgp/test/testdata/peering-default-gateway.txtar
+++ b/pkg/bgp/test/testdata/peering-default-gateway.txtar
@@ -89,10 +89,16 @@ selected: true
 operstatus: up
 
 -- routes.yaml --
+# table 254 (main) / type 1 (unicast): auto-discovery only follows the node's
+# real default route, not one from an auxiliary table.
+table: 254
+type: 1
 linkindex: 1
 dst: 0.0.0.0/0
 gw: 10.99.0.135
 ---
+table: 254
+type: 1
 linkindex: 2
 dst: ::/0
 gw: fd00::aa:bb:cc:135


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
description and a Fixes: #XXX line if the commit addresses a particular
GitHub issue.
- [x] If your commit description contains a Fixes: <commit-id> tag, then
please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
in accordance with the [Cilium AI Policy], and indicate the rating using
[AI Influence Level].
Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

BGP peer auto-discovery in defaultGateway mode walks the whole StateDB route
table and picks the default route with the lowest metric. The route table is
populated from a RT_TABLE_UNSPEC netlink dump, so it holds default routes from
every table, not just main — and a default route outside main is not the way
off the node.

This matters in practice because Cilium installs one itself. With native routing
plus any of EnableEnvoyConfig, IPsec, or WireGuard, installFromProxyRoutes*
adds default via <cilium_host address> dev cilium_host to table 2005
(RouteTableFromProxy) with no metric, i.e. priority 0. That outranks a real
uplink default route, which typically carries a non-zero metric, so
auto-discovery hands BGP the cilium_host address as the peer address and the
session never comes up. Table 2004 (RouteTableToProxy) similarly holds a
local default dev lo; it has no nexthop so it was already skipped, but nothing
made that intentional.

Restrict selection to unicast routes in the main table, which is where the
node's default gateway lives. Non-unicast types (local, blackhole, unreachable,
prohibit) do not forward anything either.

Test changes:

- A new unit case models a node with a metric-1024 main-table default route
alongside a metric-0 local default dev lo in table 2004 and a metric-0
default via 10.0.5.160 in table 2005, and asserts the main-table gateway
still wins. Existing default routes are built through a small
defaultRouteEntry helper so every fixture carries a realistic table and type.
- peering-default-gateway.txtar now sets table: 254 / type: 1 on its
routes. The fixture previously left both at zero (RT_TABLE_UNSPEC /
RTN_UNSPEC), which the kernel never reports for an installed route.

```release-note
Fix BGP `defaultGateway` peer auto-discovery selecting a default route from a
non-main routing table, such as the `default via cilium_host` route Cilium
installs in the from-proxy table, instead of the node's real default gateway.
```

This PR was prepared with AIL:2. I personally wrote or checked all code and
validated the behavior end-to-end against a live cluster and DPU as peer (on
a v1.19.x backport).
