### PR TITLE
ipam/eni: Source the ENI VPC CIDRs from IMDS

### DIFF
--- a/Documentation/operations/upgrade-next.inc
+++ b/Documentation/operations/upgrade-next.inc
@@ -21,6 +21,15 @@ Informational Notes
   where they have no effect, to preserve Gateway API infrastructure metadata
   propagation. This prevents user-controlled infrastructure metadata from
   changing proxy and policy behavior.
+* The following ``CiliumNode`` fields are deprecated and will be removed in a
+  future release:
+
+  * ``status.eni.enis[].vpc.id``, superseded by ``spec.eni.vpc-id``
+  * ``status.eni.enis[].vpc.primary-cidr``, now read from IMDS by the agent
+  * ``status.eni.enis[].vpc.cidrs``, now read from IMDS by the agent
+
+  The operator still populates them, so agent and operator rolling upgrades
+  work in either order.
 
 Changes to Features
 ~~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -198,7 +198,9 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	params.K8sWatcher.InitK8sSubsystem(ctx)
 
 	// Configure and start IPAM without using the configuration yet.
-	params.IPAMInitializer.ConfigureAndStartIPAM(ctx)
+	if err := params.IPAMInitializer.ConfigureAndStartIPAM(ctx); err != nil {
+		return err
+	}
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the

--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -684,6 +684,13 @@ func (c *Client) describeVpcs(ctx context.Context, vpcID string) ([]ec2_types.Vp
 }
 
 // GetVpcs retrieves and returns the VPC based on vpcID, or all VPCs if the vpcID is empty.
+//
+// Deprecated: the only use of the returned map is to populate the deprecated
+// ENI.VPC status field in parseENI, which no longer has any reader: the agent
+// reads the VPC of its node, and its CIDRs, from the EC2 instance metadata
+// service. This method, its ec2:DescribeVpcs permission, and the vpcs argument
+// threaded through GetInstance and GetInstances will be removed in v1.22, once
+// no supported agent reads ENI.VPC.
 func (c *Client) GetVpcs(ctx context.Context, vpcID string) (ipamTypes.VirtualNetworkMap, error) {
 	vpcs := ipamTypes.VirtualNetworkMap{}
 

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -32,6 +32,8 @@ type EC2API interface {
 	GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error)
 	GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error)
 	GetSubnets(ctx context.Context, vpcID string) (ipamTypes.SubnetMap, error)
+	// Deprecated: only feeds the deprecated ENI.VPC status field, which has no
+	// reader left. To be removed in v1.22, along with the vpcs arguments above.
 	GetVpcs(ctx context.Context, vpcID string) (ipamTypes.VirtualNetworkMap, error)
 	GetRouteTables(ctx context.Context, vpcID string) (ipamTypes.RouteTableMap, error)
 	GetSecurityGroups(ctx context.Context, vpcID string) (types.SecurityGroupMap, error)

--- a/pkg/aws/metadata/metadata.go
+++ b/pkg/aws/metadata/metadata.go
@@ -6,6 +6,9 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -100,4 +103,57 @@ func (m *metadataClient) GetInstanceMetadata(ctx context.Context) (MetaDataInfo,
 		VPCID:            vpcID,
 		SubnetID:         subnetID,
 	}, nil
+}
+
+// GetVPCIPv4CIDRs returns the IPv4 CIDRs associated with the VPC the instance
+// belongs to, as reported by the IMDS.
+//
+// The returned slice has the VPC's primary CIDR as its first element, followed
+// by the secondary CIDR associations sorted in a deterministic order.
+func (m *metadataClient) GetVPCIPv4CIDRs(ctx context.Context) ([]netip.Prefix, error) {
+	mac, err := getMetadata(ctx, m.client, "mac")
+	if err != nil {
+		return nil, err
+	}
+
+	primaryRaw, err := getMetadata(ctx, m.client, fmt.Sprintf("network/interfaces/macs/%s/vpc-ipv4-cidr-block", mac))
+	if err != nil {
+		return nil, err
+	}
+
+	allRaw, err := getMetadata(ctx, m.client, fmt.Sprintf("network/interfaces/macs/%s/vpc-ipv4-cidr-blocks", mac))
+	if err != nil {
+		return nil, err
+	}
+
+	return parseVPCIPv4CIDRs(primaryRaw, allRaw)
+}
+
+// parseVPCIPv4CIDRs turns the raw vpc-ipv4-cidr-block and vpc-ipv4-cidr-blocks
+// IMDS responses into the ordered prefix list documented on GetVPCIPv4CIDRs.
+func parseVPCIPv4CIDRs(primaryRaw, allRaw string) ([]netip.Prefix, error) {
+	primary, err := netip.ParsePrefix(strings.TrimSpace(primaryRaw))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse VPC primary IPv4 CIDR %q: %w", primaryRaw, err)
+	}
+	primary = primary.Masked()
+
+	// The response is newline-separated and includes the primary CIDR. It is
+	// dropped here to be prepended after the secondary CIDRs have been sorted.
+	fields := strings.Fields(allRaw)
+	secondary := make([]netip.Prefix, 0, len(fields))
+	for _, field := range fields {
+		prefix, err := netip.ParsePrefix(field)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse VPC IPv4 CIDR %q: %w", field, err)
+		}
+		if prefix := prefix.Masked(); prefix != primary {
+			secondary = append(secondary, prefix)
+		}
+	}
+
+	// Ensure secondary CIDRs are sorted for determinism
+	slices.SortFunc(secondary, netip.Prefix.Compare)
+
+	return append([]netip.Prefix{primary}, secondary...), nil
 }

--- a/pkg/aws/metadata/metadata_test.go
+++ b/pkg/aws/metadata/metadata_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVPCIPv4CIDRs(t *testing.T) {
+	tests := []struct {
+		name       string
+		primaryRaw string
+		allRaw     string
+		expected   []netip.Prefix
+		expectErr  bool
+	}{
+		{
+			name:       "single CIDR",
+			primaryRaw: "10.128.0.0/16",
+			allRaw:     "10.128.0.0/16",
+			expected:   []netip.Prefix{netip.MustParsePrefix("10.128.0.0/16")},
+		},
+		{
+			name:       "primary kept first, tail sorted",
+			primaryRaw: "10.128.0.0/16",
+			allRaw:     "10.132.0.0/16\n10.128.0.0/16\n10.0.0.0/16\n100.112.0.0/16",
+			expected: []netip.Prefix{
+				netip.MustParsePrefix("10.128.0.0/16"),
+				netip.MustParsePrefix("10.0.0.0/16"),
+				netip.MustParsePrefix("10.132.0.0/16"),
+				netip.MustParsePrefix("100.112.0.0/16"),
+			},
+		},
+		{
+			name:       "unparsable primary",
+			primaryRaw: "not-a-cidr",
+			allRaw:     "10.128.0.0/16",
+			expectErr:  true,
+		},
+		{
+			name:       "unparsable association",
+			primaryRaw: "10.128.0.0/16",
+			allRaw:     "10.128.0.0/16\nnot-a-cidr",
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cidrs, err := parseVPCIPv4CIDRs(tt.primaryRaw, tt.allRaw)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cidrs)
+		})
+	}
+}

