### PR TITLE
Fix bug where identities may linger for double the amount of the expected time 

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -57,9 +57,13 @@ func (igc *GC) runHeartbeatUpdater(ctx context.Context) error {
 	for event := range igc.identity.Events(ctx) {
 		switch event.Kind {
 		case resource.Upsert:
-			// Identity is marked as alive if it is new or it has
-			// been updated.
-			igc.heartbeatStore.markAlive(event.Object.Name, time.Now())
+			// Identity is marked as alive if it is new or it has been updated.
+			// Avoid marking the identity as alive if it is already marked,
+			// because otherwise that would keep the identity alive for another
+			// GC pass and defer its deletion by another heartbeat.
+			if _, marked := event.Object.Annotations[identitybackend.HeartBeatAnnotation]; !marked {
+				igc.heartbeatStore.markAlive(event.Object.Name, time.Now())
+			}
 		case resource.Delete:
 			// When the identity is deleted, delete the
 			// heartbeat entry as well. This will not be

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -4,20 +4,28 @@
 package identitygc
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/cilium/operator/auth/spire"
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -94,4 +102,136 @@ func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool)
 	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
 		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
 	}
+}
+
+// TestHeartbeatUpdater verifies that an unused identity is marked and then
+// deleted by consecutive GC passes, without unnecessarily deferring the
+// deletion by another heartbeat period. An identity with an endpoint must
+// survive.
+func TestHeartbeatUpdater(t *testing.T) {
+	const (
+		unused = "88888"
+		inUse  = "99999"
+	)
+
+	var (
+		fakeClient  *k8sClient.FakeClientset
+		identityRes resource.Resource[*cilium_v2.CiliumIdentity]
+		cepRes      resource.Resource[*cilium_v2.CiliumEndpoint]
+	)
+	h := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, id resource.Resource[*cilium_v2.CiliumIdentity], cep resource.Resource[*cilium_v2.CiliumEndpoint]) error {
+			fakeClient, identityRes, cepRes = c, id, cep
+			if err := setupCiliumIdentities(t, c); err != nil {
+				return err
+			}
+			return setupCiliumEndpoint(t, c)
+		}),
+	)
+
+	ctx := t.Context()
+	tlog := hivetest.Logger(t)
+	if err := h.Start(tlog, ctx); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+	t.Cleanup(func() {
+		// t.Context() is cancelled before cleanup runs, so use a fresh
+		// context to stop the hive.
+		if err := h.Stop(tlog, context.Background()); err != nil {
+			t.Fatalf("failed to stop: %s", err)
+		}
+	})
+
+	// Store waits for the initial listing, so both identities are present.
+	idStore, err := identityRes.Store(ctx)
+	require.NoError(t, err)
+
+	identity := &identityEvents{
+		Resource: identityRes,
+		events:   make(chan resource.Event[*cilium_v2.CiliumIdentity]),
+	}
+	igc := &GC{
+		logger:             tlog,
+		clientset:          fakeClient.CiliumV2().CiliumIdentities(),
+		identity:           identity,
+		ciliumEndpoint:     cepRes,
+		authIdentityClient: spire.NewFakeClient(),
+		heartbeatStore:     newHeartbeatStore(time.Hour, tlog),
+		rateLimiter:        rate.NewLimiter(time.Minute, 100),
+		metrics:            NewMetrics(),
+	}
+	t.Cleanup(igc.rateLimiter.Stop)
+	// Pretend the operator has been running longer than the heartbeat timeout
+	// so the startup grace period does not keep identities alive.
+	igc.heartbeatStore.firstRun = time.Now().Add(-2 * time.Hour)
+
+	updaterDone := make(chan struct{})
+	go func() {
+		defer close(updaterDone)
+		_ = igc.runHeartbeatUpdater(ctx)
+	}()
+
+	getIdentity := func(name string) (*cilium_v2.CiliumIdentity, error) {
+		return fakeClient.CiliumV2().CiliumIdentities().Get(ctx, name, meta_v1.GetOptions{})
+	}
+
+	// First pass marks the unused identity for deletion and leaves the in-use
+	// one alone.
+	require.NoError(t, igc.gc(ctx))
+	marked, err := getIdentity(unused)
+	require.NoError(t, err)
+	require.Contains(t, marked.Annotations, identitybackend.HeartBeatAnnotation)
+	_, err = getIdentity(inUse)
+	require.NoError(t, err)
+
+	// The mark-for-deletion write comes back through the informer as an
+	// Upsert. It must not keep the identity alive.
+	identity.feed(t, resource.Upsert, marked)
+
+	// Wait for the store to observe the annotation so the next pass evaluates
+	// the identity for deletion.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, exists, err := idStore.GetByKey(resource.Key{Name: unused})
+		if assert.NoError(c, err) && assert.True(c, exists) {
+			assert.Contains(c, obj.Annotations, identitybackend.HeartBeatAnnotation)
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	// Second pass deletes the unused identity and the in-use one survives.
+	require.NoError(t, igc.gc(ctx))
+	_, err = getIdentity(unused)
+	require.True(t, k8serrors.IsNotFound(err), "unused identity should be deleted, got %v", err)
+	_, err = getIdentity(inUse)
+	require.NoError(t, err)
+
+	close(identity.events)
+	select {
+	case <-updaterDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runHeartbeatUpdater did not exit")
+	}
+}
+
+type identityEvents struct {
+	resource.Resource[*cilium_v2.CiliumIdentity]
+	events chan resource.Event[*cilium_v2.CiliumIdentity]
+}
+
+func (r *identityEvents) Events(context.Context, ...resource.EventsOpt) <-chan resource.Event[*cilium_v2.CiliumIdentity] {
+	return r.events
+}
+
+// feed delivers an event to runHeartbeatUpdater and blocks until it has been
+// processed.
+func (r *identityEvents) feed(t *testing.T, kind resource.EventKind, obj *cilium_v2.CiliumIdentity) {
+	t.Helper()
+	done := make(chan error)
+	r.events <- resource.Event[*cilium_v2.CiliumIdentity]{
+		Kind:   kind,
+		Object: obj,
+		Done:   func(err error) { done <- err },
+	}
+	require.NoError(t, <-done)
 }


### PR DESCRIPTION
A CiliumIdentity object is effectively immutable. Its numeric ID is derived
from the identity's label set, so changing the labels yields a different ID and
thus a new object rather than an update to the existing one. The only times
that the Operator updates an existing identity object is:

1) Toggle the io.cilium.heartbeat "mark for deletion" annotation
2) Fill in incomplete labels in case of a failed creation

Consequently an Upsert on an identity is not evidence that the identity is in
use. An identity is considered live if it is referenced by a CiliumEndpoint or
CiliumEndpointSlice.

Previously, runHeartbeatUpdater however treated every Upsert as a lifesign.
When gc() finds an unused identity it stamps the mark-for-deletion annotation
via a Kubernetes Update (see gc()), and that Update is delivered back to
runHeartbeatUpdater as an Upsert. The GC therefore kept the identity alive in
the heartbeat store even though it was trying to delete it, deferring the
actual deletion by a full heartbeat timeout. The observable user impact is that
identities are collected after roughly 2x the heartbeat timeout instead of just
once, i.e. identities can linger for well over an hour with the default 30m
heartbeat.

This commit skips markAlive for Upserts that carry the heartbeat annotation.
Such Upserts are either the GC's own mark-for-deletion write or a still-marked
object. This is safe because of the explanation above about identity objects.

Also, add a regression test that tests gc() end to end and asserts the unused
identity is marked and then actually deleted, while an identity with an
endpoint survives.
