### PR TITLE
gha: authenticate Image CI to quay.io with OIDC

### DIFF
--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -40,6 +40,12 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    # Pins the OIDC token subject to
+    # repo:cilium/cilium:environment:publish-ci-images, which is the identity
+    # federated with the Quay robot account.
+    environment:
+      name: publish-ci-images
+      deployment: false
     needs: wait-for-base-images
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
@@ -140,12 +146,36 @@ jobs:
             [worker.oci]
              gc=false
 
+      # Quay's registry endpoint only accepts credentials or a JWT signed by
+      # Quay itself, so the GitHub OIDC token cannot be used as the registry
+      # password directly. Trade it for a short lived robot token first.
+      - name: Get a quay.io robot token via OIDC
+        id: registry-token
+        env:
+          ROBOT: ${{ secrets.QUAY_USERNAME_CI }}
+        run: |
+          oidc_token="$(curl -sSf --retry 3 --retry-all-errors \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=quay.io" \
+            | jq -er '.value')"
+          echo "::add-mask::${oidc_token}"
+
+          # Pass the credentials on stdin so that the OIDC token is not visible
+          # in the process list of the runner.
+          robot_token="$(printf 'user = "%s:%s"\n' "${ROBOT}" "${oidc_token}" \
+            | curl -sSf --retry 3 --retry-all-errors -K - \
+              "https://quay.io/oauth2/federation/robot/token" \
+            | jq -er '.token')"
+          echo "::add-mask::${robot_token}"
+
+          echo "token=${robot_token}" >> "$GITHUB_OUTPUT"
+
       - name: Login to ${{ env.REGISTRY_DEV }} for CI
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_DEV }}
           username: ${{ secrets.QUAY_USERNAME_CI }}
-          password: ${{ secrets.QUAY_PASSWORD_CI }}
+          password: ${{ steps.registry-token.outputs.token }}
 
       - name: Getting image tag
         id: tag

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -40,9 +40,7 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    # Pins the OIDC token subject to
-    # repo:cilium/cilium:environment:publish-ci-images, which is the identity
-    # federated with the Quay robot account.
+    # Also decides the subject of the OIDC token, see the login step below.
     environment:
       name: publish-ci-images
       deployment: false
@@ -149,6 +147,12 @@ jobs:
       # Quay's registry endpoint only accepts credentials or a JWT signed by
       # Quay itself, so the GitHub OIDC token cannot be used as the registry
       # password directly. Trade it for a short lived robot token first.
+      #
+      # Because the job references an environment, the subject of the token is
+      # repo:cilium@21054566/cilium@48109239:environment:publish-ci-images, the
+      # immutable form that carries the owner and repository ids. That is the
+      # identity federated with the robot account on the Quay side, so renaming
+      # the environment breaks the login.
       - name: Get a quay.io robot token via OIDC
         id: registry-token
         env:


### PR DESCRIPTION
Use OIDC to authenticate Image CI to quay.io on v1.18, instead of the static
robot password. The GitHub token cannot be used as the registry password
directly, so it is traded for a short lived robot token before the login.

 * [x] #48061 (@aanm)
 * [x] #48370 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 48061 48370
```

This PR was prepared with AIL:3.