--- a/pkg/aws/types/types.go
+++ b/pkg/aws/types/types.go
@@ -157,6 +157,10 @@ type ENI struct {
 
 	// VPC is the VPC information to which the ENI is attached to
 	//
+	// Deprecated: the agent reads the VPC of the node, and its CIDRs, from the
+	// EC2 instance metadata service instead. This field has no reader left and
+	// will be removed.
+	//
 	// +optional
 	VPC AwsVPC `json:"vpc,omitempty"`
 
@@ -235,16 +239,28 @@ type AwsSubnet struct {
 }
 
 // AwsVPC stores information regarding an AWS VPC
+//
+// Deprecated: every field is write-only. The VPC ID is already carried by
+// ENISpec.VpcID, and the agent reads the VPC CIDRs from the EC2 instance
+// metadata service. This type will be removed along with ENI.VPC.
 type AwsVPC struct {
 	/// ID is the ID of a VPC
+	//
+	// Deprecated: use ENISpec.VpcID, which the agent populates from IMDS.
 	ID string `json:"id,omitempty"`
 
 	// PrimaryCIDR is the primary CIDR of the VPC
+	//
+	// Deprecated: the agent reads the VPC CIDRs from IMDS
+	// (network/interfaces/macs/<mac>/vpc-ipv4-cidr-block).
 	//
 	// +optional
 	PrimaryCIDR iputil.Prefix `json:"primary-cidr,omitzero"`
 
 	// CIDRs is the list of CIDR ranges associated with the VPC
+	//
+	// Deprecated: the agent reads the VPC CIDRs from IMDS
+	// (network/interfaces/macs/<mac>/vpc-ipv4-cidr-blocks).
 	//
 	// +optional
 	CIDRs []iputil.Prefix `json:"cidrs,omitempty"`

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -69,7 +69,7 @@ func TestAllocatedIPDump(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	allocv4, allocv6, status := ipam.Dump()
 	require.NotEmpty(t, status)
@@ -99,7 +99,7 @@ func TestExpirationTimer(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 		MTUConfig:      &mtuMock,
 		Metadata:       fakeMetadata,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test
 	// that the allocated pool is passed to StartExpirationTimer

--- a/pkg/ipam/cell/ipam_init.go
+++ b/pkg/ipam/cell/ipam_init.go
@@ -59,7 +59,7 @@ func newIPAMInitializer(params ipamInitializerParams) *IPAMInitializer {
 	}
 }
 
-func (r *IPAMInitializer) ConfigureAndStartIPAM(ctx context.Context) {
+func (r *IPAMInitializer) ConfigureAndStartIPAM(ctx context.Context) error {
 	// If the device has been specified, the IPv4AllocPrefix and the
 	// IPv6AllocPrefix were already allocated before the k8s.Init().
 	//
@@ -75,12 +75,8 @@ func (r *IPAMInitializer) ConfigureAndStartIPAM(ctx context.Context) {
 	if r.daemonConfig.IPv4Range != autoCIDR {
 		allocCIDR, err := netip.ParsePrefix(r.daemonConfig.IPv4Range)
 		if err != nil {
-			logging.Fatal(
-				r.logger,
-				"Invalid IPv4 allocation prefix",
-				logfields.Error, err,
-				logfields.V4Prefix, r.daemonConfig.IPv4Range,
-			)
+			return fmt.Errorf("invalid IPv4 allocation prefix --%s %q: %w",
+				option.IPv4Range, r.daemonConfig.IPv4Range, err)
 		}
 
 		r.localNodeStore.Update(func(n *node.LocalNode) {
@@ -91,12 +87,8 @@ func (r *IPAMInitializer) ConfigureAndStartIPAM(ctx context.Context) {
 	if r.daemonConfig.IPv6Range != autoCIDR {
 		allocCIDR, err := netip.ParsePrefix(r.daemonConfig.IPv6Range)
 		if err != nil {
-			logging.Fatal(
-				r.logger,
-				"Invalid IPv6 allocation prefix",
-				logfields.Error, err,
-				logfields.V6Prefix, r.daemonConfig.IPv6Range,
-			)
+			return fmt.Errorf("invalid IPv6 allocation prefix --%s %q: %w",
+				option.IPv6Range, r.daemonConfig.IPv6Range, err)
 		}
 
 		r.localNodeStore.Update(func(n *node.LocalNode) {
@@ -105,13 +97,13 @@ func (r *IPAMInitializer) ConfigureAndStartIPAM(ctx context.Context) {
 	}
 
 	if err := r.AutoComplete(ctx); err != nil {
-		logging.Fatal(r.logger, "Cannot autocomplete node addresses", logfields.Error, err)
+		return fmt.Errorf("cannot autocomplete node addresses: %w", err)
 	}
 
 	// start
 	r.logger.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	r.ipam.ConfigureAllocator()
+	return r.ipam.ConfigureAllocator(ctx)
 }
 
 func (r *IPAMInitializer) RestoreFinished() {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -236,20 +236,9 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 	return store
 }
 
+// deriveVpcCIDRs derives the VPC CIDRs from the CiliumNode status. It only
+// covers Azure and AlibabaCloud.
 func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR netip.Prefix, secondaryCIDRs []netip.Prefix) {
-	// A node belongs to a single VPC so we can pick the first ENI
-	// in the list and derive the VPC CIDR from it.
-	for _, eni := range node.Status.ENI.ENIs {
-		if p := eni.VPC.PrimaryCIDR; p.IsValid() {
-			primaryCIDR = p.Masked()
-			for _, sc := range eni.VPC.CIDRs {
-				if sc.IsValid() {
-					secondaryCIDRs = append(secondaryCIDRs, sc.Masked())
-				}
-			}
-			return
-		}
-	}
 	for _, azif := range node.Status.Azure.Interfaces {
 		if p := azif.Subnet.CIDR.Prefix; p.IsValid() {
 			primaryCIDR = p.Masked()
@@ -273,6 +262,8 @@ func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR netip.Prefix, second
 	return
 }
 
+// autoDetectIPv4NativeRoutingCIDR sets the IPv4 native routing CIDR for Azure and
+// AlibabaCloud
 func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNodeStore) bool {
 	if primaryCIDR, secondaryCIDRs := deriveVpcCIDRs(n.ownNode); primaryCIDR.IsValid() {
 		allCIDRs := append([]netip.Prefix{primaryCIDR}, secondaryCIDRs...)

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -116,7 +116,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 	sharedNodeStore.updateLocalNodeResource(cn)
 
 	// Allocate the first 3 IPs
@@ -244,7 +244,7 @@ func TestAzureIPMasq(t *testing.T) {
 		MTUConfig:      &mtuMock,
 		IPMasqAgent:    ipMasqAgent,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	epipv4 := netip.MustParseAddr("10.10.1.5")
 	result, err := ipam.ipv4Allocator.Allocate(epipv4, "test1", PoolDefault())

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -11,7 +11,6 @@ import (
 	"net/netip"
 	"slices"
 	"strconv"
-	"sync"
 
 	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
@@ -31,7 +30,6 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -73,97 +71,16 @@ func startENIDeviceConfigurator(
 	)
 }
 
-// startENINativeRoutingCIDRSync starts a CiliumNode observer that auto-detects
-// the IPv4 native routing CIDR from the VPC CIDR reported in the ENI status.
-//
-// When BPF masquerading is enabled, Cilium needs the native routing CIDR to
-// know which destination CIDRs should NOT be masqueraded. Without it,
-// cross-node pod-to-pod traffic gets SNAT'd to the node IP, breaking
-// connectivity.
-//
-// If the native routing CIDR is already configured (via Helm or CLI), this
-// validates that the configured value contains the VPC CIDR.
-//
-// The returned channel is closed once the native routing CIDR has been
-// determined. Callers must wait on it before programming the datapath,
-// otherwise masquerade exclusion may be configured against an empty CIDR.
-//
-// An unusable configuration is reported by the observer, registered with
-// job.WithObserverShutdown so that it shuts the hive down cleanly.
-func startENINativeRoutingCIDRSync(
-	logger *slog.Logger,
-	jg job.Group,
-	nodeResource agentK8s.LocalCiliumNodeResource,
-	localNodeStore *node.LocalNodeStore,
-	conf *option.DaemonConfig,
-) <-chan struct{} {
-	ready := make(chan struct{})
-	var once sync.Once
-	jg.Add(
-		job.Observer(
-			"eni-native-routing-cidr-sync",
-			func(ctx context.Context, ev resource.Event[*ciliumv2.CiliumNode]) error {
-				defer ev.Done(nil)
+// VPCCIDRSource returns the IPv4 CIDRs associated with the node's VPC.
+type VPCCIDRSource func(ctx context.Context) ([]netip.Prefix, error)
 
-				if ev.Kind != resource.Upsert {
-					return nil
-				}
+var vpcCIDRSource VPCCIDRSource
 
-				// Once configured, ignore further events: a regression in
-				// the CN status (e.g. malformed CIDR written later) would
-				// otherwise degrade cell health for an issue that no longer
-				// affects the agent.
-				select {
-				case <-ready:
-					return nil
-				default:
-				}
-
-				// Each Upsert retries until the operator populates
-				// Status.ENI.ENIs[].VPC.PrimaryCIDR with a valid value.
-				// An invalid PrimaryCIDR (operator hasn't written yet) is
-				// treated as a transient absence.
-				primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(ev.Object)
-				if !primaryCIDR.IsValid() {
-					return nil
-				}
-
-				var err error
-				once.Do(func() {
-					err = autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf)
-					close(ready)
-				})
-				return err
-			},
-			nodeResource,
-			job.WithObserverShutdown[resource.Event[*ciliumv2.CiliumNode]](),
-		),
-	)
-	return ready
+// RegisterVPCCIDRSource installs the function used to read the VPC IPv4 CIDRs
+// of the node. It is called from pkg/nodediscovery/eni's init().
+func RegisterVPCCIDRSource(fn VPCCIDRSource) {
+	vpcCIDRSource = fn
 }
-
-// waitForENINativeRoutingCIDR blocks until the eni-native-routing-cidr-sync
-// observer has determined the native routing CIDR. Aborts the agent with a
-// fatal log if the operator has not reported the VPC CIDR within
-// waitForENINativeRoutingCIDRTimeout.
-func waitForENINativeRoutingCIDR(logger *slog.Logger, ready <-chan struct{}) {
-	deadline := time.After(waitForENINativeRoutingCIDRTimeout)
-	for {
-		select {
-		case <-ready:
-			return
-		case <-deadline:
-			logging.Fatal(logger,
-				"Timed out waiting for ENI VPC CIDR to be reported in CiliumNode status",
-				logfields.Duration, waitForENINativeRoutingCIDRTimeout,
-			)
-		case <-time.After(5 * time.Second):
-			logger.Info("Waiting for ENI VPC CIDR to be reported in CiliumNode status")
-		}
-	}
-}
-
-const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
 
 // autoDetectENINativeRoutingCIDR either validates an existing native routing
 // CIDR configuration against the given VPC CIDRs, or uses the VPC primary CIDR
@@ -173,30 +90,31 @@ const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
 // see the masquerading note on startENINativeRoutingCIDRSync.
 func autoDetectENINativeRoutingCIDR(
 	logger *slog.Logger,
-	primaryCIDR netip.Prefix,
-	secondaryCIDRs []netip.Prefix,
+	vpcCIDRs []netip.Prefix,
 	localNodeStore *node.LocalNodeStore,
 	conf *option.DaemonConfig,
 ) error {
 	if nativeCIDR := conf.IPv4NativeRoutingCIDR; nativeCIDR.IsValid() {
-		// Accept the configured native routing CIDR as long as it overlaps the
-		// VPC primary CIDR or one of the secondary CIDR associations, i.e. it is
-		// a VPC CIDR, a subnet of one (e.g. a single availability-zone subnet,
-		// used to masquerade cross-subnet traffic), or a supernet of one.
-		overlaps := func(c netip.Prefix) bool { return iputil.LaminarCIDRsOverlap(nativeCIDR, c) }
-		if !overlaps(primaryCIDR) && !slices.ContainsFunc(secondaryCIDRs, overlaps) {
-			return fmt.Errorf("configured --%s %s overlaps neither the VPC primary CIDR %s nor any secondary CIDR association %v",
-				option.IPv4NativeRoutingCIDR, nativeCIDR, primaryCIDR, secondaryCIDRs)
+		// Accept the configured native routing CIDR as long as it overlaps one
+		// of the VPC CIDRs, i.e. it is a VPC CIDR, a subnet of one (e.g. a
+		// single availability-zone subnet, used to masquerade cross-subnet
+		// traffic), or a supernet of one.
+		if !slices.ContainsFunc(vpcCIDRs, func(c netip.Prefix) bool {
+			return iputil.LaminarCIDRsOverlap(nativeCIDR, c)
+		}) {
+			return fmt.Errorf("configured --%s %s overlaps none of the VPC CIDRs %v",
+				option.IPv4NativeRoutingCIDR, nativeCIDR, vpcCIDRs)
 		}
 
 		logger.Info(
-			"Native routing CIDR overlaps VPC CIDR, ignoring autodetected VPC CIDR.",
-			logfields.VPCCIDR, primaryCIDR,
+			"Native routing CIDR overlaps a VPC CIDR, ignoring autodetected VPC CIDRs.",
+			logfields.VPCCIDR, vpcCIDRs,
 			option.IPv4NativeRoutingCIDR, nativeCIDR,
 		)
 		return nil
 	}
 
+	primaryCIDR := vpcCIDRs[0]
 	logger.Info(
 		"Using autodetected VPC primary CIDR as native routing CIDR.",
 		logfields.VPCCIDR, primaryCIDR,
@@ -205,28 +123,6 @@ func autoDetectENINativeRoutingCIDR(
 		n.Local.IPv4NativeRoutingCIDR = cidr.NewCIDR(netipx.PrefixIPNet(primaryCIDR))
 	})
 	return nil
-}
-
-// deriveENIVpcCIDRs extracts the VPC primary CIDR and the secondary CIDR
-// associations from the first ENI in the CiliumNode status. All ENIs on a node
-// belong to the same VPC, so any ENI can be used.
-//
-// Returns the zero netip.Prefix when no ENI has populated PrimaryCIDR yet
-// (transient startup state).
-func deriveENIVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR netip.Prefix, secondaryCIDRs []netip.Prefix) {
-	for _, eni := range node.Status.ENI.ENIs {
-		if !eni.VPC.PrimaryCIDR.IsValid() {
-			continue
-		}
-		primaryCIDR = eni.VPC.PrimaryCIDR.Masked()
-		for _, c := range eni.VPC.CIDRs {
-			if c.IsValid() {
-				secondaryCIDRs = append(secondaryCIDRs, c.Masked())
-			}
-		}
-		return primaryCIDR, secondaryCIDRs
-	}
-	return netip.Prefix{}, nil
 }
 
 // validateENIConfig validates the ENI configuration in the CiliumNode resource
@@ -238,14 +134,6 @@ func validateENIConfig(node *ciliumv2.CiliumNode) error {
 		}
 		if !eni.Subnet.CIDR.IsValid() {
 			return fmt.Errorf("subnet CIDR not set for ENI %s", eni.ID)
-		}
-		if !eni.VPC.PrimaryCIDR.IsValid() {
-			return fmt.Errorf("VPC Primary CIDR not set for ENI %s", eni.ID)
-		}
-		for _, c := range eni.VPC.CIDRs {
-			if !c.IsValid() {
-				return fmt.Errorf("VPC CIDR not set for ENI %s", eni.ID)
-			}
 		}
 	}
 
@@ -485,6 +373,7 @@ func buildENIAllocationResult(
 	allocatedAddr netip.Addr,
 	pool Pool,
 	enis map[string]awsTypes.ENI,
+	vpcCIDRs []netip.Prefix,
 	conf *option.DaemonConfig,
 	ipMasqAgent *ipmasq.IPMasqAgent,
 ) (*AllocationResult, error) {
@@ -497,14 +386,7 @@ func buildENIAllocationResult(
 			IP:         allocatedAddr,
 			IPPoolName: pool,
 			PrimaryMAC: eni.MAC,
-		}
-		if eni.VPC.PrimaryCIDR.IsValid() {
-			result.CIDRs = append(result.CIDRs, eni.VPC.PrimaryCIDR.Prefix)
-		}
-		for _, c := range eni.VPC.CIDRs {
-			if c.IsValid() {
-				result.CIDRs = append(result.CIDRs, c.Prefix)
-			}
+			CIDRs:      slices.Clone(vpcCIDRs),
 		}
 
 		// Add manually configured Native Routing CIDR
@@ -661,6 +543,7 @@ type eniMultiPoolAllocator struct {
 	logger      *slog.Logger
 	conf        *option.DaemonConfig
 	ipMasqAgent *ipmasq.IPMasqAgent
+	vpcCIDRs    []netip.Prefix
 }
 
 func (a *eniMultiPoolAllocator) enrichResult(result *AllocationResult, err error) (*AllocationResult, error) {
@@ -678,7 +561,7 @@ func (a *eniMultiPoolAllocator) enrichResult(result *AllocationResult, err error
 	}
 	a.manager.nodeMutex.Unlock()
 
-	enriched, enrichErr := buildENIAllocationResult(a.logger, result.IP, result.IPPoolName, enis, a.conf, a.ipMasqAgent)
+	enriched, enrichErr := buildENIAllocationResult(a.logger, result.IP, result.IPPoolName, enis, a.vpcCIDRs, a.conf, a.ipMasqAgent)
 	if enrichErr != nil {
 		// The underlying Allocate* call already reserved the IP in the
 		// allocator. Release it to avoid leaking the reservation when the
@@ -721,11 +604,25 @@ type ENIMultiPoolAllocatorParams struct {
 	CNClient       cilium_v2.CiliumNodeInterface
 	JobGroup       job.Group
 
-	Conf        *option.DaemonConfig
-	IPMasqAgent *ipmasq.IPMasqAgent
+	Conf          *option.DaemonConfig
+	IPMasqAgent   *ipmasq.IPMasqAgent
+	VPCCIDRSource VPCCIDRSource
 }
 
-func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Allocator) {
+// newENIMultiPoolAllocators builds the ENI IPv4 and IPv6 allocators.
+func newENIMultiPoolAllocators(ctx context.Context, p ENIMultiPoolAllocatorParams) (Allocator, Allocator, error) {
+	if p.VPCCIDRSource == nil {
+		return nil, nil, errors.New("ENI IPAM mode requires VPCCIDRSource, ensure pkg/nodediscovery/eni is imported")
+	}
+
+	vpcCIDRs, err := p.VPCCIDRSource(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to determine the VPC IPv4 CIDRs of the node: %w", err)
+	}
+	if len(vpcCIDRs) == 0 {
+		return nil, nil, errors.New("no IPv4 VPC CIDRs found for the node")
+	}
+
 	preallocMap := preAllocatePerPool{
 		Pool(defaults.IPAMDefaultIPPool): defaults.IPAMPreAllocation,
 	}
@@ -743,16 +640,18 @@ func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Alloca
 		LinearPreAlloc:       true,
 	})
 
+	if err := autoDetectENINativeRoutingCIDR(p.Logger, vpcCIDRs, p.LocalNodeStore, p.Conf); err != nil {
+		return nil, nil, err
+	}
+
 	allocCIDRsReady := startLocalNodeAllocCIDRsSync(p.IPv4Enabled, p.IPv6Enabled, p.JobGroup, p.Node, p.LocalNodeStore)
-	nativeRoutingCIDRReady := startENINativeRoutingCIDRSync(p.Logger, p.JobGroup, p.Node, p.LocalNodeStore, p.Conf)
 
 	// Wait for local node to be updated to avoid propagating spurious updates.
 	waitForLocalNodeUpdate(p.Logger, mgr)
-	// Independently wait for the alloc-CIDR and native-routing-CIDR observers:
-	// they run in separate jobs from the multi-pool manager and are not
-	// synchronized with mgr.localNodeUpdated().
+	// Independently wait for the alloc-CIDR observer: it runs in a separate job
+	// from the multi-pool manager and is not synchronized with
+	// mgr.localNodeUpdated().
 	waitForLocalNodeAllocCIDRs(p.Logger, allocCIDRsReady)
-	waitForENINativeRoutingCIDR(p.Logger, nativeRoutingCIDRReady)
 
 	newAllocator := func(family Family) *eniMultiPoolAllocator {
 		return &eniMultiPoolAllocator{
@@ -760,7 +659,8 @@ func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Alloca
 			logger:             p.Logger,
 			conf:               p.Conf,
 			ipMasqAgent:        p.IPMasqAgent,
+			vpcCIDRs:           vpcCIDRs,
 		}
 	}
-	return newAllocator(IPv4), newAllocator(IPv6)
+	return newAllocator(IPv4), newAllocator(IPv6), nil
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -5,6 +5,7 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/netip"
 	"testing"
@@ -82,100 +83,12 @@ func Test_validateENIConfig(t *testing.T) {
 										"10.1.1.226",
 										"10.1.1.229",
 									),
-									VPC: awsTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-										CIDRs: prefixes(
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										),
-									},
 								},
 							},
 						},
 					},
 				},
 			},
-		},
-		{
-			name: "Missing VPC Primary CIDR",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: awsTypes.ENIStatus{
-							ENIs: map[string]awsTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									IP: iputil.AddrFrom(netip.MustParseAddr("10.1.1.225")),
-									Subnet: awsTypes.AwsSubnet{
-										CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.1.0/24")),
-									},
-									Addresses: addrs(
-										"10.1.1.226",
-										"10.1.1.229",
-									),
-									VPC: awsTypes.AwsVPC{
-										ID: "vpc-1",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "VPC Primary CIDR not set for ENI eni-1",
-		},
-		{
-			name: "VPC CIDRs contain invalid value",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: awsTypes.ENIStatus{
-							ENIs: map[string]awsTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									IP: iputil.AddrFrom(netip.MustParseAddr("10.1.1.225")),
-									Subnet: awsTypes.AwsSubnet{
-										CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.1.0/24")),
-									},
-									Addresses: addrs(
-										"10.1.1.226",
-										"10.1.1.229",
-									),
-									VPC: awsTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-										CIDRs: []iputil.Prefix{
-											{},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "VPC CIDR not set for ENI eni-1",
 		},
 		{
 			name: "ENI not found in status",
@@ -203,14 +116,6 @@ func Test_validateENIConfig(t *testing.T) {
 										"10.1.1.226",
 										"10.1.1.229",
 									),
-									VPC: awsTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-										CIDRs: prefixes(
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										),
-									},
 								},
 							},
 						},
@@ -246,14 +151,6 @@ func Test_validateENIConfig(t *testing.T) {
 										"10.1.1.226",
 										"10.1.1.229",
 									),
-									VPC: awsTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-										CIDRs: prefixes(
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										),
-									},
 								},
 							},
 						},
@@ -289,10 +186,6 @@ func TestBuildENIAllocationResult(t *testing.T) {
 			Subnet: awsTypes.AwsSubnet{
 				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.1.0/24")),
 			},
-			VPC: awsTypes.AwsVPC{
-				PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-				CIDRs:       prefixes("10.2.0.0/16"),
-			},
 		},
 		"eni-2": {
 			ID:  "eni-2",
@@ -304,18 +197,19 @@ func TestBuildENIAllocationResult(t *testing.T) {
 			Subnet: awsTypes.AwsSubnet{
 				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.3.1.0/24")),
 			},
-			VPC: awsTypes.AwsVPC{
-				PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-				CIDRs:       prefixes("10.2.0.0/16"),
-			},
 		},
 	}
 
+	// Primary VPC CIDR first, as GetVPCIPv4CIDRs guarantees.
+	vpcCIDRs := []netip.Prefix{
+		netip.MustParsePrefix("10.1.0.0/16"),
+		netip.MustParsePrefix("10.2.0.0/16"),
+	}
 	conf := &option.DaemonConfig{}
 	logger := hivetest.Logger(t)
 
 	t.Run("secondary IP on eni-1", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
@@ -325,7 +219,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("secondary IP on eni-2", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.3.1.20"), "", node.Status.ENI.ENIs, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.3.1.20"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:02", result.PrimaryMAC)
 		require.Equal(t, "2", result.InterfaceNumber)
@@ -333,7 +227,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("unknown IP returns error", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.99.99.99"), "", node.Status.ENI.ENIs, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.99.99.99"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to find ENI for IP")
 	})
@@ -343,7 +237,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 			EnableIPv4:            true,
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("10.0.0.0/8"),
 		}
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, vpcCIDRs, confWithNative, nil)
 		require.NoError(t, err)
 		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
 	})
@@ -352,7 +246,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		confWithNative := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("10.0.0.0/8"),
 		}
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, vpcCIDRs, confWithNative, nil)
 		require.NoError(t, err)
 		require.NotContains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
 	})
