### PR TITLE
health: fix failing to serve when a node address is not bindable at startup

### DIFF
--- a/pkg/health/health_connectivity_node.go
+++ b/pkg/health/health_connectivity_node.go
@@ -59,12 +59,7 @@ func (h *ciliumHealthManager) launchCiliumNodeHealth(ctx context.Context, spec *
 		HealthAPISpec: spec,
 	}
 
-	ln, err := h.localNodeStore.Get(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get local node: %w", err)
-	}
-
-	ch.server, err = server.NewServer(h.logger, config, h.healthConfig.IsActiveHealthCheckingEnabled(), ln)
+	ch.server, err = server.NewServer(h.logger, config, h.healthConfig.IsActiveHealthCheckingEnabled(), h.localNodeStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate cilium-health server: %w", err)
 	}

--- a/pkg/health/probe/responder/responder.go
+++ b/pkg/health/probe/responder/responder.go
@@ -11,53 +11,84 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // defaultTimeout used for shutdown
 var defaultTimeout = 30 * time.Second
 
+var listenRetryInterval = 5 * time.Second
+
 // Server wraps a minimal http server for the /hello endpoint
 type Server struct {
+	// addresses is read when a listener binds rather than when the server is
+	// created, so that a listener follows the node address.
+	addresses func() []string
+	port      int
+
 	httpServers []*http.Server
+	shutdown    chan struct{}
+	shutdownOne sync.Once
 }
 
 // NewServer creates a new server listening on the given port
 func NewServers(address []string, port int) *Server {
-	if len(address) == 0 {
-		address = []string{""}
-	}
-
-	server := &Server{}
-	for _, ip := range address {
-		addr := net.JoinHostPort(ip, fmt.Sprintf("%v", port))
-		hs := http.Server{
-			Addr:    addr,
-			Handler: http.HandlerFunc(serverRequests),
-		}
-		server.httpServers = append(server.httpServers, &hs)
-	}
-
-	return server
+	return newServers(func() []string { return address }, port)
 }
 
