### PR TITLE
gateway-api: put ctx first in route status API

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -134,7 +134,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			" At a future date this annotation will be removed if no spec.addresses are set.", gw.GetNamespace(), gw.GetName(), annotation.LBIPAMIPKeyAlias))
 	}
 
-	if err := r.routeStatusManager.SetRouteStatuses(scopedLog, ctx, RouteStatusInputs{
+	if err := r.routeStatusManager.SetRouteStatuses(ctx, scopedLog, RouteStatusInputs{
 		HTTPRoutes:      inputs.HTTPRoutes,
 		TLSRoutes:       inputs.TLSRoutes,
 		GRPCRoutes:      inputs.GRPCRoutes,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1529,7 +1529,7 @@ func TestGatewayReconciler_statuses(t *testing.T) {
 
 		hrList := &gatewayv1.HTTPRouteList{}
 		require.NoError(t, c.List(ctx, hrList))
-		require.NoError(t, r.routeStatusManager.setHTTPRouteStatuses(r.logger, ctx, hrList.Items, nil))
+		require.NoError(t, r.routeStatusManager.setHTTPRouteStatuses(ctx, r.logger, hrList.Items, nil))
 
 		var updatedValidRoute, updatedInvalidRoute gatewayv1.HTTPRoute
 		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))
@@ -1597,7 +1597,7 @@ func TestGatewayReconciler_statuses(t *testing.T) {
 
 		hrList := &gatewayv1.GRPCRouteList{}
 		require.NoError(t, c.List(ctx, hrList))
-		require.NoError(t, r.routeStatusManager.setGRPCRouteStatuses(r.logger, ctx, hrList.Items, nil))
+		require.NoError(t, r.routeStatusManager.setGRPCRouteStatuses(ctx, r.logger, hrList.Items, nil))
 
 		var updatedValidRoute, updatedInvalidRoute gatewayv1.GRPCRoute
 		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -74,24 +74,24 @@ func NewRouteStatusManager(client client.Client, logger *slog.Logger, controller
 	}
 }
 
-func (m *RouteStatusManager) SetRouteStatuses(scopedLog *slog.Logger, ctx context.Context, inputs RouteStatusInputs) error {
-	if err := m.setHTTPRouteStatuses(scopedLog, ctx, inputs.HTTPRoutes, inputs.ReferenceGrants); err != nil {
+func (m *RouteStatusManager) SetRouteStatuses(ctx context.Context, scopedLog *slog.Logger, inputs RouteStatusInputs) error {
+	if err := m.setHTTPRouteStatuses(ctx, scopedLog, inputs.HTTPRoutes, inputs.ReferenceGrants); err != nil {
 		return err
 	}
-	if err := m.setTLSRouteStatuses(scopedLog, ctx, inputs.TLSRoutes, inputs.ReferenceGrants); err != nil {
+	if err := m.setTLSRouteStatuses(ctx, scopedLog, inputs.TLSRoutes, inputs.ReferenceGrants); err != nil {
 		return err
 	}
 	if m.includeTCPRoutes {
-		if err := m.setTCPRouteStatuses(scopedLog, ctx, inputs.TCPRoutes, inputs.ReferenceGrants); err != nil {
+		if err := m.setTCPRouteStatuses(ctx, scopedLog, inputs.TCPRoutes, inputs.ReferenceGrants); err != nil {
 			return err
 		}
 	}
 	if m.includeUDPRoutes {
-		if err := m.setUDPRouteStatuses(scopedLog, ctx, inputs.UDPRoutes, inputs.ReferenceGrants); err != nil {
+		if err := m.setUDPRouteStatuses(ctx, scopedLog, inputs.UDPRoutes, inputs.ReferenceGrants); err != nil {
 			return err
 		}
 	}
-	if err := m.setGRPCRouteStatuses(scopedLog, ctx, inputs.GRPCRoutes, inputs.ReferenceGrants); err != nil {
+	if err := m.setGRPCRouteStatuses(ctx, scopedLog, inputs.GRPCRoutes, inputs.ReferenceGrants); err != nil {
 		return err
 	}
 
@@ -255,7 +255,7 @@ func (m *RouteStatusManager) parentIsMatchingGateway(ctx context.Context, parent
 	return hasMatchingControllerFn(gw)
 }
 
-func (m *RouteStatusManager) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, httpRoutes []gatewayv1.HTTPRoute, grants []gatewayv1.ReferenceGrant) error {
+func (m *RouteStatusManager) setHTTPRouteStatuses(ctx context.Context, scopedLog *slog.Logger, httpRoutes []gatewayv1.HTTPRoute, grants []gatewayv1.ReferenceGrant) error {
 	scopedLog.DebugContext(ctx, "Updating HTTPRoute statuses for Gateway", numRoutes, len(httpRoutes))
 	for httpRouteIndex, original := range httpRoutes {
 		hr := original.DeepCopy()
@@ -295,7 +295,7 @@ func (m *RouteStatusManager) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx co
 	return nil
 }
 
-func (m *RouteStatusManager) setTLSRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tlsRoutes []gatewayv1.TLSRoute, grants []gatewayv1.ReferenceGrant) error {
+func (m *RouteStatusManager) setTLSRouteStatuses(ctx context.Context, scopedLog *slog.Logger, tlsRoutes []gatewayv1.TLSRoute, grants []gatewayv1.ReferenceGrant) error {
 	scopedLog.Debug("Updating TLSRoute statuses for Gateway", numRoutes, len(tlsRoutes))
 	for tlsRouteIndex, original := range tlsRoutes {
 		tlsr := original.DeepCopy()
@@ -324,7 +324,7 @@ func (m *RouteStatusManager) setTLSRouteStatuses(scopedLog *slog.Logger, ctx con
 	return nil
 }
 
-func (m *RouteStatusManager) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx context.Context, grpcRoutes []gatewayv1.GRPCRoute, grants []gatewayv1.ReferenceGrant) error {
+func (m *RouteStatusManager) setGRPCRouteStatuses(ctx context.Context, scopedLog *slog.Logger, grpcRoutes []gatewayv1.GRPCRoute, grants []gatewayv1.ReferenceGrant) error {
 	scopedLog.Debug("Updating GRPCRoute statuses for Gateway", numRoutes, len(grpcRoutes))
 	for grpcRouteIndex, original := range grpcRoutes {
 		grpcr := original.DeepCopy()
@@ -364,7 +364,7 @@ func (m *RouteStatusManager) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx co
 	return nil
 }
 
-func (m *RouteStatusManager) setTCPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tcpRoutes []gatewayv1.TCPRoute, grants []gatewayv1.ReferenceGrant) error {
+func (m *RouteStatusManager) setTCPRouteStatuses(ctx context.Context, scopedLog *slog.Logger, tcpRoutes []gatewayv1.TCPRoute, grants []gatewayv1.ReferenceGrant) error {
 	scopedLog.Debug("Updating TCPRoute statuses for Gateway", numRoutes, len(tcpRoutes))
 	for tcpRouteIndex, original := range tcpRoutes {
 		tcpr := original.DeepCopy()
@@ -393,7 +393,7 @@ func (m *RouteStatusManager) setTCPRouteStatuses(scopedLog *slog.Logger, ctx con
 	return nil
 }
 
-func (m *RouteStatusManager) setUDPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, udpRoutes []gatewayv1.UDPRoute, grants []gatewayv1.ReferenceGrant) error {
+func (m *RouteStatusManager) setUDPRouteStatuses(ctx context.Context, scopedLog *slog.Logger, udpRoutes []gatewayv1.UDPRoute, grants []gatewayv1.ReferenceGrant) error {
 	scopedLog.Debug("Updating UDPRoute statuses for Gateway", numRoutes, len(udpRoutes))
 	for udpRouteIndex, original := range udpRoutes {
 		udpr := original.DeepCopy()

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -136,7 +136,7 @@ func Test_setTCPRouteStatusesPrunesDetachedParents(t *testing.T) {
 		TCPUDPRouteSupport:      true,
 		TCPUDPUnsupportedReason: hostNetworkTCPUDPRouteUnsupportedReason,
 	})
-	require.NoError(t, m.setTCPRouteStatuses(slog.Default(), t.Context(), routes.Items, nil))
+	require.NoError(t, m.setTCPRouteStatuses(t.Context(), slog.Default(), routes.Items, nil))
 
 	updated := &gatewayv1.TCPRoute{}
 	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(route), updated))
@@ -165,7 +165,7 @@ func Test_setUDPRouteStatusesPrunesDetachedParents(t *testing.T) {
 		TCPUDPRouteSupport:      true,
 		TCPUDPUnsupportedReason: hostNetworkTCPUDPRouteUnsupportedReason,
 	})
-	require.NoError(t, m.setUDPRouteStatuses(slog.Default(), t.Context(), routes.Items, nil))
+	require.NoError(t, m.setUDPRouteStatuses(t.Context(), slog.Default(), routes.Items, nil))
 
 	updated := &gatewayv1.UDPRoute{}
 	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(route), updated))


### PR DESCRIPTION
Reorder `RouteStatusManager.SetRouteStatuses` to take `context.Context` as its first parameter, followed by the scoped logger and route status inputs.

This aligns the method with Go convention.

Fixes: #48023