### PR TITLE
bpf, socketlb: move MKE host to runtime config

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -74,7 +74,7 @@ static __always_inline __maybe_unused bool task_in_extended_hostns(void)
 {
 #ifdef ENABLE_MKE
 	/* Extension for non-Cilium managed containers on MKE. */
-	return get_cgroup_classid() == MKE_HOST;
+	return get_cgroup_classid() == CONFIG(mke_host);
 #else
 	return false;
 #endif

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -72,12 +72,12 @@ void ctx_set_port(struct bpf_sock_addr *ctx, __be16 dport)
 
 static __always_inline __maybe_unused bool task_in_extended_hostns(void)
 {
-#ifdef ENABLE_MKE
+	__u32 classid = CONFIG(mke_host);
+
+	if (!classid)
+		return false;
 	/* Extension for non-Cilium managed containers on MKE. */
-	return get_cgroup_classid() == CONFIG(mke_host);
-#else
-	return false;
-#endif
+	return get_cgroup_classid() == classid;
 }
 
 static __always_inline __maybe_unused bool

--- a/bpf/include/bpf/config/sock.h
+++ b/bpf/include/bpf/config/sock.h
@@ -11,3 +11,6 @@
 
 DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 	       "Enable routes when service has 0 endpoints")
+
+DECLARE_CONFIG(__u32, mke_host,
+	       "Cgroup class ID identifying MKE containers treated as host-networked")

--- a/pkg/datapath/config/sock_config.go
+++ b/pkg/datapath/config/sock_config.go
@@ -20,6 +20,8 @@ type BPFSock struct {
 	EnableLRP bool `config:"enable_lrp"`
 	// Enable routes when service has 0 endpoints.
 	EnableNoServiceEndpointsRoutable bool `config:"enable_no_service_endpoints_routable"`
+	// Cgroup class ID identifying MKE containers treated as host-networked.
+	MKEHost uint32 `config:"mke_host"`
 	// Port number used for the overlay network.
 	TunnelPort uint16 `config:"tunnel_port"`
 	// The identifier of the tunnel protocol used for the overlay network.
@@ -29,5 +31,5 @@ type BPFSock struct {
 }
 
 func NewBPFSock(node Node) *BPFSock {
-	return &BPFSock{false, false, false, false, false, 0x0, 0x0, node}
+	return &BPFSock{false, false, false, false, false, 0x0, 0x0, 0x0, node}
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -275,9 +275,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		if option.Config.UnsafeDaemonConfigOption.EnableHealthDatapath {
 			cDefinesMap["ENABLE_HEALTH_CHECK"] = "1"
 		}
-		if option.Config.EnableMKE && h.kprCfg.EnableSocketLB {
-			cDefinesMap["ENABLE_MKE"] = "1"
-		}
 		cDefinesMap["ENABLE_NODEPORT"] = "1"
 
 		if option.Config.EnableNat46X64Gateway {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -277,7 +277,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		}
 		if option.Config.EnableMKE && h.kprCfg.EnableSocketLB {
 			cDefinesMap["ENABLE_MKE"] = "1"
-			cDefinesMap["MKE_HOST"] = fmt.Sprintf("%d", option.HostExtensionMKE)
 		}
 		cDefinesMap["ENABLE_NODEPORT"] = "1"
 

--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -100,6 +100,11 @@ func baseSockPermutations() *loadPermutationBuilder {
 			t.EnableIPv4Fragments = true
 			t.EnableIPv6Fragments = true
 		}),
+		Increment(func(t *config.BPFSock, v bool) {
+			if v {
+				t.MKEHost = option.HostExtensionMKE
+			}
+		}),
 		IncrementOrPermute(func(t *config.BPFSock, v bool) { t.EnableLRP = v }),
 	)
 	return b

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -98,6 +98,10 @@ func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 	cfg.TunnelProtocol = lnc.TunnelProtocol
 	cfg.TunnelPort = lnc.TunnelPort
 
+	if option.Config.EnableMKE {
+		cfg.MKEHost = option.HostExtensionMKE
+	}
+
 	coll, commit, cleanup, err := collLoader.Load(ctx, logger, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		Constants:   cfg,

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -98,7 +98,7 @@ func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 	cfg.TunnelProtocol = lnc.TunnelProtocol
 	cfg.TunnelPort = lnc.TunnelPort
 
-	if option.Config.EnableMKE {
+	if option.Config.EnableMKE && lnc.KPRConfig.KubeProxyReplacement {
 		cfg.MKEHost = option.HostExtensionMKE
 	}
 

--- a/tools/dpgen/acronyms.txt
+++ b/tools/dpgen/acronyms.txt
@@ -40,6 +40,7 @@ LRP
 LXC
 MAC
 MACAddr
+MKE
 MTU
 NAT
 NetNS


### PR DESCRIPTION
Replace the MKE_HOST macro with socket level runtime configuration. Populate the value from HostExtensionMKE when MKE support is enabled.

Related: https://github.com/cilium/cilium/issues/38370
