### PR TITLE
bpf: dsr: fix outer SrcIP in ICMP error msg

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2717,7 +2717,7 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 	int ret;
 	__u32 verdict = ctx_load_meta(ctx, CB_VERDICT);
 
-	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED);
+	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED, 0);
 	if (!ret) {
 		cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL_IPV4);
 		ret = redirect_self(ctx);
@@ -2752,7 +2752,7 @@ int tail_policy_denied_ipv6(struct __ctx_buff *ctx)
 	if (!ratelimit_check_and_take(&rkey, &settings))
 		goto drop_err;
 
-	ret = generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_ADM_PROHIBITED);
+	ret = generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_ADM_PROHIBITED, 0);
 	if (!ret) {
 		cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL_IPV6);
 		ret = redirect_self(ctx);

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -17,7 +17,8 @@
 #define ICMP_PACKET_MAX_SAMPLE_SIZE 8
 
 static __always_inline
-int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
+int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
+			 __u32 icmp_data)
 {
 	__u64 full_len = ctx_full_len(ctx);
 	__u64 new_len, sample_len;
@@ -121,6 +122,9 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	icmphdr->code = icmp_code;
 	icmphdr->checksum = 0;
 	icmphdr->un.gateway = 0;
+
+	if (icmp_type == ICMP_DEST_UNREACH && icmp_code == ICMP_FRAG_NEEDED)
+		icmphdr->un.frag.mtu = (__be16)icmp_data;
 
 	/* Add ICMP header checksum to sum of its body */
 	csum += csum_diff(icmphdr, 0, icmphdr, sizeof(struct icmphdr), 0);

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -588,7 +588,8 @@ struct ipv6_pseudo_header_t {
 };
 
 static __always_inline
-int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
+int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
+			 __u32 icmp_data)
 {
 	__u64 full_len = ctx_full_len(ctx);
 	__u64 new_len, sample_len;
@@ -691,8 +692,10 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code)
 	icmphdr->icmp6_cksum = 0;
 	icmphdr->icmp6_dataun.un_data32[0] = 0;
 
-	/* Add the ICMP header to the checksum (only type and code are non-zero) */
-	csum += ((__u16)icmphdr->icmp6_code) << 8 | (__u16)icmphdr->icmp6_type;
+	if (icmp_type == ICMPV6_PKT_TOOBIG)
+		icmphdr->icmp6_mtu = icmp_data;
+
+	csum += csum_diff(icmphdr, 0, icmphdr, sizeof(*icmphdr), 0);
 
 	/* Fill pseudo header */
 	memcpy(&pseudo_header.fields.src_ip, &ip6->saddr, sizeof(struct in6_addr));

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -2388,7 +2388,7 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 	__u32 src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
 	int ret;
 
