### PR TITLE
datapath/loader: fix missing complexity coverage for enable_identity_mark

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -24,6 +24,7 @@ func setBasePermutations(t *config.Node) {
 	t.TracingIPOptionType = 1
 	t.DebugLB = true
 	t.EventsMapRateLimit = 1000
+	t.EnableIdentityMark = true
 }
 
 func baseLXCPermutations() *loadPermutationBuilder {


### PR DESCRIPTION
In commit 10e7899c89ab ("bpf, datapath: switch identity mark option to runtime config"), `ENABLE_IDENTITY_MARK` was changed to a load-time config and removed from the build-time configs of the complexity tests without being added to the load-time configs. Thus BPF complexity coverage decreased. As suggested by Julian, always enable the option.

Fixes: 10e7899c89ab ("bpf, datapath: switch identity mark option to runtime config")
Reported-by: Julian Wiedmann <jwi@isovalent.com>

Fixes #47647