@@ -375,35 +269,33 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 			Subnet: awsTypes.AwsSubnet{
 				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.1.0/24")),
 			},
-			VPC: awsTypes.AwsVPC{
-				PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-			},
 		},
 	}
 
+	vpcCIDRs := []netip.Prefix{netip.MustParsePrefix("10.1.0.0/16")}
 	conf := &option.DaemonConfig{}
 	logger := hivetest.Logger(t)
 
 	t.Run("IP in first prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.5"), "", node.Status.ENI.ENIs, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.5"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
 	})
 
 	t.Run("IP in second prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.20"), "", node.Status.ENI.ENIs, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.20"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 	})
 
 	t.Run("IP outside all prefixes", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), "", node.Status.ENI.ENIs, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("IP in IPv6 prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, vpcCIDRs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
@@ -415,7 +307,7 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 			EnableIPv6:            true,
 			IPv6NativeRoutingCIDR: netip.MustParsePrefix("2001:db8::/64"),
 		}
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, vpcCIDRs, confWithNative, nil)
 		require.NoError(t, err)
 		require.Contains(t, result.CIDRs, netip.MustParsePrefix("2001:db8::/64"))
 	})
@@ -424,7 +316,7 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 		confWithNative := &option.DaemonConfig{
 			IPv6NativeRoutingCIDR: netip.MustParsePrefix("2001:db8::/64"),
 		}
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, vpcCIDRs, confWithNative, nil)
 		require.NoError(t, err)
 		require.NotContains(t, result.CIDRs, netip.MustParsePrefix("2001:db8::/64"))
 	})