-	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PORT_UNREACH);
+	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PORT_UNREACH, 0);
 	if (!ret) {
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
@@ -2426,7 +2426,7 @@ int tail_no_service_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH);
+	ret = generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH, 0);
 	if (!ret) {
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -10,6 +10,8 @@
 #include "tailcall.h"
 #include "nat.h"
 #include "edt.h"
+#include "icmp.h"
+#include "icmp6.h"
 #include "l3.h"
 #include "lb.h"
 #include "common.h"
@@ -644,95 +646,37 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 					   int code, int ohead __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
-	const __s32 orig_dgram = 64, off = ETH_HLEN;
-	__u8 orig_ipv6_hdr[orig_dgram];
-	__u64 len_new = off + sizeof(*ip6) + orig_dgram;
-	__u64 len_old = ctx_full_len(ctx);
-	void *data_end = ctx_data_end(ctx);
-	void *data = ctx_data(ctx);
 	__u8 reason = (__u8)-code;
-	__wsum wsum;
-	union macaddr smac, dmac;
-	struct icmp6hdr icmp __align_stack_8 = {
-		.icmp6_type	= ICMPV6_PKT_TOOBIG,
-		.icmp6_mtu	= bpf_htonl(CONFIG(device_mtu) - ohead),
-	};
-	__u64 payload_len = sizeof(*ip6) + sizeof(icmp) + orig_dgram;
-	struct ipv6hdr ip __align_stack_8 = {
-		.version	= 6,
-		.priority	= ip6->priority,
-		.flow_lbl[0]	= ip6->flow_lbl[0],
-		.flow_lbl[1]	= ip6->flow_lbl[1],
-		.flow_lbl[2]	= ip6->flow_lbl[2],
-		.nexthdr	= IPPROTO_ICMPV6,
-		.hop_limit	= IPDEFTTL,
-		.saddr		= ip6->daddr,
-		.daddr		= ip6->saddr,
-		.payload_len	= bpf_htons((__u16)payload_len),
-	};
-	struct ipv6hdr inner_ipv6_hdr __align_stack_8 = *ip6;
-	__s32 l4_dport_offset;
+# if DSR_ENCAP_MODE == DSR_ENCAP_NONE || DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	int l3_off = ETH_HLEN;
+	fraginfo_t fraginfo = 0;
+	int ret, l4_off;
 
-	/* DSR changes the destination address from service ip to pod ip and
-	 * destination port from service port to pod port. While resppnding
-	 * back with ICMP error, it is necessary to set it to original ip and
-	 * port.
-	 */
-	ipv6_addr_copy((union v6addr *)&inner_ipv6_hdr.daddr, svc_addr);
-
-	if (inner_ipv6_hdr.nexthdr == IPPROTO_UDP)
-		l4_dport_offset = UDP_DPORT_OFF;
-	else if (inner_ipv6_hdr.nexthdr == IPPROTO_TCP)
-		l4_dport_offset = TCP_DPORT_OFF;
-	else
+	tuple.nexthdr = ip6->nexthdr;
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
+	if (ret < 0)
 		goto drop_err;
 
-	if (ctx_load_bytes(ctx, off + sizeof(inner_ipv6_hdr), orig_ipv6_hdr,
-			   (__u32)sizeof(orig_ipv6_hdr)) < 0)
+	l4_off = ETH_HLEN + ret;
+
+	ret = lb6_extract_tuple(ctx, ip6, fraginfo, l4_off, &tuple);
+	if (IS_ERR(ret))
 		goto drop_err;
-	memcpy(orig_ipv6_hdr + l4_dport_offset, &dport, sizeof(dport));
+
+	/* Packet was DNATed from Service IP/Port to backend. Revert this again. */
+	ret = snat_v6_rewrite_headers(ctx, tuple.nexthdr, l3_off,
+				      ipfrag_has_l4_header(fraginfo), l4_off,
+				      &tuple.daddr, svc_addr, IPV6_DADDR_OFF,
+				      tuple.sport, dport, TCP_DPORT_OFF);
+	if (IS_ERR(ret))
+		goto drop_err;
+# endif
 
 	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, reason);
 
-	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
-		goto drop_err;
-	if (unlikely(data + len_new > data_end))
-		goto drop_err;
-
-	wsum = ipv6_pseudohdr_checksum(&ip, IPPROTO_ICMPV6,
-				       bpf_ntohs(ip.payload_len), 0);
-	icmp.icmp6_cksum = csum_fold(csum_diff(NULL, 0, orig_ipv6_hdr, (__u32)sizeof(orig_ipv6_hdr),
-					       csum_diff(NULL, 0, &inner_ipv6_hdr,
-							 sizeof(inner_ipv6_hdr),
-							 csum_diff(NULL, 0, &icmp,
-								   sizeof(icmp), wsum))));
-
-	if (ctx_adjust_troom(ctx, -(__s32)(len_old - len_new)) < 0)
-		goto drop_err;
-	if (ctx_adjust_hroom(ctx, sizeof(ip) + sizeof(icmp),
-			     BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()) < 0)
-		goto drop_err;
-
-	if (eth_store_daddr(ctx, smac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_store_saddr(ctx, dmac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_store_proto(ctx, bpf_htons(ETH_P_IPV6), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off, &ip, sizeof(ip), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip), &icmp,
-			    sizeof(icmp), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip) + sizeof(icmp), &inner_ipv6_hdr,
-			    sizeof(inner_ipv6_hdr), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip) + sizeof(icmp) +
-			    sizeof(inner_ipv6_hdr) + l4_dport_offset,
-			    &dport, sizeof(dport), 0) < 0)
+	if (generate_icmp6_reply(ctx, ICMPV6_PKT_TOOBIG, 0,
+				 bpf_htonl(CONFIG(device_mtu) - ohead)))
 		goto drop_err;
 
 	return redirect_self(ctx);
@@ -2011,105 +1955,33 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 					   int code, __be16 ohead __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
-	const __s32 orig_dgram = 8, off = ETH_HLEN;
-	__u8 tmp[MAX_IPOPTLEN + sizeof(*ip4) + orig_dgram];
-	__s32 len_new = off + ipv4_hdrlen(ip4) + orig_dgram;
-	__s32 len_old = (__s32)ctx_full_len(ctx);
 	__u8 reason = (__u8)-code;
