### PR TITLE
gha/kubespray: don't wait for CoreDNS before Cilium is installed

### DIFF
--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -177,6 +177,7 @@ jobs:
           EOF
 
       - name: Deploy Kubernetes cluster
+        id: deploy-cluster
         run: |
           source kubespray-venv/bin/activate
           cd kubespray/
@@ -188,7 +189,23 @@ jobs:
           sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
           sudo chown "$(id -u)":"$(id -g)" $HOME/.kube/config
 
-          kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=300s
+          # There is no pod network until Cilium is installed, so only the
+          # host-network control plane can be Ready here.
+          kubectl wait --for=condition=Ready pod -n kube-system \
+            -l tier=control-plane --timeout=300s
+          kubectl get --raw='/readyz?verbose' > /dev/null
+
+      - name: Gather cluster state on bring-up failure
+        if: ${{ failure() && steps.deploy-cluster.conclusion == 'failure' }}
+        run: |
+          kubectl get nodes -o wide || true
+          kubectl get pods -A -o wide || true
+          kubectl describe nodes || true
+          kubectl describe pods -n kube-system || true
+          kubectl get events -A --sort-by=.metadata.creationTimestamp || true
+          # A missing CNI configuration is the usual reason pods get no sandbox.
+          sudo ls -l /etc/cni/net.d /opt/cni/bin || true
+          sudo journalctl --no-pager -u kubelet -u cri-dockerd -u docker -n 500 || true
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
@@ -248,6 +265,9 @@ jobs:
       - name: Wait for Cilium to be ready
         run: |
           cilium status --wait --interactive=false --wait-duration=2m
+          # Cilium provides the pod network now, so CoreDNS has to converge.
+          kubectl wait --for=condition=Ready node --all --timeout=5m
+          kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=5m
           kubectl get pods --all-namespaces -o wide
 
       - name: Make JUnit report directory


### PR DESCRIPTION
We run kubespray with kube_network_plugin=cni, so kubespray writes no CNI
configuration and there is no pod network until Cilium is installed, yet
bring-up waited for every kube-system pod to be Ready. That only worked by
accident, because the old image installed podman from the Ubuntu archive
and cri-dockerd picked up its /etc/cni/net.d/87-podman-bridge.conflist. The
new image ships a static podman that uses netavark, leaving /etc/cni/net.d
empty, so the wait can never be satisfied.

Wait for the host-network control plane instead, and assert kube-system
readiness after Cilium is up, where CoreDNS not converging is a real
failure. Also dump cluster state on bring-up failure, since the sysdump
step is skipped when Cilium was never installed.

This PR was prepared with AIL:3.
