### PR TITLE
[Doc] Fix broken slack link on community page.

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -157,7 +157,7 @@ run_linter() {
     ignored_messages="${ignored_messages}bpf/.*\.rst:.*: \(INFO/1\) Enumerated list start value not ordinal"
     ignored_messages="${ignored_messages}|Hyperlink target .*is not referenced\."
     ignored_messages="${ignored_messages}|Duplicate implicit target name:"
-    ignored_messages="${ignored_messages}|\(ERROR/3\) Indirect hyperlink target \".*\"  refers to target \"${CONF_PY_TARGET_NAMES}\", which does not exist."
+    ignored_messages="${ignored_messages}|\(ERROR/3\) Indirect hyperlink target \".*\".*refers to target \"${CONF_PY_TARGET_NAMES}\", which does not exist."
     ignored_messages="${ignored_messages}|\(ERROR/3\) Unknown target name: \"${CONF_PY_TARGET_NAMES}\"."
     ignored_messages="${ignored_messages}|.*expected a single document in the stream.*"
     ignored_messages="${ignored_messages})"

--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -46,11 +46,9 @@ for all Cilium community meetings.
 Slack
 =====
 
-Our `Cilium & eBPF Slack <Cilium Slack>`_ is the main discussion space for the
+Our `Cilium & eBPF Slack <Cilium Slack_>`_ is the main discussion space for the
 Cilium community. Please be sure to follow and abide by the `Slack Guidelines
 <https://github.com/cilium/community/blob/main/slack-guidelines.md>`__
-
-.. _Cilium Slack: https://slack.cilium.io
 
 Slack channels
 --------------


### PR DESCRIPTION
### Issue
https://docs.cilium.io/en/stable/community/community/#slack leads to 

`https://docs.cilium.io/en/stable/community/community/CiliumSlack`  404

https://github.com/cilium/cilium/blob/ead9c18b9d5085b0a0fe9cd95ef540560bdfbee4/Documentation/community/community.rst?plain=1#L49

By default, this will be treated as **embedded URI**, which contributes to the bug when docutils tries to expand it.

### Fix
Changed to use the named target. Post-change, the fix works fine with
`make render-docs`

But `check-build.sh` fails due to stale regex rules for skipping. Regex pattern changed to cover the URI fix.

**Testing**
```bash
make -C documentation html
```

Related to
* #10601 

**AI Influence Level:** 3

```release-note
Fixed broken Slack link on Community page.
```
