### PR TITLE
network driver: simplify statedb table management and remove redundant data from the table

### DIFF
--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -187,12 +187,8 @@ func (d *Driver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin
 	txn := d.db.ReadTxn()
 	var devices []allocation
 	for row := range DevicesByClaimUID(d.deviceTable, txn, claim.UID) {
-		if row.Dev != nil {
-			devices = append(devices, allocation{
-				Device:  row.Dev,
-				Config:  row.Config,
-				Manager: row.Manager,
-			})
+		if a, ok := allocationFromRow(row); ok {
+			devices = append(devices, a)
 		}
 	}
 
@@ -208,7 +204,7 @@ func (d *Driver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin
 
 	// Clear allocation state from the statedb table before freeing devices so
 	// the table reflects reality even on partial failure.
-	d.setAllocationInTable(devices, "", "", true)
+	d.clearAllocationInTable(devices)
 
 	var errs []error
 	for _, dev := range devices {
@@ -302,7 +298,7 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		}
 	}
 
-	driver.setAllocationInTable(alloc, pod.UID, claim.UID, false)
+	driver.setAllocationInTable(alloc, pod.UID, claim.UID)
 
 	// we dont need to return anything here.
 	return kubeletplugin.PrepareResult{}
@@ -385,11 +381,9 @@ func (driver *Driver) newClaimPrepState(pod resourceapi.ResourceClaimConsumerRef
 	existingByDevice := make(map[string]allocation)
 	txn := driver.db.ReadTxn()
 	for row := range DevicesByClaimUID(driver.deviceTable, txn, claim.UID) {
-		if row.PodUID == pod.UID && row.Dev != nil {
-			existingByDevice[row.Name] = allocation{
-				Device:  row.Dev,
-				Config:  row.Config,
-				Manager: row.Manager,
+		if row.PodUID == pod.UID {
+			if a, ok := allocationFromRow(row); ok {
+				existingByDevice[row.Name] = a
 			}
 		}
 	}
@@ -497,11 +491,10 @@ func (driver *Driver) prepareClaimDevice(
 }
 
 func (driver *Driver) prepareDeviceAllocation(ctx context.Context, claim string, result resourceapi.DeviceRequestAllocationResult, cfg types.DeviceConfig) (allocation, error) {
-	alloc := allocation{Config: cfg}
+	alloc := allocation{Config: cfg, Pool: result.Pool}
 
 	txn := driver.db.ReadTxn()
-	key := DeviceKey(result.Pool, result.Device)
-	row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(key))
+	row, _, found := driver.deviceTable.Get(txn, deviceByName.Query(result.Device))
 	if !found {
 		return alloc, fmt.Errorf("%w with ifname %s for %s", errDeviceNotFound, result.Device, claim)
 	}

--- a/pkg/networkdriver/dra_test.go
+++ b/pkg/networkdriver/dra_test.go
@@ -188,7 +188,6 @@ func TestPrepareResourceClaim(t *testing.T) {
 			Name:    dev.IfName(),
 			Manager: types.DeviceManagerTypeMock,
 			Dev:     dev,
-			Pool:    prepTestPool,
 		})
 		wtxn.Commit()
 
@@ -245,7 +244,6 @@ func TestPrepareResourceClaim(t *testing.T) {
 		wtxn := driver.db.WriteTxn(driver.deviceTable)
 		driver.deviceTable.Insert(wtxn, &DRADevice{
 			Name:     "existing-device",
-			Pool:     prepTestPool,
 			Manager:  types.DeviceManagerTypeMock,
 			PodUID:   podUID,
 			ClaimUID: claimUID,

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"path"
 	"slices"
 
@@ -76,6 +75,7 @@ type allocation struct {
 	Device  types.Device
 	Config  types.DeviceConfig
 	Manager types.DeviceManagerType
+	Pool    string
 }
 
 // watchConfig blocks until the first configuration is found (from the CRD). Update attempts are logged but not passed
@@ -330,12 +330,6 @@ func (driver *Driver) onDevices(mgrType types.DeviceManagerType, devices []types
 	wtxn := driver.db.WriteTxn(driver.deviceTable)
 	defer wtxn.Commit()
 
-	// Resolve pool assignment for each device.
-	sortedPools := slices.Clone(driver.config.Pools)
-	slices.SortFunc(sortedPools, func(a, b v2alpha1.CiliumNetworkDriverDevicePoolConfig) int {
-		return cmp.Compare(a.PoolName, b.PoolName)
-	})
-
 	seen := make(map[string]struct{}, len(devices))
 
 	for _, dev := range devices {
@@ -347,31 +341,20 @@ func (driver *Driver) onDevices(mgrType types.DeviceManagerType, devices []types
 		}
 		seen[ifname] = struct{}{}
 
-		pool := driver.resolvePool(dev, sortedPools)
-		if pool == "" {
-			// Device matches no pool — skip advertising it.
-			continue
-		}
-
-		attrs := attrsToMap(dev.GetAttrs())
-
 		row := &DRADevice{
 			Name:    ifname,
 			Manager: mgrType,
 			Dev:     dev,
-			Pool:    pool,
-			Attrs:   attrs,
 		}
 
 		_, _, err := driver.deviceTable.Modify(wtxn, row, func(old, _ *DRADevice) *DRADevice {
 			// Row already exists (written by restoreDevices or a prior onDevices call):
-			// update the live device handle and attributes, but preserve allocation state.
+			// update the live device handle, but preserve allocation state.
 			updated := old.Clone()
 			updated.Dev = dev
 			if old.Dev != nil {
 				updated.Dev.Merge(old.Dev)
 			}
-			updated.Attrs = attrs
 			return updated
 		})
 
@@ -403,52 +386,22 @@ func (driver *Driver) allocationsForPod(podUID kube_types.UID) []allocation {
 	txn := driver.db.ReadTxn()
 	var result []allocation
 	for row := range driver.deviceTable.All(txn) {
-		if row.PodUID == podUID && row.Dev != nil {
-			result = append(result, allocation{
-				Device:  row.Dev,
-				Config:  row.Config,
-				Manager: row.Manager,
-			})
+		if row.PodUID == podUID {
+			if a, ok := allocationFromRow(row); ok {
+				result = append(result, a)
+			}
 		}
 	}
 	return result
 }
 
 // setAllocationInTable updates the statedb row for each device in allocs with
-// the given podUID and claimUID, or clears those fields when clearing is true.
-func (driver *Driver) setAllocationInTable(allocs []allocation, podUID, claimUID kube_types.UID, clearing bool) {
+// the given podUID and claimUID.
+func (driver *Driver) setAllocationInTable(allocs []allocation, podUID, claimUID kube_types.UID) {
+	byName := allocationsByName(allocs)
+
 	wtxn := driver.db.WriteTxn(driver.deviceTable)
 	defer wtxn.Commit()
-
-	if clearing {
-		// Clear by iterating the provided allocs list (by device name).
-		for d := range driver.deviceTable.All(wtxn) {
-			found := false
-			for _, a := range allocs {
-				if a.Device != nil && a.Device.IfName() == d.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-			row := d.Clone()
-			row.PodUID = ""
-			row.ClaimUID = ""
-			row.Config = types.DeviceConfig{}
-			driver.deviceTable.Insert(wtxn, row)
-		}
-		return
-	}
-
-	// Build a name→allocation index so each row lookup is O(1).
-	byName := make(map[string]allocation, len(allocs))
-	for _, a := range allocs {
-		if a.Device != nil {
-			byName[a.Device.IfName()] = a
-		}
-	}
 
 	for d := range driver.deviceTable.All(wtxn) {
 		a, ok := byName[d.Name]
@@ -460,8 +413,42 @@ func (driver *Driver) setAllocationInTable(allocs []allocation, podUID, claimUID
 		row.PodUID = podUID
 		row.ClaimUID = claimUID
 		row.Config = a.Config
+		row.Pool = a.Pool
 		driver.deviceTable.Insert(wtxn, row)
 	}
+}
+
+// clearAllocationInTable clears the PodUID/ClaimUID/Config fields for each
+// device in allocs.
+func (driver *Driver) clearAllocationInTable(allocs []allocation) {
+	byName := allocationsByName(allocs)
+
+	wtxn := driver.db.WriteTxn(driver.deviceTable)
+	defer wtxn.Commit()
+
+	for d := range driver.deviceTable.All(wtxn) {
+		if _, ok := byName[d.Name]; !ok {
+			continue
+		}
+
+		row := d.Clone()
+		row.PodUID = ""
+		row.ClaimUID = ""
+		row.Config = types.DeviceConfig{}
+		driver.deviceTable.Insert(wtxn, row)
+	}
+}
+
+// allocationsByName builds a device-name→allocation index
+// for more convenient lookups.
+func allocationsByName(allocs []allocation) map[string]allocation {
+	byName := make(map[string]allocation, len(allocs))
+	for _, a := range allocs {
+		if a.Device != nil {
+			byName[a.Device.IfName()] = a
+		}
+	}
+	return byName
 }
 
 // resolvePool returns the single pool name the device should be assigned to.
@@ -495,9 +482,16 @@ func (driver *Driver) resolvePool(dev types.Device, sortedPools []v2alpha1.Ciliu
 
 // buildPoolsFromTable constructs the ResourceSlice pool map from the current
 // table snapshot. It pre-populates every configured pool (with a valid filter)
-// so pools with no devices are still published as empty slices.
+// so pools with no devices are still published as empty slices. Pool
+// membership and device attributes are resolved here, on demand,
+// using the latest information present in statedb.
 func (driver *Driver) buildPoolsFromTable() map[string]resourceslice.Pool {
 	txn := driver.db.ReadTxn()
+
+	sortedPools := slices.Clone(driver.config.Pools)
+	slices.SortFunc(sortedPools, func(a, b v2alpha1.CiliumNetworkDriverDevicePoolConfig) int {
+		return cmp.Compare(a.PoolName, b.PoolName)
+	})
 
 	pools := make(map[string]resourceslice.Pool, len(driver.config.Pools))
 	for _, p := range driver.config.Pools {
@@ -507,27 +501,50 @@ func (driver *Driver) buildPoolsFromTable() map[string]resourceslice.Pool {
 	}
 
 	for d := range driver.deviceTable.All(txn) {
-		entry, ok := pools[d.Pool]
-		if !ok {
+		if d.Dev == nil {
 			continue
 		}
 
-		attrs := maps.Clone(d.Attrs)
-		if attrs == nil {
-			attrs = make(map[string]resourceapi.DeviceAttribute)
-		}
-		attrs[string(types.PoolNameLabel)] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Pool)}
+		var pool string
 
-		qualAttrs := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, len(attrs))
-		for k, v := range attrs {
-			qualAttrs[resourceapi.QualifiedName(k)] = v
+		// if an allocation exists, the device was allocated
+		// from a pool on a previous run.
+		// we should stick with that pool
+		// until the device is eventually unallocated
+		if d.ClaimUID != "" && d.PodUID != "" {
+			if d.Pool == "" {
+				// pool is empty while we have allocation
+				// state for this device. this shouldn't happen
+				// (devices should always belong to a pool)
+				// skip advertising this device to prevent
+				// double allocation.
+				continue
+			}
+
+			pool = d.Pool
+		} else {
+			pool = driver.resolvePool(d.Dev, sortedPools)
 		}
+
+		entry, ok := pools[pool]
+		if !ok {
+			// pool does not exist in the current configuration
+			// dont advertise the device
+			continue
+		}
+
+		attrs := d.Dev.GetAttrs()
+		if attrs == nil {
+			attrs = make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+		}
+		attrs[resourceapi.QualifiedName(types.PoolNameLabel)] = resourceapi.DeviceAttribute{StringValue: ptr.To(pool)}
+		attrs[resourceapi.QualifiedName(types.DeviceManagerLabel)] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Manager.String())}
 
 		entry.Slices[0].Devices = append(entry.Slices[0].Devices, resourceapi.Device{
 			Name:       d.Name,
-			Attributes: qualAttrs,
+			Attributes: attrs,
 		})
-		pools[d.Pool] = entry
+		pools[pool] = entry
 	}
 
 	return pools
@@ -553,6 +570,7 @@ func (driver *Driver) deviceFromClaim(devStatus resourceapi.AllocatedDeviceStatu
 		Device:  dev,
 		Config:  devCfg,
 		Manager: devMgrType,
+		Pool:    devStatus.Pool,
 	}, nil
 }
 
@@ -592,20 +610,20 @@ func (driver *Driver) restoreDevicesFromClaim(claim *resourceapi.ResourceClaim, 
 		podUID := claim.Status.ReservedFor[0].UID
 
 		ifname := alloc.Device.IfName()
-		pool := driver.resolvePoolForRestore(devStatus.Pool)
 
-		// Write a placeholder row with allocation state. The live Dev field will
-		// be updated (and attrs populated) when onDevices is called by the device
-		// manager. The row must exist before DRA/NRI callbacks can arrive so they
-		// can look up the device by ClaimUID.
+		// Write a row with allocation state and a fully restored Dev handle.
+		// The row must exist before DRA/NRI callbacks can arrive so they
+		// can look up the device by ClaimUID. A later onDevices call from
+		// the device manager will merge in any live-scan updates
+		// without touching allocation state.
 		row := &DRADevice{
 			Name:     ifname,
 			Manager:  alloc.Manager,
 			Dev:      alloc.Device,
-			Pool:     pool,
 			PodUID:   podUID,
 			ClaimUID: claim.UID,
 			Config:   alloc.Config,
+			Pool:     alloc.Pool,
 		}
 		driver.deviceTable.Insert(wtxn, row)
 
@@ -618,13 +636,6 @@ func (driver *Driver) restoreDevicesFromClaim(claim *resourceapi.ResourceClaim, 
 	}
 
 	return errors.Join(errs...)
-}
-
-// resolvePoolForRestore returns the pool name for a device being restored from
-// a ResourceClaim status. It uses the pool recorded in the claim status directly
-// since driver.config may not be available at restore time.
-func (driver *Driver) resolvePoolForRestore(pool string) string {
-	return pool
 }
 
 func (driver *Driver) restoreDevices(ctx context.Context, markRestoreDone func(statedb.WriteTxn)) error {

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -368,6 +368,9 @@ func (driver *Driver) onDevices(mgrType types.DeviceManagerType, devices []types
 			// update the live device handle and attributes, but preserve allocation state.
 			updated := old.Clone()
 			updated.Dev = dev
+			if old.Dev != nil {
+				updated.Dev.Merge(old.Dev)
+			}
 			updated.Attrs = attrs
 			return updated
 		})

--- a/pkg/networkdriver/driver_test.go
+++ b/pkg/networkdriver/driver_test.go
@@ -85,7 +85,7 @@ func buildDriverForPool(t *testing.T, pools []v2alpha1.CiliumNetworkDriverDevice
 }
 
 // matchingDevice is a trackedDevice whose Match() returns the supplied bool.
-// GetAttrs returns a non-nil map; attrsToPartMap handles it without issue.
+// GetAttrs returns a non-nil map; buildPoolsFromTable handles it without issue.
 type matchingDevice struct {
 	trackedDevice
 	matches bool
@@ -95,6 +95,28 @@ func (m *matchingDevice) Match(_ v2alpha1.CiliumNetworkDriverDeviceFilter) bool 
 
 func (m *matchingDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	return make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+}
+
+// mergeTrackingDevice is a trackedDevice whose KernelIfName is mutable and
+// whose Merge implements the real copy-forward semantics required by
+// types.Device: if the fresh scan did not determine a KernelIfName, adopt the
+// old device's value instead of losing it. This exercises the behavior that
+// onDevices' Modify closure relies on (unlike trackedDevice/matchingDevice/
+// DummyDevice, whose Merge is a no-op because their KernelIfName is always
+// derivable).
+type mergeTrackingDevice struct {
+	trackedDevice
+	kernelIfName string
+	mergeCalls   int
+}
+
+func (m *mergeTrackingDevice) KernelIfName() string { return m.kernelIfName }
+
+func (m *mergeTrackingDevice) Merge(old types.Device) {
+	m.mergeCalls++
+	if m.kernelIfName == "" {
+		m.kernelIfName = old.KernelIfName()
+	}
 }
 
 // podSandbox builds a minimal NRI PodSandbox with an optional network namespace.
@@ -122,7 +144,7 @@ func buildNRIDriver(t *testing.T) *Driver {
 }
 
 func TestOnDevices(t *testing.T) {
-	t.Run("device matching a pool is inserted into table", func(t *testing.T) {
+	t.Run("device is inserted into table regardless of pool match", func(t *testing.T) {
 		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
 			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
 		})
@@ -130,13 +152,12 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, "eth0", row.Name)
-		require.Equal(t, "pool-a", row.Pool)
 	})
 
-	t.Run("device matching no pool is not inserted", func(t *testing.T) {
+	t.Run("device matching no pool is still discovered, but not advertised", func(t *testing.T) {
 		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
 			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{
 				IfNames: []string{"eth1"}, // only eth1 matches
@@ -146,8 +167,11 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		_, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
-		require.False(t, found)
+		_, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		require.True(t, found, "device must be discovered even though it matches no pool")
+
+		pools := driver.buildPoolsFromTable()
+		require.Empty(t, pools["pool-a"].Slices[0].Devices, "device must not be advertised in a pool it does not match")
 	})
 
 	t.Run("device no longer reported is deleted from table", func(t *testing.T) {
@@ -164,9 +188,9 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev0}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		_, _, found0 := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		_, _, found0 := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found0, "eth0 must remain")
-		_, _, found1 := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth1")))
+		_, _, found1 := driver.deviceTable.Get(txn, deviceByName.Query("eth1"))
 		require.False(t, found1, "eth1 must be removed")
 	})
 
@@ -180,7 +204,6 @@ func TestOnDevices(t *testing.T) {
 		driver.deviceTable.Insert(wtxn, &DRADevice{
 			Name:    "dummy0",
 			Manager: types.DeviceManagerTypeDummy,
-			Pool:    "pool-a",
 		})
 		wtxn.Commit()
 
@@ -188,11 +211,11 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		_, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "dummy0")))
+		_, _, found := driver.deviceTable.Get(txn, deviceByName.Query("dummy0"))
 		require.True(t, found, "dummy manager's device must not be deleted by mock manager")
 	})
 
-	t.Run("pool with nil filter is skipped", func(t *testing.T) {
+	t.Run("pool with nil filter never advertises devices", func(t *testing.T) {
 		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
 			{PoolName: "no-filter", Filter: nil},
 		})
@@ -204,7 +227,11 @@ func TestOnDevices(t *testing.T) {
 		for range driver.deviceTable.All(txn) {
 			count++
 		}
-		require.Zero(t, count, "nil-filter pool must not admit any devices")
+		require.Equal(t, 1, count, "device is still discovered and present in the table")
+
+		pools := driver.buildPoolsFromTable()
+		_, hasPool := pools["no-filter"]
+		require.False(t, hasPool, "a pool with a nil filter is never pre-populated or matched")
 	})
 
 	t.Run("device matches multiple pools — assigned to first alphabetically", func(t *testing.T) {
@@ -215,11 +242,9 @@ func TestOnDevices(t *testing.T) {
 		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
-		txn := driver.db.ReadTxn()
-		_, _, inAlpha := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("alpha", "eth0")))
-		_, _, inBeta := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("beta", "eth0")))
-		require.True(t, inAlpha, "eth0 must be in alpha (first alphabetically)")
-		require.False(t, inBeta, "eth0 must not be in beta")
+		pools := driver.buildPoolsFromTable()
+		require.Len(t, pools["alpha"].Slices[0].Devices, 1, "eth0 must be in alpha (first alphabetically)")
+		require.Empty(t, pools["beta"].Slices[0].Devices, "eth0 must not be in beta")
 	})
 
 	t.Run("Merge carries KernelIfName forward when a rescan cannot determine one", func(t *testing.T) {
@@ -232,7 +257,7 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev1}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, "keth0", row.Dev.KernelIfName())
 
@@ -242,11 +267,131 @@ func TestOnDevices(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev2}, func(statedb.WriteTxn) {})
 
 		txn = driver.db.ReadTxn()
-		row, _, found = driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		row, _, found = driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, "keth0", row.Dev.KernelIfName(),
 			"Merge must carry the previous KernelIfName forward when the fresh scan has none")
 	})
+}
+
+// ---------------------------------------------------------------------------
+// onDevices — Merge and attribute freshness
+// ---------------------------------------------------------------------------
+
+// TestOnDevicesMerge verifies that onDevices' Modify closure calls
+// Dev.Merge(old.Dev) so a device implementation can copy forward fields a
+// fresh scan could not determine (e.g. KernelIfName once a device has moved
+// into a pod's network namespace).
+func TestOnDevicesMerge(t *testing.T) {
+	pools := []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+		{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+	}
+
+	t.Run("Merge is not called on first discovery (no prior row)", func(t *testing.T) {
+		driver := buildDriverForPool(t, pools)
+		dev := &mergeTrackingDevice{trackedDevice: trackedDevice{name: "eth0"}, kernelIfName: "keth0"}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		require.Zero(t, dev.mergeCalls, "Merge must not be called when there is no existing row")
+
+		txn := driver.db.ReadTxn()
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		require.True(t, found)
+		require.Equal(t, "keth0", row.Dev.KernelIfName())
+	})
+
+	t.Run("Merge is called on subsequent onDevices calls and copies forward KernelIfName", func(t *testing.T) {
+		driver := buildDriverForPool(t, pools)
+
+		dev1 := &mergeTrackingDevice{trackedDevice: trackedDevice{name: "eth0"}, kernelIfName: "keth0"}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev1}, func(statedb.WriteTxn) {})
+
+		// Second scan: the device manager reports the same device but this time
+		// could not determine a kernel ifname (e.g. moved into a pod netns).
+		dev2 := &mergeTrackingDevice{trackedDevice: trackedDevice{name: "eth0"}, kernelIfName: ""}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev2}, func(statedb.WriteTxn) {})
+
+		require.Equal(t, 1, dev2.mergeCalls, "Merge must be called exactly once against the old Dev")
+
+		txn := driver.db.ReadTxn()
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		require.True(t, found)
+		require.Equal(t, "keth0", row.Dev.KernelIfName(),
+			"KernelIfName must be copied forward from the old device by Merge")
+	})
+
+	t.Run("Merge runs regardless of allocation state", func(t *testing.T) {
+		driver := buildDriverForPool(t, pools)
+
+		dev1 := &mergeTrackingDevice{trackedDevice: trackedDevice{name: "eth0"}, kernelIfName: "keth0"}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev1}, func(statedb.WriteTxn) {})
+
+		// Mark the row allocated to a pod directly (simulating a prepared claim).
+		wtxn := driver.db.WriteTxn(driver.deviceTable)
+		row, _, _ := driver.deviceTable.Get(wtxn, deviceByName.Query("eth0"))
+		allocated := row.Clone()
+		allocated.PodUID = prepTestPodUID
+		allocated.ClaimUID = prepTestClaimUID
+		driver.deviceTable.Insert(wtxn, allocated)
+		wtxn.Commit()
+
+		dev2 := &mergeTrackingDevice{trackedDevice: trackedDevice{name: "eth0"}, kernelIfName: ""}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev2}, func(statedb.WriteTxn) {})
+
+		require.Equal(t, 1, dev2.mergeCalls, "Merge must run for allocated rows too, not just free ones")
+
+		txn := driver.db.ReadTxn()
+		got, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		require.True(t, found)
+		require.Equal(t, "keth0", got.Dev.KernelIfName(), "KernelIfName preserved across an allocated row")
+		require.Equal(t, prepTestPodUID, got.PodUID, "allocation state must also be preserved")
+	})
+}
+
+// TestOnDevicesAttrsNotPersisted verifies that device attributes are never
+// stored in the statedb row (DRADevice has no Attrs field): buildPoolsFromTable
+// must reflect live changes to Dev.GetAttrs() immediately, on every publish,
+// without any stale copy lingering in the table.
+func TestOnDevicesAttrsNotPersisted(t *testing.T) {
+	pools := []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+		{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+	}
+	driver := buildDriverForPool(t, pools)
+
+	dev := &attrDevice{trackedDevice: trackedDevice{name: "eth0"}, attrValue: "v1"}
+	driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+	first := driver.buildPoolsFromTable()["pool-a"].Slices[0].Devices
+	require.Len(t, first, 1)
+	attr, ok := first[0].Attributes["custom"]
+	require.True(t, ok)
+	require.Equal(t, "v1", *attr.StringValue)
+
+	// Mutate the live device's attribute in place — no onDevices call, no
+	// statedb write. buildPoolsFromTable must pick up the new value because it
+	// reads Dev.GetAttrs() live rather than a cached copy.
+	dev.attrValue = "v2"
+
+	second := driver.buildPoolsFromTable()["pool-a"].Slices[0].Devices
+	require.Len(t, second, 1)
+	attr, ok = second[0].Attributes["custom"]
+	require.True(t, ok)
+	require.Equal(t, "v2", *attr.StringValue,
+		"buildPoolsFromTable must reflect the live device's current attributes, not a stale statedb copy")
+}
+
+// attrDevice is a trackedDevice whose GetAttrs() reflects a mutable field, so
+// tests can assert that publish-time attribute resolution is live rather than
+// cached from an earlier onDevices call.
+type attrDevice struct {
+	trackedDevice
+	attrValue string
+}
+
+func (a *attrDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	return map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		"custom": {StringValue: &a.attrValue},
+	}
 }
 
 func TestResolvePool(t *testing.T) {
@@ -346,6 +491,186 @@ func TestBuildPoolsFromTable(t *testing.T) {
 		require.Len(t, pools["dummy-pool"].Slices[0].Devices, 2,
 			"both dummy devices must appear in the pool")
 	})
