### PR TITLE
Add ServiceID keyspace metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -817,6 +817,19 @@ Name                                                 Labels                     
 
 All metrics are enabled only when the BGP Control Plane is enabled.
 
+.. _metrics_load_balancer:
+
+Load Balancer
+~~~~~~~~~~~~~
+
+==================================================== ======== ======== ===================================================================
+Name                                                 Labels   Default  Description
+==================================================== ======== ======== ===================================================================
+``cilium_loadbalancer_id_keys_allocated``            ``type`` Enabled  Number of internal IDs allocated for a particular type of internal ID
+``cilium_loadbalancer_id_keys_limit``                ``type`` Enabled  Total number of keys available for a particular type of internal ID
+``cilium_loadbalancer_id_keyspace_pressure``         ``type`` Enabled  Proportion of the keyspace used for a particular type of itnernal ID
+==================================================== ======== ======== ===================================================================
+
 cilium-operator
 ---------------
 

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -113,6 +113,7 @@ type BPFOps struct {
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
 	frontends statedb.Table[*loadbalancer.Frontend]
+	metrics   Metrics
 
 	cfg           loadbalancer.Config
 	extCfg        loadbalancer.ExternalConfig
@@ -188,6 +189,7 @@ type bpfOpsParams struct {
 	DB             *statedb.DB
 	NodeAddresses  statedb.Table[tables.NodeAddress]
 	Frontends      statedb.Table[*loadbalancer.Frontend]
+	Metrics        *LBMetrics
 }
 
 const (
@@ -206,6 +208,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 		db:        p.DB,
 		nodeAddrs: p.NodeAddresses,
 		frontends: p.Frontends,
+		metrics:   p.Metrics,
 	}
 	ops.setLastUpdatedAt()
 
@@ -230,9 +233,9 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 	ops.mu.Lock()
 	defer ops.mu.Unlock()
 
-	ops.serviceIDAlloc = newIDAllocator(firstFreeServiceID, maxSetOfServiceID)
+	ops.serviceIDAlloc = newIDAllocator(firstFreeServiceID, maxSetOfServiceID, ops.metrics, TypeLabelService)
 	ops.restoredServiceIDs = map[loadbalancer.L3n4Addr]loadbalancer.ServiceID{}
-	ops.backendIDAlloc = newIDAllocator(firstFreeBackendID, maxSetOfBackendID)
+	ops.backendIDAlloc = newIDAllocator(firstFreeBackendID, maxSetOfBackendID, ops.metrics, TypeLabelBackend)
 	ops.restoredBackendIDs = map[loadbalancer.L3n4Addr]loadbalancer.BackendID{}
 	ops.backendStates = map[loadbalancer.L3n4Addr]backendState{}
 	ops.backendReferences = map[loadbalancer.L3n4Addr]sets.Set[loadbalancer.L3n4Addr]{}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1404,6 +1404,7 @@ func TestBPFOps(t *testing.T) {
 			DB:             db,
 			NodeAddresses:  nodeAddrs,
 			Frontends:      frontends,
+			Metrics:        newMockMetrics(),
 		})
 
 		svc := baseService
@@ -1586,6 +1587,7 @@ func TestBPFOps(t *testing.T) {
 					DB:             db,
 					NodeAddresses:  nodeAddrs,
 					Frontends:      frontends,
+					Metrics:        newMockMetrics(),
 				}
 
 				ops := newBPFOps(p)
@@ -1613,6 +1615,7 @@ func TestBPFOps(t *testing.T) {
 				DB:             db,
 				NodeAddresses:  nodeAddrs,
 				Frontends:      frontends,
+				Metrics:        newMockMetrics(),
 			}
 			ops := newBPFOps(p)
 			runTests(ops, setWithAlgo.testCaseSet, setWithAlgo.algo, addr, true)

--- a/pkg/loadbalancer/reconciler/cell.go
+++ b/pkg/loadbalancer/reconciler/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/promise"
 )
 
