### PR TITLE
bpf: icmp*: fix up sample length

### DIFF
--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -14,11 +14,13 @@
 #include "overloadable.h"
 #ifdef ENABLE_IPV4
 
-#define ICMP_PACKET_MAX_SAMPLE_SIZE 64
+#define ICMP_PACKET_MAX_SAMPLE_SIZE 8
 
 static __always_inline
 int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 {
+	__u64 full_len = ctx_full_len(ctx);
+	__u64 new_len, sample_len;
 	void *data, *data_end;
 	struct ethhdr *ethhdr;
 	struct iphdr *ip4;
@@ -29,7 +31,6 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	__be32	daddr;
 	__u8	tos;
 	__wsum csum;
-	int sample_len;
 	int ret;
 	const int inner_offset = sizeof(struct ethhdr) + sizeof(struct iphdr) +
 		sizeof(struct icmphdr);
@@ -51,17 +52,24 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	daddr = ip4->daddr;
 	tos = ip4->tos;
 
-	/* Resize to ethernet header + 64 bytes or less */
-	sample_len = (int)ctx_full_len(ctx);
-	if (sample_len > ICMP_PACKET_MAX_SAMPLE_SIZE)
-		sample_len = ICMP_PACKET_MAX_SAMPLE_SIZE;
-	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
+	/* Trim down to sample size (IPv4 header + 8 bytes datagram) */
+	if (full_len < sizeof(struct ethhdr))
+		return DROP_INVALID;
+
+	sample_len = ipv4_hdrlen(ip4) + ICMP_PACKET_MAX_SAMPLE_SIZE;
+	new_len = sizeof(struct ethhdr) + sample_len;
+	if (new_len > full_len) {
+		new_len = full_len;
+		sample_len = full_len - sizeof(struct ethhdr);
+	}
+
+	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 
 	/* Calculate the checksum of the ICMP sample */
-	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, sample_len);
+	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, (int)sample_len);
 
 	/* We need to insert a IPv4 and ICMP header before the original packet.
 	 * Make that room.

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -571,7 +571,7 @@ bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 	return true;
 }
 
-#define ICMPV6_PACKET_MAX_SAMPLE_SIZE 1280 - sizeof(struct ipv6hdr) - sizeof(struct icmp6hdr)
+#define ICMPV6_PACKET_MAX_SAMPLE_SIZE (IPV6_MIN_MTU - sizeof(struct ipv6hdr) - sizeof(struct icmp6hdr))
 
 /* The IPv6 pseudo-header */
 struct ipv6_pseudo_header_t {
@@ -590,6 +590,8 @@ struct ipv6_pseudo_header_t {
 static __always_inline
 int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 {
+	__u64 full_len = ctx_full_len(ctx);
+	__u64 new_len, sample_len;
 	void *data, *data_end;
 	struct ethhdr *ethhdr;
 	struct ipv6hdr *ip6;
@@ -600,7 +602,6 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	struct in6_addr saddr;
 	struct in6_addr daddr;
 	__wsum csum;
-	__u64 sample_len;
 	int i;
 	int ret;
 	const int inner_offset = sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
@@ -622,11 +623,19 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	memcpy(&saddr, &ip6->saddr, sizeof(struct in6_addr));
 	memcpy(&daddr, &ip6->daddr, sizeof(struct in6_addr));
 
-	/* Resize to min MTU - IPv6 hdr + ICMPv6 hdr */
-	sample_len = ctx_full_len(ctx);
-	if (sample_len > (__u64)ICMPV6_PACKET_MAX_SAMPLE_SIZE)
-		sample_len = ICMPV6_PACKET_MAX_SAMPLE_SIZE;
-	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
+	/* Trim down to sample size */
+	if (full_len < sizeof(struct ethhdr))
+		return DROP_INVALID;
+
+	sample_len = ICMPV6_PACKET_MAX_SAMPLE_SIZE;
+	new_len = sizeof(struct ethhdr) + sample_len;
+	if (new_len > full_len) {
+		new_len = full_len;
+		sample_len = full_len - sizeof(struct ethhdr);
+	}
+
+	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
+
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);

--- a/bpf/tests/lib/icmp.h
+++ b/bpf/tests/lib/icmp.h
@@ -5,13 +5,8 @@
 
 struct validate_icmpv6_reply_args {
 	const struct __ctx_buff *ctx;
-	const __u8 *src_mac;
-	const __u8 *dst_mac;
-	const __u8 *src_ip;
-	const __u8 *dst_ip;
-	__u8 icmp_type;
-	__u8 icmp_code;
-	__u16 checksum;
+	const __u8 *buf_expected;
+	__u16 buf_len;
 	__u32 dst_idx;
 	__u32 retval;
 };
@@ -21,9 +16,6 @@ validate_icmpv6_reply(const struct validate_icmpv6_reply_args *args)
 {
 	void *data, *data_end;
 	__u32 *status_code;
-	struct ethhdr *l2;
-	struct ipv6hdr *l3;
-	struct icmp6hdr *l4;
 	struct ratelimit_value *value;
 
 	test_init();
@@ -39,33 +31,12 @@ validate_icmpv6_reply(const struct validate_icmpv6_reply_args *args)
 	test_log("Status code: %d", *status_code);
 	assert(*status_code == args->retval);
 
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 header out of bounds");
-
-	assert(memcmp(l2->h_dest, args->dst_mac, ETH_ALEN) == 0);
-	assert(memcmp(l2->h_source, args->src_mac, ETH_ALEN) == 0);
-	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
-
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
-		test_fatal("l3 header out of bounds");
-
-	assert(!memcmp(&l3->saddr, args->src_ip, sizeof(l3->saddr)));
-	assert(!memcmp(&l3->daddr, args->dst_ip, sizeof(l3->daddr)));
-
-	assert(l3->hop_limit == 64);
-	assert(l3->version == 6);
-	assert(l3->nexthdr == IPPROTO_ICMPV6);
-
-	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) +
-	     sizeof(struct ipv6hdr);
-	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
-		test_fatal("l4 header out of bounds");
-
-	assert(l4->icmp6_type == args->icmp_type);
-	assert(l4->icmp6_code == args->icmp_code);
-	assert(l4->icmp6_cksum == bpf_htons(args->checksum));
+	ASSERT_CTX_BUF_OFF2("icmpv6_reply",
+			    "Ether", args->ctx, sizeof(__u32),
+			    "icmpv6_reply",
+			    args->buf_expected,
+			    args->buf_len,
+			    args->buf_len);
 
 	struct ratelimit_key key = {
 		.usage = RATELIMIT_USAGE_ICMPV6,

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -21,6 +21,20 @@ lb4_clusterip_post_dnat = (
     Raw("S"*1)
 )
 
+lb4_udp_clusterip = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    UDP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(b"X" * 100)
+)
+
+lb4_udp_clusterip_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one, id=0) /
+    ICMP(type="dest-unreach", code="port-unreachable") /
+    IPerror(bytes(lb4_udp_clusterip[IP])[:28])
+)
+
 lb6_clusterip = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