+
+	t.Run("allocated device keeps its original pool when resolvePool now picks a different one", func(t *testing.T) {
+		// Simulates a NodeConfig change (e.g. pool filters reordered/renamed)
+		// that causes resolvePool to now match a different pool than the one
+		// recorded at allocation time. An already-allocated device must keep
+		// advertising under its original pool so the claim's Pool reference
+		// stays valid, rather than silently moving to the newly resolved pool.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		// Mark the device allocated with Pool "pool-b", even though
+		// resolvePool (matches both pools, picks first alphabetically) would
+		// now resolve it to "pool-a".
+		allocs := []allocation{{Device: dev, Manager: types.DeviceManagerTypeMock, Pool: "pool-b"}}
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+
+		pools := driver.buildPoolsFromTable()
+		require.Empty(t, pools["pool-a"].Slices[0].Devices, "allocated device must not appear in the newly resolved pool")
+		require.Len(t, pools["pool-b"].Slices[0].Devices, 1, "allocated device must stay in its originally allocated pool")
+		require.Equal(t, "eth0", pools["pool-b"].Slices[0].Devices[0].Name)
+
+		attr, ok := pools["pool-b"].Slices[0].Devices[0].Attributes[types.PoolNameLabel]
+		require.True(t, ok)
+		require.Equal(t, "pool-b", *attr.StringValue, "published pool attribute must reflect the retained pool")
+	})
+
+	t.Run("unallocated device follows resolvePool even if a stale Pool value is present", func(t *testing.T) {
+		// Pool is only "sticky" for devices with both PodUID and ClaimUID set.
+		// A free device must always be (re-)resolved live.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		wtxn := driver.db.WriteTxn(driver.deviceTable)
+		row, _, _ := driver.deviceTable.Get(driver.db.ReadTxn(), deviceByName.Query("eth0"))
+		cloned := row.Clone()
+		cloned.Pool = "pool-b" // stale value, no PodUID/ClaimUID
+		driver.deviceTable.Insert(wtxn, cloned)
+		wtxn.Commit()
+
+		pools := driver.buildPoolsFromTable()
+		require.Len(t, pools["pool-a"].Slices[0].Devices, 1, "free device matching a new pool should be advertised with the new pool")
+		require.Empty(t, pools["pool-b"].Slices[0].Devices, "pool that no longer matches the device should be empty")
+	})
+
+	t.Run("allocated device with empty Pool is not advertised in any pool", func(t *testing.T) {
+		// An allocated row (PodUID+ClaimUID set) with an empty Pool should
+		// never happen in practice (Pool is always set at allocation time),
+		// but if it does, the device must be skipped entirely rather than
+		// falling back to a live resolvePool() result — advertising it under
+		// a freshly resolved pool while it's still allocated could let the
+		// scheduler double-allocate it via a different claim.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		wtxn := driver.db.WriteTxn(driver.deviceTable)
+		row, _, _ := driver.deviceTable.Get(driver.db.ReadTxn(), deviceByName.Query("eth0"))
+		cloned := row.Clone()
+		cloned.PodUID = prepTestPodUID
+		cloned.ClaimUID = prepTestClaimUID
+		cloned.Pool = "" // allocated but Pool unexpectedly empty
+		driver.deviceTable.Insert(wtxn, cloned)
+		wtxn.Commit()
+
+		pools := driver.buildPoolsFromTable()
+		require.Empty(t, pools["pool-a"].Slices[0].Devices, "device allocated with no Pool recorded must not be advertised")
+	})
+
+	t.Run("unallocated device can change pools between consecutive advertisements", func(t *testing.T) {
+		// With no allocation, resolvePool must be re-evaluated fresh on every
+		// call — a device can legitimately move pools across publishes (e.g.
+		// its attributes changed, or NodeConfig pool filters were updated)
+		// as long as it was never claimed while under the old pool.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		first := driver.buildPoolsFromTable()
+		require.Len(t, first["pool-a"].Slices[0].Devices, 1, "device resolves to pool-a first (alphabetical tie-break)")
+		require.Empty(t, first["pool-b"].Slices[0].Devices)
+
+		// Simulate pool-a no longer matching (e.g. filter update) by removing
+		// it from the driver's configured pools, forcing resolvePool to now
+		// pick pool-b.
+		driver.config.Pools = []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		}
+
+		second := driver.buildPoolsFromTable()
+		require.NotContains(t, second, "pool-a", "pool-a is no longer configured")
+		require.Len(t, second["pool-b"].Slices[0].Devices, 1, "unallocated device follows the live resolvePool result on the next advertisement")
+	})
+
+	t.Run("sticky pool that no longer exists in config is not advertised anywhere", func(t *testing.T) {
+		// The device was allocated under "pool-a", but a NodeConfig change
+		// removed "pool-a" entirely (not just made it stop matching). The
+		// sticky Pool value still points at a pool that isn't in the current
+		// config map at all, so the device must be dropped rather than
+		// silently falling back to some other pool.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		allocs := []allocation{{Device: dev, Manager: types.DeviceManagerTypeMock, Pool: "pool-a"}}
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+
+		// pool-a is now removed from config entirely.
+		driver.config.Pools = []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-c", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		}
+
+		pools := driver.buildPoolsFromTable()
+		require.NotContains(t, pools, "pool-a", "pool-a is no longer configured")
+		require.Empty(t, pools["pool-c"].Slices[0].Devices, "sticky-allocated device must not fall back to another pool")
+	})
+
+	t.Run("row with only PodUID set (ClaimUID empty) is treated as unallocated", func(t *testing.T) {
+		// Sticky-pool behavior requires BOTH PodUID and ClaimUID. A
+		// partially-populated row (e.g. mid-transition, or a bug elsewhere)
+		// must not trigger stickiness — it should follow live resolvePool.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		wtxn := driver.db.WriteTxn(driver.deviceTable)
+		row, _, _ := driver.deviceTable.Get(driver.db.ReadTxn(), deviceByName.Query("eth0"))
+		cloned := row.Clone()
+		cloned.PodUID = prepTestPodUID
+		cloned.ClaimUID = "" // partially set — must not count as allocated
+		cloned.Pool = "pool-b"
+		driver.deviceTable.Insert(wtxn, cloned)
+		wtxn.Commit()
+
+		pools := driver.buildPoolsFromTable()
+		require.Len(t, pools["pool-a"].Slices[0].Devices, 1, "partially-allocated row must follow live resolvePool (pool-a, alphabetical tie-break)")
+		require.Empty(t, pools["pool-b"].Slices[0].Devices, "stale Pool value on a non-fully-allocated row must be ignored")
+	})
+
+	t.Run("sticky-allocated device and a free device in the same table do not clobber each other's pool entries", func(t *testing.T) {
+		// Regression guard for the earlier overwrite bug: fetching the pool
+		// map entry before applying the sticky override caused a device to
+		// be appended under one pool's slice but stored back under another,
+		// silently dropping whatever was already accumulated there. Verify
+		// with two devices in the same pass — one sticky-allocated to
+		// pool-b, one free and resolving live to pool-a — that both survive.
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+			{PoolName: "pool-b", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+		devAllocated := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		devFree := &matchingDevice{trackedDevice: trackedDevice{name: "eth1"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{devAllocated, devFree}, func(statedb.WriteTxn) {})
+
+		allocs := []allocation{{Device: devAllocated, Manager: types.DeviceManagerTypeMock, Pool: "pool-b"}}
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+
+		pools := driver.buildPoolsFromTable()
+		require.Len(t, pools["pool-a"].Slices[0].Devices, 1, "free device must still be advertised in pool-a")
+		require.Equal(t, "eth1", pools["pool-a"].Slices[0].Devices[0].Name)
+		require.Len(t, pools["pool-b"].Slices[0].Devices, 1, "sticky-allocated device must still be advertised in pool-b")
+		require.Equal(t, "eth0", pools["pool-b"].Slices[0].Devices[0].Name)
+	})
 }
 
 func buildClaimWithDeviceStatus(t *testing.T, driverName string, podUID, claimUID kubetypes.UID, devName string) *resourceapi.ResourceClaim {
@@ -414,6 +739,7 @@ func TestRestoreDevicesFromClaim(t *testing.T) {
 		require.Equal(t, prepTestDev0, rows[0].Name)
 		require.Equal(t, "eth-pod", rows[0].Config.PodIfName)
 		require.Equal(t, prepTestPodUID, rows[0].PodUID)
+		require.Equal(t, "test-pool", rows[0].Pool, "Pool from AllocatedDeviceStatus.Pool must be restored into the row")
 	})
 
 	t.Run("wrong driver is skipped without error", func(t *testing.T) {
@@ -642,7 +968,7 @@ func dummyPoolConfig(name string) v2alpha1.CiliumNetworkDriverDevicePoolConfig {
 }
 
 // ---------------------------------------------------------------------------
-// setAllocationInTable / commitAllocation
+// setAllocationInTable / clearAllocationInTable
 // ---------------------------------------------------------------------------
 
 func TestSetAllocationInTable(t *testing.T) {
@@ -657,14 +983,28 @@ func TestSetAllocationInTable(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		allocs := []allocation{{Device: dev, Config: types.DeviceConfig{PodIfName: "dmy0"}, Manager: types.DeviceManagerTypeMock}}
-		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, prepTestPodUID, row.PodUID)
 		require.Equal(t, prepTestClaimUID, row.ClaimUID)
 		require.Equal(t, "dmy0", row.Config.PodIfName)
+	})
+
+	t.Run("commit writes Pool from allocation into the matching row", func(t *testing.T) {
+		driver := buildDriverForPool(t, pools)
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		allocs := []allocation{{Device: dev, Config: types.DeviceConfig{PodIfName: "dmy0"}, Manager: types.DeviceManagerTypeMock, Pool: "pool-a"}}
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+
+		txn := driver.db.ReadTxn()
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		require.True(t, found)
+		require.Equal(t, "pool-a", row.Pool, "Pool from the allocation must be written into the row")
 	})
 
 	t.Run("clearing resets PodUID, ClaimUID, and Config", func(t *testing.T) {
@@ -673,11 +1013,11 @@ func TestSetAllocationInTable(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		allocs := []allocation{{Device: dev, Config: types.DeviceConfig{PodIfName: "dmy0"}, Manager: types.DeviceManagerTypeMock}}
-		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
-		driver.setAllocationInTable(allocs, "", "", true)
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+		driver.clearAllocationInTable(allocs)
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found, "row must still exist after clearing")
 		require.Empty(t, row.PodUID, "PodUID must be cleared")
 		require.Empty(t, row.ClaimUID, "ClaimUID must be cleared")
@@ -690,7 +1030,7 @@ func TestSetAllocationInTable(t *testing.T) {
 
 		allocs := []allocation{{Device: &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}}, Manager: types.DeviceManagerTypeMock}}
 		require.NotPanics(t, func() {
-			driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
+			driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
 		})
 
 		txn := driver.db.ReadTxn()
@@ -705,7 +1045,7 @@ func TestSetAllocationInTable(t *testing.T) {
 		driver := buildDriverForPool(t, pools)
 		allocs := []allocation{{Device: nil}}
 		require.NotPanics(t, func() {
-			driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
+			driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
 		})
 	})
 
@@ -716,19 +1056,39 @@ func TestSetAllocationInTable(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev0, dev1}, func(statedb.WriteTxn) {})
 
 		allocs := []allocation{{Device: dev0, Manager: types.DeviceManagerTypeMock}}
-		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
 
 		txn := driver.db.ReadTxn()
-		row0, _, _ := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
-		row1, _, _ := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth1")))
+		row0, _, _ := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		row1, _, _ := driver.deviceTable.Get(txn, deviceByName.Query("eth1"))
 		require.Equal(t, prepTestPodUID, row0.PodUID, "eth0 must be marked allocated")
 		require.Empty(t, row1.PodUID, "eth1 must remain free")
 	})
 }
 
 // ---------------------------------------------------------------------------
