### PR TITLE
Fix typos in comments and CLI help strings

### DIFF
--- a/pkg/debug/subsystem.go
+++ b/pkg/debug/subsystem.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
-// StatusFunc is a function returning the debug status of a subsytem. It is
+// StatusFunc is a function returning the debug status of a subsystem. It is
 // passed into RegisterStatusFunc().
 type StatusFunc func() string
 
@@ -18,7 +18,7 @@ type StatusFunc func() string
 // the subsystem name. The value is the subsystem debug status.
 type StatusMap map[string]string
 
-// StatusObject is the interface an object must impelement to be able to be
+// StatusObject is the interface an object must implement to be able to be
 // passed into RegisterStatusObject().
 type StatusObject interface {
 	// DebugStatus() is the equivalent of StatusFunc. It must return the

--- a/pkg/policy/commands/mapstate_diff.go
+++ b/pkg/policy/commands/mapstate_diff.go
@@ -71,7 +71,7 @@ func msStageCmd(params CmdParams) script.Cmd {
 				return nil
 			},
 			Detail: []string{
-				"Display the resulting mapstate for applying a given poliy to an endpoint.",
+				"Display the resulting mapstate for applying a given policy to an endpoint.",
 				"All existing policies are preserved unless overwritten by the proposed policy.",
 				"Optionally, will display the difference between the existing policy.",
 			},

--- a/pkg/policy/commands/topk.go
+++ b/pkg/policy/commands/topk.go
@@ -25,8 +25,8 @@ func topKCmd(params CmdParams) script.Cmd {
 			Summary: "Determine causes of mapstate entries",
 			Args:    "<pod-or-endpoint>",
 			Flags: func(fs *pflag.FlagSet) {
-				fs.IntP("num", "n", 10, "Maxiumum number of rows per endpoint to display")
-				fs.IntP("count", "c", 0, "Maxiumum number of endpoints to display")
+				fs.IntP("num", "n", 10, "Maximum number of rows per endpoint to display")
+				fs.IntP("count", "c", 0, "Maximum number of endpoints to display")
 				fs.StringP("output", "o", "table", "Format to write in (table, json)")
 			},
 			AutocompleteFlag: func(_ *script.State, _ []string, flag, cur string) []string {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -620,7 +620,7 @@ func (old *passMetas) MergeClone(other *passMetas) *passMetas {
 	return &new
 }
 
-// mapStateEntry is the entry type with additional internal bookkeping of the relation between
+// mapStateEntry is the entry type with additional internal bookkeeping of the relation between
 // explicitly and implicitly added entries.
 type mapStateEntry struct {
 	MapStateEntry
@@ -630,7 +630,7 @@ type mapStateEntry struct {
 	passes *passMetas
 
 	// derivedFromRules tracks the policy rules this entry derives from.
-	// Must be initialized explicitly, zero-intialization does not work with unique.Handle[].
+	// Must be initialized explicitly, zero-initialization does not work with unique.Handle[].
 	derivedFromRules ruleOrigin
 }
 


### PR DESCRIPTION
Spelling fixes only:

- `subsytem` -> `subsystem`, `impelement` -> `implement` (`pkg/debug/subsystem.go`, comments)
- `bookkeping` -> `bookkeeping`, `zero-intialization` -> `zero-initialization` (`pkg/policy/mapstate.go`, comments)
- `Maxiumum` -> `Maximum` (`cilium policy topk` flag help)
- `poliy` -> `policy` (`cilium policy mapstate-diff` help text)

I stayed away from the `pkg/policy/api` comments since those feed CRD generation.