@@ -17,6 +18,8 @@ import (
 var Cell = cell.Module(
 	"loadbalancer-reconciler",
 	"Load-balancing BPF map reconciliation",
+
+	metrics.Metric(NewLBMetrics),
 
 	cell.Provide(
 		// Provide [BPFOps] for reconciling a changed frontend.

--- a/pkg/loadbalancer/reconciler/id_allocator.go
+++ b/pkg/loadbalancer/reconciler/id_allocator.go
@@ -32,6 +32,12 @@ type idAllocator[ID idConstraint] struct {
 
 	// initMaxID is the initial maxID
 	initMaxID ID
+
+	// Metrics is the metrics package
+	metrics Metrics
+
+	// metricsTypeLabel is the label to attach to the metrics
+	metricsTypeLabel TypeLabel
 }
 
 const (
@@ -51,20 +57,42 @@ const (
 	maxSetOfBackendID = loadbalancer.BackendID(0xFFFFFFFF)
 )
 
-func newIDAllocator[ID idConstraint](nextID ID, maxID ID) idAllocator[ID] {
-	return idAllocator[ID]{
+func newIDAllocator[ID idConstraint](nextID ID, maxID ID, metrics Metrics, metricsTypeLabel TypeLabel) idAllocator[ID] {
+	allocator := idAllocator[ID]{
 		idToAddr:   map[ID]loadbalancer.L3n4Addr{},
 		addrToId:   map[loadbalancer.L3n4Addr]ID{},
 		nextID:     nextID,
 		maxID:      maxID,
 		initNextID: nextID,
 		initMaxID:  maxID,
+
+		metrics:           metrics,
+		metricsTypeLabel:  metricsTypeLabel,
+	}
+	allocator.updateIDMetrics()
+	return allocator
+}
+
+func (alloc *idAllocator[ID]) updateIDMetrics() {
+	limit := alloc.maxID-alloc.initNextID;
+	allocated := len(alloc.idToAddr);
+	alloc.metrics.SetKeysLimit(alloc.metricsTypeLabel, uint32(limit));
+	alloc.metrics.SetKeysAllocated(alloc.metricsTypeLabel, uint32(allocated));
+	if limit <= 0 {
+		// If the limit of the keyspace is not positive, just set the pressure to 1.0
+		// (maximum pressure). Technically it's undefined, but this way we'll still
+		// trigger monitoring alerts that are looking at keyspace pressure even if the
+		// keyspace is configured to be zero or negitive and no IDs can be assigned.
+		alloc.metrics.SetKeyspacePressure(alloc.metricsTypeLabel, 1.0)
+	} else {
+		alloc.metrics.SetKeyspacePressure(alloc.metricsTypeLabel, float64(allocated)/float64(limit))
 	}
 }
 
 func (alloc *idAllocator[ID]) addID(addr loadbalancer.L3n4Addr, id ID) ID {
 	alloc.idToAddr[id] = addr
 	alloc.addrToId[addr] = id
+	alloc.updateIDMetrics()
 	return id
 }
 
@@ -99,6 +127,7 @@ func (alloc *idAllocator[ID]) deleteLocalID(id ID) {
 	if addr, ok := alloc.idToAddr[id]; ok {
 		delete(alloc.idToAddr, id)
 		delete(alloc.addrToId, addr)
+		alloc.updateIDMetrics()
 	}
 }
 

--- a/pkg/loadbalancer/reconciler/metrics.go
+++ b/pkg/loadbalancer/reconciler/metrics.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	subsystem = "loadbalancer"
+	typeLabel = "type"
+	TypeLabelService TypeLabel = "service"
+	TypeLabelBackend TypeLabel = "backend"
+)
+
+type TypeLabel string
+
+type LBMetrics struct {
+	// IDKeysAllocated is the number of keys currently allocated
+	IDKeysAllocated metric.Vec[metric.Gauge]
+
+	// IDKeysLimit is the maximum number of keys that can be allocated
+	IDKeysLimit metric.Vec[metric.Gauge]
+
+	// IDKeyspacePressure is the pressure on the ID keyspace
+	IDKeyspacePressure metric.Vec[metric.Gauge]
+}
+
+type Metrics interface {
+	SetKeysAllocated(typeLabel TypeLabel, current uint32)
+	SetKeysLimit(typeLabel TypeLabel, limit uint32)
+	SetKeyspacePressure(typeLabel TypeLabel, pressure float64)
+}
+
+var _ Metrics = (*LBMetrics)(nil)
+
+func NewLBMetrics() *LBMetrics {
+	return &LBMetrics{
+		IDKeysAllocated: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name: "id_keys_allocated",
+		}, []string{typeLabel}),
+		IDKeysLimit: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name: "id_keys_limit",
+		}, []string{typeLabel}),
+		IDKeyspacePressure: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name: "id_keyspace_pressure",
+		}, []string{typeLabel}),
+	}
+}
+
+func (lb *LBMetrics) SetKeysAllocated(idType TypeLabel, allocated uint32) {
+	lb.IDKeysAllocated.WithLabelValues(string(idType)).Set(float64(allocated))
+}
+
+func (lb *LBMetrics) SetKeysLimit(idType TypeLabel, limit uint32) {
+	lb.IDKeysLimit.WithLabelValues(string(idType)).Set(float64(limit))
+}
+
+func (lb *LBMetrics) SetKeyspacePressure(idType TypeLabel, pressure float64) {
+	lb.IDKeyspacePressure.WithLabelValues(string(idType)).Set(pressure)
+}
+

