### PR TITLE
policy: fix wildcard CIDR selector to match host/remote-node under policyCIDRMatchMode=nodes

### DIFF
--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -544,9 +544,21 @@ func (p *CIDRSelector) Matches(ls labels.LabelArray) bool {
 }
 
 // matchesCIDRWildcard returns true if the requirement is a wildcard and matches
-// the target under the PolicyCIDRMatchesPods configuration.
+// the target under the PolicyCIDRMatchesPods/PolicyCIDRMatchesNodes configuration.
 func matchesCIDRWildcard(req *Requirement, lbls labels.Labels) bool {
-	if !option.Config.PolicyCIDRMatchesPods() || req.key.Source != labels.LabelSourceReserved {
+	if req.key.Source != labels.LabelSourceReserved {
+		return false
+	}
+
+	// A wildcard CIDR (e.g. 0.0.0.0/0) requirement only carries a CIDR label
+	// for targets that are permitted to be matched by CIDR selectors, i.e.
+	// pods when PolicyCIDRMatchesPods() is set, or nodes/host when
+	// PolicyCIDRMatchesNodes() is set (see resolveLabels() in
+	// pkg/ipcache/metadata.go). If neither applies to this target, bail out
+	// early rather than allowing every in-cluster wildcard-selector to
+	// resolve to a false match.
+	isNode := lbls.HasHostLabel() || lbls.HasRemoteNodeLabel()
+	if !option.Config.PolicyCIDRMatchesPods() && !(isNode && option.Config.PolicyCIDRMatchesNodes()) {
 		return false
 	}
 

--- a/pkg/policy/types/selector_test.go
+++ b/pkg/policy/types/selector_test.go
@@ -351,6 +351,53 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 				"cidr:192.168.1.10/32;reserved:host",
 			},
 		},
+		{
+			// Regression test for a bug where a 0.0.0.0/0 CIDRRule (which
+			// expands to a wildcard requirement on reserved:world/world-ipv4,
+			// see resolveLabels() in pkg/ipcache/metadata.go) would never
+			// match host/remote-node identities even with
+			// policyCIDRMatchMode=nodes enabled, because
+			// matchesCIDRWildcard() only consulted PolicyCIDRMatchesPods().
+			// See cilium/cilium#48034.
+			name: "world v4 wildcard matching nodes enabled, matches host and remote-node",
+			rule: api.CIDRRule{Cidr: "0.0.0.0/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:0.0.0.0/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabelV4),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesNodes: true,
+			matchesLabels: []string{
+				"cidr:1.1.1.1/32;reserved:world-ipv4",
+				"cidr:192.168.1.10/32;reserved:host",
+				"cidr:192.168.1.10/32;reserved:remote-node",
+			},
+			notMatchesLabels: []string{
+				"cidr:::/0;reserved:world-ipv6",
+				"cidr:::1/128;reserved:world-ipv6",
+			},
+		},
+		{
+			name: "world v4 wildcard matching nodes disabled, does not match host or remote-node",
+			rule: api.CIDRRule{Cidr: "0.0.0.0/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:0.0.0.0/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabelV4),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesNodes: false,
+			matchesLabels: []string{
+				"cidr:1.1.1.1/32;reserved:world-ipv4",
+			},
+			notMatchesLabels: []string{
+				"cidr:192.168.1.10/32;reserved:host",
+				"cidr:192.168.1.10/32;reserved:remote-node",
+			},
+		},
 	}
 
 	for _, test := range tt {


### PR DESCRIPTION
## Problem

\`matchesCIDRWildcard()\` in \`pkg/policy/types/selector.go\` only checked \`option.Config.PolicyCIDRMatchesPods()\` when deciding whether a wildcard CIDR requirement (e.g. one produced from a \`0.0.0.0/0\` \`CIDRRule\`) matches a target's labels. It never checked \`PolicyCIDRMatchesNodes()\`.

As a result, when \`policyCIDRMatchMode\` is set to \`nodes\` (or \`nodes,pods\`) instead of the default \`pods\`, a \`0.0.0.0/0\` egress/ingress CIDR selector would **never** match \`host\`/\`remote-node\` identities, even though \`resolveLabels()\` (in \`pkg/ipcache/metadata.go\`) does attach a CIDR label to those identities under that same configuration. The selector's wildcard-matching short-circuit and the label-attachment logic had fallen out of sync.

### Impact

This breaks connectivity to any host-networked destination (kube-apiserver, apiserver-proxy, etc.) reachable only via a wildcard CIDR egress rule, whenever an operator enables \`policyCIDRMatchMode=nodes\`. We observed this concretely on OpenShift 4.22 (HyperShift-hosted clusters), where CoreDNS's egress traffic to the API server was dropped with \`Policy denied\` (`bpf_lxc.c`, drop reason \`Policy denied\`), so DNS never stabilized despite CoreDNS actually being healthy — see #48034 for the full write-up including live \`cilium-dbg monitor --type drop\` captures showing this exact failure signature.

## Fix

Extend \`matchesCIDRWildcard()\` to also permit a match when the target carries the \`host\` or \`remote-node\` reserved label **and** \`PolicyCIDRMatchesNodes()\` is enabled — mirroring exactly the condition used in \`resolveLabels()\` to decide whether to attach a CIDR label to that target in the first place.

## Testing

- Added two new table-driven cases to \`TestCIDRRuleToCIDRSelectors\` in \`pkg/policy/types/selector_test.go\` covering: a wildcard CIDR rule matching \`host\`/\`remote-node\` when \`policyCIDRMatchesNodes\` is enabled, and *not* matching them when disabled (existing \`pods\`-only behavior is unchanged).
- Live-validated end-to-end against a real OCP 4.22 HyperShift cluster (ARO-HCP) with custom-built agent+operator images including this fix: Cilium came up healthy, all default cluster operators (network, dns, ingress, etc.) reported Available, and no \`Policy denied\` drops were observed on CoreDNS→apiserver traffic — confirming the root cause and the fix.

Fixes #48034