### PR TITLE
gha: bound the LLVM prereq apt step with a 5m timeout

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -396,6 +396,7 @@ jobs:
         run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
 
       - name: Install LLVM and Clang prerequisites
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libtinfo6


### PR DESCRIPTION
In run 32225900868 the "Install LLVM and Clang prerequisites" step of
build-commits-test hung inside apt-get for 2h51m and only stopped because the
run was cancelled by hand. The step has no bound of its own, so the only thing
that would have ended it is the job's timeout-minutes: 180, which burns nearly
three hours of an extra-power runner before the PR reports anything.

Across the last successful Build Commits runs the step completes in 6 to 18
seconds, so 5 minutes leaves plenty of headroom for a slow mirror while still
failing fast when apt wedges. A hung apt is not something a retry inside the
step can recover from, so failing the job and letting it be re-run is the right
outcome.

This PR was prepared with AIL:3.