### PR TITLE
ciliumendpointslice: fix flaky TestRegisterControllerNoCEPs 

### DIFF
--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -166,10 +166,11 @@ func TestRegisterControllerNoCEPs(t *testing.T) {
 	fakeClient, pod, ciliumEndpointSlice, namespace, ciliumNode, ciliumIdentity, _, hive := initHiveTest(t, true, true)
 
 	tlog := hivetest.Logger(t)
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+
 	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
 
 	cesCreated, err := createPodandVerifyCESCreated(t, fakeClient, pod, ciliumEndpointSlice, namespace, ciliumIdentity, ciliumNode)
 


### PR DESCRIPTION
Fixes: #47963

`TestRegisterControllerNoCEPs` was intermittently failing because `labelsfilter.ParseLabelPrefixCfg` was called after `hive.Start()`. 

The SlimController starts processing pod events immediately on startup, and `resolvePodPlacement` calls `key.GetCIDKeyFromLabels` which depends on the label filter being initialized. With an uninitialized filter, pods were dropped during bootstrap or mapped to a wrong identity key, so no CES was written to the apiserver within the test's 1s timeout.

AIL: 0