### PR TITLE
datapath: Migrate auxilary prefixes to netip

### DIFF
--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -37,10 +36,6 @@ func TestAgentCell(t *testing.T) {
 	defer metrics.Reinitialize()
 
 	logging.SetLogLevel(slog.LevelDebug)
-
-	// Populate config with default values normally set by Viper flag defaults
-	option.Config.IPv4ServiceRange = AutoCIDR
-	option.Config.IPv6ServiceRange = AutoCIDR
 
 	err := hive.New(Agent).Populate(hivetest.Logger(t))
 	assert.NoError(t, err, "Populate()")

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -20,11 +20,6 @@ import (
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
-const (
-	// AutoCIDR indicates that a CIDR should be allocated
-	AutoCIDR = "auto"
-)
-
 func initAndValidateDaemonConfig(params daemonConfigParams) error {
 	// WireGuard and IPSec are mutually exclusive.
 	if params.IPSecConfig.Enabled() && params.WireguardConfig.Enabled() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -359,19 +359,19 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.IPAM, ipamOption.IPAMClusterPool, "Backend to use for IPAM")
 	option.BindEnv(vp, option.IPAM)
 
-	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
+	flags.String(option.IPv4Range, option.AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(vp, option.IPv4Range)
 
-	flags.String(option.IPv6Range, AutoCIDR, "Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96")
+	flags.String(option.IPv6Range, option.AutoCIDR, "Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96")
 	option.BindEnv(vp, option.IPv6Range)
 
 	flags.String(option.IPv6ClusterAllocCIDRName, defaults.IPv6ClusterAllocCIDR, "IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR")
 	option.BindEnv(vp, option.IPv6ClusterAllocCIDRName)
 
-	flags.String(option.IPv4ServiceRange, AutoCIDR, "Kubernetes IPv4 services CIDR if not inside cluster prefix")
+	flags.String(option.IPv4ServiceRange, option.AutoCIDR, "Kubernetes IPv4 services CIDR if not inside cluster prefix")
 	option.BindEnv(vp, option.IPv4ServiceRange)
 
-	flags.String(option.IPv6ServiceRange, AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
+	flags.String(option.IPv6ServiceRange, option.AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
 	option.BindEnv(vp, option.IPv6ServiceRange)
 
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/mac"
@@ -145,7 +146,7 @@ type Config struct {
 	//
 	// This field is mutable. The implementation of
 	// NodeConfigurationChanged() must adjust the routes accordingly.
-	AuxiliaryPrefixes []*cidr.CIDR
+	AuxiliaryPrefixes []ip.Prefix
 
 	// EnableIPv4 enables use of IPv4. Routing to the IPv4 allocation CIDR
 	// of other nodes must be enabled.

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -141,7 +141,7 @@ func (in *Config) deepEqual(other *Config) bool {
 			return false
 		} else {
 			for i, inElement := range *in {
-				if !inElement.DeepEqual((*other)[i]) {
+				if !inElement.DeepEqual(&(*other)[i]) {
 					return false
 				}
 			}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -30,6 +30,7 @@ import (
 	dpTunnel "github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/lock"
@@ -39,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -443,21 +445,6 @@ func (n *linuxNodeHandler) deleteNodeRoute(prefix netip.Prefix, isLocalNode bool
 	return nil
 }
 
-// cidrsToPrefixes converts a slice of *cidr.CIDR to a slice of netip.Prefix,
-// skipping nil or invalid entries.
-func cidrsToPrefixes(cidrs []*cidr.CIDR) []netip.Prefix {
-	prefixes := make([]netip.Prefix, 0, len(cidrs))
-	for _, c := range cidrs {
-		if c == nil {
-			continue
-		}
-		if prefix, ok := netipx.FromStdIPNet(c.IPNet); ok {
-			prefixes = append(prefixes, prefix)
-		}
-	}
-	return prefixes
-}
-
 func (n *linuxNodeHandler) familyEnabled(prefix netip.Prefix) bool {
 	return (prefix.Addr().Is4() && n.nodeConfig.EnableIPv4) || (prefix.Addr().Is6() && n.nodeConfig.EnableIPv6)
 }
@@ -724,7 +711,12 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig config.Config) err
 		n.enableEncapsulation = func(*nodeTypes.Node) bool { return n.nodeConfig.EnableEncapsulation }
 	}
 
-	if err := n.updateOrRemoveNodeRoutes(cidrsToPrefixes(prevConfig.AuxiliaryPrefixes), cidrsToPrefixes(newConfig.AuxiliaryPrefixes), true); err != nil {
+	unwrapPrefix := func(prefix ip.Prefix) netip.Prefix { return prefix.Prefix }
+	if err := n.updateOrRemoveNodeRoutes(
+		cslices.Map(prevConfig.AuxiliaryPrefixes, unwrapPrefix),
+		cslices.Map(newConfig.AuxiliaryPrefixes, unwrapPrefix),
+		true,
+	); err != nil {
 		return fmt.Errorf("failed to update or remove node routes: %w", err)
 	}
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -217,30 +217,24 @@ func mustValidateNodeImplementation(tb testing.TB, ns *netns.NetNS, lnh *linuxNo
 	}))
 }
 
-func mustUpdateNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, cidr *cidr.CIDR) {
+func mustUpdateNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, prefix netip.Prefix) {
 	tb.Helper()
-	prefix, ok := netipx.FromStdIPNet(cidr.IPNet)
-	require.True(tb, ok)
 	require.NoError(tb, ns.Do(func() error {
 		return lnh.updateNodeRoute(prefix, true, false)
 	}))
 }
 
-func mustDeleteNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, cidr *cidr.CIDR) {
+func mustDeleteNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, prefix netip.Prefix) {
 	tb.Helper()
-	prefix, ok := netipx.FromStdIPNet(cidr.IPNet)
-	require.True(tb, ok)
 	require.NoError(tb, ns.Do(func() error {
 		return lnh.deleteNodeRoute(prefix, false)
 	}))
 }
 
-// mustGetNodeRoute looks up a node route for the given CIDR in the given namespace and returns it.
-func mustGetNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, cidr *cidr.CIDR) *route.Route {
+// mustGetNodeRoute looks up a node route for the given prefix in the given namespace and returns it.
+func mustGetNodeRoute(tb testing.TB, ns *netns.NetNS, lnh *linuxNodeHandler, prefix netip.Prefix) *route.Route {
 	tb.Helper()
 
-	prefix, ok := netipx.FromStdIPNet(cidr.IPNet)
-	require.True(tb, ok)
 	var r *route.Route
 	require.NoError(tb, ns.Do(func() error {
 		var err error
@@ -269,11 +263,8 @@ func TestPrivilegedUpdateNodeRoute(t *testing.T) {
 func testUpdateNodeRoute(t *testing.T, family string) {
 	s := setup(t, family)
 
-	ip4CIDR := cidr.MustParseCIDR("254.254.254.0/24")
-	require.NotNil(t, ip4CIDR)
-
-	ip6CIDR := cidr.MustParseCIDR("cafe:cafe:cafe:cafe::/96")
-	require.NotNil(t, ip6CIDR)
+	ip4CIDR := netip.MustParsePrefix("254.254.254.0/24")
+	ip6CIDR := netip.MustParsePrefix("cafe:cafe:cafe:cafe::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
@@ -317,8 +308,8 @@ func TestPrivilegedAuxiliaryPrefixes(t *testing.T) {
 func testAuxiliaryPrefixes(t *testing.T, family string) {
 	s := setup(t, family)
 
-	net1 := cidr.MustParseCIDR("30.30.0.0/24")
-	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
+	net1 := netip.MustParsePrefix("30.30.0.0/24")
+	net2 := netip.MustParsePrefix("cafe:f00d::/112")
 
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
@@ -328,7 +319,7 @@ func testAuxiliaryPrefixes(t *testing.T, family string) {
 
 	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsecAgent, fakeipsec.Config{}, lns)
 	nodeConfig := s.nodeConfigTemplate
-	nodeConfig.AuxiliaryPrefixes = []*cidr.CIDR{net1, net2}
+	nodeConfig.AuxiliaryPrefixes = []ip.Prefix{ip.PrefixFrom(net1), ip.PrefixFrom(net2)}
 	mustConfigureNode(t, s.ns, lnh, nodeConfig)
 
 	if s.enableIPv4 {
@@ -342,7 +333,7 @@ func testAuxiliaryPrefixes(t *testing.T, family string) {
 	}
 
 	// remove aux prefix net2
-	nodeConfig.AuxiliaryPrefixes = []*cidr.CIDR{net1}
+	nodeConfig.AuxiliaryPrefixes = []ip.Prefix{ip.PrefixFrom(net1)}
 	mustConfigureNode(t, s.ns, lnh, nodeConfig)
 
 	if s.enableIPv4 {
@@ -356,7 +347,7 @@ func testAuxiliaryPrefixes(t *testing.T, family string) {
 	}
 
 	// remove aux prefix net1, re-add net2
-	nodeConfig.AuxiliaryPrefixes = []*cidr.CIDR{net2}
+	nodeConfig.AuxiliaryPrefixes = []ip.Prefix{ip.PrefixFrom(net2)}
 	mustConfigureNode(t, s.ns, lnh, nodeConfig)
 
 	if s.enableIPv4 {
@@ -393,10 +384,10 @@ func testNodeUpdateEncapsulationWithOverride(t *testing.T, family string) {
 func commonNodeUpdateEncapsulation(t *testing.T, family string, encap bool, override func(*nodeTypes.Node) bool) {
 	s := setup(t, family)
 
-	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
-	ip4Alloc2 := cidr.MustParseCIDR("6.6.6.0/24")
-	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
-	ip6Alloc2 := cidr.MustParseCIDR("2001:bbbb::/96")
+	ip4Alloc1 := netip.MustParsePrefix("5.5.5.0/24")
+	ip4Alloc2 := netip.MustParsePrefix("6.6.6.0/24")
+	ip6Alloc1 := netip.MustParsePrefix("2001:aaaa::/96")
+	ip6Alloc2 := netip.MustParsePrefix("2001:bbbb::/96")
 
 	externalNodeIP1 := net.ParseIP("4.4.4.4")
 
@@ -423,10 +414,10 @@ func commonNodeUpdateEncapsulation(t *testing.T, family string, encap bool, over
 	}
 
 	if s.enableIPv4 {
-		nodev1.IPv4AllocCIDR = cidrToNodePrefix(ip4Alloc1)
+		nodev1.IPv4AllocCIDR = nodeTypes.PrefixFrom(ip4Alloc1)
 	}
 	if s.enableIPv6 {
-		nodev1.IPv6AllocCIDR = cidrToNodePrefix(ip6Alloc1)
+		nodev1.IPv6AllocCIDR = nodeTypes.PrefixFrom(ip6Alloc1)
 	}
 
 	mustAddNode(t, s.ns, lnh, nodev1)
@@ -451,10 +442,10 @@ func commonNodeUpdateEncapsulation(t *testing.T, family string, encap bool, over
 	}
 
 	if s.enableIPv4 {
-		nodev2.IPv4AllocCIDR = cidrToNodePrefix(ip4Alloc2)
+		nodev2.IPv4AllocCIDR = nodeTypes.PrefixFrom(ip4Alloc2)
 	}
 	if s.enableIPv6 {
-		nodev2.IPv6AllocCIDR = cidrToNodePrefix(ip6Alloc2)
+		nodev2.IPv6AllocCIDR = nodeTypes.PrefixFrom(ip6Alloc2)
 	}
 
 	mustUpdateNode(t, s.ns, lnh, nodev1, nodev2)
@@ -511,10 +502,10 @@ func commonNodeUpdateEncapsulation(t *testing.T, family string, encap bool, over
 	}
 
 	if s.enableIPv4 {
-		nodev4.IPv4AllocCIDR = cidrToNodePrefix(ip4Alloc2)
+		nodev4.IPv4AllocCIDR = nodeTypes.PrefixFrom(ip4Alloc2)
 	}
 	if s.enableIPv6 {
-		nodev4.IPv6AllocCIDR = cidrToNodePrefix(ip6Alloc2)
+		nodev4.IPv6AllocCIDR = nodeTypes.PrefixFrom(ip6Alloc2)
 	}
 
 	mustUpdateNode(t, s.ns, lnh, nodev3, nodev4)

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -38,11 +38,6 @@ import (
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
-const (
-	// AutoCIDR indicates that a CIDR should be allocated
-	AutoCIDR = "auto"
-)
-
 // prefixToCIDR converts a netip.Prefix to the legacy *cidr.CIDR representation,
 // returning nil for the zero/invalid prefix. It is a transitional boundary
 // helper: the datapath LocalNodeConfiguration still carries *cidr.CIDR fields.
@@ -88,22 +83,12 @@ func newLocalNodeConfig(
 ) (config.Config, <-chan struct{}, error) {
 	auxPrefixes := []*cidr.CIDR{}
 
-	if daemon.IPv4ServiceRange != AutoCIDR {
-		serviceCIDR, err := cidr.ParseCIDR(daemon.IPv4ServiceRange)
-		if err != nil {
-			return config.Config{}, nil, fmt.Errorf("Invalid IPv4 service prefix %q: %w", daemon.IPv4ServiceRange, err)
-		}
-
-		auxPrefixes = append(auxPrefixes, serviceCIDR)
+	if daemon.IPv4ServiceRange.IsValid() {
+		auxPrefixes = append(auxPrefixes, prefixToCIDR(daemon.IPv4ServiceRange))
 	}
 
-	if daemon.IPv6ServiceRange != AutoCIDR {
-		serviceCIDR, err := cidr.ParseCIDR(daemon.IPv6ServiceRange)
-		if err != nil {
-			return config.Config{}, nil, fmt.Errorf("Invalid IPv6 service prefix %q: %w", daemon.IPv6ServiceRange, err)
-		}
-
-		auxPrefixes = append(auxPrefixes, serviceCIDR)
+	if daemon.IPv6ServiceRange.IsValid() {
+		auxPrefixes = append(auxPrefixes, prefixToCIDR(daemon.IPv6ServiceRange))
 	}
 
 	nativeDevices, devsWatch := tables.SelectedDevices(devices, txn)

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -81,14 +81,14 @@ func newLocalNodeConfig(
 	connectorConfig connector.Config,
 	plugins plugin.Plugins,
 ) (config.Config, <-chan struct{}, error) {
-	auxPrefixes := []*cidr.CIDR{}
+	auxPrefixes := []ip.Prefix{}
 
 	if daemon.IPv4ServiceRange.IsValid() {
-		auxPrefixes = append(auxPrefixes, prefixToCIDR(daemon.IPv4ServiceRange))
+		auxPrefixes = append(auxPrefixes, ip.PrefixFrom(daemon.IPv4ServiceRange))
 	}
 
 	if daemon.IPv6ServiceRange.IsValid() {
-		auxPrefixes = append(auxPrefixes, prefixToCIDR(daemon.IPv6ServiceRange))
+		auxPrefixes = append(auxPrefixes, ip.PrefixFrom(daemon.IPv6ServiceRange))
 	}
 
 	nativeDevices, devsWatch := tables.SelectedDevices(devices, txn)

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -34,9 +34,6 @@ var fakeConfig = &option.DaemonConfig{
 
 func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	logger := hivetest.Logger(tb)
-	option.Config.IPv4ServiceRange = "auto"
-	option.Config.IPv6ServiceRange = "auto"
-
 	h, _ := cell.NewSimpleHealth()
 	nm, err := New(logger, fakeConfig, cmtypes.DefaultClusterInfo, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(tb, err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -160,6 +160,9 @@ const (
 	// IPv6ServiceRange is the Kubernetes IPv6 services CIDR if not inside cluster prefix
 	IPv6ServiceRange = "ipv6-service-range"
 
+	// AutoCIDR indicates that a CIDR should be allocated
+	AutoCIDR = "auto"
+
 	// IPv6ClusterAllocCIDRName is the name of the IPv6ClusterAllocCIDR option
 	IPv6ClusterAllocCIDRName = "ipv6-cluster-alloc-cidr"
 
@@ -1449,8 +1452,8 @@ type DaemonConfig struct {
 	FixedZoneMappingValidator     Validator `json:"-"`
 	IPv4Range                     string
 	IPv6Range                     string
-	IPv4ServiceRange              string
-	IPv6ServiceRange              string
+	IPv4ServiceRange              netip.Prefix // zero value: inside the cluster prefix (AutoCIDR)
+	IPv6ServiceRange              netip.Prefix // zero value: inside the cluster prefix (AutoCIDR)
 	K8sSyncTimeout                time.Duration
 	AllocatorListTimeout          time.Duration
 	LabelPrefixFile               string
@@ -2480,11 +2483,9 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.IPAMDefaultIPPool = vp.GetString(IPAMDefaultIPPool)
 	c.IPv4Range = vp.GetString(IPv4Range)
 	c.IPv4NodeAddr = vp.GetString(IPv4NodeAddr)
-	c.IPv4ServiceRange = vp.GetString(IPv4ServiceRange)
 	c.IPv6ClusterAllocCIDR = vp.GetString(IPv6ClusterAllocCIDRName)
 	c.IPv6NodeAddr = vp.GetString(IPv6NodeAddr)
 	c.IPv6Range = vp.GetString(IPv6Range)
-	c.IPv6ServiceRange = vp.GetString(IPv6ServiceRange)
 	c.K8sRequireIPv4PodCIDR = vp.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = vp.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sSyncTimeout = vp.GetDuration(K8sSyncTimeoutName)
@@ -2628,6 +2629,33 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	}
 
 	c.EnableEncryptionStrictModeIngress = vp.GetBool(EnableEncryptionStrictModeIngress)
+
+	// The service ranges are optional: the AutoCIDR sentinel (the flag
+	// default) means the services CIDR is inside the cluster prefix, and is
+	// represented by the zero Prefix.
+	if ipv4ServiceRange := vp.GetString(IPv4ServiceRange); ipv4ServiceRange != AutoCIDR && ipv4ServiceRange != "" {
+		prefix, err := netip.ParsePrefix(ipv4ServiceRange)
+		if err != nil {
+			logging.Fatal(logger, fmt.Sprintf("Unable to parse CIDR '%s'", ipv4ServiceRange), logfields.Error, err)
+		}
+		c.IPv4ServiceRange = prefix.Masked()
+
+		if !c.IPv4ServiceRange.Addr().Is4() {
+			logging.Fatal(logger, fmt.Sprintf("%s must be an IPv4 CIDR", IPv4ServiceRange))
+		}
+	}
+
+	if ipv6ServiceRange := vp.GetString(IPv6ServiceRange); ipv6ServiceRange != AutoCIDR && ipv6ServiceRange != "" {
+		prefix, err := netip.ParsePrefix(ipv6ServiceRange)
+		if err != nil {
+			logging.Fatal(logger, fmt.Sprintf("Unable to parse CIDR '%s'", ipv6ServiceRange), logfields.Error, err)
+		}
+		c.IPv6ServiceRange = prefix.Masked()
+
+		if !c.IPv6ServiceRange.Addr().Is6() {
+			logging.Fatal(logger, fmt.Sprintf("%s must be an IPv6 CIDR", IPv6ServiceRange))
+		}
+	}
 
 	ipv4NativeRoutingCIDR := vp.GetString(IPv4NativeRoutingCIDR)
 


### PR DESCRIPTION
This PR continues the netip migration, moving the service range configuration flags from strings to `netip.Prefix` and the datapath's auxiliary prefixes from `*cidr.CIDR` to `ip.Prefix`.

See each commit message for details.

Relates to #24246