### PR TITLE
Gateway-api: add support for session persistence

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -70,6 +70,7 @@ Cilium's Gateway API features:
    https
    grpc
    splitting
+   session-persistence
    header
    parameterized-gatewayclass
    default-tls-certificate

--- a/Documentation/network/servicemesh/gateway-api/session-persistence.rst
+++ b/Documentation/network/servicemesh/gateway-api/session-persistence.rst
@@ -142,8 +142,9 @@ Cilium supports the following Gateway API fields and values:
      - ``Cookie`` (default)
      - ``Header``
    * - ``sessionName``
-     - A non-empty string, or omitted to let Cilium generate a name
-     - An empty string
+     - A valid, non-empty HTTP cookie name, or omitted to let Cilium generate
+       a name
+     - An empty or invalid HTTP cookie name
    * - ``cookieConfig.lifetimeType``
      - ``Session`` (default)
      - ``Permanent``

--- a/Documentation/network/servicemesh/gateway-api/session-persistence.rst
+++ b/Documentation/network/servicemesh/gateway-api/session-persistence.rst
@@ -1,0 +1,168 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gateway_session_persistence:
+
+*******************
+Session Persistence
+*******************
+
+Session persistence directs multiple related requests to the same upstream
+endpoint. Cilium supports cookie-based session persistence on individual
+``HTTPRoute`` and ``GRPCRoute`` rules that are attached through Gateway API.
+
+The ``sessionPersistence`` field is experimental in Gateway API. Install the
+experimental ``HTTPRoute`` and ``GRPCRoute`` CRDs as described in
+:ref:`gs_gateway_api_prerequisites` before using this feature.
+
+.. note::
+
+    Session persistence is not supported for GAMMA routes whose parent is a
+    ``Service``. Cilium rejects such a route with an ``Accepted`` condition set
+    to ``False`` and the ``UnsupportedValue`` reason.
+
+Configure session persistence
+#############################
+
+Session persistence is configured per route rule. Each rule that requires
+persistence must set ``sessionPersistence``. Rules without this field continue
+to use normal load balancing.
+
+The following ``HTTPRoute`` rule uses an explicitly named session cookie:
+
+.. code-block:: yaml
+
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: persistent-http-route
+    spec:
+      parentRefs:
+      - name: tls-gateway
+      hostnames:
+      - app.example.com
+      rules:
+      - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+        backendRefs:
+        - name: app-v1
+          port: 8080
+          weight: 50
+        - name: app-v2
+          port: 8080
+          weight: 50
+        sessionPersistence:
+          type: Cookie
+          sessionName: app-session
+          cookieConfig:
+            lifetimeType: Session
+
+The first request is load balanced normally. The response sets the
+``app-session`` cookie, and subsequent requests that include that cookie are
+directed to the same upstream endpoint.
+
+The default value for the ``type`` field is ``Cookie``, and is currently the
+only supported value. Similarly, the default and only supported value for the
+``cookieConfig.lifetimeType`` is ``Session``. These fields can be safely omitted.
+
+The same field is available on a ``GRPCRoute`` rule:
+
+.. code-block:: yaml
+
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: GRPCRoute
+    metadata:
+      name: persistent-grpc-route
+    spec:
+      parentRefs:
+      - name: tls-gateway
+      rules:
+      - matches:
+        - method:
+            service: example.v1.ExampleService
+        backendRefs:
+        - name: grpc-app
+          port: 7070
+        sessionPersistence:
+          sessionName: grpc-session
+
+Cookie behavior
+===============
+
+Cilium configures session persistence cookies as follows:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Setting
+     - Behavior
+   * - Name
+     - Cilium uses ``sessionName`` when it is set. If it is omitted, Cilium
+       generates a name beginning with ``cilium-gw-session-`` from the route
+       kind, namespace, name, and rule position. Set an explicit name if the
+       name must remain stable when rules are reordered.  When choosing a name,
+       ensure that it is unique among routes serving the same hostname with
+       overlapping cookie paths.
+   * - Path
+     - Cilium uses an exact or prefix route path when one is available, or
+       defaults to ``/``.
+   * - Lifetime
+     - The cookie is a session cookie. Cilium does not set ``Max-Age`` or
+       ``Expires`` attributes.
+   * - Attributes
+     - Cilium always sets ``Secure``, ``HttpOnly``, and ``SameSite=Strict``.
+       These attributes are not configurable.
+   * - Unavailable endpoint
+     - If the endpoint encoded in the cookie is unavailable, Cilium falls back
+       to normal load balancing and updates the session cookie for the newly
+       selected endpoint.
+
+Because the cookie always has the ``Secure`` attribute, web browsers only send
+it over HTTPS. Configure a TLS listener as described in
+:ref:`gs_gateway_https` when browser clients use session persistence.
+
+Supported fields
+================
+
+Cilium supports the following Gateway API fields and values:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Supported values
+     - Unsupported values
+   * - ``type``
+     - ``Cookie`` (default)
+     - ``Header``
+   * - ``sessionName``
+     - A non-empty string, or omitted to let Cilium generate a name
+     - An empty string
+   * - ``cookieConfig.lifetimeType``
+     - ``Session`` (default)
+     - ``Permanent``
+   * - ``absoluteTimeout``
+     - None (unsupported)
+     - Any specified duration
+
+When a route uses an unsupported value, Cilium sets its ``Accepted`` condition
+to ``False`` with the ``UnsupportedValue`` reason. Inspect the route status for
+the specific validation message:
+
+.. code-block:: shell-session
+
+    $ kubectl describe httproute <route-name>
+    $ kubectl describe grpcroute <route-name>
+
+Security considerations
+=======================
+
+The persistence cookie identifies an upstream endpoint. Its contents are not
+signed or encrypted, so clients can inspect or modify them. Do not use the
+cookie as proof of authentication or as an application session identity.

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -216,6 +216,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 			}
 
 			for _, fn := range []routechecks.CheckWithParentFunc{
+				routechecks.CheckSessionPersistence,
 				routechecks.CheckAgainstCrossNamespaceBackendReferences,
 				routechecks.CheckBackend,
 				routechecks.CheckBackendIsExistingService,
@@ -326,6 +327,7 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 			}
 
 			for _, fn := range []routechecks.CheckWithParentFunc{
+				routechecks.CheckSessionPersistence,
 				routechecks.CheckAgainstCrossNamespaceBackendReferences,
 				routechecks.CheckBackend,
 				routechecks.CheckBackendIsExistingService,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -283,6 +283,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-request-multiple-mirrors", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-request-percentage-mirror", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-response-header-modifier", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "route-session-persistence", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-timeout-backend-request", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-timeout-request", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-weight", gateway: []gwDetails{gatewaySameNamespace}},

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -62,6 +62,10 @@ func (g *GRPCRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
 	return refs
 }
 
