### PR TITLE
clustermesh: add FuncObserver and generic bridge to ctrlruntime requests

### DIFF
--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -36,7 +36,11 @@ var Cell = cell.Module(
 		return observer.NewFactoryOut(newFactory(params))
 	}),
 	cell.ProvidePrivate(newGlobalServiceExportCache),
-	cell.ProvidePrivate(newRemoteClusterServiceExportSource),
+	cell.ProvidePrivate(func() *operator.RemoteObjectSource[*mcsapitypes.MCSAPIServiceSpec] {
+		return operator.NewRemoteObjectSource(
+			operator.NewEnqueueRequestForNamespacedNameFunc[*mcsapitypes.MCSAPIServiceSpec](),
+		)
+	}),
 	metrics.Metric(NewMetrics),
 	cell.Invoke(registerMCSAPIController),
 
@@ -62,7 +66,7 @@ type mcsAPIParams struct {
 	JobGroup        job.Group
 	MetricsRegistry *metrics.Registry
 	Cache           *globalServiceExportCache
-	Source          *remoteClusterServiceExportSource
+	Source          *operator.RemoteObjectSource[*mcsapitypes.MCSAPIServiceSpec]
 
 	NamespaceConfig cmnamespace.Config
 }

--- a/pkg/clustermesh/mcsapi/observer.go
+++ b/pkg/clustermesh/mcsapi/observer.go
@@ -12,6 +12,7 @@ import (
 
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	"github.com/cilium/cilium/pkg/clustermesh/observer"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -26,7 +27,7 @@ type paramsObserver struct {
 	Metrics      Metrics
 	CfgMCSAPI    mcsapitypes.MCSAPIConfig
 	Cache        *globalServiceExportCache
-	Source       *remoteClusterServiceExportSource
+	Source       *operator.RemoteObjectSource[*mcsapitypes.MCSAPIServiceSpec]
 }
 
 func newFactory(params paramsObserver) observer.Factory {
@@ -46,11 +47,11 @@ func newFactory(params paramsObserver) observer.Factory {
 			&store.FuncObserver[*mcsapitypes.ValidatingMCSAPIServiceSpec]{
 				OnUpdateFunc: func(obj *mcsapitypes.ValidatingMCSAPIServiceSpec) {
 					params.Cache.OnUpdate(&obj.MCSAPIServiceSpec)
-					params.Source.onClusterServiceExportEvent(&obj.MCSAPIServiceSpec)
+					params.Source.OnEvent(&obj.MCSAPIServiceSpec)
 				},
 				OnDeleteFunc: func(obj *mcsapitypes.ValidatingMCSAPIServiceSpec) {
 					params.Cache.OnDelete(&obj.MCSAPIServiceSpec)
-					params.Source.onClusterServiceExportEvent(&obj.MCSAPIServiceSpec)
+					params.Source.OnEvent(&obj.MCSAPIServiceSpec)
 				},
 			},
 			store.RWSWithOnSyncCallback(func(context.Context) { onSync() }),

--- a/pkg/clustermesh/mcsapi/observer.go
+++ b/pkg/clustermesh/mcsapi/observer.go
@@ -43,11 +43,16 @@ func newFactory(params paramsObserver) observer.Factory {
 				mcsapitypes.ClusterNameValidator(cluster),
 				mcsapitypes.NamespacedNameValidator(),
 			),
-			newServiceExportsObserver(
-				params.Cache,
-				params.Source.onClusterServiceExportEvent,
-				params.Source.onClusterServiceExportEvent,
-			),
+			&store.FuncObserver[*mcsapitypes.ValidatingMCSAPIServiceSpec]{
+				OnUpdateFunc: func(obj *mcsapitypes.ValidatingMCSAPIServiceSpec) {
+					params.Cache.OnUpdate(&obj.MCSAPIServiceSpec)
+					params.Source.onClusterServiceExportEvent(&obj.MCSAPIServiceSpec)
+				},
+				OnDeleteFunc: func(obj *mcsapitypes.ValidatingMCSAPIServiceSpec) {
+					params.Cache.OnDelete(&obj.MCSAPIServiceSpec)
+					params.Source.onClusterServiceExportEvent(&obj.MCSAPIServiceSpec)
+				},
+			},
 			store.RWSWithOnSyncCallback(func(context.Context) { onSync() }),
 			store.RWSWithEntriesMetric(params.Metrics.TotalServiceExports.WithLabelValues(cluster)),
 		)

--- a/pkg/clustermesh/mcsapi/service_exports.go
+++ b/pkg/clustermesh/mcsapi/service_exports.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -116,39 +115,4 @@ func (c *globalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIService
 
 func (c *globalServiceExportCache) Size() uint64 {
 	return c.size
-}
-
-type remoteServiceExportObserver struct {
-	cache *globalServiceExportCache
-
-	onUpdate func(*mcsapitypes.MCSAPIServiceSpec)
-	onDelete func(*mcsapitypes.MCSAPIServiceSpec)
-}
-
-// newServiceExportsObserver returns an observer implementing the logic to convert
-// and filter export notifications, update the global service export cache and
-// call the upstream handlers when appropriate.
-func newServiceExportsObserver(
-	cache *globalServiceExportCache, onUpdate, onDelete func(*mcsapitypes.MCSAPIServiceSpec),
-) store.Observer {
-	return &remoteServiceExportObserver{
-		cache: cache,
-
-		onUpdate: onUpdate,
-		onDelete: onDelete,
-	}
-}
-
-// OnUpdate is called when a service export in a remote cluster is updated
-func (r *remoteServiceExportObserver) OnUpdate(key store.Key) {
-	svcExport := &(key.(*mcsapitypes.ValidatingMCSAPIServiceSpec).MCSAPIServiceSpec)
-	r.cache.OnUpdate(svcExport)
-	r.onUpdate(svcExport)
-}
-
-// OnDelete is called when a service export in a remote cluster is deleted
-func (r *remoteServiceExportObserver) OnDelete(key store.NamedKey) {
-	svcExport := &(key.(*mcsapitypes.ValidatingMCSAPIServiceSpec).MCSAPIServiceSpec)
-	r.cache.OnDelete(svcExport)
-	r.onDelete(svcExport)
 }

--- a/pkg/clustermesh/mcsapi/serviceimport_controller.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller.go
@@ -17,12 +17,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	mcsapicontrollers "sigs.k8s.io/mcs-api/controllers"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
@@ -53,7 +53,7 @@ type mcsAPIServiceImportReconciler struct {
 
 	cluster                    string
 	globalServiceExports       *globalServiceExportCache
-	remoteClusterServiceSource *remoteClusterServiceExportSource
+	remoteClusterServiceSource source.Source
 
 	enableIPv4 bool
 	enableIPv6 bool
@@ -61,7 +61,7 @@ type mcsAPIServiceImportReconciler struct {
 	namespaceConfig cmnamespace.Config
 }
 
-func newMCSAPIServiceImportReconciler(mgr ctrl.Manager, logger *slog.Logger, cluster string, globalServiceExports *globalServiceExportCache, remoteClusterServiceSource *remoteClusterServiceExportSource, enableIPv4, enableIPv6 bool, namespaceConfig cmnamespace.Config) *mcsAPIServiceImportReconciler {
+func newMCSAPIServiceImportReconciler(mgr ctrl.Manager, logger *slog.Logger, cluster string, globalServiceExports *globalServiceExportCache, remoteClusterServiceSource source.Source, enableIPv4, enableIPv6 bool, namespaceConfig cmnamespace.Config) *mcsAPIServiceImportReconciler {
 	return &mcsAPIServiceImportReconciler{
 		Client:                     mgr.GetClient(),
 		Logger:                     logger,
@@ -809,48 +809,4 @@ func (r *mcsAPIServiceImportReconciler) SetupWithManager(mgr ctrl.Manager) error
 		// Watch changes to external services
 		WatchesRawSource(r.remoteClusterServiceSource).
 		Complete(r)
-}
-
-// remoteClusterServiceExportSource is a source to watch remote cluster service exports.
-// The actual type returned by the watch is a ServiceExport to match the interface
-// needed by a regular controller-runtime controller. This prevents us from
-// implementing a more complicated/hands-on pattern of controller.
-type remoteClusterServiceExportSource struct {
-	Logger *slog.Logger
-
-	ctx   context.Context
-	queue workqueue.TypedRateLimitingInterface[ctrl.Request]
-}
-
-func newRemoteClusterServiceExportSource(logger *slog.Logger) *remoteClusterServiceExportSource {
-	return &remoteClusterServiceExportSource{Logger: logger}
-}
-
-func (s *remoteClusterServiceExportSource) onClusterServiceExportEvent(svcExport *mcsapitypes.MCSAPIServiceSpec) {
-	if s.ctx == nil || s.queue == nil {
-		// At this point the controller is not started yet and the namespace
-		// watcher will enqueue any initial state from remote clusters
-		// on start.
-		return
-	}
-
-	s.Logger.
-		Debug(
-			"Queueing update from remote cluster",
-			logfields.K8sNamespace, svcExport.Namespace,
-			logfields.K8sExportName, svcExport.Name,
-		)
-	s.queue.Add(ctrl.Request{NamespacedName: types.NamespacedName{
-		Name:      svcExport.Name,
-		Namespace: svcExport.Namespace,
-	}})
-}
-
-func (s *remoteClusterServiceExportSource) Start(
-	ctx context.Context,
-	queue workqueue.TypedRateLimitingInterface[ctrl.Request],
-) error {
-	s.ctx = ctx
-	s.queue = queue
-	return nil
 }

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
 )
 
 const (
@@ -674,7 +675,9 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 		WithScheme(testScheme()).
 		Build()
 	globalServiceExports := newGlobalServiceExportCache()
-	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: hivetest.Logger(t)}
+	remoteClusterServiceSource := operator.NewRemoteObjectSource(
+		operator.NewEnqueueRequestForNamespacedNameFunc[*mcsapitypes.MCSAPIServiceSpec](),
+	)
 	for _, svcExport := range remoteSvcImportTestFixtures {
 		globalServiceExports.OnUpdate(svcExport)
 	}

--- a/pkg/clustermesh/operator/remote_object_source.go
+++ b/pkg/clustermesh/operator/remote_object_source.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type NamespacedNamed interface {
+	NamespacedName() types.NamespacedName
+}
+
+// NewEnqueueRequestForNamespacedNameFunc returns a simple handler that
+// enqueues a reconcile request with the object namespaced name.
+func NewEnqueueRequestForNamespacedNameFunc[T NamespacedNamed]() handler.TypedEventHandler[T, ctrl.Request] {
+	return handler.TypedEnqueueRequestsFromMapFunc(
+		func(ctx context.Context, obj T) []ctrl.Request {
+			return []ctrl.Request{{NamespacedName: obj.NamespacedName()}}
+		},
+	)
+}
+
+var _ source.Source = &RemoteObjectSource[any]{}
+
+type remoteObjectEvent[T any] func(
+	ctx context.Context, handler handler.TypedEventHandler[T, ctrl.Request],
+	queue workqueue.TypedRateLimitingInterface[ctrl.Request],
+)
+
+// RemoteObjectSource bridges remote clustermesh object events into
+// controller-runtime reconcile requests.
+type RemoteObjectSource[T any] struct {
+	handler handler.TypedEventHandler[T, ctrl.Request]
+
+	mutex lock.Mutex
+	buf   []remoteObjectEvent[T]
+	ctx   context.Context
+	queue workqueue.TypedRateLimitingInterface[ctrl.Request]
+}
+
+// NewRemoteObjectSource creates a controller-runtime source for remote
+// clustermesh object events.
+func NewRemoteObjectSource[T any](
+	handler handler.TypedEventHandler[T, ctrl.Request],
+) *RemoteObjectSource[T] {
+	return &RemoteObjectSource[T]{
+		handler: handler,
+	}
+}
+
+func (s *RemoteObjectSource[T]) OnEvent(obj T) {
+	s.enqueue(func(
+		ctx context.Context, handler handler.TypedEventHandler[T, ctrl.Request],
+		queue workqueue.TypedRateLimitingInterface[ctrl.Request],
+	) {
+		evt := event.TypedGenericEvent[T]{Object: obj}
+		handler.Generic(ctx, evt, queue)
+	})
+}
+
+func (s *RemoteObjectSource[T]) enqueue(evt remoteObjectEvent[T]) {
+	s.mutex.Lock()
+	if s.queue == nil {
+		// Start was not called yet, buffer the event
+		s.buf = append(s.buf, evt)
+		s.mutex.Unlock()
+		return
+	}
+	ctx := s.ctx
+	queue := s.queue
+	s.mutex.Unlock()
+
+	evt(ctx, s.handler, queue)
+}
+
+func (s *RemoteObjectSource[T]) Start(
+	ctx context.Context, queue workqueue.TypedRateLimitingInterface[ctrl.Request],
+) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.ctx = ctx
+	s.queue = queue
+	for _, evt := range s.buf {
+		// Queue the events that were received before Start was called
+		evt(ctx, s.handler, s.queue)
+	}
+	s.buf = nil
+
+	return nil
+}

--- a/pkg/clustermesh/operator/remote_object_source_test.go
+++ b/pkg/clustermesh/operator/remote_object_source_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type testRemoteObject struct {
+	namespace string
+	name      string
+}
+
+func (o testRemoteObject) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{Namespace: o.namespace, Name: o.name}
+}
+
+func requireRequest(t *testing.T, queue workqueue.TypedRateLimitingInterface[ctrl.Request], name string) {
+	t.Helper()
+
+	item, shutdown := queue.Get()
+	require.False(t, shutdown)
+	defer queue.Done(item)
+	require.Equal(t, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: name}}, item)
+}
+
+func TestRemoteObjectSource(t *testing.T) {
+	src := NewRemoteObjectSource(
+		NewEnqueueRequestForNamespacedNameFunc[NamespacedNamed](),
+	)
+
+	src.OnEvent(testRemoteObject{namespace: "default", name: "before-start"})
+
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[ctrl.Request]())
+	t.Cleanup(queue.ShutDown)
+	require.NoError(t, src.Start(t.Context(), queue))
+	require.Equal(t, 1, queue.Len())
+
+	src.OnEvent(testRemoteObject{namespace: "default", name: "generic"})
+
+	require.Equal(t, 2, queue.Len())
+	requireRequest(t, queue, "before-start")
+	requireRequest(t, queue, "generic")
+	require.Zero(t, queue.Len())
+}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -170,6 +170,25 @@ type Key interface {
 	Unmarshal(key string, data []byte) error
 }
 
+// FuncObserver is an implementation of the Observer interface. It provides a
+// convenient way to implement an observer without having to create a new type.
+type FuncObserver[T Key] struct {
+	OnUpdateFunc func(T)
+	OnDeleteFunc func(T)
+}
+
+func (o *FuncObserver[T]) OnUpdate(k Key) {
+	if o.OnUpdateFunc != nil {
+		o.OnUpdateFunc(k.(T))
+	}
+}
+
+func (o *FuncObserver[T]) OnDelete(k NamedKey) {
+	if o.OnDeleteFunc != nil {
+		o.OnDeleteFunc(k.(T))
+	}
+}
+
 // KVPair represents a basic implementation of the Key interface
 type KVPair struct {
 	Key   string


### PR DESCRIPTION
This PR add a convenient FuncObserver utils and a generic bridge `RemoteObjectSource[T]` from kvstore to ctrlruntime request replacing the specific MCS-API one. `RemoteObjectSource` will also be useful for EndpointSliceSync with `ClusterEndpointSlice` as source.