@@ -33,6 +47,20 @@ lb6_clusterip_post_dnat = (
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one) /
     Raw("S"*1)
+)
+
+lb6_udp_clusterip = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    UDP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(b"X" * 100)
+)
+
+lb6_udp_clusterip_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    ICMPv6DestUnreach(code=4, cksum=58197) /
+    IPerror6(bytes(lb6_udp_clusterip[IPv6]))
 )
 
 # Packets for testing N/S LB path with ExternalIPs.
@@ -184,6 +212,20 @@ lb4_ew_nodeport_fragment2_post_dnat = (
     Raw(load="S" * 1)
 )
 
+lb4_ew_udp_nodeport = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_one, dst=v4_svc_one) /
+    UDP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(b"X" * 100)
+)
+
+lb4_ew_udp_nodeport_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_pod_one, id=0) /
+    ICMP(type="dest-unreach", code="port-unreachable") /
+    IPerror(bytes(lb4_ew_udp_nodeport[IP])[:28])
+)
+
 lb6_ew_nodeport_fragment1 = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_pod_two, dst=v6_svc_one, nh=44) /
@@ -214,3 +256,16 @@ lb6_ew_nodeport_fragment2_post_dnat = (
     Raw(load="S" * 1)
 )
 
+lb6_ew_udp_nodeport = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_one, dst=v6_svc_one) /
+    UDP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(b"X" * 100)
+)
+
+lb6_ew_udp_nodeport_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_pod_one) /
+    ICMPv6DestUnreach(code=4, cksum=1618) /
+    IPerror6(bytes(lb6_ew_udp_nodeport[IPv6]))
+)

