### PR TITLE
install/kubernetes: Disable IPv6 masquerade by default in ENI mode

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1331,7 +1331,7 @@
    * - :spelling:ignore:`enableIPv6Masquerade`
      - Enables masquerading of IPv6 traffic leaving the node from endpoints.
      - bool
-     - ``true``
+     - ``true`` unless ipam eni mode is active
    * - :spelling:ignore:`enableInternalTrafficPolicy`
      - Enable Internal Traffic Policy
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -382,7 +382,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv4BIGTCP | bool | `false` | Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods |
 | enableIPv4Masquerade | bool | `true` unless ipam eni mode is active | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6BIGTCP | bool | `false` | Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods |
-| enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
+| enableIPv6Masquerade | bool | `true` unless ipam eni mode is active | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableInternalTrafficPolicy | bool | `true` | Enable Internal Traffic Policy |
 | enableLBIPAM | bool | `true` | Enable LoadBalancer IP Address Management |
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -14,6 +14,7 @@
 {{- $defaultK8sClientBurst := 10 -}}
 {{- $defaultDNSProxyEnableTransparentMode := "false" -}}
 {{- $defaultEnableIPv4Masquerade := "true" -}}
+{{- $defaultEnableIPv6Masquerade := "true" -}}
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 {{- $readSecretsOnlyFromSecretsNamespace := eq (include "readSecretsOnlyFromSecretsNamespace" .) "true" -}}
 {{- $secretSyncEnabled := eq (include "secretSyncEnabled" .) "true" -}}
@@ -58,9 +59,27 @@
   {{- /* defaultIPv4Masquerad in ENI mode for 1.18 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
   {{- if .Values.eni.enabled }}
     {{- $defaultEnableIPv4Masquerade = "false" -}}
-    # Will also do this for ipv6 when ENI mode works with ipv6.
   {{- end }}
 {{- end -}}
+
+{{- /* Default values when 1.21 was initially deployed */ -}}
+{{- if semverCompare ">=1.21" (default "1.21" .Values.upgradeCompatibility) -}}
+  {{- /* IPv6 counterpart of the ENI IPv4 masquerading default set above. */ -}}
+  {{- if .Values.eni.enabled }}
+    {{- $defaultEnableIPv6Masquerade = "false" -}}
+  {{- end }}
+{{- end -}}
+
+{{- /* Effective masquerading settings */ -}}
+{{- $enableIPv4Masquerade := $defaultEnableIPv4Masquerade -}}
+{{- if not (kindIs "invalid" .Values.enableIPv4Masquerade) -}}
+  {{- $enableIPv4Masquerade = toString .Values.enableIPv4Masquerade -}}
+{{- end -}}
+{{- $enableIPv6Masquerade := $defaultEnableIPv6Masquerade -}}
+{{- if not (kindIs "invalid" .Values.enableIPv6Masquerade) -}}
+  {{- $enableIPv6Masquerade = toString .Values.enableIPv6Masquerade -}}
+{{- end -}}
+
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- if .Values.eni.enabled }}
   {{- $ipam = "eni" -}}
@@ -558,14 +577,14 @@ data:
   tunnel-protocol: {{ .Values.tunnelProtocol | default "vxlan" | quote }}
 
 {{- if eq .Values.routingMode "native" }}
-  {{- if and .Values.ipv4.enabled .Values.enableIPv4Masquerade (not .Values.ipMasqAgent.enabled) }}
+  {{- if and .Values.ipv4.enabled (eq $enableIPv4Masquerade "true") (not .Values.ipMasqAgent.enabled) }}
     {{- if and (ne $ipam "eni") (ne $ipam "alibabacloud") }}
       {{- if and (not .Values.ipv4NativeRoutingCIDR) (not (and (eq $ipam "cluster-pool") .Values.nativeRoutingCIDRFromClusterPool)) }}
         {{- fail " ipv4NativeRoutingCIDR must be set when routingMode is native"}}
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- if and .Values.ipv6.enabled .Values.enableIPv6Masquerade (not .Values.ipMasqAgent.enabled) }}
+  {{- if and .Values.ipv6.enabled (eq $enableIPv6Masquerade "true") (not .Values.ipMasqAgent.enabled) }}
     {{- if and (not .Values.ipv6NativeRoutingCIDR) (not (and (eq $ipam "cluster-pool") .Values.nativeRoutingCIDRFromClusterPool)) }}
       {{- fail "ipv6NativeRoutingCIDR must be set when routingMode is native"  }}
     {{- end }}
@@ -717,14 +736,10 @@ data:
   enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
 {{- end }}
 
-{{- if (not (kindIs "invalid" .Values.enableIPv4Masquerade)) }}
-  enable-ipv4-masquerade: {{.Values.enableIPv4Masquerade | quote }}
-{{- else }}
-  enable-ipv4-masquerade: {{ $defaultEnableIPv4Masquerade | quote }}
-{{- end }}
+  enable-ipv4-masquerade: {{ $enableIPv4Masquerade | quote }}
   enable-ipv4-big-tcp: {{ .Values.enableIPv4BIGTCP | quote }}
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
-  enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}
+  enable-ipv6-masquerade: {{ $enableIPv6Masquerade | quote }}
 
 {{- if hasKey .Values.bpf "enableTCX" }}
   enable-tcx: {{ .Values.bpf.enableTCX | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1919,7 +1919,10 @@
       "type": "boolean"
     },
     "enableIPv6Masquerade": {
-      "type": "boolean"
+      "type": [
+        "null",
+        "boolean"
+      ]
     },
     "enableInternalTrafficPolicy": {
       "type": "boolean"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2513,8 +2513,12 @@ maglev: {}
 # -- (bool) Enables masquerading of IPv4 traffic leaving the node from endpoints.
 # @default -- `true` unless ipam eni mode is active
 enableIPv4Masquerade: ~
-# -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
-enableIPv6Masquerade: true
+# @schema
+# type: [null, boolean]
+# @schema
+# -- (bool) Enables masquerading of IPv6 traffic leaving the node from endpoints.
+# @default -- `true` unless ipam eni mode is active
+enableIPv6Masquerade: ~
 # -- Enables masquerading to the source of the route for traffic leaving the node from endpoints.
 enableMasqueradeRouteSource: false
 # -- Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2540,8 +2540,12 @@ maglev: {}
 # -- (bool) Enables masquerading of IPv4 traffic leaving the node from endpoints.
 # @default -- `true` unless ipam eni mode is active
 enableIPv4Masquerade: ~
-# -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
-enableIPv6Masquerade: true
+# @schema
+# type: [null, boolean]
+# @schema
+# -- (bool) Enables masquerading of IPv6 traffic leaving the node from endpoints.
+# @default -- `true` unless ipam eni mode is active
+enableIPv6Masquerade: ~
 # -- Enables masquerading to the source of the route for traffic leaving the node from endpoints.
 enableMasqueradeRouteSource: false
 # -- Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods


### PR DESCRIPTION
This replicates the behavior of the IPv4 masquerade flag in ENI mode for IPv6. Concretely, the default for enableIPv6Masquerade is now true everywhere except in ENI mode where it is false by default.

There was also a problem in the validation when masquerading was enabled where the rule only considered the user provided value and not the default value. This fixes that problem by calculating the effective value and using it for both the validation and the configuration for both IPv4 and IPv6.

This PR was prepared with AIL:3.

```release-note
install/kubernetes: IPv6 masquerading is now disabled by default when installing with mode ENI matching the IPv4 behavior.
```