-// Serve http requests until shut down
-func (s *Server) Serve() error {
-	errors := make(chan error)
-	for _, hs := range s.httpServers {
-		tmpHttpServer := hs
-		go func() {
-			errors <- tmpHttpServer.ListenAndServe()
-		}()
-	}
+// NewServersFunc is NewServers for addresses that change while running:
+// addresses is called again every time a listener binds.
+func NewServersFunc(addresses func() []string, port int) *Server {
+	return newServers(addresses, port)
+}
 
-	// Block for the first error, then return.
-	err := <-errors
-	return err
+func newServers(addresses func() []string, port int) *Server {
+	s := &Server{addresses: addresses, port: port, shutdown: make(chan struct{})}
+	for range addresses() {
+		s.httpServers = append(s.httpServers, &http.Server{
+			Handler: http.HandlerFunc(serverRequests),
+		})
+	}
+	return s
+}
+
+func (s *Server) listenAddr(i int) string {
+	ips := s.addresses()
+	if i >= len(ips) {
+		return ""
+	}
+	return net.JoinHostPort(ips[i], fmt.Sprintf("%v", s.port))
+}
+
+// Serve http requests until shut down, rebinding a listener whose address is
+// not assignable yet or has since changed.
+func (s *Server) Serve() error {
+	var wg sync.WaitGroup
+	for i, hs := range s.httpServers {
+		wg.Go(func() {
+			for {
+				if hs.Addr = s.listenAddr(i); hs.Addr != "" {
+					if errors.Is(hs.ListenAndServe(), http.ErrServerClosed) {
+						return
+					}
+				}
+				select {
+				case <-s.shutdown:
+					return
+				case <-time.After(listenRetryInterval):
+				}
+			}
+		})
+	}
+	wg.Wait()
+	return http.ErrServerClosed
 }
 
 // Shutdown server gracefully
 func (s *Server) Shutdown() error {
+	s.shutdownOne.Do(func() { close(s.shutdown) })
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	errs := make([]error, 0, len(s.httpServers))

--- a/pkg/health/probe/responder/responder_test.go
+++ b/pkg/health/probe/responder/responder_test.go
@@ -4,9 +4,16 @@
 package responder
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewServersInitialization(t *testing.T) {
@@ -35,10 +42,10 @@ func TestNewServersInitialization(t *testing.T) {
 			exptectedServerAddress: []string{"192.168.1.4:4240", "[fc00:c111::2]:4240"},
 		},
 		{
-			name:                   "Initialize http server with nil address",
+			name:                   "No address means no listener",
 			address:                []string{},
-			expectedServerCount:    1,
-			exptectedServerAddress: []string{":4240"},
+			expectedServerCount:    0,
+			exptectedServerAddress: nil,
 		},
 	}
 
@@ -46,8 +53,124 @@ func TestNewServersInitialization(t *testing.T) {
 		s := NewServers(tt.address, 4240)
 		assert.NotNil(t, s)
 		assert.Len(t, s.httpServers, tt.expectedServerCount, "Number of listen address doesn't match")
-		for i, s := range s.httpServers {
-			assert.Equal(t, tt.exptectedServerAddress[i], s.Addr)
+		for i := range s.httpServers {
+			assert.Equal(t, tt.exptectedServerAddress[i], s.listenAddr(i))
 		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	listenRetryInterval = 10 * time.Millisecond
+	os.Exit(m.Run())
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func serving(url string) bool {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// An address that is not assignable must not stop the listeners that did bind.
+func TestServeRetriesWithoutStoppingOthers(t *testing.T) {
+	port := freePort(t)
+
+	// 192.0.2.0/24 is TEST-NET-1: never assigned to an interface.
+	s := NewServers([]string{"127.0.0.1", "192.0.2.1"}, port)
+	go s.Serve()
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/hello", port)
+	require.Eventually(t, func() bool { return serving(url) },
+		5*time.Second, 20*time.Millisecond, "assignable address must serve while another fails")
+
+	time.Sleep(50 * time.Millisecond)
+	require.True(t, serving(url), "must keep serving while the other address retries")
+}
+
+// A listener must follow the address when it changes.
+func TestServeFollowsAddressChange(t *testing.T) {
+	port := freePort(t)
+
+	var mu sync.Mutex
+	host := "192.0.2.1"
+	s := NewServersFunc(func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return []string{host}
+	}, port)
+	go s.Serve()
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/hello", port)
+	require.False(t, serving(url), "must not serve before the address is assignable")
+
+	mu.Lock()
+	host = "127.0.0.1"
+	mu.Unlock()
+
+	require.Eventually(t, func() bool { return serving(url) },
+		5*time.Second, 20*time.Millisecond, "listener must bind the new address")
+}
+
+// A family gaining an address must not move another family's listener.
+func TestServeAddressPositionStable(t *testing.T) {
+	port := freePort(t)
+	var mu sync.Mutex
+	// v4 enabled but absent, v6 present: one empty slot, one address.
+	ips := []string{"", "::1"}
+	s := NewServersFunc(func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return ips
+	}, port)
+	go s.Serve()
+	defer s.Shutdown()
+
+	url6 := fmt.Sprintf("http://[::1]:%d/hello", port)
+	require.Eventually(t, func() bool { return serving(url6) }, 5*time.Second, 20*time.Millisecond,
+		"v6 must serve")
+
+	mu.Lock()
+	ips = []string{"127.0.0.1", "::1"}
+	mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		return serving(url6) && serving(fmt.Sprintf("http://127.0.0.1:%d/hello", port))
+	}, 5*time.Second, 20*time.Millisecond, "both families must serve once v4 appears")
+}
+
+// Shutdown must stop Serve while a listener is waiting for an address.
+func TestShutdownWhileWaitingForAddress(t *testing.T) {
+	// Two listeners created, but the address list shrinks to one: listener 1
+	// has no address and only ever waits.
+	n := 2
+	s := NewServersFunc(func() []string {
+		if n == 2 {
+			n = 1
+			return []string{"127.0.0.1", "::1"}
+		}
+		return []string{"127.0.0.1"}
+	}, freePort(t))
+
+	done := make(chan error, 1)
+	go func() { done <- s.Serve() }()
+	time.Sleep(100 * time.Millisecond)
+	s.Shutdown()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after Shutdown: a listener with no address spins forever")
 	}
 }

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
@@ -415,7 +416,7 @@ func (s *Server) newServer(logger *slog.Logger, spec *healthApi.Spec) *healthApi
 }
 
 // NewServer creates a server to handle health requests.
