### PR TITLE
nodediscovery: Make ENI instance facts unoverridable by CNI conf

### DIFF
--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -12,13 +12,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	awsMetadata "github.com/cilium/cilium/pkg/aws/metadata"
 	awsTypes "github.com/cilium/cilium/pkg/aws/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/nodediscovery"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
 func init() {
@@ -28,9 +31,6 @@ func init() {
 // mutate populates the ENI-specific fields of nodeResource using EC2 IMDS
 // metadata and the agent configuration carried in in.
 func mutate(ctx context.Context, in nodediscovery.ENIMutateInputs, nodeResource *ciliumv2.CiliumNode) error {
-	// set ENI field in the node only when the ENI ipam is specified
-	nodeResource.Spec.ENI = awsTypes.ENISpec{}
-
 	imds, err := awsMetadata.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to create EC2 metadata client: %w", err)
@@ -43,71 +43,119 @@ func mutate(ctx context.Context, in nodediscovery.ENIMutateInputs, nodeResource 
 		return errors.New("InstanceID of own EC2 instance is empty")
 	}
 
-	// It is important to determine the interface index here because this
-	// function will be called when the agent is first coming up and is
-	// initializing the IPAM layer (CRD allocator in this case). Later on,
-	// the Operator will adjust this value based on the PreAllocate value,
-	// so to ensure that the agent and the Operator are not conflicting
-	// with each other, we must have similar logic to determine the
-	// appropriate value to place inside the resource.
-	nodeResource.Spec.ENI.VpcID = info.VPCID
-	nodeResource.Spec.ENI.FirstInterfaceIndex = aws.Int(in.FirstInterfaceIndex)
-	nodeResource.Spec.ENI.UsePrimaryAddress = aws.Bool(in.UsePrimaryAddress)
-	nodeResource.Spec.ENI.DisablePrefixDelegation = aws.Bool(in.DisablePrefixDelegation)
-	nodeResource.Spec.ENI.DeleteOnTermination = aws.Bool(in.DeleteOnTermination)
+	apply(in, info, nodeResource)
+	return nil
+}
 
-	nodeResource.Spec.ENI.SubnetIDs = in.SubnetIDs
-	nodeResource.Spec.ENI.SubnetTags = in.SubnetTags
-	nodeResource.Spec.ENI.SecurityGroups = in.SecurityGroups
-	nodeResource.Spec.ENI.SecurityGroupTags = in.SecurityGroupTags
-	nodeResource.Spec.ENI.ExcludeInterfaceTags = in.ExcludeInterfaceTags
-
-	nodeResource.Spec.IPAM.MinAllocate = in.IPAMMinAllocate
-	nodeResource.Spec.IPAM.PreAllocate = in.IPAMPreAllocate
-	nodeResource.Spec.IPAM.MaxAllocate = in.IPAMMaxAllocate
-
+// apply writes the ENI-specific fields of nodeResource from the instance
+// metadata in info and the agent configuration in in. It is separated from
+// mutate so that the precedence rules between the agent configuration, the
+// CNI configuration file and the instance metadata are testable without an
+// IMDS endpoint.
+//
+// Precedence is expressed as the order of the three stages below rather than
+// as statement position within a single function: whatever the CNI
+// configuration file sets can only reach fields written by
+// applyAgentConfiguration, since applyInstanceFacts runs last and
+// unconditionally. Fields describing the instance the agent runs on therefore
+// belong in applyInstanceFacts, which no configuration can override.
+func apply(in nodediscovery.ENIMutateInputs, info awsMetadata.MetaDataInfo, nodeResource *ciliumv2.CiliumNode) {
+	applyAgentConfiguration(in, &nodeResource.Spec)
 	if c := in.CNIConfigManager.GetCustomNetConf(); c != nil {
-		if c.IPAM.MinAllocate != 0 {
-			nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
-		}
-		if c.IPAM.PreAllocate != 0 {
-			nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-		}
-		if c.ENI.FirstInterfaceIndex != nil {
-			nodeResource.Spec.ENI.FirstInterfaceIndex = c.ENI.FirstInterfaceIndex
-		}
-		if len(c.ENI.SecurityGroups) > 0 {
-			nodeResource.Spec.ENI.SecurityGroups = c.ENI.SecurityGroups
-		}
-		if len(c.ENI.SecurityGroupTags) > 0 {
-			nodeResource.Spec.ENI.SecurityGroupTags = c.ENI.SecurityGroupTags
-		}
-		if len(c.ENI.SubnetIDs) > 0 {
-			nodeResource.Spec.ENI.SubnetIDs = c.ENI.SubnetIDs
-		}
-		if len(c.ENI.SubnetTags) > 0 {
-			nodeResource.Spec.ENI.SubnetTags = c.ENI.SubnetTags
-		}
-		if c.ENI.VpcID != "" {
-			nodeResource.Spec.ENI.VpcID = c.ENI.VpcID
-		}
-		if len(c.ENI.ExcludeInterfaceTags) > 0 {
-			nodeResource.Spec.ENI.ExcludeInterfaceTags = c.ENI.ExcludeInterfaceTags
-		}
-		if c.ENI.UsePrimaryAddress != nil {
-			nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
-		}
-		if c.ENI.DisablePrefixDelegation != nil {
-			nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
-		}
-		if c.ENI.DeleteOnTermination != nil {
-			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
-		}
+		overrideFromNetConf(in.Logger, &nodeResource.Spec, c, info)
+	}
+	applyInstanceFacts(&nodeResource.Spec, info)
+}
+
+// applyAgentConfiguration writes the fields chosen by the agent
+// configuration, i.e. every field which the CNI configuration file is allowed
+// to override.
+func applyAgentConfiguration(in nodediscovery.ENIMutateInputs, spec *ciliumv2.NodeSpec) {
+	spec.ENI = awsTypes.ENISpec{
+		FirstInterfaceIndex:     aws.Int(in.FirstInterfaceIndex),
+		UsePrimaryAddress:       aws.Bool(in.UsePrimaryAddress),
+		DisablePrefixDelegation: aws.Bool(in.DisablePrefixDelegation),
+		DeleteOnTermination:     aws.Bool(in.DeleteOnTermination),
+
+		SubnetIDs:            in.SubnetIDs,
+		SubnetTags:           in.SubnetTags,
+		SecurityGroups:       in.SecurityGroups,
+		SecurityGroupTags:    in.SecurityGroupTags,
+		ExcludeInterfaceTags: in.ExcludeInterfaceTags,
 	}
 
-	nodeResource.Spec.InstanceID = info.InstanceID
-	nodeResource.Spec.ENI.InstanceType = info.InstanceType
-	nodeResource.Spec.ENI.AvailabilityZone = info.AvailabilityZone
-	nodeResource.Spec.ENI.NodeSubnetID = info.SubnetID
-	return nil
+	spec.IPAM.MinAllocate = in.IPAMMinAllocate
+	spec.IPAM.PreAllocate = in.IPAMPreAllocate
+	spec.IPAM.MaxAllocate = in.IPAMMaxAllocate
+}
+
+// overrideFromNetConf applies the ENI and IPAM settings of the CNI
+// configuration file c on top of the agent configuration. Settings which
+// describe the instance are not applied, only reported when they disagree
+// with the instance metadata in info, see warnIgnoredInstanceFact.
+func overrideFromNetConf(logger *slog.Logger, spec *ciliumv2.NodeSpec, c *cnitypes.NetConf, info awsMetadata.MetaDataInfo) {
+	if c.IPAM.MinAllocate != 0 {
+		spec.IPAM.MinAllocate = c.IPAM.MinAllocate
+	}
+	if c.IPAM.PreAllocate != 0 {
+		spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+	}
+	if c.ENI.FirstInterfaceIndex != nil {
+		spec.ENI.FirstInterfaceIndex = c.ENI.FirstInterfaceIndex
+	}
+	if len(c.ENI.SecurityGroups) > 0 {
+		spec.ENI.SecurityGroups = c.ENI.SecurityGroups
+	}
+	if len(c.ENI.SecurityGroupTags) > 0 {
+		spec.ENI.SecurityGroupTags = c.ENI.SecurityGroupTags
+	}
+	if len(c.ENI.SubnetIDs) > 0 {
+		spec.ENI.SubnetIDs = c.ENI.SubnetIDs
+	}
+	if len(c.ENI.SubnetTags) > 0 {
+		spec.ENI.SubnetTags = c.ENI.SubnetTags
+	}
+	if len(c.ENI.ExcludeInterfaceTags) > 0 {
+		spec.ENI.ExcludeInterfaceTags = c.ENI.ExcludeInterfaceTags
+	}
+	if c.ENI.UsePrimaryAddress != nil {
+		spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
+	}
+	if c.ENI.DisablePrefixDelegation != nil {
+		spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
+	}
+	if c.ENI.DeleteOnTermination != nil {
+		spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
+	}
+
+	warnIgnoredInstanceFact(logger, "vpc-id", c.ENI.VpcID, info.VPCID)
+	warnIgnoredInstanceFact(logger, "instance-type", c.ENI.InstanceType, info.InstanceType)
+	warnIgnoredInstanceFact(logger, "availability-zone", c.ENI.AvailabilityZone, info.AvailabilityZone)
+	warnIgnoredInstanceFact(logger, "node-subnet-id", c.ENI.NodeSubnetID, info.SubnetID)
+}
+
+// applyInstanceFacts writes the fields describing the EC2 instance the agent
+// runs on. It runs after overrideFromNetConf so that instance metadata always
+// wins over configuration.
+func applyInstanceFacts(spec *ciliumv2.NodeSpec, info awsMetadata.MetaDataInfo) {
+	spec.InstanceID = info.InstanceID
+	spec.ENI.VpcID = info.VPCID
+	spec.ENI.InstanceType = info.InstanceType
+	spec.ENI.AvailabilityZone = info.AvailabilityZone
+	spec.ENI.NodeSubnetID = info.SubnetID
+}
+
+// warnIgnoredInstanceFact reports an ENISpec field which the CNI
+// configuration file sets to something other than what EC2 instance metadata
+// reports, and which is therefore ignored.
+func warnIgnoredInstanceFact(logger *slog.Logger, key, confValue, imdsValue string) {
+	if confValue == "" || confValue == imdsValue {
+		return
+	}
+	logger.Warn(
+		"Ignoring CNI configuration field determined by EC2 instance metadata",
+		logfields.ConfigKey, key,
+		logfields.Value, confValue,
+		logfields.Actual, imdsValue,
+	)
 }

--- a/pkg/nodediscovery/eni/eni_test.go
+++ b/pkg/nodediscovery/eni/eni_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eni
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cnifake "github.com/cilium/cilium/daemon/cmd/cni/fake"
+	awsMetadata "github.com/cilium/cilium/pkg/aws/metadata"
+	awsTypes "github.com/cilium/cilium/pkg/aws/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
+// netConfManager serves a fixed CNI configuration file.
+type netConfManager struct {
+	cnifake.FakeCNIConfigManager
+	conf *cnitypes.NetConf
+}
+
+func (m *netConfManager) GetCustomNetConf() *cnitypes.NetConf { return m.conf }
+
+// TestApplyInstanceFactsNotOverridable asserts that the fields of ENISpec
+// which describe the instance rather than a configuration choice keep their
+// IMDS values, even when the CNI configuration file sets all of them.
+//
+// NetConf embeds the whole ENISpec (plugins/cilium-cni/types/types.go), so
+// every field of it is CNI-configurable for free, and which ones are actually
+// honored is expressed as the order in which apply() runs
+// overrideFromNetConf and applyInstanceFacts. This test turns that ordering
+// into a checked invariant.
+func TestApplyInstanceFactsNotOverridable(t *testing.T) {
+	info := awsMetadata.MetaDataInfo{
+		InstanceID:       "i-instance",
+		InstanceType:     "m5.large",
+		AvailabilityZone: "us-east-1a",
+		VPCID:            "vpc-imds",
+		SubnetID:         "subnet-imds",
+	}
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	in := nodediscovery.ENIMutateInputs{
+		Logger: logger,
+		CNIConfigManager: &netConfManager{conf: &cnitypes.NetConf{
+			ENI: awsTypes.ENISpec{
+				VpcID:            "vpc-cni",
+				InstanceType:     "c5.xlarge",
+				AvailabilityZone: "eu-west-1b",
+				NodeSubnetID:     "subnet-cni",
+			},
+		}},
+	}
+
+	node := &ciliumv2.CiliumNode{}
+	apply(in, info, node)
+
+	require.Equal(t, info.InstanceID, node.Spec.InstanceID)
+	require.Equal(t, info.VPCID, node.Spec.ENI.VpcID)
+	require.Equal(t, info.InstanceType, node.Spec.ENI.InstanceType)
+	require.Equal(t, info.AvailabilityZone, node.Spec.ENI.AvailabilityZone)
+	require.Equal(t, info.SubnetID, node.Spec.ENI.NodeSubnetID)
+
+	for _, key := range []string{"vpc-id", "instance-type", "availability-zone", "node-subnet-id"} {
+		require.Contains(t, logs.String(), "configKey="+key)
+	}
+}

--- a/pkg/nodediscovery/nodediscovery_eni.go
+++ b/pkg/nodediscovery/nodediscovery_eni.go
@@ -5,6 +5,7 @@ package nodediscovery
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -18,6 +19,7 @@ import (
 // pkg/nodediscovery/eni, is what links against the AWS SDK and the EC2 IMDS
 // client.
 type ENIMutateInputs struct {
+	Logger                  *slog.Logger
 	FirstInterfaceIndex     int
 	UsePrimaryAddress       bool
 	DisablePrefixDelegation bool
@@ -58,6 +60,7 @@ func (n *NodeDiscovery) mutateENINodeResource(ctx context.Context, nodeResource 
 		return nil
 	}
 	return eniMutator(ctx, ENIMutateInputs{
+		Logger:                  n.logger,
 		FirstInterfaceIndex:     n.config.ENIFirstInterfaceIndex,
 		UsePrimaryAddress:       n.config.ENIUsePrimaryAddress,
 		DisablePrefixDelegation: n.config.ENIDisablePrefixDelegation,


### PR DESCRIPTION
`NetConf.ENI` embeds the whole `awsTypes.ENISpec`, so every `ENISpec` field is CNI-configurable by default. Which of them the mutator actually honors is expressed only as statement position relative to the `GetCustomNetConf` block: `InstanceType`, `AvailabilityZone` and `NodeSubnetID` are assigned after it and are therefore currently unoverridable, but `VpcID` was assigned before it and could be clobbered.

Overriding `vpc-id` has exactly two reachable outcomes: set it to the real VPC (a no-op), or set it to any other VPC, in which case the operator selects subnets and security groups in a VPC the instance is not in, `CreateNetworkInterface` would succeed there, but `AttachNetworkInterface` would fail with a cross-VPC attachment error. That happens on allocation attempt, so the misconfiguration would manifest as IP exhaustion rather than as a config error.

This PR moves the VpcID assignment down beside its three siblings so IMDS wins, and replace the override with a warning that names both values and states that the CNI conf value is discarded.

No currently-working configuration changes behavior, previously-broken ones start working instead of failing obscurely.

Note: I discovered this while working on #47974

```release-note
The AWS ENI `vpc-id` field in the CNI configuration can no longer override the value discovered from IMDS. A warning is logged instead if the two differ.
```