-// onDevices — allocation restore path
+// allocationsForPod / allocationFromRow — Pool propagation
 // ---------------------------------------------------------------------------
+
+func TestAllocationsForPodIncludesPool(t *testing.T) {
+	pool := "pool-a"
+	pools := []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+		{PoolName: pool, Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+	}
+
+	t.Run("allocationFromRow carries Pool through allocationsForPod", func(t *testing.T) {
+		driver := buildDriverForPool(t, pools)
+		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
+
+		allocs := []allocation{{Device: dev, Manager: types.DeviceManagerTypeMock, Pool: "pool-a"}}
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
+
+		got := driver.allocationsForPod(prepTestPodUID)
+		require.Len(t, got, 1)
+		require.Equal(t, "pool-a", got[0].Pool, "Pool must survive the row → allocation round trip")
+	})
+}
 
 func TestOnDevicesAllocationRestore(t *testing.T) {
 	pool := "pool-a"
@@ -745,7 +1105,6 @@ func TestOnDevicesAllocationRestore(t *testing.T) {
 		wtxn := driver.db.WriteTxn(driver.deviceTable)
 		driver.deviceTable.Insert(wtxn, &DRADevice{
 			Name:     "eth0",
-			Pool:     pool,
 			Manager:  types.DeviceManagerTypeMock,
 			PodUID:   prepTestPodUID,
 			ClaimUID: prepTestClaimUID,
@@ -758,7 +1117,7 @@ func TestOnDevicesAllocationRestore(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, prepTestPodUID, row.PodUID, "PodUID must be preserved by onDevices Modify")
 		require.Equal(t, prepTestClaimUID, row.ClaimUID, "ClaimUID must be preserved by onDevices Modify")
@@ -774,16 +1133,16 @@ func TestOnDevicesAllocationRestore(t *testing.T) {
 		// First call: inserts the row.
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
-		// Manually set allocation state (as commitAllocation would).
+		// Manually set allocation state (as setAllocationInTable would).
 		allocs := []allocation{{Device: dev, Config: types.DeviceConfig{PodIfName: "dmy0"}, Manager: types.DeviceManagerTypeMock}}
-		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID, false)
+		driver.setAllocationInTable(allocs, prepTestPodUID, prepTestClaimUID)
 
 		// Second call: device manager fires again (e.g. a re-sync). The existing
 		// row's PodUID must survive — onDevices clones the existing row.
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
 		require.True(t, found)
 		require.Equal(t, prepTestPodUID, row.PodUID, "PodUID must not be clobbered by subsequent onDevices call")
 	})
@@ -797,7 +1156,6 @@ func TestOnDevicesAllocationRestore(t *testing.T) {
 		wtxn := driver.db.WriteTxn(driver.deviceTable)
 		driver.deviceTable.Insert(wtxn, &DRADevice{
 			Name:     "eth0",
-			Pool:     pool,
 			Manager:  types.DeviceManagerTypeMock,
 			PodUID:   prepTestPodUID,
 			ClaimUID: prepTestClaimUID,
@@ -807,8 +1165,8 @@ func TestOnDevicesAllocationRestore(t *testing.T) {
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev0, dev1}, func(statedb.WriteTxn) {})
 
 		txn := driver.db.ReadTxn()
-		row0, _, _ := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth0")))
-		row1, _, _ := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(pool, "eth1")))
+		row0, _, _ := driver.deviceTable.Get(txn, deviceByName.Query("eth0"))
+		row1, _, _ := driver.deviceTable.Get(txn, deviceByName.Query("eth1"))
 		require.Equal(t, prepTestPodUID, row0.PodUID, "eth0 is allocated — must have PodUID")
 		require.Empty(t, row1.PodUID, "eth1 is free — PodUID must be empty")
 	})