--- a/bpf/tests/scapy/lxc_policy_reject_defs.py
+++ b/bpf/tests/scapy/lxc_policy_reject_defs.py
@@ -1,0 +1,32 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+
+from pkt_defs_common import *
+
+v4_lxc_to_external = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_one, dst=v4_ext_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one,flags="S")
+)
+
+v4_lxc_to_external_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, id=0) /
+    ICMP(type="dest-unreach", code="communication-prohibited") /
+    IPerror(bytes(v4_lxc_to_external[IP])[:28])
+)
+
+v6_lxc_to_external = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one,flags="S")
+)
+
+v6_lxc_to_external_icmp_unreach = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    ICMPv6DestUnreach(code=1) /
+    IPerror6(bytes(v6_lxc_to_external[IPv6]))
+)

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -9,6 +9,7 @@ from pkt_defs_common import *
 from selftest_pkt_defs import *
 from ipsec_from_netdev_pkt_defs import *
 from ipv6_ndp_pkt_defs import *
+from lxc_policy_reject_defs import *
 from tc_l2_announce_pkt_defs import *
 from tc_l2_announce6_pkt_defs import *
 from wg_from_netdev_pkt_defs import *

--- a/bpf/tests/tc_lxc_lb_no_backend.c
+++ b/bpf/tests/tc_lxc_lb_no_backend.c
@@ -4,26 +4,16 @@
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
+#include "scapy.h"
 
 /* Enable code paths under test */
 #define ENABLE_IPV4			1
 #define ENABLE_IPV6			1
 #define SERVICE_NO_BACKEND_RESPONSE	1
 
-#define CLIENT_IP		v4_ext_one
-#define CLIENT_IPV6		v6_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
-
-#define FRONTEND_IP		v4_svc_two
-#define FRONTEND_IPV6		v6_pod_two
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IPV6		v6_svc_one
 #define FRONTEND_PORT		tcp_svc_one
-
-#define BACKEND_IP		v4_pod_two
-#define BACKEND_IPV6		v6_node_two
-#define BACKEND_PORT		__bpf_htons(8080)
-
-static volatile const __u8 *client_mac = mac_one;
-static volatile const __u8 *lb_mac = mac_host;
 
 #include "lib/bpf_lxc.h"
 
@@ -32,29 +22,33 @@ ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 #include "lib/ipcache.h"
 #include "lib/lb.h"
 
-/* Test that a SVC without backends returns a TCP RST or ICMP error */
+const __u8 lb4_ew_udp_nodeport[] = {
+	SCAPY_BUF_BYTES(lb4_ew_udp_nodeport)
+};
+
+const __u8 lb4_ew_udp_nodeport_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(lb4_ew_udp_nodeport_icmp_unreach)
+};
+
+const __u8 lb6_ew_udp_nodeport[] = {
+	SCAPY_BUF_BYTES(lb6_ew_udp_nodeport)
+};
+
+const __u8 lb6_ew_udp_nodeport_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(lb6_ew_udp_nodeport_icmp_unreach)
+};
+
+/* Test that a SVC without backends returns an ICMP error */
 PKTGEN(PROG_TYPE, "tc_lxc4_no_backend")
 int lxc4_no_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
-	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_tcp_packet(&builder,
-					  (__u8 *)client_mac, (__u8 *)lb_mac,
-					  CLIENT_IP, FRONTEND_IP,
-					  CLIENT_PORT, FRONTEND_PORT);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, lb4_ew_udp_nodeport,
+			sizeof(lb4_ew_udp_nodeport));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -65,9 +59,7 @@ int lxc4_no_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
-
-	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP, 0, revnat_id);
 
 	return pod_send_packet(ctx);
 }
@@ -77,9 +69,6 @@ int lxc4_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	struct icmphdr *l4;
 
 	test_init();
 