+func (g *GRPCRouteRule) GetSessionPersistence() *gatewayv1.SessionPersistence {
+	return g.Rule.SessionPersistence
+}
+
 func (g *GRPCRouteInput) GetRules() []GenericRule {
 	var rules []GenericRule
 	for _, rule := range g.GRPCRoute.Spec.Rules {

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -174,6 +174,10 @@ func (t *HTTPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
 	return refs
 }
 
+func (t *HTTPRouteRule) GetSessionPersistence() *gatewayv1.SessionPersistence {
+	return t.Rule.SessionPersistence
+}
+
 func invalidHeaderModifierCondition(headerName gatewayv1.HTTPHeaderName) metav1.Condition {
 	return metav1.Condition{
 		Type:    string(gatewayv1.RouteConditionAccepted),

--- a/operator/pkg/gateway-api/routechecks/route_checks.go
+++ b/operator/pkg/gateway-api/routechecks/route_checks.go
@@ -17,6 +17,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+type sessionPersistenceRule interface {
+	GetSessionPersistence() *gatewayv1.SessionPersistence
+}
+
 func CheckAgainstCrossNamespaceBackendReferences(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
 	continueChecks := true
 
@@ -161,4 +165,61 @@ func checkBackendServicePort(svc *corev1.Service, be gatewayv1.BackendRef) error
 	}
 
 	return fmt.Errorf("Service port %d could not be resolved for backend %s/%s", *be.Port, svc.Namespace, svc.Name)
+}
+
+func CheckSessionPersistence(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	continueChecks := true
+	for _, rule := range input.GetRules() {
+		sessionRule, ok := rule.(sessionPersistenceRule)
+		if !ok {
+			continue
+		}
+
+		sp := sessionRule.GetSessionPersistence()
+		if sp == nil {
+			continue
+		}
+
+		if helpers.IsGammaService(parentRef) {
+			setUnsupportedValue(input, parentRef, "Cilium does not support session persistence for GAMMA routes")
+			return false, nil
+		}
+
+		if sp.Type != nil && *sp.Type != gatewayv1.CookieBasedSessionPersistence {
+			setUnsupportedValue(input, parentRef, "Cilium only supports cookie-based session persistence")
+			continueChecks = false
+			continue
+		}
+
+		if sp.SessionName != nil && *sp.SessionName == "" {
+			setUnsupportedValue(input, parentRef, "Session name cannot be explicitly empty")
+			continueChecks = false
+			continue
+		}
+
+		if sp.AbsoluteTimeout != nil {
+			setUnsupportedValue(input, parentRef, "Unsupported session persistence field AbsoluteTimeout")
+			continueChecks = false
+			continue
+		}
+
+		if cc := sp.CookieConfig; cc != nil {
+
+			if cc.LifetimeType != nil && *cc.LifetimeType != gatewayv1.SessionCookieLifetimeType {
+				setUnsupportedValue(input, parentRef, "Cilium only supports session cookie persistence")
+				continueChecks = false
+			}
+		}
+	}
+
+	return continueChecks, nil
+}
+
+func setUnsupportedValue(input Input, parentRef gatewayv1.ParentReference, message string) {
+	input.SetParentCondition(parentRef, metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+		Message: message,
+	})
 }

--- a/operator/pkg/gateway-api/routechecks/route_checks.go
+++ b/operator/pkg/gateway-api/routechecks/route_checks.go
@@ -5,6 +5,7 @@ package routechecks
 
 import (
 	"fmt"
+	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -197,6 +198,12 @@ func CheckSessionPersistence(input Input, parentRef gatewayv1.ParentReference) (
 			continue
 		}
 
+		if sp.SessionName != nil && !isValidCookieName(*sp.SessionName) {
+			setUnsupportedValue(input, parentRef, "Session name must be a valid HTTP cookie name")
+			continueChecks = false
+			continue
+		}
+
 		if sp.AbsoluteTimeout != nil {
 			setUnsupportedValue(input, parentRef, "Unsupported session persistence field AbsoluteTimeout")
 			continueChecks = false
@@ -213,6 +220,10 @@ func CheckSessionPersistence(input Input, parentRef gatewayv1.ParentReference) (
 	}
 
 	return continueChecks, nil
+}
+
+func isValidCookieName(name string) bool {
+	return (&http.Cookie{Name: name}).Valid() == nil
 }
 
 func setUnsupportedValue(input Input, parentRef gatewayv1.ParentReference, message string) {

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -151,6 +151,7 @@ var gatewayCheckFuncs = []routechecks.CheckWithParentFunc{
 }
 
 var backendCheckFuncs = []routechecks.CheckWithParentFunc{
+	routechecks.CheckSessionPersistence,
 	routechecks.CheckAgainstCrossNamespaceBackendReferences,
 	routechecks.CheckBackend,
 	routechecks.CheckHasServiceImportSupport,

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/input/routes.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/input/routes.yaml
@@ -1,0 +1,151 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-http
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /exact
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        type: Cookie
+        sessionName: exact-session
+        cookieConfig:
+          lifetimeType: Session
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /prefix
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence: {}
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        sessionName: fallback-session
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /same
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        sessionName: same-session-a
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /same
+      backendRefs:
+        - name: infra-backend-v2
+          port: 8080
+      sessionPersistence:
+        sessionName: same-session-b
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /plain
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /redirect
+      filters:
+        - type: RequestRedirect
+          requestRedirect: {}
+      sessionPersistence: {}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /direct
+      sessionPersistence: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: session-persistence-grpc
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - method:
+            service: persistence.Session
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8081
+      sessionPersistence:
+        sessionName: grpc-session
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: session-persistence-header
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8081
+      sessionPersistence:
+        type: Header
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-permanent
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        cookieConfig:
+          lifetimeType: Permanent
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-absolute-timeout
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        absoluteTimeout: 1h
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-empty-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        sessionName: ""

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/input/routes.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/input/routes.yaml
@@ -149,3 +149,18 @@ spec:
           port: 8080
       sessionPersistence:
         sessionName: ""
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-invalid-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      sessionPersistence:
+        sessionName: session:name

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/cec-same-namespace.yaml
@@ -1,0 +1,301 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+    - "8081"
+  - name: infra-backend-v2
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.stateful_session
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          path: /exact
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: exact-session
+                    path: /exact
+                    ttl: 0s
+      - match:
+          pathSeparatedPrefix: /persistence.Session
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8081
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: grpc-session
+                    path: /persistence.Session/
+                    ttl: 0s
+      - match:
+          pathSeparatedPrefix: /redirect
+        redirect:
+          portRedirect: 80
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            disabled: true
+      - match:
+          pathSeparatedPrefix: /prefix
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: cilium-gw-session-18fabe3ffd1e9d91
+                    path: /prefix
+                    ttl: 0s
+      - directResponse:
+          body:
+            inlineString: ""
+          status: 500
+        match:
+          pathSeparatedPrefix: /direct
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            disabled: true
+      - match:
+          pathSeparatedPrefix: /plain
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            disabled: true
+      - match:
+          pathSeparatedPrefix: /same
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: same-session-a
+                    path: /same
+                    ttl: 0s
+      - match:
+          pathSeparatedPrefix: /same
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v2:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: same-session-b
+                    path: /same
+                    ttl: 0s
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+        typedPerFilterConfig:
+          envoy.filters.http.stateful_session:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+            statefulSession:
+              sessionState:
+                name: envoy.http.stateful_session.cookie
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                  cookie:
+                    attributes:
+                    - name: Secure
+                    - name: HttpOnly
+                    - name: SameSite
+                      value: Strict
+                    name: fallback-session
+                    path: /
+                    ttl: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8081
+    name: gateway-conformance-infra:infra-backend-v1:8081
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v2:8080
+    name: gateway-conformance-infra:infra-backend-v2:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - name: cilium-gateway-same-namespace
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/grpcroute-session-persistence-grpc.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/grpcroute-session-persistence-grpc.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: session-persistence-grpc
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8081
+    matches:
+    - method:
+        service: persistence.Session
+    sessionPersistence:
+      sessionName: grpc-session
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Accepted GRPCRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/grpcroute-session-persistence-header.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/grpcroute-session-persistence-header.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: session-persistence-header
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8081
+    sessionPersistence:
+      type: Header
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Cilium only supports cookie-based session persistence
+      reason: UnsupportedValue
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-absolute-timeout.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-absolute-timeout.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-absolute-timeout
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    sessionPersistence:
+      absoluteTimeout: 1h
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Unsupported session persistence field AbsoluteTimeout
+      reason: UnsupportedValue
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-empty-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-empty-name.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-empty-name
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    sessionPersistence:
+      sessionName: ""
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Session name cannot be explicitly empty
+      reason: UnsupportedValue
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-http.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-http.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-http
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - path:
+        type: Exact
+        value: /exact
+    sessionPersistence:
+      cookieConfig:
+        lifetimeType: Session
+      sessionName: exact-session
+      type: Cookie
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /prefix
+    sessionPersistence: {}
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    sessionPersistence:
+      sessionName: fallback-session
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /same
+    sessionPersistence:
+      sessionName: same-session-a
+  - backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /same
+    sessionPersistence:
+      sessionName: same-session-b
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /plain
+  - filters:
+    - requestRedirect: {}
+      type: RequestRedirect
+    matches:
+    - path:
+        type: PathPrefix
+        value: /redirect
+    sessionPersistence: {}
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /direct
+    sessionPersistence: {}
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-invalid-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-invalid-name.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-invalid-name
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    sessionPersistence:
+      sessionName: session:name
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Session name must be a valid HTTP cookie name
+      reason: UnsupportedValue
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-permanent.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/httproute-session-persistence-permanent.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-permanent
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    sessionPersistence:
+      cookieConfig:
+        lifetimeType: Permanent
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Cilium only supports session cookie persistence
+      reason: UnsupportedValue
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/route-session-persistence/output/same-namespace.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+status:
+  conditions:
+  - lastTransitionTime: "2026-08-17T16:39:26Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-08-17T16:39:26Z"
+    message: Gateway waiting for address
+    reason: AddressNotAssigned
+    status: "False"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 2
+    conditions:
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-08-17T16:39:26Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -5,6 +5,8 @@ package ingestion
 
 import (
 	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -517,14 +519,16 @@ func extractRoutes(logger *slog.Logger,
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
 				CORS:                   requestCORS,
+				SessionPersistence:     toHTTPSessionPersistence(rule.SessionPersistence, helpers.HTTPRouteKind, hr.Namespace, hr.Name, ruleIndex, model.StringMatch{}),
 			})
 		}
 
 		for matchIndex, match := range rule.Matches {
+			pathMatch := toPathMatch(match)
 			httpRoutes = append(httpRoutes, model.HTTPRoute{
 				SourceRule:             sourceHTTPRouteRule(hr, ruleIndex, matchIndex),
 				Hostnames:              hostnames,
-				PathMatch:              toPathMatch(match),
+				PathMatch:              pathMatch,
 				HeadersMatch:           toHeaderMatch(match),
 				QueryParamsMatch:       toQueryMatch(match),
 				Method:                 (*string)(match.Method),
@@ -540,6 +544,7 @@ func extractRoutes(logger *slog.Logger,
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
 				CORS:                   requestCORS,
+				SessionPersistence:     toHTTPSessionPersistence(rule.SessionPersistence, helpers.HTTPRouteKind, hr.Namespace, hr.Name, ruleIndex, pathMatch),
 			})
 		}
 	}
@@ -763,7 +768,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 
 func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
-	for _, rule := range grpcr.Spec.Rules {
+	for ruleIndex, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
 			if !helpers.IsBackendReferenceAllowed(grpcr.GetNamespace(), be.BackendRef, helpers.GatewayV1GVK("GRPCRoute"), grants) {
@@ -857,13 +862,15 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				RequestHeaderFilter:    requestHeaderFilter,
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
+				SessionPersistence:     toHTTPSessionPersistence(rule.SessionPersistence, helpers.GRPCRouteKind, grpcr.Namespace, grpcr.Name, ruleIndex, model.StringMatch{}),
 			})
 		}
 
 		for _, match := range rule.Matches {
+			pathMatch := toGRPCPathMatch(match)
 			grpcRoutes = append(grpcRoutes, model.HTTPRoute{
 				Hostnames:              hostnames,
-				PathMatch:              toGRPCPathMatch(match),
+				PathMatch:              pathMatch,
 				HeadersMatch:           toGRPCHeaderMatch(match),
 				Backends:               bes,
 				DirectResponse:         dr,
@@ -871,6 +878,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
 				IsGRPC:                 true,
+				SessionPersistence:     toHTTPSessionPersistence(rule.SessionPersistence, helpers.GRPCRouteKind, grpcr.Namespace, grpcr.Name, ruleIndex, pathMatch),
 			})
 		}
 	}
@@ -1475,4 +1483,40 @@ func toStringSlice[S ~string](s []S) []string {
 		res = append(res, string(h))
 	}
 	return res
+}
+
+func toHTTPSessionPersistence(sp *gatewayv1.SessionPersistence, kind, namespace, routeName string, ruleIndex int, pathMatch model.StringMatch) *model.HTTPSessionPersistence {
+	if sp == nil {
+		return nil
+	}
+
+	sessionName := defaultSessionName(kind, namespace, routeName, ruleIndex)
+	if sp.SessionName != nil {
+		sessionName = *sp.SessionName
+	}
+
+	cookiePath := ""
+	switch {
+	case pathMatch.Exact != "":
+		cookiePath = pathMatch.Exact
+	case pathMatch.Prefix != "":
+		cookiePath = pathMatch.Prefix
+	default:
+		cookiePath = "/"
+	}
+
+	return &model.HTTPSessionPersistence{
+		Cookie: &model.HTTPCookieSessionPersistence{
+			Name:     sessionName,
+			Path:     cookiePath,
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: "Strict",
+		},
+	}
+}
+
+func defaultSessionName(kind, namespace, routeName string, ruleIndex int) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s/%s/%s/%d", kind, namespace, routeName, ruleIndex))
+	return fmt.Sprintf("cilium-gw-session-%s", hex.EncodeToString(sum[:8]))
 }

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1908,3 +1908,69 @@ func readGatewayInput(t *testing.T, testName string) Input {
 
 	return input
 }