@@ -834,20 +1192,31 @@ func TestBuildPoolsFromTablePoolAttr(t *testing.T) {
 		require.True(t, ok, "pool attribute must be present in published device")
 		require.NotNil(t, attr.StringValue)
 		require.Equal(t, "pool-a", *attr.StringValue)
+
+		mgrAttr, ok := devices[0].Attributes[types.DeviceManagerLabel]
+		require.True(t, ok, "deviceManager attribute must be present in published device")
+		require.NotNil(t, mgrAttr.StringValue)
+		require.Equal(t, types.DeviceManagerTypeMock.String(), *mgrAttr.StringValue)
 	})
 
-	t.Run("pool attribute is not stored in the statedb row itself", func(t *testing.T) {
+	t.Run("pool attribute is not persisted — repeated publishes stay consistent", func(t *testing.T) {
+		// DRADevice has no Attrs field: attributes are computed fresh from
+		// Dev.GetAttrs() on every publish. Calling buildPoolsFromTable twice
+		// must not leak the injected pool label back into the device's own
+		// attribute set (which would happen if GetAttrs() returned a shared,
+		// mutable map instead of a fresh one).
 		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
 			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
 		})
 		dev := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
 		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev}, func(statedb.WriteTxn) {})
 
-		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
-		require.True(t, found)
+		first := driver.buildPoolsFromTable()
+		second := driver.buildPoolsFromTable()
 
