### PR TITLE
ciliumidentity: include named-port labels in operator-managed identities

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -18,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/operator/pkg/ciliumidentity"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -486,7 +487,7 @@ func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key
 		return "", nil, errSkipPodEvent
 	}
 
-	cidKey, err := getPodCIDKey(pod, c.logger, c.reconciler.namespaceStore, c.reconciler.clusterInfo)
+	cidKey, err := ciliumidentity.GetCIDKeyForPod(c.logger, pod, c.reconciler.namespaceStore, c.reconciler.clusterInfo)
 	if err != nil {
 		c.logger.Debug("could not get labels for pod",
 			logfields.K8sPodName, pod.Name,

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -14,16 +14,13 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/operator/pkg/ciliumidentity"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -458,13 +455,4 @@ func getNodeNameForPod(pod *slim_corev1.Pod) (string, error) {
 		return "", fmt.Errorf("pod has empty node name")
 	}
 	return pod.Spec.NodeName, nil
-}
-
-func getPodCIDKey(pod *slim_corev1.Pod, logger *slog.Logger, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (*key.GlobalIdentity, error) {
-	k8sLabels, err := ciliumidentity.GetRelevantLabelsForPod(logger, pod, nsStore, clusterInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get relevant labels for pod: %w", err)
-	}
-	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
-	return cidKey, nil
 }

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -282,11 +283,10 @@ func (r *reconciler) cidIsUsedInCEPOrCES(cidName string) bool {
 // 1. CID exists: No action.
 // 2. CID doesn't exist: Create CID.
 func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
-	k8sLabels, err := GetRelevantLabelsForPod(r.logger, pod, r.nsStore, r.clusterInfo)
+	cidKey, err := GetCIDKeyForPod(r.logger, pod, r.nsStore, r.clusterInfo)
 	if err != nil {
-		return fmt.Errorf("failed to get relevant labels for pod: %w", err)
+		return fmt.Errorf("failed to get CID key for pod: %w", err)
 	}
-	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
 
 	r.cidCreateLock.Lock()
 	defer r.cidCreateLock.Unlock()
@@ -306,7 +306,7 @@ func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
 			logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 			logfields.CIDName, cidName,
 			logfields.IdentityOld, prevCIDName,
-			logfields.Labels, k8sLabels)
+			logfields.Labels, cidKey.GetAsMap())
 	}
 
 	if isNewCID {
@@ -348,15 +348,21 @@ func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, erro
 	return allocatedID.String(), true, nil
 }
 
-// GetRelevantLabelsForPod returns the pod and namespace labels for a given pod
-func GetRelevantLabelsForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (map[string]string, error) {
+// GetCIDKeyForPod returns the GlobalIdentity key for a pod, including
+// named-port identity labels derived from the pod's container ports.
+func GetCIDKeyForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (*key.GlobalIdentity, error) {
 	ns, err := getNamespace(pod.Namespace, nsStore)
 	if err != nil {
 		return nil, err
 	}
 
-	_, labelsMap := k8s.GetPodMetadata(logger, clusterInfo, ns, pod)
-	return labelsMap, nil
+	namedPorts, labelsMap := k8s.GetPodMetadata(logger, clusterInfo, ns, pod)
+	lbs := labels.Map2Labels(labelsMap, labels.LabelSourceK8s)
+	for _, lbl := range k8s.NamedPortsIdentityLabels(namedPorts) {
+		lbs[lbl.Key] = lbl
+	}
+	idLabels, _ := labelsfilter.Filter(lbs)
+	return &key.GlobalIdentity{LabelArray: idLabels.LabelArray()}, nil
 }
 
 func getNamespace(namespace string, nsStore resource.Store[*slim_corev1.Namespace]) (*slim_corev1.Namespace, error) {

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -480,7 +480,7 @@ func TestReconcileNS(t *testing.T) {
 	}
 }
 
-func TestGetRelevantLabelsForPodDoesNotIncludeGeneratedNamedPorts(t *testing.T) {
+func TestGetCIDKeyForPodIncludesNamedPorts(t *testing.T) {
 	ctx := t.Context()
 	reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, false)
 	defer cleanupFunc()
@@ -491,15 +491,18 @@ func TestGetRelevantLabelsForPodDoesNotIncludeGeneratedNamedPorts(t *testing.T) 
 	pod := cidtest.NewPod("pod1", ns.Name, testLbsA, "node1")
 	pod.Spec.Containers = []slim_corev1.Container{{
 		Ports: []slim_corev1.ContainerPort{{
-			Name:          "http",
-			ContainerPort: 8080,
+			Name:          "grpc",
+			ContainerPort: 4245,
 			Protocol:      slim_corev1.ProtocolTCP,
 		}},
 	}}
 
-	k8sLabels, err := GetRelevantLabelsForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo)
+	cidKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo)
 	require.NoError(t, err)
-	require.NotContains(t, k8sLabels, ciliumio.NamedPortsIdentityLabelName)
+
+	keyMap := cidKey.GetAsMap()
+	require.Contains(t, keyMap, labels.LabelSourceGenerated+":"+ciliumio.NamedPortsIdentityLabelName)
+	require.Equal(t, "grpc.TCP.4245", keyMap[labels.LabelSourceGenerated+":"+ciliumio.NamedPortsIdentityLabelName])
 }
 
 func TestHandleStoreCIDMatch(t *testing.T) {


### PR DESCRIPTION
Fixes: #47214 

Pods with named container ports get stuck in ContainerCreating when identityManagementMode=operator. The root cause is a mismatch between how the agent and the operator build the CiliumIdentity key for such pods.

The agent includes a gen:io.cilium.k8s.named-ports label in the key, derived from the pod's named container ports. The operator did not, because it called GetCIDKeyFromLabels on the raw k8s label map without ever calling GetPodMetadata, so the named ports were never seen.

With different keys, the operator allocates an identity the agent never looks up, and the agent waits for an identity the operator never creates. CNI endpoint creation times out and the pod stays stuck.

AIL: 0

```release-note
Fixes a bug where pods with named ports could never be created when operator-managed-identities was enabled.
```