@@ -94,67 +83,25 @@ int lxc4_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_log("Status code: %d", *status_code);
 	assert(*status_code == CTX_ACT_REDIRECT);
 
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 header out of bounds");
-
-	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
-	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
-	assert(l2->h_proto == __bpf_htons(ETH_P_IP));
-
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 header out of bounds");
-
-	assert(l3->ihl == 5);
-	assert(l3->version == 4);
-	assert(l3->tos == 0);
-	assert(l3->ttl == 64);
-	assert(l3->protocol == IPPROTO_ICMP);
-
-	if (l3->check != bpf_htons(0x4b8e))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
-
-	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
-	if ((void *) l4 + sizeof(struct icmphdr) > data_end)
-		test_fatal("l4 header out of bounds");
-
-	assert(l4->type == ICMP_DEST_UNREACH);
-	assert(l4->code == ICMP_PORT_UNREACH);
-
-	/* reference checksum is calculated with wireshark by dumping the
-	 * context with the runner option and importing the packet into
-	 * wireshark
-	 */
-	assert(l4->checksum == bpf_htons(0x2c3f));
+	ASSERT_CTX_BUF_OFF("lb4_ew_udp_nodeport_icmp_unreach",
+			   "Ether", ctx, sizeof(__u32),
+			   lb4_ew_udp_nodeport_icmp_unreach,
+			   sizeof(lb4_ew_udp_nodeport_icmp_unreach));
 
 	test_finish();
 }
 
-/* Test that a SVC without backends returns a TCP RST or ICMP error */
+/* Test that a SVC without backends returns an ICMP error */
 PKTGEN(PROG_TYPE, "tc_lxc6_no_backend")
 int lxc6_no_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
-	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_tcp_packet(&builder,
-					  (__u8 *)client_mac, (__u8 *)lb_mac,
-					  (__u8 *)CLIENT_IPV6,
-					  (__u8 *)FRONTEND_IPV6,
-					  tcp_src_one, tcp_svc_one);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, lb6_ew_udp_nodeport,
+			sizeof(lb6_ew_udp_nodeport));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -169,13 +116,7 @@ int lxc6_no_backend_setup(struct __ctx_buff *ctx)
 
 	memcpy(frontend_ip.addr, (void *)FRONTEND_IPV6, 16);
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
-
-	union v6addr backend_ip = {};
-
-	memcpy(backend_ip.addr, (void *)BACKEND_IPV6, 16);
-
-	ipcache_v6_add_entry(&backend_ip, 0, 112233, 0, 0);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_UDP, 0, revnat_id);
 
 	return pod_send_packet(ctx);
 }
@@ -185,9 +126,6 @@ int lxc6_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;
-	struct ethhdr *l2;
-	struct ipv6hdr *l3;
-	struct icmp6hdr *l4;
 
 	test_init();
 
@@ -202,34 +140,10 @@ int lxc6_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_log("Status code: %d", *status_code);
 	assert(*status_code == CTX_ACT_REDIRECT);
 
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 header out of bounds");
-
-	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
-	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
-	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
-
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
-		test_fatal("l3 header out of bounds");
-
-	assert(l3->hop_limit == 64);
-	assert(l3->version == 6);
-	assert(l3->nexthdr == IPPROTO_ICMPV6);
-
-	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
-	if ((void *) l4 + sizeof(struct icmp6hdr) > data_end)
-		test_fatal("l4 header out of bounds");
-
-	assert(l4->icmp6_type == ICMPV6_DEST_UNREACH);
-	assert(l4->icmp6_code == ICMPV6_PORT_UNREACH);
-
-	/* reference checksum is calculated with wireshark by dumping the
-	 * context with the runner option and importing the packet into
-	 * wireshark
-	 */
-	assert(l4->icmp6_cksum == bpf_htons(0x9e14));
+	ASSERT_CTX_BUF_OFF("lb6_ew_udp_nodeport_icmp_unreach",
+			   "Ether", ctx, sizeof(__u32),
+			   lb6_ew_udp_nodeport_icmp_unreach,
+			   sizeof(lb6_ew_udp_nodeport_icmp_unreach));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb_no_backend.c
@@ -4,6 +4,7 @@
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
+#include "scapy.h"
 
 /* Enable code paths under test */
 #define ENABLE_IPV4			1
@@ -13,20 +14,9 @@
 #define ENABLE_MASQUERADE_IPV4		1
 #define ENABLE_MASQUERADE_IPV6		1
 
-#define CLIENT_IP		v4_ext_one
-#define CLIENT_IPV6		v6_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
-
 #define FRONTEND_IP		v4_svc_one
-#define FRONTEND_IPV6		v6_pod_two
+#define FRONTEND_IPV6		v6_svc_one
 #define FRONTEND_PORT		tcp_svc_one
