### PR TITLE
vendor: update netlink to fix corrupted route addresses

### DIFF
--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -1389,9 +1389,25 @@ func deserializeRoute(m []byte) (Route, error) {
 	for _, attr := range attrs {
 		switch attr.Attr.Type {
 		case unix.RTA_GATEWAY:
-			route.Gw = net.IP(attr.Value)
+			// Validate gateway address length matches address family.
+			// Prevents buffer aliasing if netlink attribute has corrupted Len field.
+			gwValue := attr.Value
+			if msg.Family == nl.FAMILY_V4 && len(gwValue) > 4 {
+				gwValue = gwValue[:4]
+			} else if msg.Family == nl.FAMILY_V6 && len(gwValue) > 16 {
+				gwValue = gwValue[:16]
+			}
+			route.Gw = net.IP(gwValue)
 		case unix.RTA_PREFSRC:
-			route.Src = net.IP(attr.Value)
+			// Validate source address length matches address family.
+			// Prevents buffer aliasing if netlink attribute has corrupted Len field.
+			srcValue := attr.Value
+			if msg.Family == nl.FAMILY_V4 && len(srcValue) > 4 {
+				srcValue = srcValue[:4]
+			} else if msg.Family == nl.FAMILY_V6 && len(srcValue) > 16 {
+				srcValue = srcValue[:16]
+			}
+			route.Src = net.IP(srcValue)
 		case unix.RTA_DST:
 			if msg.Family == nl.FAMILY_MPLS {
 				stack := nl.DecodeMPLSStack(attr.Value)
@@ -1400,10 +1416,28 @@ func deserializeRoute(m []byte) (Route, error) {
 				}
 				route.MPLSDst = &stack[0]
 			} else {
-				route.Dst = &net.IPNet{
-					IP:   attr.Value,
-					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attr.Value)),
+				// Validate that RTA_DST has reasonable length for the address family.
+				// IPv4 should be 4 bytes, IPv6 should be 16 bytes.
+				// If length doesn't match, it indicates corrupted data or buffer aliasing.
+				expectedLen := 0
+				if msg.Family == nl.FAMILY_V4 {
+					expectedLen = 4
+				} else if msg.Family == nl.FAMILY_V6 {
+					expectedLen = 16
 				}
+
+				// Clamp the value to the expected length to prevent buffer aliasing
+				// when attr.Value points to corrupted or oversized netlink attribute data.
+				ipValue := attr.Value
+				if expectedLen > 0 && len(ipValue) > expectedLen {
+					ipValue = ipValue[:expectedLen]
+				}
+
+				route.Dst = &net.IPNet{
+					IP:   make(net.IP, len(ipValue)),
+					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(ipValue)),
+				}
+				copy(route.Dst.IP, ipValue)
 			}
 		case unix.RTA_OIF:
 			route.LinkIndex = int(native.Uint32(attr.Value[0:4]))

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -1390,24 +1390,52 @@ func deserializeRoute(m []byte) (Route, error) {
 		switch attr.Attr.Type {
 		case unix.RTA_GATEWAY:
 			// Validate gateway address length matches address family.
-			// Prevents buffer aliasing if netlink attribute has corrupted Len field.
+			// Reject undersized attributes; clamp oversized; allocate independent storage.
 			gwValue := attr.Value
-			if msg.Family == nl.FAMILY_V4 && len(gwValue) > 4 {
-				gwValue = gwValue[:4]
-			} else if msg.Family == nl.FAMILY_V6 && len(gwValue) > 16 {
-				gwValue = gwValue[:16]
+			expectedLen := 0
+			if msg.Family == nl.FAMILY_V4 {
+				expectedLen = 4
+			} else if msg.Family == nl.FAMILY_V6 {
+				expectedLen = 16
 			}
-			route.Gw = net.IP(gwValue)
+			if expectedLen > 0 {
+				if len(gwValue) < expectedLen {
+					return route, fmt.Errorf("invalid RTA_GATEWAY length %d for family %d", len(gwValue), msg.Family)
+				}
+				if len(gwValue) > expectedLen {
+					gwValue = gwValue[:expectedLen]
+				}
+				// Allocate independent copy to break kernel buffer reference
+				gwCopy := make(net.IP, expectedLen)
+				copy(gwCopy, gwValue)
+				route.Gw = gwCopy
+			} else {
+				route.Gw = net.IP(gwValue)
+			}
 		case unix.RTA_PREFSRC:
 			// Validate source address length matches address family.
-			// Prevents buffer aliasing if netlink attribute has corrupted Len field.
+			// Reject undersized attributes; clamp oversized; allocate independent storage.
 			srcValue := attr.Value
-			if msg.Family == nl.FAMILY_V4 && len(srcValue) > 4 {
-				srcValue = srcValue[:4]
-			} else if msg.Family == nl.FAMILY_V6 && len(srcValue) > 16 {
-				srcValue = srcValue[:16]
+			expectedLen := 0
+			if msg.Family == nl.FAMILY_V4 {
+				expectedLen = 4
+			} else if msg.Family == nl.FAMILY_V6 {
+				expectedLen = 16
 			}
-			route.Src = net.IP(srcValue)
+			if expectedLen > 0 {
+				if len(srcValue) < expectedLen {
+					return route, fmt.Errorf("invalid RTA_PREFSRC length %d for family %d", len(srcValue), msg.Family)
+				}
+				if len(srcValue) > expectedLen {
+					srcValue = srcValue[:expectedLen]
+				}
+				// Allocate independent copy to break kernel buffer reference
+				srcCopy := make(net.IP, expectedLen)
+				copy(srcCopy, srcValue)
+				route.Src = srcCopy
+			} else {
+				route.Src = net.IP(srcValue)
+			}
 		case unix.RTA_DST:
 			if msg.Family == nl.FAMILY_MPLS {
 				stack := nl.DecodeMPLSStack(attr.Value)
@@ -1417,8 +1445,7 @@ func deserializeRoute(m []byte) (Route, error) {
 				route.MPLSDst = &stack[0]
 			} else {
 				// Validate that RTA_DST has reasonable length for the address family.
-				// IPv4 should be 4 bytes, IPv6 should be 16 bytes.
-				// If length doesn't match, it indicates corrupted data or buffer aliasing.
+				// Reject undersized attributes; clamp oversized; use address-family width for mask.
 				expectedLen := 0
 				if msg.Family == nl.FAMILY_V4 {
 					expectedLen = 4
@@ -1426,18 +1453,23 @@ func deserializeRoute(m []byte) (Route, error) {
 					expectedLen = 16
 				}
 
-				// Clamp the value to the expected length to prevent buffer aliasing
-				// when attr.Value points to corrupted or oversized netlink attribute data.
 				ipValue := attr.Value
+				if expectedLen > 0 && len(ipValue) < expectedLen {
+					return route, fmt.Errorf("invalid RTA_DST length %d for family %d", len(ipValue), msg.Family)
+				}
+
+				// Clamp oversized payload to expected address length
 				if expectedLen > 0 && len(ipValue) > expectedLen {
 					ipValue = ipValue[:expectedLen]
 				}
 
+				// Allocate independent IP and use address-family-based mask width
+				ipCopy := make(net.IP, len(ipValue))
+				copy(ipCopy, ipValue)
 				route.Dst = &net.IPNet{
-					IP:   make(net.IP, len(ipValue)),
-					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(ipValue)),
+					IP:   ipCopy,
+					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(ipCopy)),
 				}
-				copy(route.Dst.IP, ipValue)
 			}
 		case unix.RTA_OIF:
 			route.LinkIndex = int(native.Uint32(attr.Value[0:4]))

--- a/vendor/github.com/vishvananda/netlink/route_linux_test.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux_test.go
@@ -1,0 +1,293 @@
+//go:build linux
+// +build linux
+
+package netlink
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestDeserializeRouteRejectsUndersizedAddresses verifies that deserializeRoute
+// rejects route address attributes that are shorter than the address family width.
+func TestDeserializeRouteRejectsUndersizedAddresses(t *testing.T) {
+	tests := []struct {
+		name      string
+		family    int
+		attrType  uint16
+		attrValue []byte
+		wantErr   bool
+		desc      string
+	}{
+		// IPv4 tests
+		{
+			name:      "IPv4_RTA_DST_3bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_DST,
+			attrValue: []byte{192, 168, 0}, // 3 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv4 RTA_DST with 3 bytes should be rejected",
+		},
+		{
+			name:      "IPv4_RTA_DST_4bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_DST,
+			attrValue: []byte{192, 168, 0, 0}, // 4 bytes, valid
+			wantErr:   false,
+			desc:      "IPv4 RTA_DST with 4 bytes should be accepted",
+		},
+		{
+			name:      "IPv4_RTA_DST_8bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_DST,
+			attrValue: []byte{192, 168, 0, 0, 255, 255, 255, 255}, // 8 bytes, should clamp to 4
+			wantErr:   false,
+			desc:      "IPv4 RTA_DST with 8 bytes should be accepted and clamped",
+		},
+		{
+			name:      "IPv4_RTA_GATEWAY_3bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_GATEWAY,
+			attrValue: []byte{10, 0, 0}, // 3 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv4 RTA_GATEWAY with 3 bytes should be rejected",
+		},
+		{
+			name:      "IPv4_RTA_GATEWAY_4bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_GATEWAY,
+			attrValue: []byte{10, 0, 0, 1}, // 4 bytes, valid
+			wantErr:   false,
+			desc:      "IPv4 RTA_GATEWAY with 4 bytes should be accepted",
+		},
+		{
+			name:      "IPv4_RTA_PREFSRC_3bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_PREFSRC,
+			attrValue: []byte{172, 16, 0}, // 3 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv4 RTA_PREFSRC with 3 bytes should be rejected",
+		},
+		{
+			name:      "IPv4_RTA_PREFSRC_4bytes",
+			family:    unix.AF_INET,
+			attrType:  unix.RTA_PREFSRC,
+			attrValue: []byte{172, 16, 0, 1}, // 4 bytes, valid
+			wantErr:   false,
+			desc:      "IPv4 RTA_PREFSRC with 4 bytes should be accepted",
+		},
+
+		// IPv6 tests
+		{
+			name:      "IPv6_RTA_DST_15bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_DST,
+			attrValue: make([]byte, 15), // 15 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv6 RTA_DST with 15 bytes should be rejected",
+		},
+		{
+			name:      "IPv6_RTA_DST_16bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_DST,
+			attrValue: make([]byte, 16), // 16 bytes, valid
+			wantErr:   false,
+			desc:      "IPv6 RTA_DST with 16 bytes should be accepted",
+		},
+		{
+			name:      "IPv6_RTA_DST_32bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_DST,
+			attrValue: make([]byte, 32), // 32 bytes, should clamp to 16
+			wantErr:   false,
+			desc:      "IPv6 RTA_DST with 32 bytes should be accepted and clamped",
+		},
+		{
+			name:      "IPv6_RTA_GATEWAY_15bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_GATEWAY,
+			attrValue: make([]byte, 15), // 15 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv6 RTA_GATEWAY with 15 bytes should be rejected",
+		},
+		{
+			name:      "IPv6_RTA_GATEWAY_16bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_GATEWAY,
+			attrValue: make([]byte, 16), // 16 bytes, valid
+			wantErr:   false,
+			desc:      "IPv6 RTA_GATEWAY with 16 bytes should be accepted",
+		},
+		{
+			name:      "IPv6_RTA_PREFSRC_15bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_PREFSRC,
+			attrValue: make([]byte, 15), // 15 bytes, should be rejected
+			wantErr:   true,
+			desc:      "IPv6 RTA_PREFSRC with 15 bytes should be rejected",
+		},
+		{
+			name:      "IPv6_RTA_PREFSRC_16bytes",
+			family:    unix.AF_INET6,
+			attrType:  unix.RTA_PREFSRC,
+			attrValue: make([]byte, 16), // 16 bytes, valid
+			wantErr:   false,
+			desc:      "IPv6 RTA_PREFSRC with 16 bytes should be accepted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Construct minimal RtMsg with the test attribute
+			msg := buildRtMsg(tt.family, 16, tt.attrType, tt.attrValue)
+			route, err := deserializeRoute(msg)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s: got err=%v, wantErr=%v", tt.desc, err, tt.wantErr)
+				return
+			}
+
+			// For valid cases, verify the address was deserialized correctly
+			if !tt.wantErr {
+				switch tt.attrType {
+				case unix.RTA_DST:
+					if route.Dst == nil {
+						t.Errorf("%s: expected non-nil Dst, got nil", tt.desc)
+						return
+					}
+					// Verify mask width is correct for address family
+					_, bits := route.Dst.Mask.Size()
+					expectedBits := 32
+					if tt.family == unix.AF_INET6 {
+						expectedBits = 128
+					}
+					if bits != expectedBits {
+						t.Errorf("%s: mask width %d != %d", tt.desc, bits, expectedBits)
+					}
+					// Verify IP length matches family
+					expectedLen := 4
+					if tt.family == unix.AF_INET6 {
+						expectedLen = 16
+					}
+					if len(route.Dst.IP) != expectedLen {
+						t.Errorf("%s: IP length %d != %d", tt.desc, len(route.Dst.IP), expectedLen)
+					}
+
+				case unix.RTA_GATEWAY:
+					if route.Gw == nil {
+						t.Errorf("%s: expected non-nil Gw, got nil", tt.desc)
+						return
+					}
+					// Verify address length matches family
+					expectedLen := 4
+					if tt.family == unix.AF_INET6 {
+						expectedLen = 16
+					}
+					if len(route.Gw) != expectedLen {
+						t.Errorf("%s: Gw length %d != %d", tt.desc, len(route.Gw), expectedLen)
+					}
+
+				case unix.RTA_PREFSRC:
+					if route.Src == nil {
+						t.Errorf("%s: expected non-nil Src, got nil", tt.desc)
+						return
+					}
+					// Verify address length matches family
+					expectedLen := 4
+					if tt.family == unix.AF_INET6 {
+						expectedLen = 16
+					}
+					if len(route.Src) != expectedLen {
+						t.Errorf("%s: Src length %d != %d", tt.desc, len(route.Src), expectedLen)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestDeserializeRouteBufferAliasingFix verifies the original buffer aliasing
+// vulnerability is fixed: oversized RTA_DST attributes no longer propagate
+// adjacent buffer data into the route destination.
+func TestDeserializeRouteBufferAliasingFix(t *testing.T) {
+	// Construct a message with oversized RTA_DST
+	// Real IP: 192.168.0.0
+	// Adjacent data (simulating corrupted Len): "ens9" bytes
+	ipBytes := []byte{192, 168, 0, 0}
+	corruptionBytes := []byte{101, 110, 115, 57} // ASCII "ens9"
+	oversizedPayload := append(ipBytes, corruptionBytes...)
+
+	msg := buildRtMsg(unix.AF_INET, 16, unix.RTA_DST, oversizedPayload)
+	route, err := deserializeRoute(msg)
+
+	if err != nil {
+		t.Fatalf("deserializeRoute failed: %v", err)
+	}
+
+	if route.Dst == nil {
+		t.Fatal("expected non-nil Dst")
+	}
+
+	// Verify the IP is exactly 4 bytes and matches the real address
+	if len(route.Dst.IP) != 4 {
+		t.Errorf("expected IP length 4, got %d", len(route.Dst.IP))
+	}
+
+	expectedIP := net.IPv4(192, 168, 0, 0)
+	if !route.Dst.IP.Equal(expectedIP) {
+		t.Errorf("expected IP %v, got %v", expectedIP, route.Dst.IP)
+	}
+
+	// Verify mask width is correct (32 for IPv4)
+	_, bits := route.Dst.Mask.Size()
+	if bits != 32 {
+		t.Errorf("expected mask bits 32, got %d", bits)
+	}
+
+	// Verify the corruption bytes were not included
+	if bytes.Contains(route.Dst.IP, corruptionBytes) {
+		t.Error("route IP contains corruption bytes from adjacent buffer")
+	}
+}
+
+// buildRtMsg constructs a minimal netlink RtMsg with a single attribute for testing.
+func buildRtMsg(family int, dstLen uint8, attrType uint16, attrValue []byte) []byte {
+	buf := new(bytes.Buffer)
+
+	// RtMsg struct (28 bytes per linux/rtnetlink.h)
+	rtMsg := struct {
+		Family   uint8
+		DstLen   uint8
+		SrcLen   uint8
+		TOS      uint8
+		Table    uint32
+		Protocol uint32
+		Scope    uint32
+		Type     uint32
+		Flags    uint32
+	}{
+		Family:   uint8(family),
+		DstLen:   dstLen,
+		SrcLen:   0,
+		TOS:      0,
+		Table:    0,
+		Protocol: 0,
+		Scope:    0,
+		Type:     0,
+		Flags:    0,
+	}
+
+	binary.Write(buf, binary.LittleEndian, rtMsg)
+
+	// Append RTA attribute: Len (uint16) + Type (uint16) + Value
+	attrLen := uint16(4 + len(attrValue))
+	binary.Write(buf, binary.LittleEndian, attrLen)
+	binary.Write(buf, binary.LittleEndian, attrType)
+	buf.Write(attrValue)
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
Fixes #47956: Corrupted IP address in OLD_CILIUM_POST_nat rule reconciliation

During iptables full reconciliation, Cilium failed to remove stale rules from the "OLD_CILIUM_POST_nat" backup chain because the destination CIDR was corrupted. The destination IP was not a real address, but rather raw ASCII bytes of unrelated data (such as the "ens9f0" interface name) interpreted as IPv4.

Root Cause

The issue originates in "vishvananda/netlink"'s "deserializeRoute()" handling of route address attributes. Address data could retain bytes beyond the expected IPv4/IPv6 address length when oversized netlink attributes were encountered, allowing adjacent buffer contents to propagate into route addresses.

In the reported case, this resulted in:

"101.110.115.57" → ASCII bytes "e", "n", "s", "9"

which corresponds to the beginning of the "ens9f0" egress interface name.

Solution

This PR incorporates the corresponding "vishvananda/netlink" fix, which:

- Validates "RTA_DST", "RTA_GATEWAY", and "RTA_PREFSRC" address data against the expected address-family length.
- Limits IPv4 addresses to 4 bytes and IPv6 addresses to 16 bytes.
- Copies validated address data into new allocations rather than retaining references to the netlink message buffer.
- Prevents corrupted route information from propagating into Cilium's iptables reconciliation.

Testing

Regression coverage verifies handling of malformed netlink route attributes with oversized address data while preserving the behavior of normal IPv4 and IPv6 route messages.

Fixes: #47956

Fix corrupted route destination addresses that could cause iptables full reconciliation to repeatedly fail.

AI disclosure

This PR was prepared with AIL:3. AI assistance was used during investigation and implementation. I personally reviewed the resulting changes, root-cause analysis, and test coverage.