### PR TITLE
node: fix CiliumNode retaining a stale node IP when the address changes after agent startup

### DIFF
--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -64,6 +64,10 @@ type localNodeSynchronizerParams struct {
 type localNodeSynchronizer struct {
 	localNodeSynchronizerParams
 	old node.LocalNode
+
+	// Node IPs pinned via --ipv{4,6}-node-addr are never synced from k8s.
+	staticIPv4NodeAddr bool
+	staticIPv6NodeAddr bool
 }
 
 func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.LocalNode) error {
@@ -150,6 +154,7 @@ func (ini *localNodeSynchronizer) initFromConfig(n *node.LocalNode) error {
 				return fmt.Errorf("Invalid IPv6 node address: %q not a global unicast address", ip)
 			}
 			n.SetNodeInternalIP(ip)
+			ini.staticIPv6NodeAddr = true
 		}
 	}
 	if ini.Config.IPv4NodeAddr != "auto" {
@@ -157,6 +162,7 @@ func (ini *localNodeSynchronizer) initFromConfig(n *node.LocalNode) error {
 			return fmt.Errorf("Invalid IPv4 node address: %q", ini.Config.IPv4NodeAddr)
 		} else {
 			n.SetNodeInternalIP(ip)
+			ini.staticIPv4NodeAddr = true
 		}
 	}
 	return nil
@@ -258,7 +264,32 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 func (ini *localNodeSynchronizer) mutableFieldsEqual(new *node.LocalNode) bool {
 	return maps.Equal(ini.old.Labels, new.Labels) &&
 		maps.Equal(ini.old.Annotations, new.Annotations) &&
-		ini.old.Local.UID == new.Local.UID && ini.old.Local.ProviderID == new.Local.ProviderID
+		ini.old.Local.UID == new.Local.UID && ini.old.Local.ProviderID == new.Local.ProviderID &&
+		ini.nodeIPsEqual(new)
+}
+
+func (ini *localNodeSynchronizer) nodeIPsEqual(new *node.LocalNode) bool {
+	for _, ipv6 := range []bool{false, true} {
+		if ini.staticNodeAddr(ipv6) {
+			continue
+		}
+		// Skip absent families, as syncNodeIPsFromK8s does: reporting a change
+		// that it then declines to apply would make every event an update.
+		if ip := new.GetNodeIP(ipv6); ip != nil && !ini.old.GetNodeIP(ipv6).Equal(ip) {
+			return false
+		}
+		if ip := new.GetExternalIP(ipv6); ip != nil && !ini.old.GetExternalIP(ipv6).Equal(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ini *localNodeSynchronizer) staticNodeAddr(ipv6 bool) bool {
+	if ipv6 {
+		return ini.staticIPv6NodeAddr
+	}
+	return ini.staticIPv4NodeAddr
 }
 
 // syncFromK8s synchronizes the fields that can be mutated at runtime
@@ -305,6 +336,41 @@ func (ini *localNodeSynchronizer) syncFromK8s(ln, new *node.LocalNode) {
 		logfields.UID, ln.Local.UID,
 		logfields.ProviderID, ln.Local.ProviderID,
 	)
+
+	ini.syncNodeIPsFromK8s(ln, new)
+}
+
+// syncNodeIPsFromK8s adopts node IPs that changed after startup.
+func (ini *localNodeSynchronizer) syncNodeIPsFromK8s(ln, new *node.LocalNode) {
+	for _, ipv6 := range []bool{false, true} {
+		if ini.staticNodeAddr(ipv6) {
+			continue
+		}
+
+		// GetNodeIP returns nil for a family the Node object omits, and
+		// SetNodeInternalIP(nil) would delete the address rather than update it.
+		if ip := new.GetNodeIP(ipv6); ip != nil {
+			if !ln.GetNodeIP(ipv6).Equal(ip) {
+				ln.SetNodeInternalIP(ip)
+				ini.Logger.Info(
+					"Local node internal IP updated",
+					logfields.IPAddr, ip,
+				)
+			}
+			ini.old.SetNodeInternalIP(ip)
+		}
+
+		if ip := new.GetExternalIP(ipv6); ip != nil {
+			if !ln.GetExternalIP(ipv6).Equal(ip) {
+				ln.SetNodeExternalIP(ip)
+				ini.Logger.Info(
+					"Local node external IP updated",
+					logfields.IPAddr, ip,
+				)
+			}
+			ini.old.SetNodeExternalIP(ip)
+		}
+	}
 }
 
 func parseNode(logger *slog.Logger, k8sNode *slim_corev1.Node) *node.LocalNode {

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -365,3 +365,150 @@ func testNodeDeletion(t *testing.T, nodeEvent resource.Event[*slim_corev1.Node])
 	}
 	assert.True(t, foundDeleted, "Node should be marked as being deleted")
 }