-
-#define BACKEND_IP		v4_pod_two
-#define BACKEND_IPV6		v6_node_two
-#define BACKEND_PORT		__bpf_htons(8080)
-
-static volatile const __u8 *client_mac = mac_one;
-static volatile const __u8 *lb_mac = mac_host;
 
 #include "lib/bpf_host.h"
 
@@ -37,29 +27,34 @@ ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 #include "lib/ipcache.h"
 #include "lib/lb.h"
 
-/* Test that a SVC without backends returns a TCP RST or ICMP error */
+const __u8 lb4_udp_clusterip[] = {
+	SCAPY_BUF_BYTES(lb4_udp_clusterip)
+};
+
+const __u8 lb4_udp_clusterip_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(lb4_udp_clusterip_icmp_unreach)
+};
+
+const __u8 lb6_udp_clusterip[] = {
+	SCAPY_BUF_BYTES(lb6_udp_clusterip)
+};
+
+const __u8 lb6_udp_clusterip_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(lb6_udp_clusterip_icmp_unreach)
+};
+
+/* Test that a SVC without backends returns an ICMP error */
 PKTGEN(PROG_TYPE, "tc_nodeport_no_backend4")
 int nodeport_no_backend4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_tcp_packet(&builder,
-					  (__u8 *)client_mac, (__u8 *)lb_mac,
-					  CLIENT_IP, FRONTEND_IP,
-					  CLIENT_PORT, FRONTEND_PORT);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, lb4_udp_clusterip,
+			sizeof(lb4_udp_clusterip));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -70,9 +65,7 @@ int nodeport_no_backend4_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
-
-	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_UDP, 0, revnat_id);
 
 	return netdev_receive_packet(ctx);
 }
@@ -82,9 +75,6 @@ validate_icmp_reply(const struct __ctx_buff *ctx, __u32 retval)
 {
 	void *data, *data_end;
 	__u32 *status_code;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	struct icmphdr *l4;
 
 	test_init();
 
@@ -99,43 +89,10 @@ validate_icmp_reply(const struct __ctx_buff *ctx, __u32 retval)
 	test_log("Status code: %d", *status_code);
 	assert(*status_code == retval);
 
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 header out of bounds");
-
-	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
-	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
-	assert(l2->h_proto == __bpf_htons(ETH_P_IP));
-
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 header out of bounds");
-
-	assert(l3->saddr == FRONTEND_IP);
-	assert(l3->daddr == CLIENT_IP);
-
-	assert(l3->ihl == 5);
-	assert(l3->version == 4);
-	assert(l3->tos == 0);
-	assert(l3->ttl == 64);
-	assert(l3->protocol == IPPROTO_ICMP);
-
-	if (l3->check != bpf_htons(0x4b8f))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
-
-	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
-	if ((void *) l4 + sizeof(struct icmphdr) > data_end)
-		test_fatal("l4 header out of bounds");
-
-	assert(l4->type == ICMP_DEST_UNREACH);
-	assert(l4->code == ICMP_PORT_UNREACH);
-
-	/* reference checksum is calculated with wireshark by dumping the
-	 * context with the runner option and importing the packet into
-	 * wireshark
-	 */
-	if (l4->checksum != bpf_htons(0x2c3e))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->checksum));
+	ASSERT_CTX_BUF_OFF("lb4_udp_clusterip_icmp_unreach",
+			   "Ether", ctx, sizeof(__u32),
+			   lb4_udp_clusterip_icmp_unreach,
+			   sizeof(lb4_udp_clusterip_icmp_unreach));
 
 	test_finish();
 }
@@ -150,16 +107,21 @@ int nodeport_no_backend4_check(__maybe_unused const struct __ctx_buff *ctx)
 PKTGEN(PROG_TYPE, "tc_nodeport_no_backend4_2_reply")
 int nodeport_no_backend4_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	/* Start with the initial request, and let SETUP() below rebuild it. */
-	return nodeport_no_backend4_pktgen(ctx);
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, lb4_udp_clusterip_icmp_unreach,
+			sizeof(lb4_udp_clusterip_icmp_unreach));
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP(PROG_TYPE, "tc_nodeport_no_backend4_2_reply")
 int nodeport_no_backend4_2_reply_setup(struct __ctx_buff *ctx)
 {
-	if (tail_no_service_ipv4(ctx) != CTX_ACT_REDIRECT)
-		return TEST_ERROR;
-
 	return netdev_send_packet(ctx);
 }
 