-		_, hasPoolAttr := row.GetAttr(string(types.PoolNameLabel))
-		require.False(t, hasPoolAttr, "pool attribute must not be stored in the statedb row")
+		require.Len(t, first["pool-a"].Slices[0].Devices, 1)
+		require.Len(t, second["pool-a"].Slices[0].Devices, 1)
+		require.Equal(t, first["pool-a"].Slices[0].Devices, second["pool-a"].Slices[0].Devices,
+			"published attributes must be identical across independent publishes")
 	})
 }

--- a/pkg/networkdriver/driver_test.go
+++ b/pkg/networkdriver/driver_test.go
@@ -221,6 +221,32 @@ func TestOnDevices(t *testing.T) {
 		require.True(t, inAlpha, "eth0 must be in alpha (first alphabetically)")
 		require.False(t, inBeta, "eth0 must not be in beta")
 	})
+
+	t.Run("Merge carries KernelIfName forward when a rescan cannot determine one", func(t *testing.T) {
+		driver := buildDriverForPool(t, []v2alpha1.CiliumNetworkDriverDevicePoolConfig{
+			{PoolName: "pool-a", Filter: &v2alpha1.CiliumNetworkDriverDeviceFilter{}},
+		})
+
+		// First scan: device manager reports a live kernel interface name.
+		dev1 := &matchingDevice{trackedDevice: trackedDevice{name: "eth0", kernelIfName: "keth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev1}, func(statedb.WriteTxn) {})
+
+		txn := driver.db.ReadTxn()
+		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		require.True(t, found)
+		require.Equal(t, "keth0", row.Dev.KernelIfName())
+
+		// Second scan: the device has moved into a pod's netns, so the fresh
+		// scan can no longer determine a kernel interface name.
+		dev2 := &matchingDevice{trackedDevice: trackedDevice{name: "eth0"}, matches: true}
+		driver.onDevices(types.DeviceManagerTypeMock, []types.Device{dev2}, func(statedb.WriteTxn) {})
+
+		txn = driver.db.ReadTxn()
+		row, _, found = driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey("pool-a", "eth0")))
+		require.True(t, found)
+		require.Equal(t, "keth0", row.Dev.KernelIfName(),
+			"Merge must carry the previous KernelIfName forward when the fresh scan has none")
+	})
 }
 
 func TestResolvePool(t *testing.T) {

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -96,9 +96,6 @@ type DummyDevice struct {
 	Flags  string
 }
 
-func (d DummyDevice) Merge(types.Device) {
-}
-
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
@@ -207,6 +204,10 @@ func (d DummyDevice) IfName() string {
 func (d DummyDevice) KernelIfName() string {
 	return d.Name
 }
+
+// Merge is a no-op for DummyDevice: its KernelIfName always mirrors Name and
+// is never derived from live host state, so nothing can be lost on rescan.
+func (d DummyDevice) Merge(_ types.Device) {}
 
 func (d DummyDevice) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(d)

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -96,6 +96,9 @@ type DummyDevice struct {
 	Flags  string
 }
 
+func (d DummyDevice) Merge(types.Device) {
+}
+
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -80,9 +80,10 @@ func (driver *Driver) startNRI(ctx context.Context) error {
 // Synchronize is invoked by the runtime when the NRI plugin (re)connects — notably right
 // after an agent restart — with every running pod. The sandbox tasks are alive here, so
 // the netns is populated; we capture it so a later StopPodSandbox can recover the netns
-// on containerd < 2.1 even across an agent restart. This mirrors how driver.allocations
-// is rebuilt from ResourceClaims on restart: node-local runtime state reconstructed from
-// a durable source rather than persisted to disk. We request no container updates.
+// on containerd < 2.1 even across an agent restart. This mirrors how the statedb
+// device table is rebuilt from ResourceClaims on restart: node-local runtime state
+// reconstructed from a durable source rather than persisted to disk. We request no
+// container updates.
 func (driver *Driver) Synchronize(ctx context.Context, pods []*api.PodSandbox, _ []*api.Container) ([]*api.ContainerUpdate, error) {
 	err := driver.withLock(func() error {
 		n := 0

--- a/pkg/networkdriver/nri_test.go
+++ b/pkg/networkdriver/nri_test.go
@@ -7,7 +7,7 @@ package networkdriver
 // that require no real kernel network namespaces:
 //
 //   - host-network pod (empty network namespace in the sandbox) → skipped
-//   - pod UID not found in driver.allocations → skipped
+//   - pod UID not found in the statedb device table → skipped
 //   - containerd <2.1 fallback: StopPodSandbox evicts the netns cache entry
 //     even when the netns open fails (path doesn't exist on the test host)
 //
@@ -39,11 +39,10 @@ func buildNRIDriverWithAlloc(t *testing.T, podUID kubetypes.UID, claimUID kubety
 	d := buildPrepDriver(t, cs)
 	d.podNetns = make(map[kubetypes.UID]string)
 	dev := &dummy.DummyDevice{Name: "dummy0"}
-	// Write the allocation into statedb directly (replaces driver.allocations).
+	// Write the allocation into statedb directly (replaces the driver's device table row).
 	wtxn := d.db.WriteTxn(d.deviceTable)
 	d.deviceTable.Insert(wtxn, &DRADevice{
 		Name:     dev.IfName(),
-		Pool:     "dummy-pool",
 		Manager:  types.DeviceManagerTypeDummy,
 		Dev:      dev,
 		PodUID:   podUID,
@@ -70,12 +69,12 @@ func TestRunPodSandbox_HostNetwork_Skipped(t *testing.T) {
 }
 
 // TestRunPodSandbox_NoAllocation_Skipped verifies that a pod whose UID is not
-// in driver.allocations is silently skipped without an error.
+// found allocated in the statedb device table is silently skipped without an error.
 func TestRunPodSandbox_NoAllocation_Skipped(t *testing.T) {
 	d := buildNRIDriver(t)
 	// Give the sandbox a non-empty netns path to pass the host-network gate.
-	// Because driver.allocations is empty, the function must return nil early
-	// before attempting to open the netns file.
+	// Because the device table has no allocation for this pod, the function
+	// must return nil early before attempting to open the netns file.
 	sb := podSandbox("unknown-pod-uid", "/run/netns/some-netns")
 
 	err := d.RunPodSandbox(t.Context(), sb)

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -99,10 +99,31 @@ type trackedDevice struct {
 	setupCalls atomic.Int32
 	freeCalls  atomic.Int32
 	setupCfgs  []types.DeviceConfig
+
+	// kernelIfName backs KernelIfName(). When empty, KernelIfName() falls back
+	// to name so existing tests that never set it keep their prior behavior.
+	// Merge copies this field forward from an old device when a fresh scan
+	// left it empty, mirroring how a real device manager can lose the kernel
+	// interface name once a device has moved into a pod's network namespace.
+	kernelIfName string
 }
 
-func (d *trackedDevice) IfName() string       { return d.name }
-func (d *trackedDevice) KernelIfName() string { return d.name }
+func (d *trackedDevice) IfName() string { return d.name }
+
+func (d *trackedDevice) KernelIfName() string {
+	if d.kernelIfName != "" {
+		return d.kernelIfName
+	}
+	return d.name
+}
+
+// Merge copies KernelIfName forward from old if this device's fresh scan did
+// not determine one.
+func (d *trackedDevice) Merge(old types.Device) {
+	if d.kernelIfName == "" {
+		d.kernelIfName = old.KernelIfName()
+	}
+}
 
 // GetAttrs intentionally returns nil — these tests do not exercise device
 // attributes, and attrsToPartMap handles a nil map safely.

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -5,9 +5,9 @@ package networkdriver
 
 // Tests for prepareResourceClaim covering:
 //
-//   - driver.allocations is written only after UpdateStatus
-//     succeeds; if UpdateStatus fails the map stays empty.
-//     this avoids keeping a local map entry that does not have a
+//   - the statedb device table's allocation fields are written only after
+//     UpdateStatus succeeds; if UpdateStatus fails the table stays unallocated.
+//     this avoids keeping a row with allocation state that does not have a
 //     persistent reference in kubernetes
 //
 //   - when any step inside the device loop fails, rollback
@@ -126,7 +126,7 @@ func (d *trackedDevice) Merge(old types.Device) {
 }
 
 // GetAttrs intentionally returns nil — these tests do not exercise device
-// attributes, and attrsToPartMap handles a nil map safely.
+// attributes, and buildPoolsFromTable handles a nil map safely.
 func (d *trackedDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	return nil
 }
@@ -288,7 +288,6 @@ func buildPrepDriver(t *testing.T, cs *k8sClient.FakeClientset, devs ...*tracked
 				Name:    dev.IfName(),
 				Manager: types.DeviceManagerTypeMock,
 				Dev:     dev,
-				Pool:    prepTestPool,
 			})
 		}
 		wtxn.Commit()
@@ -355,7 +354,7 @@ func TestPrepare(t *testing.T) {
 		require.NotEmpty(t, allocatedRowsForPod(t, driver, prepTestPodUID), "must have allocations for pod")
 		require.Len(t, allocatedRowsForClaim(t, driver, prepTestClaimUID), 1)
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(prepTestPool, prepTestDev0)))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query(prepTestDev0))
 		require.True(t, found, "device row must exist in statedb")
 		require.Equal(t, prepTestPodUID, row.PodUID, "statedb row must have PodUID set after prepare")
 		require.Equal(t, prepTestClaimUID, row.ClaimUID, "statedb row must have ClaimUID set after prepare")
@@ -672,7 +671,7 @@ func TestUnprepare(t *testing.T) {
 
 		// Statedb row must still exist but have allocation fields cleared.
 		txn := driver.db.ReadTxn()
-		row, _, found := driver.deviceTable.Get(txn, deviceByKey.Query(DeviceKey(prepTestPool, prepTestDev0)))
+		row, _, found := driver.deviceTable.Get(txn, deviceByName.Query(prepTestDev0))
 		require.True(t, found, "device row must still exist after unprepare")
 		require.Empty(t, row.PodUID, "PodUID must be cleared in statedb row after unprepare")
 		require.Empty(t, row.ClaimUID, "ClaimUID must be cleared in statedb row after unprepare")

--- a/pkg/networkdriver/tables.go
+++ b/pkg/networkdriver/tables.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
-	resourceapi "k8s.io/api/resource/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/networkdriver/types"
@@ -20,15 +19,15 @@ import (
 // The table is populated by device manager goroutines via onDevices and
 // reflects both discovery state and allocation state:
 //
-//   - Discovery fields (Name, Manager, Dev, Pool, Attrs) are always populated
-//     by onDevices whenever the device manager reports a device.
+//   - Discovery fields (Name, Manager, Dev) are always populated by onDevices
+//     whenever the device manager reports a device.
 //
-//   - Allocation fields (PodUID, ClaimUID, Config) are set by commitAllocation
+//   - Allocation fields (PodUID, ClaimUID, Config) are set by setAllocationInTable
 //     when the kubelet calls PrepareResourceClaims, and cleared by
 //     unprepareResourceClaim when the kubelet calls UnprepareResourceClaims.
-//     On agent restart, onDevices repopulates the allocation fields from the
-//     in-memory allocations map (which was itself restored from ResourceClaim
-//     status by restoreDevices).
+//     On agent restart, restoreDevices repopulates these fields (and the Dev
+//     handle) directly from ResourceClaim status before any device manager
+//     has run.
 //
 // The table is therefore the single observable source of truth for "which pod
 // holds which device" and is visible via `cilium-dbg statedb dump`.
@@ -36,13 +35,11 @@ import (
 
 const DevicesTableName = "networkdriver-dra-devices"
 
-// deviceByKey is the single primary index, keyed as "<pool>/<name>".
-// This allows O(log n) prefix scans over all devices in a pool via
-// DevicesByPool, without any secondary indices.
-var deviceByKey = statedb.Index[*DRADevice, string]{
+// deviceByName is the single primary index, keyed by device name.
+var deviceByName = statedb.Index[*DRADevice, string]{
 	Name: "id",
 	FromObject: func(d *DRADevice) index.KeySet {
-		return index.NewKeySet(index.String(DeviceKey(d.Pool, d.Name)))
+		return index.NewKeySet(index.String(d.Name))
 	},
 	FromKey:    index.String,
 	FromString: index.FromString,
@@ -67,22 +64,28 @@ func DevicesByClaimUID(tbl statedb.Table[*DRADevice], txn statedb.ReadTxn, claim
 	return tbl.List(txn, deviceByClaimUID.Query(string(claimUID)))
 }
 
-// DeviceKey returns the primary key for a device.
-func DeviceKey(pool, name string) string { return pool + "/" + name }
-
-// DevicesByPool returns an iterator over all devices in the given pool.
-func DevicesByPool(tbl statedb.Table[*DRADevice], txn statedb.ReadTxn, pool string) iter.Seq2[*DRADevice, statedb.Revision] {
-	return tbl.Prefix(txn, deviceByKey.Query(DeviceKey(pool, "")))
+// allocationFromRow projects a statedb row into an allocation. Returns the
+// zero allocation and ok=false if the row has no live device handle.
+func allocationFromRow(row *DRADevice) (allocation, bool) {
+	if row.Dev == nil {
+		return allocation{}, false
+	}
+	return allocation{
+		Device:  row.Dev,
+		Config:  row.Config,
+		Manager: row.Manager,
+		Pool:    row.Pool,
+	}, true
 }
 
 // DRADevice represents a device known to the network driver.
 //
-// Discovery fields (Name, Manager, Dev, Pool, Attrs) are always present.
+// Discovery fields (Name, Manager, Dev) are always present.
+//
 // Allocation fields (PodUID, ClaimUID, Config) are non-zero when the device
 // has been prepared for a pod via PrepareResourceClaims, and are cleared by
 // UnprepareResourceClaims. On agent restart they are restored from the
-// ResourceClaim status via restoreDevices, then written back to the table
-// when the device manager goroutine calls onDevices for the first time.
+// ResourceClaim status via restoreDevices.
 type DRADevice struct {
 	// Name is the device name assigned by the device manager.
 	// It is the primary key and the name used in ResourceSlice advertisements.
@@ -90,22 +93,12 @@ type DRADevice struct {
 	Name    string
 	Manager types.DeviceManagerType
 	Dev     types.Device
-	Pool    string
-	Attrs   map[string]resourceapi.DeviceAttribute
 
 	// Allocation fields — non-zero when the device is prepared for a pod.
+	Pool     string
 	PodUID   kube_types.UID
 	ClaimUID kube_types.UID
 	Config   types.DeviceConfig
-}
-
-// IsAllocated reports whether the device has been prepared for a pod.
-func (d *DRADevice) IsAllocated() bool { return d.PodUID != "" }
-
-// GetAttr returns the attribute value for the given key and whether it was found.
-func (d *DRADevice) GetAttr(key string) (resourceapi.DeviceAttribute, bool) {
-	v, ok := d.Attrs[key]
-	return v, ok
 }
 
 func (d *DRADevice) Clone() *DRADevice {
@@ -114,12 +107,12 @@ func (d *DRADevice) Clone() *DRADevice {
 }
 
 func (d *DRADevice) TableHeader() []string {
-	return []string{"Name", "Manager", "Pool", "PodUID", "ClaimUID", "PodIfName"}
+	return []string{"Name", "Manager", "PodUID", "ClaimUID", "PodIfName"}
 }
 
 func (d *DRADevice) TableRow() []string {
 	return []string{
-		d.Name, d.Manager.String(), d.Pool,
+		d.Name, d.Manager.String(),
 		string(d.PodUID), string(d.ClaimUID), d.Config.PodIfName,
 	}
 }
@@ -128,20 +121,7 @@ func newDeviceTable(db *statedb.DB) (statedb.RWTable[*DRADevice], error) {
 	return statedb.NewTable(
 		db,
 		DevicesTableName,
-		deviceByKey,
+		deviceByName,
 		deviceByClaimUID,
 	)
-}
-
-// attrsToMap converts a device attribute map keyed by QualifiedName to a plain
-// string-keyed map for storage in DRADevice.Attrs.
-func attrsToMap(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute) map[string]resourceapi.DeviceAttribute {
-	if len(attrs) == 0 {
-		return nil
-	}
-	m := make(map[string]resourceapi.DeviceAttribute, len(attrs))
-	for k, v := range attrs {
-		m[string(k)] = v
-	}
-	return m
 }

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -118,23 +118,17 @@ func (d DeviceManagerType) String() string {
 func (d DeviceManagerType) MarshalText() (text []byte, err error) {
 	switch d {
 	case DeviceManagerTypeMock:
-		return json.Marshal(deviceManagerTypeMockStr)
+		return []byte(deviceManagerTypeMockStr), nil
 
 	case DeviceManagerTypeDummy:
-		return json.Marshal(dummyDeviceManagerStr)
+		return []byte(dummyDeviceManagerStr), nil
 	}
 
 	return nil, errUnknownDeviceManagerType
 }
 
 func (d *DeviceManagerType) UnmarshalText(text []byte) error {
-	var s string
-	err := json.Unmarshal(text, &s)
-	if err != nil {
-		return err
-	}
-
-	switch strings.ToLower(s) {
+	switch strings.ToLower(string(text)) {
 	case deviceManagerTypeMockStr:
 		*d = DeviceManagerTypeMock
 	case dummyDeviceManagerStr:

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -29,8 +29,6 @@ const (
 	// as assigned by the device managers.
 	// must be unique across all devices on the node.
 	IfNameLabel = "ifName"
-	// HWAddrLabel contains the MAC address of the device.
-	HWAddrLabel = "macAddress"
 	// DeviceManagerLabel identifies which Device Manager
 	// published the device.
 	DeviceManagerLabel = "deviceManager"
@@ -162,10 +160,6 @@ type DeviceManager interface {
 	// updated set.
 	Run(ctx context.Context, publish func([]Device)) error
 	RestoreDevice([]byte) (Device, error)
-}
-
-type DeviceManagerConfig interface {
-	IsEnabled() bool
 }
 
 type DeviceConfig struct {

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -150,6 +150,7 @@ type Device interface {
 	Match(filter v2alpha1.CiliumNetworkDriverDeviceFilter) bool
 	IfName() string
 	KernelIfName() string
+	Merge(Device)
 }
 
 type DeviceManager interface {


### PR DESCRIPTION
1st commit fixes the text encoding/decoding for types.DeviceManager
2nd commit adds a merge method to the device - so we can preserve previously known attributes that
did not show up in the more recent scan. for dummy devices this is no-op (no scanning takes place) but sr-iov devices may come in without a kernel interface name in the case the device is allocated to a pod (and therefore not visible in the root ns)
3rd commit includes:
- removes attrs from statedb. these are only relevant when publishing resourceslices. produce these only when publishing. 
- publish step now ensures an allocated device retain the pool name it was allocated for. pool can only change between restarts/discovery events if the devices are not allocated
- encapsulate row creation into a common function
- use interface name instead of pool/interface name for the indexes
- rewording some comments, dead code removal

```release-note
network driver: simplify statedb table management and remove redundant data from the table
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