+
+// A node IP corrected after startup must reach the LocalNodeStore.
+func TestLocalNodeSync_NodeIPChange(t *testing.T) {
+	nodeWith := func(ipv4, ipv6 string) *slim_corev1.Node {
+		var addrs []slim_corev1.NodeAddress
+		for _, ip := range []string{ipv4, ipv6} {
+			if ip != "" {
+				addrs = append(addrs, slim_corev1.NodeAddress{Type: slim_corev1.NodeInternalIP, Address: ip})
+			}
+		}
+		return &slim_corev1.Node{
+			ObjectMeta: slim_metav1.ObjectMeta{Name: "foo", UID: k8stypes.UID("uid1")},
+			Status:     slim_corev1.NodeStatus{Addresses: addrs},
+		}
+	}
+
+	// Each case starts on the stale pair, then observes the fresh one.
+	tests := []struct {
+		name                 string
+		ipv4NodeAddr         string
+		ipv6NodeAddr         string
+		freshIPv4, freshIPv6 string
+		wantIPv4, wantIPv6   string
+	}{
+		{
+			name:         "ipv6 changed",
+			ipv4NodeAddr: "auto", ipv6NodeAddr: "auto",
+			freshIPv4: "10.0.0.1", freshIPv6: "fc00::2",
+			wantIPv4: "10.0.0.1", wantIPv6: "fc00::2",
+		},
+		{
+			name:         "ipv4 changed",
+			ipv4NodeAddr: "auto", ipv6NodeAddr: "auto",
+			freshIPv4: "10.0.0.2", freshIPv6: "fc00::1",
+			wantIPv4: "10.0.0.2", wantIPv6: "fc00::1",
+		},
+		{
+			name:         "both changed",
+			ipv4NodeAddr: "auto", ipv6NodeAddr: "auto",
+			freshIPv4: "10.0.0.2", freshIPv6: "fc00::2",
+			wantIPv4: "10.0.0.2", wantIPv6: "fc00::2",
+		},
+		{
+			name:         "statically configured families are not overridden",
+			ipv4NodeAddr: "10.0.0.1", ipv6NodeAddr: "fc00::1",
+			freshIPv4: "10.0.0.2", freshIPv6: "fc00::2",
+			wantIPv4: "10.0.0.1", wantIPv6: "fc00::1",
+		},
+		{
+			name:         "absent family is not removed",
+			ipv4NodeAddr: "auto", ipv6NodeAddr: "auto",
+			freshIPv4: "", freshIPv6: "fc00::2",
+			wantIPv4: "10.0.0.1", wantIPv6: "fc00::2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := make(chan resource.Event[*slim_corev1.Node], 2)
+			for _, n := range []*slim_corev1.Node{
+				nodeWith("10.0.0.1", "fc00::1"),
+				nodeWith(tt.freshIPv4, tt.freshIPv6),
+			} {
+				events <- resource.Event[*slim_corev1.Node]{
+					Kind:   resource.Upsert,
+					Key:    resource.Key{Name: "foo"},
+					Object: n,
+					Done:   func(err error) {},
+				}
+			}
+			close(events)
+
+			sync := newLocalNodeSynchronizer(localNodeSynchronizerParams{
+				Logger:       hivetest.Logger(t),
+				Config:       &option.DaemonConfig{IPv4NodeAddr: tt.ipv4NodeAddr, IPv6NodeAddr: tt.ipv6NodeAddr},
+				K8sLocalNode: &fakeLocalNode{events: events},
+				K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+					items: []resource.Event[*v2.CiliumNode]{{Kind: resource.Sync, Done: func(err error) {}}},
+				},
+				IPsecConfig: fakeipsec.Config{},
+			})
+
+			local := node.LocalNode{Local: &node.LocalNodeInfo{}}
+			require.NoError(t, sync.InitLocalNode(t.Context(), &local))
+			// Init consumed the first event, so the agent starts on the stale pair.
+			require.Equal(t, "fc00::1", local.GetNodeInternalIPv6().String())
+
+			store := node.NewTestLocalNodeStore(local)
+			sync.SyncLocalNode(t.Context(), store)
+
+			n, err := store.Get(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, tt.wantIPv4, n.GetNodeInternalIPv4().String())
+			require.Equal(t, tt.wantIPv6, n.GetNodeInternalIPv6().String())
+		})
+	}
+}
+
+// An unchanged Node must compare equal, or every event becomes a store update.
+// For a v6-only Node: GetNodeIP is nil for IPv4, which is a valid steady state
+// rather than a change to apply.
+func TestLocalNodeSync_NodeIPsEqualIsStable(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		ipv4, ipv6 string
+	}{
+		{name: "dual stack", ipv4: "10.0.0.1", ipv6: "fc00::1"},
+		{name: "ipv6 only", ipv4: "", ipv6: "fc00::1"},
+		{name: "ipv4 only", ipv4: "10.0.0.1", ipv6: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var addrs []slim_corev1.NodeAddress
+			for _, ip := range []string{tt.ipv4, tt.ipv6} {
+				if ip != "" {
+					addrs = append(addrs, slim_corev1.NodeAddress{Type: slim_corev1.NodeInternalIP, Address: ip})
+				}
+			}
+			k8sNode := &slim_corev1.Node{
+				ObjectMeta: slim_metav1.ObjectMeta{Name: "foo", UID: k8stypes.UID("uid1")},
+				Status:     slim_corev1.NodeStatus{Addresses: addrs},
+			}
+
+			events := make(chan resource.Event[*slim_corev1.Node], 1)
+			events <- resource.Event[*slim_corev1.Node]{
+				Kind: resource.Upsert, Key: resource.Key{Name: "foo"},
+				Object: k8sNode, Done: func(err error) {},
+			}
+			close(events)
+
+			sync := newLocalNodeSynchronizer(localNodeSynchronizerParams{
+				Logger:       hivetest.Logger(t),
+				Config:       &option.DaemonConfig{IPv4NodeAddr: "auto", IPv6NodeAddr: "auto"},
+				K8sLocalNode: &fakeLocalNode{events: events},
+				K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+					items: []resource.Event[*v2.CiliumNode]{{Kind: resource.Sync, Done: func(err error) {}}},
+				},
+				IPsecConfig: fakeipsec.Config{},
+			})
+
+			local := node.LocalNode{Local: &node.LocalNodeInfo{}}
+			require.NoError(t, sync.InitLocalNode(t.Context(), &local))
+
+			require.True(t, sync.(*localNodeSynchronizer).mutableFieldsEqual(parseNode(hivetest.Logger(t), k8sNode)),
+				"re-observing the same Node must not report a change")
+		})
+	}
+}


### PR DESCRIPTION
Changes to the node's addresses never reached the LocalNodeStore and the agent kept the IP it read at init. If the kubelet published a stale address at agent start, CiliumNode kept the old IP.

In syncFromK8s, compare and adopt the node IPs.

An absent family is skipped: on a v4- or v6-only cluster the other family is legitimately nil.

Fixes: #15406, #17500

```release-note
Fix CiliumNode retaining a stale node IP when the address changes after agent startup.
```

This PR was prepared with AIL:4. I personally validated the before and after results. My system is IPv6-first with IPv4.  The IPv4 address is semi-stable by DHCP (will eventually expire if not renewed) but a new IPv6 is chosen with SLAAC on every boot.  On boot the Kubelet initially publishes a stale IP that is then updated, but in the original code CiliumNode kept the stale IP, causing Cilium to not come up on reboot.  Following this change and a similar one to cilium-health (next PR) reboots now work with no errors.