-	union macaddr smac, dmac;
-	struct icmphdr icmp __align_stack_8 = {
-		.type		= ICMP_DEST_UNREACH,
-		.code		= ICMP_FRAG_NEEDED,
-		.un = {
-			.frag = {
-				.mtu = bpf_htons(CONFIG(device_mtu) - ohead),
-			},
-		},
-	};
-	__u64 tot_len = sizeof(struct iphdr) + ipv4_hdrlen(ip4) + sizeof(icmp) + orig_dgram;
-	struct iphdr ip __align_stack_8 = {
-		.ihl		= sizeof(ip) >> 2,
-		.version	= IPVERSION,
-		.ttl		= IPDEFTTL,
-		.tos		= ip4->tos,
-		.id		= ip4->id,
-		.protocol	= IPPROTO_ICMP,
-		.saddr		= ip4->daddr,
-		.daddr		= ip4->saddr,
-		.frag_off	= bpf_htons(IP_DF),
-		.tot_len	= bpf_htons((__u16)tot_len),
-	};
+# if DSR_ENCAP_MODE == DSR_ENCAP_NONE || DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	struct ipv4_ct_tuple tuple = {};
+	int l3_off = ETH_HLEN;
+	fraginfo_t fraginfo;
+	int ret, l4_off;
 
-	struct iphdr inner_ip_hdr __align_stack_8 = *ip4;
-	__s32 l4_dport_offset;
+	fraginfo = ipfrag_encode_ipv4(ip4);
+	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-	/* DSR changes the destination address from service ip to pod ip and
-	 * destination port from service port to pod port. While resppnding
-	 * back with ICMP error, it is necessary to set it to original ip and
-	 * port.
-	 * We do recompute the whole checksum here. Another way would be to
-	 * unfold checksum and then do the math adding the diff.
-	 */
-	inner_ip_hdr.daddr = svc_addr;
-	inner_ip_hdr.check = 0;
-	inner_ip_hdr.check = csum_fold(csum_diff(NULL, 0, &inner_ip_hdr,
-						 sizeof(inner_ip_hdr), 0));
+	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
+	if (IS_ERR(ret))
+		goto drop_err;
 
-	if (inner_ip_hdr.protocol == IPPROTO_UDP)
-		l4_dport_offset = UDP_DPORT_OFF;
-	else if (inner_ip_hdr.protocol == IPPROTO_TCP)
-		l4_dport_offset = TCP_DPORT_OFF;
+	/* Packet was DNATed from Service IP/Port to backend. Revert this again. */
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, l3_off,
+				      ipfrag_has_l4_header(fraginfo), l4_off,
+				      ip4->daddr, svc_addr, IPV4_DADDR_OFF,
+				      tuple.sport, dport, TCP_DPORT_OFF, 0);
+	if (IS_ERR(ret))
+		goto drop_err;
+# endif
 
 	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, reason);
 
-	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
-		goto drop_err;
-
-	ip.check = csum_fold(csum_diff(NULL, 0, &ip, sizeof(ip), 0));
-
-	/* We use a workaround here in that we push zero-bytes into the
-	 * payload in order to support dynamic IPv4 header size. This
-	 * works given one's complement sum does not change.
-	 */
-	memset(tmp, 0, MAX_IPOPTLEN);
-	if (ctx_store_bytes(ctx, len_new, tmp, MAX_IPOPTLEN, 0) < 0)
-		goto drop_err;
-	if (ctx_load_bytes(ctx, off, tmp, (__u32)sizeof(tmp)) < 0)
-		goto drop_err;
-
-	memcpy(tmp, &inner_ip_hdr, sizeof(inner_ip_hdr));
-	memcpy(tmp + sizeof(inner_ip_hdr) + l4_dport_offset, &dport, sizeof(dport));
-
-	icmp.checksum = csum_fold(csum_diff(NULL, 0, tmp, (__u32)sizeof(tmp),
-					    csum_diff(NULL, 0, &icmp,
-						      sizeof(icmp), 0)));
-
-	if (ctx_adjust_troom(ctx, -(len_old - len_new)) < 0)
-		goto drop_err;
-	if (ctx_adjust_hroom(ctx, sizeof(ip) + sizeof(icmp),
-			     BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()) < 0)
-		goto drop_err;
-
-	if (eth_store_daddr(ctx, smac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_store_saddr(ctx, dmac.addr, 0) < 0)
-		goto drop_err;
-	if (eth_store_proto(ctx, bpf_htons(ETH_P_IP), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off, &ip, sizeof(ip), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip), &icmp,
-			    sizeof(icmp), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip) + sizeof(icmp),
-			    &inner_ip_hdr, sizeof(inner_ip_hdr), 0) < 0)
-		goto drop_err;
-	if (ctx_store_bytes(ctx, off + sizeof(ip) + sizeof(icmp)
-			    + sizeof(inner_ip_hdr) + l4_dport_offset,
-			    &dport, sizeof(dport), 0) < 0)
+	if (generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_FRAG_NEEDED,
+				 bpf_htons(CONFIG(device_mtu) - ohead)))
 		goto drop_err;
 
 	return redirect_self(ctx);

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -12,6 +12,8 @@
 #include "pktgen.h"
 #include "scapy.h"
 