-func NewServer(logger *slog.Logger, config Config, enableActiveChecks bool, localNode node.LocalNode) (*Server, error) {
+func NewServer(logger *slog.Logger, config Config, enableActiveChecks bool, localNodeStore *node.LocalNodeStore) (*Server, error) {
 	server := &Server{
 		logger:             logger,
 		startTime:          time.Now(),
@@ -433,32 +434,37 @@ func NewServer(logger *slog.Logger, config Config, enableActiveChecks bool, loca
 	server.Client = cl
 	server.Server = *server.newServer(logger, config.HealthAPISpec)
 
-	server.httpPathServer = responder.NewServers(getAddresses(localNode), config.HTTPPathPort)
+	server.httpPathServer = responder.NewServersFunc(
+		func() []string { return getAddresses(localNodeStore) }, config.HTTPPathPort)
 
 	return server, nil
 }
 
-// Get internal node ipv4/ipv6 addresses based on config enabled.
-// If it fails to get either of internal node address, it returns "0.0.0.0" if ipv4 or "::" if ipv6.
-func getAddresses(localNode node.LocalNode) []string {
+// Get internal node ipv4/ipv6 addresses based on config enabled. One entry per
+// enabled family, empty while that family has no address: the listener waits
+// for one rather than binding every interface.
+func getAddresses(localNodeStore *node.LocalNodeStore) []string {
+	// Get only fails on a cancelled context, and blocks until initialized.
+	localNode, _ := localNodeStore.Get(context.Background())
+
 	addresses := make([]string, 0, 2)
 
+	// An entry stays empty while its family has no address, so that a family
+	// gaining one does not move another family's listener.
 	if option.Config.EnableIPv4 {
+		var addr string
 		if ip := localNode.GetNodeInternalIPv4(); ip != nil {
-			addresses = append(addresses, ip.String())
-		} else {
-			// if Get ipv4 fails, then listen on all addresses.
-			return nil
+			addr = ip.String()
 		}
+		addresses = append(addresses, addr)
 	}
 
 	if option.Config.EnableIPv6 {
+		var addr string
 		if ip := localNode.GetNodeInternalIPv6(); ip != nil {
-			addresses = append(addresses, ip.String())
-		} else {
-			// if Get ipv6 fails, then listen on all addresses.
-			return nil
+			addr = ip.String()
 		}
+		addresses = append(addresses, addr)
 	}
 
 	return addresses


### PR DESCRIPTION
The /hello listener addresses were read once when the health server is created, so a listener kept the address the node had at agent startup. At startup kubelet can still be advertising a stale node address, in which case Serve() returned on the bind error and health serving stopped on every address until the agent restarted.

Read the addresses in the responder when a listener binds, and retry a listener that fails instead of returning.

Agent use treats a family with no address as missing rather than a request to listen on all interfaces, which #23353 asked cilium-health not to do. Standalone use retains the wildcard listening behaviour.

Fixes cases where a stale address would be used on startup.  If the address becomes stale during operation in a way that does not cause the listener to fail then it will still not detect that the address changed. This can be done with a more significant change.  Relates to #15406, #17500 on Cilium failures when the node IP changes.

```release-note
Fix cilium-health failing to serve when a node address is not bindable at startup.
```                                                                                                                

This PR was prepared with AIL:4. I personally validated the before and after results. My system is IPv6-first with IPv4.  The IPv4 address is semi-stable by DHCP but a new IPv6 is chosen with SLAAC on every boot.  On boot the Kubelet initially publishes a stale IP.  Without this change cilium-health binds the stale address indefinitely and stops serving on every address. Following this change and #47981 reboots now work with no errors.