@@ -441,22 +333,19 @@ func TestBuildENIAllocationResultIPMasq(t *testing.T) {
 			Subnet: awsTypes.AwsSubnet{
 				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.1.0/24")),
 			},
-			VPC: awsTypes.AwsVPC{
-				ID:          "vpc-1",
-				PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.0.0/16")),
-				CIDRs: prefixes(
-					"10.2.0.0/16",
-				),
-			},
 		},
 	}
 
+	vpcCIDRs := []netip.Prefix{
+		netip.MustParsePrefix("10.1.0.0/16"),
+		netip.MustParsePrefix("10.2.0.0/16"),
+	}
 	conf := &option.DaemonConfig{EnableIPMasqAgent: true}
 	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
 	require.NoError(t, ipMasqAgent.Start())
 	defer ipMasqAgent.Stop()
 
-	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("10.1.1.226"), "", enis, conf, ipMasqAgent)
+	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("10.1.1.226"), "", enis, vpcCIDRs, conf, ipMasqAgent)
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the VPC CIDRs and the default
 	// ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
@@ -495,12 +384,15 @@ func TestBuildENIAllocationResultIPMasqIPv6(t *testing.T) {
 		},
 	}
 
+	// IPv6 VPC CIDRs are not sourced from IMDS yet, so the VPC CIDR set is
+	// empty for an IPv6-only allocation.
+	var vpcCIDRs []netip.Prefix
 	conf := &option.DaemonConfig{EnableIPv6: true, EnableIPMasqAgent: true}
 	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
 	require.NoError(t, ipMasqAgent.Start())
 	defer ipMasqAgent.Stop()
 
