### PR TITLE
gateway-api: precompute namespace labels during input loading

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -176,8 +176,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		MergedListeners:     mergedListeners,
 	})
 
-	namespaceLabels := helpers.NewNamespaceLabelIndex(inputs.Namespaces)
-
 	listenersStatus, err := r.setListenerStatus(
 		ctx,
 		gw,
@@ -188,7 +186,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		inputs.TCPRoutes,
 		inputs.UDPRoutes,
 		inputs.ReferenceGrants,
-		namespaceLabels,
+		inputs.NamespaceLabels,
 	)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
@@ -226,7 +224,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		inputs.TCPRoutes,
 		inputs.UDPRoutes,
 		inputs.ReferenceGrants,
-		namespaceLabels,
+		inputs.NamespaceLabels,
 	)
 
 	// Step 3: Translate the listeners into Cilium model

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1081,7 +1081,7 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				helpers.NewNamespaceLabelIndex(nil),
+				nil,
 			)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, gotStatus)

--- a/operator/pkg/gateway-api/loading/loading.go
+++ b/operator/pkg/gateway-api/loading/loading.go
@@ -38,7 +38,7 @@ type TranslationInputs struct {
 	TCPRoutes              []gatewayv1.TCPRoute
 	UDPRoutes              []gatewayv1.UDPRoute
 	ReferenceGrants        []gatewayv1.ReferenceGrant
-	Namespaces             []corev1.Namespace
+	NamespaceLabels        helpers.NamespaceLabelIndex
 	BackendTLSPolicies     []gatewayv1.BackendTLSPolicy
 	Services               []corev1.Service
 	ServiceImports         []mcsapiv1beta1.ServiceImport
@@ -325,7 +325,6 @@ func (l *TranslationInputLoader) Load(ctx context.Context, scopedLog *slog.Logge
 		}
 		namespaces = namespaceList.Items
 	}
-
 	servicesList := &corev1.ServiceList{}
 	if err := l.client.List(ctx, servicesList); err != nil {
 		return TranslationInputs{}, fmt.Errorf("failed to list Services: %w", err)
@@ -355,7 +354,7 @@ func (l *TranslationInputLoader) Load(ctx context.Context, scopedLog *slog.Logge
 		TCPRoutes:              routeCollections.tcpRoutes,
 		UDPRoutes:              routeCollections.udpRoutes,
 		ReferenceGrants:        grants.Items,
-		Namespaces:             namespaces,
+		NamespaceLabels:        helpers.NewNamespaceLabelIndex(namespaces),
 		BackendTLSPolicies:     btlspList.Items,
 		Services:               servicesList.Items,
 		ServiceImports:         serviceImportsList.Items,


### PR DESCRIPTION
Populate NamespaceLabels during translation input loading and
pass the precomputed index into Gateway listener and ListenerSet status handling.

This avoids the need for building the index on the usage side.

TranslationInputs now exposes the derived namespace label index directly
and drops the raw Namespace slice, since status handling only needs
the indexed view and no remaining caller consumes the unprocessed namespace list.