@@ -169,30 +131,18 @@ int nodeport_no_backend4_2_reply_check(__maybe_unused const struct __ctx_buff *c
 	return validate_icmp_reply(ctx, CTX_ACT_OK);
 }
 
-/* Test that a SVC without backends returns a TCP RST or ICMP error */
+/* Test that a SVC without backends returns an ICMP error */
 PKTGEN(PROG_TYPE, "tc_nodeport_no_backend6")
 int nodeport_no_backend6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_tcp_packet(&builder,
-					  (__u8 *)client_mac, (__u8 *)lb_mac,
-					  (__u8 *)CLIENT_IPV6,
-					  (__u8 *)FRONTEND_IPV6,
-					  tcp_src_one, tcp_svc_one);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, lb6_udp_clusterip,
+			sizeof(lb6_udp_clusterip));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -207,28 +157,18 @@ int nodeport_no_backend6_setup(struct __ctx_buff *ctx)
 
 	memcpy(frontend_ip.addr, (void *)FRONTEND_IPV6, 16);
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
-
-	union v6addr backend_ip = {};
-
-	memcpy(backend_ip.addr, (void *)BACKEND_IPV6, 16);
-
-	ipcache_v6_add_entry(&backend_ip, 0, 112233, 0, 0);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_UDP, 0, revnat_id);
 
 	return netdev_receive_packet(ctx);
 }
 
 static __always_inline int
-validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval) {
+validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval)
+{
 	struct validate_icmpv6_reply_args args = {
 		.ctx = ctx,
-		.src_mac = (__u8 *)lb_mac,
-		.dst_mac = (__u8 *)client_mac,
-		.src_ip = (__u8 *)FRONTEND_IPV6,
-		.dst_ip = (__u8 *)CLIENT_IPV6,
-		.icmp_type = ICMPV6_DEST_UNREACH,
-		.icmp_code = ICMPV6_PORT_UNREACH,
-		.checksum = 0x9e14,
+		.buf_expected = lb6_udp_clusterip_icmp_unreach,
+		.buf_len = sizeof(lb6_udp_clusterip_icmp_unreach),
 		.dst_idx = 1,
 		.retval = retval,
 	};
@@ -245,16 +185,21 @@ int nodeport_no_backend6_check(__maybe_unused const struct __ctx_buff *ctx)
 PKTGEN(PROG_TYPE, "tc_nodeport_no_backend6_2_reply")
 int nodeport_no_backend6_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	/* Start with the initial request, and let SETUP() below rebuild it. */
-	return nodeport_no_backend6_pktgen(ctx);
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, lb6_udp_clusterip_icmp_unreach,
+			sizeof(lb6_udp_clusterip_icmp_unreach));
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP(PROG_TYPE, "tc_nodeport_no_backend6_2_reply")
 int nodeport_no_backend6_2_reply_setup(struct __ctx_buff *ctx)
 {
-	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH))
-		return TEST_ERROR;
-
 	return netdev_send_packet(ctx);
 }
 

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -4,6 +4,7 @@
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
+#include "scapy.h"
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
@@ -21,28 +22,33 @@ ASSIGN_CONFIG(bool, policy_deny_response_enabled, true)
 #define CLIENT_IP v4_pod_one
 #define TARGET_IP v4_ext_one
 
+const __u8 v4_lxc_to_external[] = {
+	SCAPY_BUF_BYTES(v4_lxc_to_external)
+};
+
+const __u8 v4_lxc_to_external_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(v4_lxc_to_external_icmp_unreach)
+};
+
+const __u8 v6_lxc_to_external[] = {
+	SCAPY_BUF_BYTES(v6_lxc_to_external)
+};
+
+const __u8 v6_lxc_to_external_icmp_unreach[] = {
+	SCAPY_BUF_BYTES(v6_lxc_to_external_icmp_unreach)
+};
+
 PKTGEN(PROG_TYPE, "policy_reject_response_v4")
 int policy_reject_response_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_tcp_packet(&builder,
-					  (__u8 *)mac_one, (__u8 *)mac_two,
-					  CLIENT_IP, TARGET_IP,
-					  tcp_src_one, tcp_dst_one);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, v4_lxc_to_external,
+			sizeof(v4_lxc_to_external));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -69,8 +75,6 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;
-	struct iphdr *l3;
-	struct icmphdr *icmp;
 
 	test_init();
 