+#define ENABLE_DSR_ICMP_ERRORS		1
+
 #define IPV4_DIRECT_ROUTING		v4_node_one
 
 #define fib_lookup mock_fib_lookup
@@ -100,6 +102,8 @@ ASSIGN_CONFIG(__u16, tunnel_port, 6081)
 ASSIGN_CONFIG(__u32, hash_init4_seed, 0xcafe)
 ASSIGN_CONFIG(__u32, hash_init6_seed, 0xeb9f)
 
+ASSIGN_CONFIG(__u16, device_mtu, 200);
+
 #include "lib/ipcache.h"
 #include "lib/lb.h"
 
@@ -175,6 +179,18 @@ const __u8 kpr_v4_dsr_lb2_data2_post_geneve_xdp[] = {
 	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_geneve_xdp)
 };
 
+const __u8 kpr_v4_dsr_lb3_mtu[] = {
+       SCAPY_BUF_BYTES(kpr_v4_dsr_lb3_mtu)
+};
+
+const __u8 kpr_v4_dsr_lb3_mtu_post_option[] = {
+       SCAPY_BUF_BYTES(kpr_v4_dsr_lb3_mtu_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb3_mtu_post_geneve[] = {
+       SCAPY_BUF_BYTES(kpr_v4_dsr_lb3_mtu_post_geneve)
+};
+
 const __u8 kpr_v6_dsr_lb1_syn[] = {
 	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn)
 };
@@ -245,6 +261,18 @@ const __u8 kpr_v6_dsr_lb2_data2_post_option_xdp[] = {
 
 const __u8 kpr_v6_dsr_lb2_data2_post_geneve_xdp[] = {
 	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb3_mtu[] = {
+       SCAPY_BUF_BYTES(kpr_v6_dsr_lb3_mtu)
+};
+
+const __u8 kpr_v6_dsr_lb3_mtu_post_option[] = {
+       SCAPY_BUF_BYTES(kpr_v6_dsr_lb3_mtu_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb3_mtu_post_geneve[] = {
+       SCAPY_BUF_BYTES(kpr_v6_dsr_lb3_mtu_post_geneve)
 };
 
 #ifdef ENABLE_IPV4
@@ -645,6 +673,66 @@ int kpr_v4_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_finish();
 }
+
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_lb3_mtu")
+int kpr_v4_dsr_lb3_mtu_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb3_mtu,
+			sizeof(kpr_v4_dsr_lb3_mtu));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "kpr_v4_dsr_lb3_mtu")
+int kpr_v4_dsr_lb3_mtu_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 3;
+
+	lb_v4_add_service(v4_svc_one, tcp_svc_three, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_three, 1, 124,
+			  v4_pod_one, tcp_dst_three, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "kpr_v4_dsr_lb3_mtu")
+int kpr_v4_dsr_lb3_mtu_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_TX);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb3_mtu_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb3_mtu_post_geneve,
+			   sizeof(kpr_v4_dsr_lb3_mtu_post_geneve));
+#else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb3_mtu_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb3_mtu_post_option,
+			   sizeof(kpr_v4_dsr_lb3_mtu_post_option));
+#endif
+
+	test_finish();
+}
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
@@ -1038,6 +1126,69 @@ int kpr_v6_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
 			   kpr_v6_dsr_lb2_data2_post_option,
 			   sizeof(kpr_v6_dsr_lb2_data2_post_option));
 # endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_lb3_mtu")