-	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("2001:db8::1"), "", enis, conf, ipMasqAgent)
+	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("2001:db8::1"), "", enis, vpcCIDRs, conf, ipMasqAgent)
 	require.NoError(t, err)
 	// Only the IPv6 ip-masq-agent CIDRs should be appended; the family
 	// filter in buildENIAllocationResult must exclude the IPv4 defaults.
@@ -671,9 +563,6 @@ func TestENIMultiPoolAllocator(t *testing.T) {
 				ENIs: map[string]awsTypes.ENI{
 					"eni-1": {
 						Addresses: addrs(eniCIDR1.Addr().String(), eniCIDR2.Addr().String()),
-						VPC: awsTypes.AwsVPC{
-							PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/16")),
-						},
 					},
 				},
 			},
@@ -712,7 +601,7 @@ func TestENIMultiPoolAllocator(t *testing.T) {
 	_, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), initialNode, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	ipv4Allocator, ipv6Allocator := newENIMultiPoolAllocators(ENIMultiPoolAllocatorParams{
+	ipv4Allocator, ipv6Allocator, err := newENIMultiPoolAllocators(t.Context(), ENIMultiPoolAllocatorParams{
 		Logger:               hivetest.Logger(t),
 		IPv4Enabled:          true,
 		IPv6Enabled:          false,
@@ -722,7 +611,9 @@ func TestENIMultiPoolAllocator(t *testing.T) {
 		CNClient:             clientset.CiliumV2().CiliumNodes(),
 		JobGroup:             jg,
 		Conf:                 &option.DaemonConfig{},
+		VPCCIDRSource:        fakeVPCCIDRSource(netip.MustParsePrefix("10.0.0.0/16")),
 	})
+	require.NoError(t, err)
 	require.NotNil(t, ipv4Allocator)
 	require.NotNil(t, ipv6Allocator)
 
@@ -739,78 +630,76 @@ func TestENIMultiPoolAllocator(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-func TestDeriveENIVpcCIDRs(t *testing.T) {
-	t.Run("returns primary VPC CIDR from first ENI", func(t *testing.T) {
-		node := &ciliumv2.CiliumNode{}
-		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
-			"eni-1": {
-				VPC: awsTypes.AwsVPC{
-					PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/16")),
-				},
-			},
-		}
-		primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(node)
-		require.Equal(t, netip.MustParsePrefix("10.0.0.0/16"), primaryCIDR)
-		require.Empty(t, secondaryCIDRs)
+func TestENIMultiPoolAllocatorVPCCIDRSourceFailure(t *testing.T) {
+	// A VPC CIDR set that cannot be determined must fail loudly at
+	// initialization: it drives masquerade exclusion, so proceeding without it
+	// would silently SNAT cross-node pod traffic.
+	params := ENIMultiPoolAllocatorParams{
+		Logger: hivetest.Logger(t),
+		Conf:   &option.DaemonConfig{},
+	}
+
+	t.Run("no source injected", func(t *testing.T) {
+		_, _, err := newENIMultiPoolAllocators(t.Context(), params)
+		require.ErrorContains(t, err, "ensure pkg/nodediscovery/eni is imported")
 	})
 
-	t.Run("returns the secondary VPC CIDR associations", func(t *testing.T) {
-		node := &ciliumv2.CiliumNode{}
-		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
-			"eni-1": {
-				VPC: awsTypes.AwsVPC{
-					PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.1.128.0/19")),
-					CIDRs:       prefixes("100.64.0.0/16"),
-				},
-			},
-		}
-		primaryCIDR, secondaryCIDRs := deriveENIVpcCIDRs(node)
-		require.Equal(t, netip.MustParsePrefix("10.1.128.0/19"), primaryCIDR)
-		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}, secondaryCIDRs)
+	t.Run("source fails", func(t *testing.T) {
+		p := params
+		p.VPCCIDRSource = errVPCCIDRSource(errors.New("IMDS unreachable"))
+		_, _, err := newENIMultiPoolAllocators(t.Context(), p)
+		require.ErrorContains(t, err, "IMDS unreachable")
 	})
 
-	t.Run("returns zero when no ENIs", func(t *testing.T) {
-		node := &ciliumv2.CiliumNode{}
-		primaryCIDR, _ := deriveENIVpcCIDRs(node)
-		require.False(t, primaryCIDR.IsValid())
-	})
-
-	t.Run("returns zero when VPC CIDR is empty", func(t *testing.T) {
-		node := &ciliumv2.CiliumNode{}
-		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
-			"eni-1": {
-				VPC: awsTypes.AwsVPC{},
-			},
-		}
-		primaryCIDR, _ := deriveENIVpcCIDRs(node)
-		require.False(t, primaryCIDR.IsValid())
+	t.Run("source returns no CIDR", func(t *testing.T) {
+		p := params
+		p.VPCCIDRSource = fakeVPCCIDRSource()
+		_, _, err := newENIMultiPoolAllocators(t.Context(), p)
+		require.ErrorContains(t, err, "no IPv4 VPC CIDRs")
 	})
 }
 
+// fakeVPCCIDRSource returns a fixed CIDR set, primary first.
+func fakeVPCCIDRSource(cidrs ...netip.Prefix) VPCCIDRSource {
+	return func(context.Context) ([]netip.Prefix, error) {
+		return cidrs, nil
+	}
+}
+
+// errVPCCIDRSource stands in for an unreachable or misbehaving IMDS.
+func errVPCCIDRSource(err error) VPCCIDRSource {
+	return func(context.Context) ([]netip.Prefix, error) {
+		return nil, err
+	}
+}
+
 func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
-	t.Run("auto-detects VPC CIDR when not configured", func(t *testing.T) {
+	t.Run("auto-detects the primary VPC CIDR when not configured", func(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
+		vpcCIDRs := []netip.Prefix{
+			netip.MustParsePrefix("10.128.0.0/16"), // primary CIDR
+			netip.MustParsePrefix("10.0.0.0/16"),
+		}
 		conf := &option.DaemonConfig{}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, vpcCIDRs, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, localNode.Local.IPv4NativeRoutingCIDR)
-		require.Equal(t, "10.0.0.0/16", localNode.Local.IPv4NativeRoutingCIDR.String())
+		require.Equal(t, "10.128.0.0/16", localNode.Local.IPv4NativeRoutingCIDR.String())
 	})
 
 	t.Run("does not overwrite when already configured", func(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("10.0.0.0/16")
+		vpcCIDRs := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/16")}
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("10.0.0.0/8"),
 		}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, vpcCIDRs, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -825,11 +714,11 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("192.168.0.0/16")
+		vpcCIDRs := []netip.Prefix{netip.MustParsePrefix("192.168.0.0/16")}
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.64.0/19"),
 		}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, nil, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, vpcCIDRs, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -843,12 +732,14 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("10.1.128.0/19")
-		secondaryCIDRs := []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}
+		vpcCIDRs := []netip.Prefix{
+			netip.MustParsePrefix("10.1.128.0/19"),
+			netip.MustParsePrefix("100.64.0.0/16"),
+		}
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("100.64.0.0/16"),
 		}
-		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf))
+		require.NoError(t, autoDetectENINativeRoutingCIDR(logger, vpcCIDRs, localNodeStore, conf))
 
 		localNode, err := localNodeStore.Get(context.Background())
 		require.NoError(t, err)
@@ -860,11 +751,13 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		logger := hivetest.Logger(t)
 		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 
-		primaryCIDR := netip.MustParsePrefix("10.1.128.0/19")
-		secondaryCIDRs := []netip.Prefix{netip.MustParsePrefix("100.64.0.0/16")}
+		vpcCIDRs := []netip.Prefix{
+			netip.MustParsePrefix("10.1.128.0/19"),
+			netip.MustParsePrefix("100.64.0.0/16"),
+		}
 		conf := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: netip.MustParsePrefix("192.168.0.0/16"),
 		}
-		require.Error(t, autoDetectENINativeRoutingCIDR(logger, primaryCIDR, secondaryCIDRs, localNodeStore, conf))
+		require.Error(t, autoDetectENINativeRoutingCIDR(logger, vpcCIDRs, localNodeStore, conf))
 	})
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -4,6 +4,8 @@
 package ipam
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -17,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipam/podippool"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -119,7 +120,7 @@ func NewIPAM(params NewIPAMParams) *IPAM {
 // ConfigureAllocator initializes the IPAM allocator according to the configuration.
 // As a precondition, the NodeAddressing must be fully initialized - therefore the method
 // must be called after Daemon.WaitForNodeInformation.