+
+func TestToHTTPSessionPersistence(t *testing.T) {
+	wantPersistence := func(name, path string) *model.HTTPSessionPersistence {
+		return &model.HTTPSessionPersistence{
+			Cookie: &model.HTTPCookieSessionPersistence{
+				Name:     name,
+				Path:     path,
+				Secure:   true,
+				HTTPOnly: true,
+				SameSite: "Strict",
+			},
+		}
+	}
+
+	ns := "default"
+	name := "route"
+	index := 0
+	generatedName := defaultSessionName(helpers.HTTPRouteKind, ns, name, index)
+
+	tests := []struct {
+		name  string
+		input *gatewayv1.SessionPersistence
+		path  model.StringMatch
+		want  *model.HTTPSessionPersistence
+	}{
+		{
+			name:  "no persistence",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "explicit name and exact path",
+			input: &gatewayv1.SessionPersistence{
+				SessionName: ptr.To("custom-session"),
+			},
+			path: model.StringMatch{Exact: "/exact"},
+			want: wantPersistence("custom-session", "/exact"),
+		},
+		{
+			name:  "generated name and prefix path",
+			input: &gatewayv1.SessionPersistence{},
+			path:  model.StringMatch{Prefix: "/prefix"},
+			want:  wantPersistence(generatedName, "/prefix"),
+		},
+		{
+			name:  "regex path falls back to root",
+			input: &gatewayv1.SessionPersistence{},
+			path:  model.StringMatch{Regex: "/items/[0-9]+"},
+			want:  wantPersistence(generatedName, "/"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toHTTPSessionPersistence(
+				tt.input,
+				helpers.HTTPRouteKind,
+				ns,
+				name,
+				index,
+				tt.path,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -506,15 +506,15 @@ func (s *HTTPSessionPersistence) String() string {
 
 	sb := strings.Builder{}
 	sb.WriteString("cookie:")
-	sb.WriteString(s.Cookie.Name)
+	sb.WriteString(strconv.Quote(s.Cookie.Name))
 	sb.WriteString(":")
-	sb.WriteString(s.Cookie.Path)
+	sb.WriteString(strconv.Quote(s.Cookie.Path))
 	sb.WriteString(":")
 	sb.WriteString(strconv.FormatBool(s.Cookie.Secure))
 	sb.WriteString(":")
 	sb.WriteString(strconv.FormatBool(s.Cookie.HTTPOnly))
 	sb.WriteString(":")
-	sb.WriteString(s.Cookie.SameSite)
+	sb.WriteString(strconv.Quote(s.Cookie.SameSite))
 	return sb.String()
 }
 

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -495,6 +495,37 @@ type HTTPCORSFilter struct {
 	MaxAge int32 `json:"maxAge,omitempty"`
 }
 
+type HTTPSessionPersistence struct {
+	Cookie *HTTPCookieSessionPersistence `json:"cookie,omitempty"`
+}
+
+func (s *HTTPSessionPersistence) String() string {
+	if s == nil || s.Cookie == nil {
+		return ""
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString("cookie:")
+	sb.WriteString(s.Cookie.Name)
+	sb.WriteString(":")
+	sb.WriteString(s.Cookie.Path)
+	sb.WriteString(":")
+	sb.WriteString(strconv.FormatBool(s.Cookie.Secure))
+	sb.WriteString(":")
+	sb.WriteString(strconv.FormatBool(s.Cookie.HTTPOnly))
+	sb.WriteString(":")
+	sb.WriteString(s.Cookie.SameSite)
+	return sb.String()
+}
+
+type HTTPCookieSessionPersistence struct {
+	Name     string `json:"name,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Secure   bool   `json:"secure,omitempty"`
+	HTTPOnly bool   `json:"httpOnly,omitempty"`
+	SameSite string `json:"sameSite,omitempty"`
+}
+
 // HTTPRoute holds all the details needed to route HTTP traffic to a backend.
 type HTTPRoute struct {
 	Name string `json:"name,omitempty"`
@@ -550,6 +581,9 @@ type HTTPRoute struct {
 
 	// CORS holds cross-origin resource sharing filters for a route.
 	CORS *HTTPCORSFilter `json:"cors,omitempty"`
+
+	// SessionPersistence holds session persistence configuration for a route.
+	SessionPersistence *HTTPSessionPersistence `json:"session_persistence,omitempty"`
 }
 
 type BackendHTTPFilter struct {
@@ -625,6 +659,12 @@ func (r *HTTPRoute) GetMatchKey() string {
 			sb.WriteString(":")
 			sb.WriteString(r.ExternalAuth.Backend.Port.GetPort())
 		}
+		sb.WriteString("|")
+	}
+
+	if r.SessionPersistence != nil {
+		sb.WriteString("session:")
+		sb.WriteString(r.SessionPersistence.String())
 		sb.WriteString("|")
 	}
 
@@ -950,6 +990,18 @@ func (m *Model) IsCORSFilterConfigured() bool {
 		}
 	}
 
+	return false
+}
+
+// IsSessionPersistenceConfigured returns true if any HTTP route has configured session persistence.
+func (m *Model) IsSessionPersistenceConfigured() bool {
+	for _, h := range m.HTTP {
+		for _, r := range h.Routes {
+			if r.SessionPersistence != nil && r.SessionPersistence.Cookie != nil {
+				return true
+			}
+		}
+	}
 	return false
 }
 

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -989,3 +989,137 @@ func TestModel_IsTCPAccessLogsConfigured(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_IsSessionPersistenceConfigured(t *testing.T) {
+	tests := []struct {
+		name          string
+		httpListeners []HTTPListener
+		want          bool
+	}{
+		{
+			name:          "no HTTP listeners",
+			httpListeners: []HTTPListener{},
+			want:          false,
+		},
+		{
+			name:          "HTTP listener without session persistence",
+			httpListeners: []HTTPListener{{Routes: []HTTPRoute{{SessionPersistence: nil}}}},
+			want:          false,
+		},
+		{
+			name:          "HTTP listener with empty session persistence",
+			httpListeners: []HTTPListener{{Routes: []HTTPRoute{{SessionPersistence: &HTTPSessionPersistence{}}}}},
+			want:          false,
+		},
+		{
+			name: "one HTTP listener with session persistence",
+			httpListeners: []HTTPListener{
+				{
+					Routes: []HTTPRoute{
+						{
+							SessionPersistence: &HTTPSessionPersistence{
+								Cookie: &HTTPCookieSessionPersistence{Name: "session"},
+							},
+						},
+					}},
+			},
+			want: true,
+		},
+		{
+			name: "multiple HTTP listeners with mixed session persistence",
+			httpListeners: []HTTPListener{
+				{
+					Routes: []HTTPRoute{{SessionPersistence: nil}},
+				},
+				{
+					Routes: []HTTPRoute{
+						{
+							SessionPersistence: &HTTPSessionPersistence{
+								Cookie: &HTTPCookieSessionPersistence{Name: "session"},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{HTTP: tt.httpListeners}
+			if got := m.IsSessionPersistenceConfigured(); got != tt.want {
+				t.Errorf("Model.IsSessionPersistenceConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPRouteSessionPersistenceMatchKey(t *testing.T) {
+	baseRoute := HTTPRoute{
+		PathMatch: StringMatch{Prefix: "/api"},
+		SessionPersistence: &HTTPSessionPersistence{
+			Cookie: &HTTPCookieSessionPersistence{
+				Name: "gateway-session",
+				Path: "/api",
+			},
+		},
+	}
+	baseKey := baseRoute.GetMatchKey()
+
+	tests := []struct {
+		name        string
+		persistence *HTTPSessionPersistence
+		wantEqual   bool
+	}{
+		{
+			name:        "no persistence",
+			persistence: nil,
+			wantEqual:   false,
+		},
+		{
+			name: "identical configuration",
+			persistence: &HTTPSessionPersistence{
+				Cookie: &HTTPCookieSessionPersistence{
+					Name: "gateway-session",
+					Path: "/api",
+				},
+			},
+			wantEqual: true,
+		},
+		{
+			name: "different cookie name",
+			persistence: &HTTPSessionPersistence{
+				Cookie: &HTTPCookieSessionPersistence{
+					Name: "other-session",
+					Path: "/api",
+				},
+			},
+			wantEqual: false,
+		},
+		{
+			name: "different cookie path",
+			persistence: &HTTPSessionPersistence{
+				Cookie: &HTTPCookieSessionPersistence{
+					Name: "gateway-session",
+					Path: "/other",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := HTTPRoute{
+				PathMatch:          StringMatch{Prefix: "/api"},
+				SessionPersistence: tt.persistence,
+			}
+			got := route.GetMatchKey()
+
+			if tt.wantEqual {
+				assert.Equal(t, baseKey, got)
+			} else {
+				assert.NotEqual(t, baseKey, got)
+			}
+		})
+	}
+}

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -1123,3 +1123,17 @@ func TestHTTPRouteSessionPersistenceMatchKey(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPSessionPersistenceString(t *testing.T) {
+	persistence := &HTTPSessionPersistence{
+		Cookie: &HTTPCookieSessionPersistence{
+			Name:     "session|name",
+			Path:     "/tenant:v1",
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: "Strict",
+		},
+	}
+
+	assert.Equal(t, `cookie:"session|name":"/tenant:v1":true:true:"Strict"`, persistence.String())
+}

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -16,6 +16,7 @@ import (
 	grpcStatsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	grpcWebv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
 	httpRouterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	statefulsessionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	httpConnectionManagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -116,6 +117,15 @@ func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model) []*h
 			Name: "envoy.filters.http.cors",
 			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
 				TypedConfig: toAny(&httpCorsv3.Cors{}),
+			},
+		})
+	}
+
+	if m.IsSessionPersistenceConfigured() {
+		hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+			Name: "envoy.filters.http.stateful_session",
+			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+				TypedConfig: toAny(&statefulsessionv3.StatefulSession{}),
 			},
 		})
 	}

--- a/operator/pkg/model/translation/envoy_http_connection_manager_test.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager_test.go
@@ -6,11 +6,18 @@ package translation
 import (
 	"testing"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	httpCORSv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	statefulsessionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	httpConnectionManagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
+	envoy_type_http_v3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 )
@@ -127,6 +134,28 @@ func Test_getHTTPConnectionManagerHttpFilters(t *testing.T) {
 		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
 		require.Equal(t, "envoy.filters.http.grpc_stats", res[1].Name)
 		require.Equal(t, "envoy.filters.http.cors", res[2].Name)
+		require.Equal(t, "envoy.filters.http.router", res[3].Name)
+
+	})
+	t.Run("stateful session filter enabled", func(t *testing.T) {
+		m := &model.Model{HTTP: []model.HTTPListener{
+			{
+				Routes: []model.HTTPRoute{
+					{
+						SessionPersistence: &model.HTTPSessionPersistence{
+							Cookie: &model.HTTPCookieSessionPersistence{},
+						},
+					},
+				},
+			},
+		}}
+		i := &cecTranslator{}
+		res := i.getHTTPConnectionManagerHttpFilters(m)
+
+		require.Len(t, res, 4)
+		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
+		require.Equal(t, "envoy.filters.http.grpc_stats", res[1].Name)
+		require.Equal(t, "envoy.filters.http.stateful_session", res[2].Name)
 		require.Equal(t, "envoy.filters.http.router", res[3].Name)
 
 	})
@@ -310,7 +339,7 @@ func Test_getTypedPerFilterConfig(t *testing.T) {
 	}
 
 	t.Run("route without auth disables all filters", func(t *testing.T) {
-		cfg := getTypedPerFilterConfig(nil, authFilters, model.HTTPRoute{})
+		cfg := getTypedPerFilterConfig(nil, authFilters, model.HTTPRoute{}, false)
 		require.Len(t, cfg, 2)
 		for _, v := range cfg {
 			perRoute := &extauthzv3.ExtAuthzPerRoute{}
@@ -324,7 +353,7 @@ func Test_getTypedPerFilterConfig(t *testing.T) {
 			Backend:  model.Backend{Name: "svc-a", Namespace: "ns", Port: &model.BackendPort{Port: 9000}},
 			Protocol: model.ExternalAuthProtocolGRPC,
 		}
-		cfg := getTypedPerFilterConfig(routeAuth, authFilters, model.HTTPRoute{})
+		cfg := getTypedPerFilterConfig(routeAuth, authFilters, model.HTTPRoute{}, false)
 		// Only svc-b should be disabled; svc-a has no entry (enabled by default)
 		require.Len(t, cfg, 1)
 		_, hasSvcA := cfg["envoy.filters.http.ext_authz/GRPC:ns:svc-a:9000"]
@@ -339,14 +368,64 @@ func Test_getTypedPerFilterConfig(t *testing.T) {
 	t.Run("route with CORS filter", func(t *testing.T) {
 		cfg := getTypedPerFilterConfig(nil, nil, model.HTTPRoute{
 			CORS: &model.HTTPCORSFilter{MaxAge: 42},
-		})
+		}, false)
 		require.Len(t, cfg, 1)
 		cors := &httpCORSv3.CorsPolicy{}
 		require.NoError(t, proto.Unmarshal(cfg["envoy.filters.http.cors"].Value, cors))
 	})
 
 	t.Run("no auth filters returns nil", func(t *testing.T) {
-		require.Nil(t, getTypedPerFilterConfig(nil, nil, model.HTTPRoute{}))
+		require.Nil(t, getTypedPerFilterConfig(nil, nil, model.HTTPRoute{}, false))
+	})
+
+	t.Run("route without persistence disables stateful sessions", func(t *testing.T) {
+		cfg := getTypedPerFilterConfig(nil, nil, model.HTTPRoute{}, true)
+		entry, ok := cfg["envoy.filters.http.stateful_session"]
+		require.True(t, ok)
+		perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+		require.True(t, perRoute.GetDisabled())
+	})
+
+	t.Run("route with persistence configures cookie session state", func(t *testing.T) {
+		cfg := getTypedPerFilterConfig(nil, nil, model.HTTPRoute{
+			SessionPersistence: &model.HTTPSessionPersistence{
+				Cookie: &model.HTTPCookieSessionPersistence{
+					Name: "gateway-session",
+					Path: "/api",
+				},
+			},
+		}, true)
+		entry, ok := cfg["envoy.filters.http.stateful_session"]
+		require.True(t, ok)
+		perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+
+		want := &statefulsessionv3.StatefulSessionPerRoute{
+			Override: &statefulsessionv3.StatefulSessionPerRoute_StatefulSession{
+				StatefulSession: &statefulsessionv3.StatefulSession{
+					SessionState: &envoy_config_core_v3.TypedExtensionConfig{
+						Name: "envoy.http.stateful_session.cookie",
+						TypedConfig: toAny(&cookiev3.CookieBasedSessionState{
+							Cookie: &envoy_type_http_v3.Cookie{
+								Name: "gateway-session",
+								Path: "/api",
+								Ttl:  durationpb.New(0),
+								Attributes: []*envoy_type_http_v3.CookieAttribute{
+									{Name: "Secure"},
+									{Name: "HttpOnly"},
+									{Name: "SameSite", Value: "Strict"},
+								},
+							},
+						}),
+					},
+					Strict: false,
+				},
+			},
+		}
+		if diff := cmp.Diff(want, perRoute, protocmp.Transform()); diff != "" {
+			t.Errorf("Stateful session configuration did not match (-want +got):\n%s", diff)
+		}
 	})
 }
 

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -24,6 +24,7 @@ type RouteConfigurationMutator func(*envoy_config_route_v3.RouteConfiguration) *
 func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	var res []ciliumv2.XDSResource
 	allAuthFilters := i.getUniqueAuthFilters(m)
+	statefulSessionFilterEnabled := m.IsSessionPersistenceConfigured()
 
 	type hostnameRedirect struct {
 		hostname string
@@ -139,10 +140,11 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 						}
 						redirectedHost[h.hostname] = struct{}{}
 						vhs := i.desiredVirtualHost(hostNamePortRoutes[h.hostname][httpsPort], VirtualHostParameter{
-							HostNames:      []string{h.hostname},
-							HTTPSRedirect:  true,
-							ListenerPort:   m.HTTP[0].Port,
-							AllAuthFilters: allAuthFilters,
+							HostNames:                    []string{h.hostname},
+							HTTPSRedirect:                true,
+							ListenerPort:                 m.HTTP[0].Port,
+							AllAuthFilters:               allAuthFilters,
+							StatefulSessionFilterEnabled: statefulSessionFilterEnabled,
 						})
 						virtualhosts = append(virtualhosts, vhs)
 					}
@@ -160,10 +162,11 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 				continue
 			}
 			vhs := i.desiredVirtualHost(routes, VirtualHostParameter{
-				HostNames:      []string{h.hostname},
-				HTTPSRedirect:  false,
-				ListenerPort:   m.HTTP[0].Port,
-				AllAuthFilters: allAuthFilters,
+				HostNames:                    []string{h.hostname},
+				HTTPSRedirect:                false,
+				ListenerPort:                 m.HTTP[0].Port,
+				AllAuthFilters:               allAuthFilters,
+				StatefulSessionFilterEnabled: statefulSessionFilterEnabled,
 			})
 			virtualhosts = append(virtualhosts, vhs)
 		}

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -16,6 +16,10 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_extensions_filters_http_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+
+	statefulsessionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
+	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
+	envoy_type_http_v3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -144,9 +148,10 @@ func (s SortableRoute) Swap(i, j int) {
 
 // VirtualHostParameter is the parameter for NewVirtualHost
 type VirtualHostParameter struct {
-	HostNames     []string
-	HTTPSRedirect bool
-	ListenerPort  uint32
+	HostNames                    []string
+	HTTPSRedirect                bool
+	ListenerPort                 uint32
+	StatefulSessionFilterEnabled bool
 	// AllAuthFilters is the deduplicated list of external auth filters active on this listener.
 	// It is used to build per-route TypedPerFilterConfig entries that enable/disable each filter.
 	AllAuthFilters []*model.HTTPExternalAuthFilter
@@ -157,9 +162,9 @@ type VirtualHostParameter struct {
 func (i *cecTranslator) desiredVirtualHost(httpRoutes []model.HTTPRoute, param VirtualHostParameter, mutators ...VirtualHostMutator) *envoy_config_route_v3.VirtualHost {
 	var routes SortableRoute
 	if param.HTTPSRedirect {
-		routes = envoyHTTPSRoutes(httpRoutes, param.HostNames, i.Config.RouteConfig.HostNameSuffixMatch, param.AllAuthFilters)
+		routes = envoyHTTPSRoutes(httpRoutes, param.HostNames, i.Config.RouteConfig.HostNameSuffixMatch, param.AllAuthFilters, param.StatefulSessionFilterEnabled)
 	} else {
-		routes = envoyHTTPRoutes(httpRoutes, param.HostNames, i.Config.RouteConfig.HostNameSuffixMatch, param.ListenerPort, param.AllAuthFilters)
+		routes = envoyHTTPRoutes(httpRoutes, param.HostNames, i.Config.RouteConfig.HostNameSuffixMatch, param.ListenerPort, param.AllAuthFilters, param.StatefulSessionFilterEnabled)
 	}
 
 	// This is to make sure that the Exact match is always having higher priority.
@@ -237,8 +242,41 @@ func getCORS(cors *model.HTTPCORSFilter) *anypb.Any {
 	})
 }
 
+func getStatefulSession(sp *model.HTTPSessionPersistence) *anypb.Any {
+	if sp == nil || sp.Cookie == nil {
+		return toAny(&statefulsessionv3.StatefulSessionPerRoute{
+			Override: &statefulsessionv3.StatefulSessionPerRoute_Disabled{
+				Disabled: true,
+			},
+		})
+	}
+
+	return toAny(&statefulsessionv3.StatefulSessionPerRoute{
+		Override: &statefulsessionv3.StatefulSessionPerRoute_StatefulSession{
+			StatefulSession: &statefulsessionv3.StatefulSession{
+				SessionState: &envoy_config_core_v3.TypedExtensionConfig{
+					Name: "envoy.http.stateful_session.cookie",
+					TypedConfig: toAny(&cookiev3.CookieBasedSessionState{
+						Cookie: &envoy_type_http_v3.Cookie{
+							Name: sp.Cookie.Name,
+							Path: sp.Cookie.Path,
+							Ttl:  durationpb.New(0),
+							Attributes: []*envoy_type_http_v3.CookieAttribute{
+								{Name: "Secure"},
+								{Name: "HttpOnly"},
+								{Name: "SameSite", Value: "Strict"},
+							},
+						},
+					}),
+				},
+				Strict: false,
+			},
+		},
+	})
+}
+
 // getTypedPerFilterConfig returns the TypedPerFilterConfig map for a route.
-func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFilters []*model.HTTPExternalAuthFilter, route model.HTTPRoute) map[string]*anypb.Any {
+func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFilters []*model.HTTPExternalAuthFilter, route model.HTTPRoute, statefulSessionFilterEnabled bool) map[string]*anypb.Any {
 	var activeKey string
 	if routeAuth != nil {
 		activeKey = extAuthzFilterKey(routeAuth)
@@ -266,6 +304,10 @@ func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFil
 		config["envoy.filters.http.cors"] = getCORS(route.CORS)
 	}
 
+	if statefulSessionFilterEnabled {
+		config["envoy.filters.http.stateful_session"] = getStatefulSession(route.SessionPersistence)
+	}
+
 	if len(config) == 0 {
 		return nil
 	}
@@ -273,7 +315,7 @@ func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFil
 	return config
 }
 
-func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
+func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter, statefulSessionFilterEnabled bool) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
 		key := r.GetBackendAggregationKey()
@@ -295,6 +337,9 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 				},
 			},
 		}
+
+		// always disable session persistence for HTTPS redirects, since Envoy does not route to a backend.
+		r.SessionPersistence = nil
 		route := envoy_config_route_v3.Route{
 			Match: getRouteMatch(hostnames,
 				hostNameSuffixMatch,
@@ -303,7 +348,7 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 				hRoutes[0].HeadersMatch,
 				hRoutes[0].Method),
 			Action:               rRedirect,
-			TypedPerFilterConfig: getTypedPerFilterConfig(nil, allAuthFilters, r),
+			TypedPerFilterConfig: getTypedPerFilterConfig(nil, allAuthFilters, r, statefulSessionFilterEnabled),
 		}
 		routes = append(routes, &route)
 		delete(matchBackendMap, key)
@@ -311,7 +356,7 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 	return routes
 }
 
-func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, listenerPort uint32, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
+func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, listenerPort uint32, allAuthFilters []*model.HTTPExternalAuthFilter, statefulSessionFilterEnabled bool) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
 		key := r.GetBackendAggregationKey()
@@ -331,10 +376,15 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 		}
 
 		if hRoutes[0].DirectResponse != nil {
-			noBackendRoute := envoyHTTPRouteDirectResponse(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters)
+			noBackendRoute := envoyHTTPRouteDirectResponse(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters, statefulSessionFilterEnabled)
 			routes = append(routes, noBackendRoute)
 			delete(matchBackendMap, key)
 			continue
+		}
+
+		if hRoutes[0].RequestRedirect != nil {
+			// redirects don't select an upstream backend.
+			r.SessionPersistence = nil
 		}
 
 		route := envoy_config_route_v3.Route{
@@ -348,7 +398,7 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 			RequestHeadersToRemove:  getHeadersToRemove(hRoutes[0].RequestHeaderFilter),
 			ResponseHeadersToAdd:    getHeadersToAdd(hRoutes[0].ResponseHeaderModifier),
 			ResponseHeadersToRemove: getHeadersToRemove(hRoutes[0].ResponseHeaderModifier),
-			TypedPerFilterConfig:    getTypedPerFilterConfig(hRoutes[0].ExternalAuth, allAuthFilters, r),
+			TypedPerFilterConfig:    getTypedPerFilterConfig(hRoutes[0].ExternalAuth, allAuthFilters, r, statefulSessionFilterEnabled),
 		}
 
 		if hRoutes[0].RequestRedirect != nil {
@@ -645,10 +695,12 @@ func getRouteRedirectMatch(match string) *envoy_config_route_v3.HeaderMatcher {
 	}
 }
 
-func envoyHTTPRouteDirectResponse(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) *envoy_config_route_v3.Route {
+func envoyHTTPRouteDirectResponse(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter, statefulSessionFilterEnabled bool) *envoy_config_route_v3.Route {
 	if route.DirectResponse == nil {
 		return nil
 	}
+
+	route.SessionPersistence = nil
 
 	return &envoy_config_route_v3.Route{
 		Match: getRouteMatch(hostnames,
@@ -667,7 +719,7 @@ func envoyHTTPRouteDirectResponse(route model.HTTPRoute, hostnames []string, hos
 				},
 			},
 		},
-		TypedPerFilterConfig: getTypedPerFilterConfig(route.ExternalAuth, allAuthFilters, route),
+		TypedPerFilterConfig: getTypedPerFilterConfig(route.ExternalAuth, allAuthFilters, route, statefulSessionFilterEnabled),
 	}
 }
 

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -14,6 +14,7 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_extensions_filters_http_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	statefulsessionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -743,7 +744,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 		require.Len(t, res, 2)
 		// Redirect Route
 		require.NotNil(t, res[0])
@@ -786,7 +787,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 		require.Len(t, res, 2)
 		sort.Stable(SortableRoute(res))
 		// Backend Route
@@ -837,7 +838,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 			},
 		}
 
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 		require.Len(t, res, 2)
 
 		sort.Stable(SortableRoute(res))
@@ -894,7 +895,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 		require.Len(t, res, 1)
 		require.NotNil(t, res[0])
 		require.NotNil(t, res[0].GetDirectResponse())
@@ -917,7 +918,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 			},
 		}
 
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 
 		require.Len(t, res, 1)
 		weightedClusters := res[0].GetRoute().GetWeightedClusters()
@@ -944,7 +945,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 			},
 		}
 
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 
 		require.Len(t, res, 2)
 		require.Equal(t, "default:backend-v1:8080", res[0].GetRoute().GetCluster())
@@ -968,7 +969,7 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 			},
 		}
 
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 
 		require.Len(t, res, 2)
 		require.NotNil(t, res[0].GetDirectResponse())
@@ -988,12 +989,82 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 			},
 		}
 
-		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil, false)
 
 		require.Len(t, res, 1)
 		require.NotNil(t, res[0].GetDirectResponse())
 		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
 		require.Nil(t, res[0].GetRoute())
+	})
+
+	t.Run("backend route configures stateful sessions", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch: model.StringMatch{Prefix: "/api"},
+				Backends: []model.Backend{
+					backend("backend", 8080),
+				},
+				SessionPersistence: &model.HTTPSessionPersistence{
+					Cookie: &model.HTTPCookieSessionPersistence{
+						Name: "gateway-session",
+						Path: "/api",
+					},
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, nil, true)
+		require.Len(t, res, 1)
+		entry, ok := res[0].GetTypedPerFilterConfig()["envoy.filters.http.stateful_session"]
+		require.True(t, ok)
+		perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+		require.NotNil(t, perRoute.GetStatefulSession())
+	})
+
+	t.Run("request redirect disables stateful sessions", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch: model.StringMatch{Prefix: "/"},
+				RequestRedirect: &model.HTTPRequestRedirectFilter{
+					Scheme:     ptr.To("https"),
+					StatusCode: ptr.To(302),
+				},
+				SessionPersistence: &model.HTTPSessionPersistence{
+					Cookie: &model.HTTPCookieSessionPersistence{
+						Name: "gateway-session",
+						Path: "/",
+					},
+				},
+			},
+		}
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, nil, true)
+
+		require.Len(t, res, 1)
+		entry, ok := res[0].GetTypedPerFilterConfig()["envoy.filters.http.stateful_session"]
+		require.True(t, ok)
+		perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+		require.True(t, perRoute.GetDisabled())
+	})
+
+	t.Run("backend route without persistence disables stateful sessions", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch: model.StringMatch{Prefix: "/"},
+				Backends: []model.Backend{
+					{Name: "backend", Namespace: "default", Port: &model.BackendPort{Port: 8080}},
+				},
+			},
+		}
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, nil, true)
+
+		require.Len(t, res, 1)
+		entry, ok := res[0].GetTypedPerFilterConfig()["envoy.filters.http.stateful_session"]
+		require.True(t, ok)
+		perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+		require.True(t, perRoute.GetDisabled())
 	})
 }
 
@@ -1008,7 +1079,7 @@ func Test_envoyHTTPSRoutes_disablesExtAuthzFilters(t *testing.T) {
 		{PathMatch: model.StringMatch{Prefix: "/"}},
 	}
 
-	result := envoyHTTPSRoutes(routes, []string{"example.com"}, false, authFilters)
+	result := envoyHTTPSRoutes(routes, []string{"example.com"}, false, authFilters, false)
 	require.Len(t, result, 1)
 
 	// The redirect route must disable all auth filters so that redirect requests
@@ -1053,7 +1124,7 @@ func Test_envoyHTTPRoutes_differentAuthFilters(t *testing.T) {
 		},
 	}
 
-	res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, allAuthFilters)
+	res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, allAuthFilters, false)
 	require.Len(t, res, 2, "routes with different auth filters must not be merged")
 
 	filterNameA := ExtAuthzFilterName(extAuthzFilterKey(authA))
@@ -1082,9 +1153,52 @@ func Test_envoyHTTPSRoutes_noAuthFilters(t *testing.T) {
 	routes := []model.HTTPRoute{
 		{PathMatch: model.StringMatch{Prefix: "/"}},
 	}
-	result := envoyHTTPSRoutes(routes, []string{"example.com"}, false, nil)
+	result := envoyHTTPSRoutes(routes, []string{"example.com"}, false, nil, false)
 	require.Len(t, result, 1)
 	require.Nil(t, result[0].TypedPerFilterConfig, "redirect route must not set TypedPerFilterConfig when there are no auth filters")
+}
+
+func Test_envoyHTTPSRoutes_statefulSessionDisabled(t *testing.T) {
+	httpsRoutes := []model.HTTPRoute{
+		{
+			PathMatch: model.StringMatch{Prefix: "/"},
+			SessionPersistence: &model.HTTPSessionPersistence{
+				Cookie: &model.HTTPCookieSessionPersistence{
+					Name: "gateway-session",
+					Path: "/",
+				},
+			},
+		},
+	}
+	res := envoyHTTPSRoutes(httpsRoutes, []string{"example.com"}, false, nil, true)
+
+	require.Len(t, res, 1)
+	entry, ok := res[0].GetTypedPerFilterConfig()["envoy.filters.http.stateful_session"]
+	require.True(t, ok)
+	perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+	require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+	require.True(t, perRoute.GetDisabled(), "HTTPS redirect route must disable stateful sessions because it does not select a backend")
+}
+
+func Test_envoyHTTPRouteDirectResponse_statefulSessionDisabled(t *testing.T) {
+	httpRoute := model.HTTPRoute{
+		PathMatch:      model.StringMatch{Prefix: "/"},
+		DirectResponse: &model.DirectResponse{StatusCode: 500},
+		SessionPersistence: &model.HTTPSessionPersistence{
+			Cookie: &model.HTTPCookieSessionPersistence{
+				Name: "gateway-session",
+				Path: "/",
+			},
+		},
+	}
+	res := envoyHTTPRouteDirectResponse(httpRoute, []string{"*"}, false, nil, true)
+
+	require.NotNil(t, res)
+	entry, ok := res.GetTypedPerFilterConfig()["envoy.filters.http.stateful_session"]
+	require.True(t, ok)
+	perRoute := &statefulsessionv3.StatefulSessionPerRoute{}
+	require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+	require.True(t, perRoute.GetDisabled(), "direct response route must disable stateful sessions because it does not select a backend")
 }
 
 func Test_getCORSStringMatcher(t *testing.T) {


### PR DESCRIPTION
Add cookie-based Gateway API session persistence for HTTPRoute and GRPCRoute rules as described in [CFP-47089](https://github.com/cilium/design-cfps/pull/102).

Supported session persistence options are validated, with unsupported values being rejected. Accepted routes are ingested into the internal model and translated into CiliumEnvoyConfig. If a Gateway has any attached route rule containing a session persistence config, the Envoy stateful session filter is applied, alongside per-route cookie settings. Any routes attached to the Gateway without session persistence will explicitly disable the stateful session filter.

The following HTTPRoute enables persistence for `/persistent`, while `/not-persistent` continues to use normal load balancing:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: example-route
spec:
  parentRefs:
  - name: example-gateway
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /persistent
    backendRefs:
    - name: example-service
      port: 8080
    sessionPersistence:
      type: Cookie
      sessionName: app-session
      cookieConfig:
        lifetimeType: Session
  - matches:
    - path:
        type: PathPrefix
        value: /not-persistent
    backendRefs:
    - name: example-service
      port: 8080
```

```release-note
Add support for Gateway API session persistence
```

AIL 2: Used to assist in planning, review, and generating some test cases.