+int kpr_v6_dsr_lb3_mtu_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb3_mtu,
+			sizeof(kpr_v6_dsr_lb3_mtu));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "kpr_v6_dsr_lb3_mtu")
+int kpr_v6_dsr_lb3_mtu_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 3;
+
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	lb_v6_add_service(&frontend_ip, tcp_svc_three, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, tcp_svc_three, 1, 124,
+			  &backend_ip, tcp_dst_three, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "kpr_v6_dsr_lb3_mtu")
+int kpr_v6_dsr_lb3_mtu_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_TX);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb3_mtu_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb3_mtu_post_geneve,
+			   sizeof(kpr_v6_dsr_lb3_mtu_post_geneve));
+#else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb3_mtu_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb3_mtu_post_option,
+			   sizeof(kpr_v6_dsr_lb3_mtu_post_option));
 #endif
 
 	test_finish();

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -206,6 +206,27 @@ kpr_v4_dsr_lb2_data2_post_geneve_xdp = (
     b"foobar"
 )
 
+kpr_v4_dsr_lb3_mtu = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_three, flags="") /
+    Raw(load=b'\x00' * 200)
+)
+
+kpr_v4_dsr_lb3_mtu_post_option = (
+    Ether(src=mac_one, dst=host_mac_addr) /
+    IP(src=v4_svc_one, dst=v4_ext_one, id=0) /
+    ICMP(type="dest-unreach", code="fragmentation-needed", nexthopmtu=192) /
+    IPerror(bytes(kpr_v4_dsr_lb3_mtu[IP])[:28])
+)
+
+kpr_v4_dsr_lb3_mtu_post_geneve = (
+    Ether(src=mac_one, dst=host_mac_addr) /
+    IP(src=v4_svc_one, dst=v4_ext_one, id=0) /
+    ICMP(type="dest-unreach", code="fragmentation-needed", nexthopmtu=138) /
+    IPerror(bytes(kpr_v4_dsr_lb3_mtu[IP])[:28])
+)
+
 kpr_v4_dsr_remote_node_reply = (
     Ether(src=mac_two, dst=mac_one) /
     IP(src=v4_pod_one, dst=v4_ext_one) /
@@ -371,6 +392,27 @@ kpr_v6_dsr_lb2_data2_post_geneve_xdp = (
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
     b"foobar"
+)
+
+kpr_v6_dsr_lb3_mtu = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_three, flags="") /
+    Raw(load=b'\x00' * 200)
+)
+
+kpr_v6_dsr_lb3_mtu_post_option = (
+    Ether(src=mac_one, dst=host_mac_addr) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    ICMPv6PacketTooBig(mtu=176) /
+    IPerror6(bytes(kpr_v6_dsr_lb3_mtu[IPv6]))
+)
+
+kpr_v6_dsr_lb3_mtu_post_geneve = (
+    Ether(src=mac_one, dst=host_mac_addr) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    ICMPv6PacketTooBig(mtu=106) /
+    IPerror6(bytes(kpr_v6_dsr_lb3_mtu[IPv6]))
 )
 
 kpr_v6_dsr_remote_node_reply = (

--- a/bpf/tests/tc_nodeport_lb_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb_wildcard_drop.c
@@ -556,7 +556,7 @@ int tc_nodeport_lb6_wildcard_drop_not_unknown2_pktgen(struct __ctx_buff *ctx)
 SETUP(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown2")
 int tc_nodeport_lb6_wildcard_drop_not_unknown2_setup(struct __ctx_buff *ctx)
 {
-	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH))
+	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH, 0))
 		return TEST_ERROR;
 
 	setup_services6(ctx);


### PR DESCRIPTION
By the time that we check whether a DSR request exceeds the MTU (and respond with an ICMP error msg), the request has already been DNATed to the backend IP/port (when using "opt" or "geneve" dispatch). We are currently RevNATing only the inner headers (the original request) - but the outer IP header still uses the backend's IP as sourceIP.

Instead of fixing this up manually, split the code into two stages
1. RevNAT of the rejected DSR request, and then
2. use generate_icmp*_reply() to produce the ICMP msg, replacing all the custom rewrite logic.

Note that for IPIP the request is in its original form at this point, and doesn't require any RevNAT processing.

```release-note
When using DSR with --bpf-lb-dsr-dispatch set to "opt" or "geneve" in combination with --enable-pmtu-discovery, fix the outer source IP of the ICMP error message which is generated when a forwarded DSR request exceeds the network interface's MTU.
```