### PR TITLE
clustermesh: add extra safeguard when parsing service backends

### DIFF
--- a/pkg/clustermesh/loadbalancer/service_merger.go
+++ b/pkg/clustermesh/loadbalancer/service_merger.go
@@ -88,7 +88,13 @@ func (sm *serviceMerger) MergeExternalServiceUpdate(service *serviceStore.Cluste
 
 func ClusterServiceToBackendParams(service *serviceStore.ClusterService) (beps []loadbalancer.Backend) {
 	for ipString, portConfig := range service.Backends {
-		addrCluster := cmtypes.MustParseAddrCluster(ipString)
+		addrCluster, err := cmtypes.ParseAddrCluster(ipString)
+		if err != nil {
+			// Errors are never expected to happen, as the addresses are already
+			// validated upon reception. Still, let's lean on the safe side.
+			continue
+		}
+
 		var backendZone *loadbalancer.BackendZone
 		if zone, ok := service.Zones[ipString]; ok {
 			backendZone = ptr.To(zone.ToLBBackendZone())

--- a/pkg/clustermesh/store/store.go
+++ b/pkg/clustermesh/store/store.go
@@ -145,14 +145,18 @@ func (s *ClusterService) validate() error {
 	}
 
 	for address := range s.Frontends {
-		if _, err := netip.ParseAddr(address); err != nil {
+		if parsed, err := netip.ParseAddr(address); err != nil {
 			return err
+		} else if parsed.Zone() != "" {
+			return fmt.Errorf("unsupported IPv6 zone in address %s", address)
 		}
 	}
 
 	for address := range s.Backends {
-		if _, err := netip.ParseAddr(address); err != nil {
+		if parsed, err := netip.ParseAddr(address); err != nil {
 			return err
+		} else if parsed.Zone() != "" {
+			return fmt.Errorf("unsupported IPv6 zone in address %s", address)
 		}
 	}
 

--- a/pkg/clustermesh/store/store_test.go
+++ b/pkg/clustermesh/store/store_test.go
@@ -154,6 +154,16 @@ func TestClusterServiceValidate(t *testing.T) {
 			},
 			assert: assert.Error,
 		},
+		{
+			name: "backend IP with IPv6 zone",
+			svc: ClusterService{
+				Cluster: "foo", Namespace: "bar", Name: "qux",
+				Backends:  map[string]PortConfiguration{"dcba::0001%zone": {}},
+				Zones:     map[string]BackendZone{},
+				Hostnames: map[string]string{},
+			},
+			assert: assert.Error,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clustermesh/types/endpointslice/endpointslice.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice.go
@@ -170,7 +170,7 @@ func (eps *ClusterEndpointSlice) validate() error {
 				}
 			case slim_discovery_v1.AddressTypeIPv6:
 				addr, err := netip.ParseAddr(address)
-				if err != nil || !addr.Is6() {
+				if err != nil || !addr.Is6() || addr.Zone() != "" {
 					return fmt.Errorf("invalid IPv6 endpoint address: %s", address)
 				}
 			}

--- a/pkg/clustermesh/types/endpointslice/endpointslice_test.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice_test.go
@@ -116,6 +116,19 @@ func TestClusterEndpointSliceValidate(t *testing.T) {
 			},
 			errstr: "invalid IPv6 endpoint address: 10.1.2.3",
 		},
+		{
+			name: "IPv6 endpoint address with zone",
+			eps: ClusterEndpointSlice{
+				Cluster:     "foo",
+				Namespace:   "bar",
+				Name:        "qux",
+				AddressType: slim_discovery_v1.AddressTypeIPv6,
+				Endpoints: []slim_discovery_v1.Endpoint{{
+					Addresses: []string{"fd10::1234%zone"},
+				}},
+			},
+			errstr: "invalid IPv6 endpoint address: fd10::1234%zone",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Please review commit by commit, and refer to the individual commit messages for additional details.

AIL: 0

<!-- Description of change -->

```release-note
Strengthen the validation when ingesting service backends from Cluster Mesh to prevent issues in case of specially crafted values
```