### PR TITLE
hubble: Correlate policy verdicts for the host endpoint

### DIFF
--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -306,8 +306,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	decoded.Interface = p.decodeNetworkInterface(tn, dbg)
 	decoded.ProxyPort = decodeProxyPort(dbg, tn)
 
-	if p.correlateL3L4Policy && p.endpointGetter != nil {
-		correlation.CorrelatePolicy(p.log, p.endpointGetter, decoded)
+	if p.correlateL3L4Policy && p.endpointGetter != nil && pvn != nil {
+		correlation.CorrelatePolicy(p.log, p.endpointGetter, decoded, pvn.Source)
 	}
 
 	return nil

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -2727,3 +2727,124 @@ func TestDecode_CustomPacketDecoder(t *testing.T) {
 		t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 	}
 }
+
+// The host endpoint registers no IP, so the flow carries no endpoint ID and only
+// the notification's own ID can correlate the verdict. See cilium/cilium#33870.
+func TestDecode_PolicyVerdictNotifyHostEndpoint(t *testing.T) {
+	nodeIP := netip.MustParseAddr("10.211.60.1")
+
+	policyLabel := utils.GetPolicyLabels("", "host-fw", "1234-5678", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
+	expectedPolicy := []*flowpb.Policy{
+		{
+			Name: "host-fw",
+			Kind: "CiliumClusterwideNetworkPolicy",
+			Labels: []string{
+				"k8s:io.cilium.k8s.policy.derived-from=CiliumClusterwideNetworkPolicy",
+				"k8s:io.cilium.k8s.policy.name=host-fw",
+				"k8s:io.cilium.k8s.policy.uid=1234-5678",
+			},
+			Revision: 1,
+		},
+	}
+
+	ingressKey := policy.IngressKey().WithIdentity(remoteID).WithTCPPort(22)
+	egressKey := policy.EgressKey().WithIdentity(remoteID).WithTCPPort(443)
+
+	testCases := []struct {
+		name      string
+		key       policyTypes.Key
+		audited   bool
+		verdict   int32
+		allowedBy func(*flowpb.Flow) []*flowpb.Policy
+	}{
+		{
+			name:      "ingress_allowed",
+			key:       ingressKey,
+			allowedBy: (*flowpb.Flow).GetIngressAllowedBy,
+		},
+		{
+			name:      "egress_allowed",
+			key:       egressKey,
+			allowedBy: (*flowpb.Flow).GetEgressAllowedBy,
+		},
+		{
+			name:      "ingress_audited",
+			key:       ingressKey,
+			audited:   true,
+			allowedBy: (*flowpb.Flow).GetIngressDeniedBy,
+		},
+		{
+			name:      "ingress_denied",
+			key:       ingressKey,
+			verdict:   -int32(flowpb.DropReason_POLICY_DENIED),
+			allowedBy: (*flowpb.Flow).GetIngressDeniedBy,
+		},
+		{
+			name:      "egress_denied",
+			key:       egressKey,
+			verdict:   -int32(flowpb.DropReason_POLICY_DENIED),
+			allowedBy: (*flowpb.Flow).GetEgressDeniedBy,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hostEPInfo := &testutils.FakeEndpointInfo{
+				PolicyMap: map[policyTypes.Key]labels.LabelArrayListString{
+					tc.key: labels.LabelArrayList{policyLabel}.ArrayListString(),
+				},
+				PolicyRevision: 1,
+			}
+
+			endpointGetter := &testutils.FakeEndpointGetter{
+				OnGetEndpointInfo: func(netip.Addr) (endpoint getters.EndpointInfo, ok bool) {
+					return nil, false
+				},
+				OnGetEndpointInfoByID: func(id uint16) (endpoint getters.EndpointInfo, ok bool) {
+					if id == hostEP {
+						return hostEPInfo, true
+					}
+					return nil, false
+				},
+			}
+
+			parser, err := New(hivetest.Logger(t), endpointGetter, nil, nil, nil, nil, nil)
+			require.NoError(t, err)
+
+			flags, srcIP, dstIP := uint8(monitorAPI.PolicyEgress), nodeIP, remoteIP
+			if tc.key.IsIngress() {
+				flags, srcIP, dstIP = monitorAPI.PolicyIngress, remoteIP, nodeIP
+			}
+			if tc.audited {
+				flags |= monitor.PolicyVerdictNotifyFlagIsAudited
+			}
+
+			pvn := monitor.PolicyVerdictNotify{
+				Type:        byte(monitorAPI.MessageTypePolicyVerdict),
+				Source:      hostEP,
+				Flags:       flags,
+				RemoteLabel: remoteID,
+				Verdict:     tc.verdict,
+			}
+			data, err := testutils.CreateL3L4Payload(pvn,
+				&layers.Ethernet{
+					SrcMAC:       srcMAC,
+					DstMAC:       dstMAC,
+					EthernetType: layers.EthernetTypeIPv4,
+				},
+				&layers.IPv4{
+					SrcIP:    srcIP.AsSlice(),
+					DstIP:    dstIP.AsSlice(),
+					Protocol: layers.IPProtocolTCP,
+				},
+				&layers.TCP{SrcPort: 37304, DstPort: layers.TCPPort(tc.key.DestPort), SYN: true})
+			require.NoError(t, err)
+
+			f := new(flowpb.Flow)
+			require.NoError(t, parser.Decode(data, f))
+
+			require.Zero(t, f.GetSource().GetID())
+			require.Zero(t, f.GetDestination().GetID())
+			testutils.AssertProtoEqual(t, expectedPolicy, tc.allowedBy(f))
+		})
+	}
+}

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -4,6 +4,7 @@
 package correlation
 
 import (
+	"cmp"
 	"log/slog"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -20,8 +21,10 @@ import (
 )
 
 // CorrelatePolicy updates the IngressAllowedBy/EgressAllowedBy fields on the
-// provided flow.
-func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
+// provided flow. notifyEPID is the endpoint the datapath reported the verdict
+// at, zero if the notification carried none, and takes precedence over the ID
+// derived from the flow, which is unset for the host endpoint.
+func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *flowpb.Flow, notifyEPID uint16) {
 	if f.GetEventType().GetType() != int32(monitorAPI.MessageTypePolicyVerdict) {
 		// If it's not a policy verdict, we don't care.
 		return
@@ -43,6 +46,7 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 
 	// extract fields relevant for looking up the policy
 	direction, endpointID, remoteIdentity, proto, dport := extractFlowKey(f)
+	endpointID = cmp.Or(notifyEPID, endpointID)
 	if dport == 0 || proto == 0 {
 		logger.Debug(
 			"failed to extract flow key",

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -85,7 +85,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	expected := []*flowpb.Policy{
 		{
@@ -138,7 +138,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -189,7 +189,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -212,7 +212,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -263,7 +263,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -314,7 +314,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -365,7 +365,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -425,7 +425,7 @@ func TestCorrelatePolicy(t *testing.T) {
 			return nil, false
 		},
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -463,7 +463,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -526,7 +526,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	expected = []*flowpb.Policy{
 		{
@@ -624,7 +624,7 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -683,7 +683,7 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -769,7 +769,7 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -829,7 +829,7 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -888,7 +888,7 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
 	expected := []*flowpb.Policy{
 		{
@@ -911,4 +911,66 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
+}
+
+func TestCorrelatePolicy_NotifyEndpointID(t *testing.T) {
+	nodeIP := "10.211.60.1"
+	remoteIP := "10.211.59.133"
+	remoteIdentity := uint32(16777244)
+	hostEPID := uint16(1092)
+	dstPort := uint32(22)
+
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		Verdict:          flowpb.Verdict_FORWARDED,
+		TrafficDirection: flowpb.TrafficDirection_INGRESS,
+		IP:               &flowpb.IP{Source: remoteIP, Destination: nodeIP},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: dstPort}},
+		},
+		Source: &flowpb.Endpoint{Identity: remoteIdentity},
+		// No ID: the node IP resolves to no local endpoint.
+		Destination: &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)},
+	}
+
+	policyLabel := utils.GetPolicyLabels("", "host-fw", "abcd-ef01", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
+	policyKey := policy.IngressKey().
+		WithIdentity(identity.NumericIdentity(remoteIdentity)).
+		WithTCPPort(uint16(dstPort))
+
+	ep := &testutils.FakeEndpointInfo{
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			policyKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (getters.EndpointInfo, bool) {
+			if id == hostEPID {
+				return ep, true
+			}
+			return nil, false
+		},
+	}
+
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, hostEPID)
+
+	expected := []*flowpb.Policy{
+		{
+			Name: "host-fw",
+			Kind: utils.ResourceTypeCiliumClusterwideNetworkPolicy,
+			Labels: []string{
+				"k8s:io.cilium.k8s.policy.derived-from=CiliumClusterwideNetworkPolicy",
+				"k8s:io.cilium.k8s.policy.name=host-fw",
+				"k8s:io.cilium.k8s.policy.uid=abcd-ef01",
+			},
+			Revision: 1,
+		},
+	}
+
+	require.Nil(t, flow.EgressAllowedBy)
+	require.Nil(t, flow.EgressDeniedBy)
+	require.Nil(t, flow.IngressDeniedBy)
+	testutils.AssertProtoEqual(t, expected, flow.IngressAllowedBy)
 }


### PR DESCRIPTION
Previously, policy verdict flows that were generated by host firewall
policies always had an empty ingress_allowed_by and egress_allowed_by
because we did not have policy correlation for them implemented.

The way policy correlation works is that it looks up the endpoint by the
ID within the flow, and that ID is only set when the IP within the flow
resolves to a local endpoint. In the host firewall case, the IP within
the flow is the node IP, and the host endpoint does not register its IPs
with the endpoint manager, so that lookup misses. Therefore we pass 0 as
the endpoint ID to GetEndpointInfoByID() which then results in no policy
correlation.

Now, the datapath notification event (policy verdict) that is passed up
to Cilium already has the endpoint ID contained in it:

  * bpf_host sets EVENT_SOURCE to CONFIG(host_ep_id)
  * bpf_lxc sets it to LXC_ID

Therefore, we can use the endpoint ID from EVENT_SOURCE to pass it to
GetEndpointInfoByID() to fetch the policy correlation information.

Fixes: #33870

---

See the script below to validate the behavior of this PR. 

<details>
<summary>Repro script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

VALUES=$(mktemp -p . kind-hostfw-XXXXXX.yaml)
cat > "$VALUES" <<'EOF'
hostFirewall:
  enabled: true
EOF

make kind
make kind-image-fast
make kind-install-cilium-fast ADDITIONAL_KIND_VALUES_FILE="$VALUES"

cilium status --wait

POD=$(kubectl -n kube-system get pod -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
HOST_EP=$(kubectl -n kube-system exec "$POD" -c cilium-agent -- \
  cilium-dbg endpoint list -o json | jq -r '.[] | select(.status.identity.id == 1) | .id')

# Audit mode first, so a host policy cannot cut off the node or API server.
kubectl -n kube-system exec "$POD" -c cilium-agent -- \
  cilium-dbg endpoint config "$HOST_EP" PolicyAuditMode=Enabled

kubectl apply -f - <<'EOF'
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: host-fw-repro
spec:
  nodeSelector: {}
  ingress:
    - fromEntities: ["world", "cluster"]
      toPorts:
        - ports:
            - port: "6443"
              protocol: TCP
EOF

# The node the cilium agent above is running on.
kubectl get pod -n kube-system "$POD" -o jsonpath='{.status.hostIP}{"\n"}'

# Now trigger traffic to that node IP:
#
#   curl -sk https://<node-ip>:6443/version
#
# and check the correlation:
#
#   kubectl -n kube-system exec ds/cilium -c cilium-agent -- \
#     hubble observe --type policy-verdict -o json | grep ingress_allowed_by
```

</details>

With the fix, the host firewall policy verdict flow is correlated even though
the flow carries no endpoint ID:

```json
{
  "destination": {
    "identity": 1,
    "labels": ["reserved:host", "reserved:kube-apiserver"]
  },
  "ingress_allowed_by": [
    {
      "name": "host-fw-repro",
      "kind": "CiliumClusterwideNetworkPolicy"
    }
  ]
}
```

```release-note
Hubble now populates ingress_allowed_by / egress_allowed_by on policy verdict flows for the host endpoint (host firewall).
```