-func (ipam *IPAM) ConfigureAllocator() {
+func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 	switch ipam.config.IPAMMode() {
 	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool:
 		ipam.logger.Info(
@@ -132,7 +133,7 @@ func (ipam *IPAM) ConfigureAllocator() {
 		if ipam.config.IPv6Enabled() {
 			prefix := ipam.nodeAddressing.IPv6().AllocationCIDR()
 			if !prefix.IsValid() {
-				logging.Fatal(ipam.logger, "Invalid IPv6 allocation CIDR")
+				return errors.New("invalid IPv6 allocation CIDR")
 			}
 			ipam.ipv6Allocator = newHostScopeAllocator(prefix)
 		}
@@ -140,7 +141,7 @@ func (ipam *IPAM) ConfigureAllocator() {
 		if ipam.config.IPv4Enabled() {
 			prefix := ipam.nodeAddressing.IPv4().AllocationCIDR()
 			if !prefix.IsValid() {
-				logging.Fatal(ipam.logger, "Invalid IPv4 allocation CIDR")
+				return errors.New("invalid IPv4 allocation CIDR")
 			}
 			ipam.ipv4Allocator = newHostScopeAllocator(prefix)
 		}
@@ -170,7 +171,7 @@ func (ipam *IPAM) ConfigureAllocator() {
 	case ipamOption.IPAMENI:
 		ipam.logger.Info("Initializing ENI multi-pool IPAM")
 		startENIDeviceConfigurator(ipam.logger, ipam.jg, ipam.nodeResource, ipam.mtuConfig, ipam.sysctl)
-		v4Allocator, v6Allocator := newENIMultiPoolAllocators(ENIMultiPoolAllocatorParams{
+		v4Allocator, v6Allocator, err := newENIMultiPoolAllocators(ctx, ENIMultiPoolAllocatorParams{
 			Logger:               ipam.logger,
 			IPv4Enabled:          ipam.config.IPv4Enabled(),
 			IPv6Enabled:          ipam.config.IPv6Enabled(),
@@ -181,7 +182,11 @@ func (ipam *IPAM) ConfigureAllocator() {
 			JobGroup:             ipam.jg,
 			Conf:                 ipam.config,
 			IPMasqAgent:          ipam.ipMasqAgent,
+			VPCCIDRSource:        vpcCIDRSource,
 		})
+		if err != nil {
+			return fmt.Errorf("unable to initialize ENI multi-pool IPAM: %w", err)
+		}
 		if ipam.config.IPv6Enabled() {
 			ipam.ipv6Allocator = v6Allocator
 		}
@@ -206,8 +211,10 @@ func (ipam *IPAM) ConfigureAllocator() {
 			ipam.ipv4Allocator = &noOpAllocator{}
 		}
 	default:
-		logging.Fatal(ipam.logger, fmt.Sprintf("Unknown IPAM backend %s", ipam.config.IPAMMode()))
+		return fmt.Errorf("unknown IPAM backend %s", ipam.config.IPAMMode())
 	}
+
+	return nil
 }
 
 // getIPOwner returns the owner for an IP in a particular pool or the empty

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -130,7 +130,7 @@ func TestLock(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
@@ -163,7 +163,7 @@ func TestExcludeIP(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
@@ -221,7 +221,7 @@ func TestIPAMMetadata(t *testing.T) {
 		MTUConfig:      &mtuMock,
 		Metadata:       fakeMetadata,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 	ipam.ipv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
 		"test":    "192.168.178.0/24",
@@ -290,7 +290,7 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 		MTUConfig:      &mtuMock,
 		Metadata:       fakeMetadata,
 	})
-	ipam.ConfigureAllocator()
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
 
 	// AllocateIP requires explicit pool
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)

--- a/pkg/ipam/migration/script_test.go
+++ b/pkg/ipam/migration/script_test.go
@@ -143,8 +143,7 @@ func commands(initializer *ipamcell.IPAMInitializer, manager *ipam.IPAM) map[str
 				if len(args) != 0 {
 					return nil, script.ErrUsage
 				}
-				initializer.ConfigureAndStartIPAM(state.Context())
-				return nil, nil
+				return nil, initializer.ConfigureAndStartIPAM(state.Context())
 			},
 		),
 		"ipam/restore-endpoint": script.Command(

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -681,22 +681,35 @@ spec:
                             not be managed by Cilium
                           type: object
                         vpc:
-                          description: VPC is the VPC information to which the ENI
-                            is attached to
+                          description: |-
+                            VPC is the VPC information to which the ENI is attached to
+
+                            Deprecated: the agent reads the VPC of the node, and its CIDRs, from the
+                            EC2 instance metadata service instead. This field has no reader left and
+                            will be removed.
                           properties:
                             cidrs:
-                              description: CIDRs is the list of CIDR ranges associated
-                                with the VPC
+                              description: |-
+                                CIDRs is the list of CIDR ranges associated with the VPC
+
+                                Deprecated: the agent reads the VPC CIDRs from IMDS
+                                (network/interfaces/macs/<mac>/vpc-ipv4-cidr-blocks).
                               items:
                                 format: cidr
                                 type: string
                               type: array
                             id:
-                              description: / ID is the ID of a VPC
+                              description: |-
+                                / ID is the ID of a VPC
+
+                                Deprecated: use ENISpec.VpcID, which the agent populates from IMDS.
                               type: string
                             primary-cidr:
-                              description: PrimaryCIDR is the primary CIDR of the
-                                VPC
+                              description: |-
+                                PrimaryCIDR is the primary CIDR of the VPC
+
+                                Deprecated: the agent reads the VPC CIDRs from IMDS
+                                (network/interfaces/macs/<mac>/vpc-ipv4-cidr-block).
                               format: cidr
                               type: string
                           type: object

--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -1,28 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// Package eni wires the ENI-specific CiliumNode mutator (using the EC2 IMDS
-// client and the AWS SDK helpers) into pkg/nodediscovery. It is imported
-// (with a blank import) by the cilium-agent so that ENI IPAM works at
-// runtime, while keeping the AWS SDK out of non-AWS binaries (notably
-// cilium-operator-generic) which do not import this package.
+// Package eni wires the ENI-specific CiliumNode mutator and the VPC CIDR
+// source (both using the EC2 IMDS client and the AWS SDK helpers) into
+// pkg/nodediscovery and pkg/ipam respectively. It is imported (with a blank
+// import) by the cilium-agent so that ENI IPAM works at runtime, while keeping
+// the AWS SDK out of non-AWS binaries (notably cilium-operator-generic) which
+// do not import this package but do import both of those.
 package eni
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	awsMetadata "github.com/cilium/cilium/pkg/aws/metadata"
 	awsTypes "github.com/cilium/cilium/pkg/aws/types"
+	"github.com/cilium/cilium/pkg/ipam"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 )
 
 func init() {
 	nodediscovery.RegisterENIMutator(mutate)
+	ipam.RegisterVPCCIDRSource(vpcIPv4CIDRs)
+}
+
+// vpcIPv4CIDRs returns the IPv4 CIDRs of the node's VPC, primary CIDR first.
+//
+// The IMDS client is built here rather than at registration time: init() runs
+// in every binary that links this package, regardless of the configured IPAM
+// mode.
+func vpcIPv4CIDRs(ctx context.Context) ([]netip.Prefix, error) {
+	imds, err := awsMetadata.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create EC2 metadata client: %w", err)
+	}
+
+	return imds.GetVPCIPv4CIDRs(ctx)
 }
 
 // mutate populates the ENI-specific fields of nodeResource using EC2 IMDS


### PR DESCRIPTION
Today every ENI's status carries its VPC's CIDRs (`status.eni.enis.[].vpc`). But all ENIs for a given node can only belong to a single VPC, the node's VPC, so there is unnecessary duplication in having the VPC properties be present on each ENI's status. But in addition to that, we don't even need this to be in the `CiliumNode` CRD at all.

Today the operator makes AWS EC2 API calls to get VPC CIDRs, then writes them to each ENI's status on the `CiliumNode` and the agent watches those on startup and waits to see them populated by the operator. The operator never reads those, only the agent needs them. And the agent doesn't even need the operator to get them. The agent already queries its node's IMDS for some node properties (including its VPC ID), we can just extend this IMDS-based facts gathering to get the agent the VPC CIDRs (which are available via IMDS). That way the agent no longer needs to wait for the operator to write those in the `CiliumNode` and the operator no longer needs to make AWS API calls to regularly fetch VPC properties.

This PR implements the first half of that: update the agent to read the VPC CIDRs from the IMDS instead of from the operator-populated `CiliumNode`. The operator continues to fetch VPC data and write it to the `CiliumNode`, this is now advertised as deprecated and will be removed with cilium 1.22.

See each commit message for details.


Some tracing views of how the new IMDS-backed VPC CIDRs discovery fits in the agent bootstrap phase:
<img width="1459" height="247" alt="image" src="https://github.com/user-attachments/assets/6c73a830-f55d-4876-80af-7194deb2f31a" />
<img width="1045" height="496" alt="image" src="https://github.com/user-attachments/assets/ad8115cb-45da-4214-9ebf-b3feeafd24cd" />