@@ -87,33 +91,10 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 	/* Should redirect ICMP response back to interface */
 	assert(*status_code == TC_ACT_REDIRECT);
 
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 out of bounds");
-
-	/* Verify this is an ICMP response packet */
-	if (l3->protocol != IPPROTO_ICMP)
-		test_fatal("expected ICMP protocol, got %d", l3->protocol);
-
-	/* Source should be swapped to target, destination should be client */
-	if (l3->saddr != TARGET_IP)
-		test_fatal("ICMP src should be target IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("ICMP dst should be client IP");
-
-	icmp = (void *)l3 + sizeof(struct iphdr);
-
-	if ((void *)icmp + sizeof(struct icmphdr) > data_end)
-		test_fatal("ICMP header out of bounds");
-
-	/* Verify ICMP error type and code for policy rejection */
-	if (icmp->type != ICMP_DEST_UNREACH)
-		test_fatal("expected ICMP_DEST_UNREACH, got type %d", icmp->type);
-
-	if (icmp->code != ICMP_PKT_FILTERED)
-		test_fatal("expected ICMP_PKT_FILTERED, got code %d", icmp->code);
+	ASSERT_CTX_BUF_OFF("v4_lxc_to_external_icmp_unreach",
+			   "Ether", ctx, sizeof(__u32),
+			   v4_lxc_to_external_icmp_unreach,
+			   sizeof(v4_lxc_to_external_icmp_unreach));
 
 	test_finish();
 }
@@ -129,13 +110,8 @@ validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval)
 {
 	struct validate_icmpv6_reply_args args = {
 		.ctx = ctx,
-		.src_mac = (__u8 *)mac_two,
-		.dst_mac = (__u8 *)mac_one,
-		.src_ip = (__u8 *)TARGET_IPv6,
-		.dst_ip = (__u8 *)CLIENT_IPv6,
-		.icmp_type = ICMPV6_DEST_UNREACH,
-		.icmp_code = ICMPV6_ADM_PROHIBITED,
-		.checksum = 0x9e17,
+		.buf_expected = v6_lxc_to_external_icmp_unreach,
+		.buf_len = sizeof(v6_lxc_to_external_icmp_unreach),
 		.dst_idx = 1,
 		.retval = retval,
 	};
@@ -146,25 +122,13 @@ PKTGEN(PROG_TYPE, "policy_reject_response_v6")
 int policy_reject_response_v6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
 
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_tcp_packet(&builder,
-					  (__u8 *)mac_one, (__u8 *)mac_two,
-					  (__u8 *)CLIENT_IPv6,
-					  (__u8 *)TARGET_IPv6,
-					  tcp_src_one, tcp_dst_one);
-	if (!l4)
-		return TEST_ERROR;
+	scapy_push_data(&builder, v6_lxc_to_external,
+			sizeof(v6_lxc_to_external));
 
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
 	return 0;
@@ -199,15 +163,21 @@ int policy_reject_response_v6_check(const struct __ctx_buff *ctx)
 PKTGEN(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_pktgen(struct __ctx_buff *ctx)
 {
-	/* Start with the initial request, and let SETUP() below rebuild it. */
-	return policy_reject_response_v6_pktgen(ctx);
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, v6_lxc_to_external_icmp_unreach,
+			sizeof(v6_lxc_to_external_icmp_unreach));
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_setup(struct __ctx_buff *ctx)
 {
-	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_ADM_PROHIBITED))
-		return TEST_ERROR;
 	/* we have no allow policy for this packet so we expect it to be dropped. */
 	return pod_receive_packet(ctx);
 }


### PR DESCRIPTION
```
For IPv4 we are supposed to sample the full IPv4 header plus the first
8 bytes of the L4 datagram. Not the first 64 bytes.

For IPv6 we are meant to sample as much as fits into the MTU - but
ctx_full_len() includes the packet's current L2 header. Consider this when
calculating the sample size for the ICMP error msg's payload.

Otherwise calling ctx_adjust_troom() for a full-length sample ends up
adding an *additional* L2 header at the end of the packet.

While doing so convert the ICMP-related tests over to
scapy, so that we don't have to fix up the various golden
checksum values.
```