--- a/pkg/loadbalancer/reconciler/metrics_mock_test.go
+++ b/pkg/loadbalancer/reconciler/metrics_mock_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+type mockMetrics struct {
+	allocated map[TypeLabel]uint64
+	total map[TypeLabel]uint64
+	pressure map[TypeLabel]float64
+}
+
+func newMockMetrics() *mockMetrics {
+	return &mockMetrics{}
+}
+
+func (m *mockMetrics) SetKeysAllocated(typeLabel TypeLabel, allocated uint64) {
+	m.allocated[typeLabel] = allocated
+}
+
+func (m *mockMetrics) SetKeysTotal(typeLabel TypeLabel, total uint64) {
+	m.total[typeLabel] = total
+}
+
+func (m *mockMetrics) SetKeyspacePressure(typeLabel TypeLabel, pressure float64) {
+	m.pressure[typeLabel] = pressure
+}
+


### PR DESCRIPTION
The `cilium_loadbalancer_id_keys_allocated`, `cilium_loadbalancer_id_keys_limit`, and `cilium_loadbalancer_id_keyspace_pressure` metrics expose how full an internal Cilium keyspace is. If the keyspace is full Cilium will fail to reconcile new services. See https://github.com/cilium/cilium/issues/38727 for more details.

This isn't the same as map pressure. Although these keys are used as keys in an eBPF map (`cilium_lb{4,6}_reverse_sk`) simply increasing the size of the map doesn't help because the keys of the map itself are u16 (16-bit unsigned integers) which can represent a maximum limit of 65,535 entries.

Entries in these maps that use this keyspace depend on not only the number of services but the number of ports on the service and the type of service in question. For example, a ClusterIP service requires one service ID per port, a node port service requires two, a load balancer service requires three, and a service where `spec.externalTrafficPolicy` and `spec.internalTrafficPolicy` are different requires an additional ID per port. This complex relationship makes it hard to effectively estimate the used IDs from services alone, and so a "live" metric enables operators of clusters with lots of services to better manage this limit.

This PR was prepared with [AIL:0](https://danielmiessler.com/blog/ai-influence-level-ail). No AI tools were used at any stage.

```release-note
Add `cilium_loadbalancer_id_keys_allocated`, `cilium_loadbalancer_id_keys_limit`, and `cilium_loadbalancer_id_keyspace_pressure` metrics.
```
