### PR TITLE
hubble: Observe node table for peer updates

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 )
 
 // The top-level Hubble cell, implements several Hubble subsystems: reports pod
@@ -85,7 +84,6 @@ type hubbleParams struct {
 	EndpointManager   endpointmanager.EndpointManager
 	IPCache           *ipcache.IPCache
 	CGroupManager     manager.CGroupManager
-	NodeManager       nodeManager.NodeManager
 	NodeLocalStore    *node.LocalNodeStore
 	MonitorAgent      monitorAgent.Agent
 
@@ -119,7 +117,6 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.EndpointManager,
 		params.IPCache,
 		params.CGroupManager,
-		params.NodeManager,
 		params.NodeLocalStore,
 		params.MonitorAgent,
 		params.TLSConfigPromise,

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -62,7 +61,6 @@ type hubbleIntegration struct {
 	endpointManager   endpointmanager.EndpointManager
 	ipcache           *ipcache.IPCache
 	cgroupManager     manager.CGroupManager
-	nodeManager       nodeManager.NodeManager
 	nodeLocalStore    *node.LocalNodeStore
 	monitorAgent      monitorAgent.Agent
 	tlsConfigPromise  tlsConfigPromise
@@ -91,7 +89,6 @@ func createHubbleIntegration(
 	endpointManager endpointmanager.EndpointManager,
 	ipcache *ipcache.IPCache,
 	cgroupManager manager.CGroupManager,
-	nodeManager nodeManager.NodeManager,
 	nodeLocalStore *node.LocalNodeStore,
 	monitorAgent monitorAgent.Agent,
 	tlsConfigPromise tlsConfigPromise,
@@ -122,7 +119,6 @@ func createHubbleIntegration(
 		endpointManager:      endpointManager,
 		ipcache:              ipcache,
 		cgroupManager:        cgroupManager,
-		nodeManager:          nodeManager,
 		nodeLocalStore:       nodeLocalStore,
 		monitorAgent:         monitorAgent,
 		tlsConfigPromise:     tlsConfigPromise,

--- a/pkg/hubble/peer/cell/cell.go
+++ b/pkg/hubble/peer/cell/cell.go
@@ -10,11 +10,12 @@ import (
 	"strconv"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 // Cell provides the Hubble peer service that handles peer discovery and notifications.
@@ -35,11 +36,12 @@ type HubbleConfig struct {
 type peerServiceParams struct {
 	cell.In
 
-	Logger      *slog.Logger
-	Lifecycle   cell.Lifecycle
-	NodeManager nodeManager.NodeManager
-	Config      *HubbleConfig
-	Health      cell.Health
+	Logger    *slog.Logger
+	Lifecycle cell.Lifecycle
+	DB        *statedb.DB
+	Nodes     statedb.Table[*node.Node]
+	Config    *HubbleConfig
+	Health    cell.Health
 }
 
 // getPort extracts the port from an address string.
@@ -87,7 +89,7 @@ func newPeerService(params peerServiceParams) (*peer.Service, error) {
 		}
 	}
 
-	service := peer.NewService(params.NodeManager, peerServiceOptions...)
+	service := peer.NewService(params.DB, params.Nodes, peerServiceOptions...)
 
 	// Register stop hook to properly close the peer service
 	params.Lifecycle.Append(cell.Hook{

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -12,16 +12,11 @@ import (
 	ciliumDefaults "github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 )
 
-// handler implements the node.Handler interface so that it can be
-// subscribed to a node manager and receives update about nodes being
-// added/updated/deleted. Node update information is turned into
-// peerpb.ChangeNotification and sent to the channel C. As this channel is
-// unbuffered, clients must be ready to read from it before subscribing the
-// handler to the node manager.
+// handler turns node table changes into peerpb.ChangeNotifications. As C is
+// unbuffered, clients must be ready to read from it before processing changes.
 // Once not used anymore, Close must be called to free resources.
 type handler struct {
 	stop        chan struct{}
@@ -41,39 +36,28 @@ func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPref
 	}
 }
 
-func (h *handler) Name() string {
-	return "hubble-peer"
-}
-
-// Ensure that Service implements the NodeHandler interface so that it can be
-// notified of nodes updates by the daemon's node manager.
-var _ node.Handler = (*handler)(nil)
-
-// NodeAdd implements node.Handler.NodeAdd.
-func (h *handler) NodeAdd(n types.Node) error {
+func (h *handler) nodeAdded(n types.Node) {
 	cn := h.newChangeNotification(n, peerpb.ChangeNotificationType_PEER_ADDED)
 	select {
 	case h.C <- cn:
 	case <-h.stop:
 	}
-	return nil
 }
 
-// NodeUpdate implements node.Handler.NodeUpdate.
-func (h *handler) NodeUpdate(o, n types.Node) error {
+func (h *handler) nodeUpdated(o, n types.Node) {
 	oAddr, nAddr := nodeAddress(o, h.addressPref), nodeAddress(n, h.addressPref)
 	if o.Fullname() == n.Fullname() {
 		if oAddr.String() == nAddr.String() {
 			// this corresponds to the same peer
 			// => no need to send a notification
-			return nil
+			return
 		}
 		cn := h.newChangeNotification(n, peerpb.ChangeNotificationType_PEER_UPDATED)
 		select {
 		case h.C <- cn:
 		case <-h.stop:
 		}
-		return nil
+		return
 	}
 	// the name has changed; from a service consumer perspective, this is the
 	// same as if the peer with the old name was removed and a new one added
@@ -81,35 +65,21 @@ func (h *handler) NodeUpdate(o, n types.Node) error {
 	select {
 	case h.C <- ocn:
 	case <-h.stop:
-		return nil
+		return
 	}
 	ncn := h.newChangeNotification(n, peerpb.ChangeNotificationType_PEER_ADDED)
 	select {
 	case h.C <- ncn:
 	case <-h.stop:
 	}
-	return nil
 }
 
-// NodeDelete implements node.Handler.NodeDelete.
-func (h *handler) NodeDelete(n types.Node) error {
+func (h *handler) nodeDeleted(n types.Node) {
 	cn := h.newChangeNotification(n, peerpb.ChangeNotificationType_PEER_DELETED)
 	select {
 	case h.C <- cn:
 	case <-h.stop:
 	}
-	return nil
-}
-
-// AllNodeValidateImplementation implements
-func (h handler) AllNodeValidateImplementation() {
-}
-
-// NodeValidateImplementation implements
-// node.Handler.NodeValidateImplementation. It is a no-op.
-func (h handler) NodeValidateImplementation(_ types.Node) error {
-	// no-op
-	return nil
 }
 
 // Close frees handler resources.

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -198,7 +198,7 @@ func TestNodeAdd(t *testing.T) {
 			wg.Go(func() {
 				got = <-h.C
 			})
-			h.NodeAdd(tt.arg)
+			h.nodeAdded(tt.arg)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
 		})
@@ -480,7 +480,7 @@ func TestNodeUpdate(t *testing.T) {
 					got = append(got, <-h.C)
 				}
 			})
-			h.NodeUpdate(tt.args.old, tt.args.updated)
+			h.nodeUpdated(tt.args.old, tt.args.updated)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
 		})
@@ -641,7 +641,7 @@ func TestNodeDelete(t *testing.T) {
 			wg.Go(func() {
 				got = <-h.C
 			})
-			h.NodeDelete(tt.arg)
+			h.nodeDeleted(tt.arg)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
 		})
@@ -695,7 +695,7 @@ func TestHubblePort(t *testing.T) {
 			wg.Go(func() {
 				got = <-h.C
 			})
-			h.NodeAdd(tt.arg)
+			h.nodeAdded(tt.arg)
 
 			want := &peerpb.ChangeNotification{
 				Address: tt.want,

--- a/pkg/hubble/peer/service.go
+++ b/pkg/hubble/peer/service.go
@@ -8,11 +8,14 @@ import (
 	"errors"
 	"io"
 
+	"github.com/cilium/statedb"
 	"golang.org/x/sync/errgroup"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
-	"github.com/cilium/cilium/pkg/node/manager"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // ErrStreamSendBlocked is returned by Notify when the send operation is
@@ -21,24 +24,26 @@ var ErrStreamSendBlocked = errors.New("server stream send was blocked for too lo
 
 // Service implements the peerpb.PeerServer gRPC service.
 type Service struct {
-	stop     chan struct{}
-	notifier manager.Notifier
-	opts     serviceoption.Options
+	stop  chan struct{}
+	db    *statedb.DB
+	nodes statedb.Table[*node.Node]
+	opts  serviceoption.Options
 }
 
 // Ensure that Service implements the peerpb.PeerServer interface.
 var _ peerpb.PeerServer = (*Service)(nil)
 
 // NewService creates a new Service.
-func NewService(notifier manager.Notifier, options ...serviceoption.Option) *Service {
+func NewService(db *statedb.DB, nodes statedb.Table[*node.Node], options ...serviceoption.Option) *Service {
 	opts := serviceoption.Default
 	for _, opt := range options {
 		opt(&opts)
 	}
 	return &Service{
-		stop:     make(chan struct{}),
-		notifier: notifier,
-		opts:     opts,
+		stop:  make(chan struct{}),
+		db:    db,
+		nodes: nodes,
+		opts:  opts,
 	}
 }
 
@@ -46,10 +51,16 @@ func NewService(notifier manager.Notifier, options ...serviceoption.Option) *Ser
 // to process change notifications fast enough, the server will terminate the
 // connection.
 func (s *Service) Notify(_ *peerpb.NotifyRequest, stream peerpb.Peer_NotifyServer) error {
-	// The node manager sends notifications upon call to Subscribe. As the
-	// handler's channel is unbuffered, make sure that the client is ready to
-	// read notifications to avoid a deadlock situation.
-	ctx, cancel := context.WithCancel(context.Background())
+	wtxn := s.db.WriteTxn(s.nodes)
+	changes, err := s.nodes.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+	defer changes.Close()
+
+	ctx, cancel := context.WithCancel(stream.Context())
+	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 
 	// monitor for global stop signal to tear down all routines
@@ -62,6 +73,44 @@ func (s *Service) Notify(_ *peerpb.NotifyRequest, stream peerpb.Peer_NotifyServe
 			return nil
 		case <-ctx.Done():
 			return nil
+		}
+	})
+
+	// Translate the initial node snapshot and subsequent table changes into
+	// notifications. Keep the previous version to suppress updates that do not
+	// change the peer's address.
+	g.Go(func() error {
+		// Process change bursts at most once every 50 milliseconds. The initial
+		// snapshot is processed immediately before the limiter is consulted.
+		limiter := rate.NewLimiter(50*time.Millisecond, 1)
+		defer limiter.Stop()
+
+		previous := map[string]*node.Node{}
+		for {
+			seq, watch := changes.Next(s.db.ReadTxn())
+			for change := range seq {
+				n := change.Object
+				name := n.Fullname()
+				if change.Deleted {
+					h.nodeDeleted(n.Node)
+					delete(previous, name)
+				} else if old, found := previous[name]; found {
+					h.nodeUpdated(old.Node, n.Node)
+					previous[name] = n
+				} else {
+					h.nodeAdded(n.Node)
+					previous[name] = n
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-watch:
+			}
+			if limiter.Wait(ctx) != nil {
+				return nil
+			}
 		}
 	})
 
@@ -101,8 +150,6 @@ func (s *Service) Notify(_ *peerpb.NotifyRequest, stream peerpb.Peer_NotifyServe
 		}
 	})
 
-	s.notifier.Subscribe(h)
-	defer s.notifier.Unsubscribe(h)
 	return g.Wait()
 }
 

--- a/pkg/hubble/peer/service_test.go
+++ b/pkg/hubble/peer/service_test.go
@@ -4,20 +4,21 @@
 package peer
 
 import (
+	"context"
 	"net"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
-	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -727,33 +728,35 @@ func TestService_Notify(t *testing.T) {
 			var got []*peerpb.ChangeNotification
 			var wg sync.WaitGroup
 			fakeServer := &testutils.FakePeerNotifyServer{
+				FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+					OnContext: t.Context,
+				},
 				OnSend: func(resp *peerpb.ChangeNotification) error {
 					got = append(got, resp)
 					wg.Done()
 					return nil
 				},
 			}
-			ready := make(chan struct{})
-			cb := func(nh node.Handler) {
-				ready <- struct{}{}
-			}
-			notif := newNotifier(cb, tt.args.init)
+			fixture := newNodeTableFixture(t, tt.args.init)
 			wg.Add(len(tt.args.init))
-			svc := NewService(notif, tt.svcOptions...)
+			svc := NewService(fixture.db, fixture.nodes, tt.svcOptions...)
 			done := make(chan struct{})
 			go func() {
 				err := svc.Notify(&peerpb.NotifyRequest{}, fakeServer)
 				assert.NoError(t, err)
 				close(done)
 			}()
-			<-ready
+			// Initial table contents are delivered as peer additions. Waiting for
+			// them also ensures that the change iterator is running before the
+			// table is mutated below.
+			wg.Wait()
 			for _, n := range tt.args.add {
 				wg.Add(1)
-				notif.notifyAdd(n)
+				fixture.notifyAdd(t, n)
 			}
 			for _, n := range tt.args.del {
 				wg.Add(1)
-				notif.notifyDelete(n)
+				fixture.notifyDelete(t, n)
 			}
 			// the update slice shall always be even with odd entry
 			// corresponding to the old node and following even entries to the
@@ -777,7 +780,7 @@ func TestService_Notify(t *testing.T) {
 				default:
 					wg.Add(1)
 				}
-				notif.notifyUpdate(o, n)
+				fixture.notifyUpdate(t, o, n)
 			}
 			wg.Wait()
 			svc.Close()
@@ -790,14 +793,13 @@ func TestService_Notify(t *testing.T) {
 
 func TestService_NotifyWithBlockedSend(t *testing.T) {
 	fakeServer := &testutils.FakePeerNotifyServer{
+		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+			OnContext: t.Context,
+		},
 		OnSend: func(resp *peerpb.ChangeNotification) error {
 			<-time.After(100 * time.Millisecond)
 			return nil
 		},
-	}
-	ready := make(chan struct{})
-	cb := func(nh node.Handler) {
-		ready <- struct{}{}
 	}
 	init := []types.Node{
 		{
@@ -824,78 +826,92 @@ func TestService_NotifyWithBlockedSend(t *testing.T) {
 			},
 		},
 	}
-	notif := newNotifier(cb, init)
-	svc := NewService(notif, serviceoption.WithMaxSendBufferSize(2), serviceoption.WithoutTLSInfo())
+	fixture := newNodeTableFixture(t, init)
+	svc := NewService(fixture.db, fixture.nodes, serviceoption.WithMaxSendBufferSize(2), serviceoption.WithoutTLSInfo())
 	done := make(chan struct{})
 	go func() {
 		err := svc.Notify(&peerpb.NotifyRequest{}, fakeServer)
 		assert.Equal(t, ErrStreamSendBlocked, err)
 		close(done)
 	}()
-	<-ready
-	for _, n := range init {
-		notif.notifyAdd(n)
-	}
-	svc.Close()
 	// wait for the notify call routine to finish
 	<-done
+	svc.Close()
 }
 
-type notifier struct {
-	nodes       []types.Node
-	subscribers map[node.Handler]struct{}
-	cb          func(nh node.Handler)
-	mu          lock.Mutex
-}
+func TestService_NotifyStopsWhenStreamContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	fakeServer := &testutils.FakePeerNotifyServer{
+		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
+			OnContext: func() context.Context { return ctx },
+		},
+		OnSend: func(*peerpb.ChangeNotification) error {
+			return nil
+		},
+	}
+	fixture := newNodeTableFixture(t, nil)
+	svc := NewService(fixture.db, fixture.nodes)
+	defer svc.Close()
 
-var _ manager.Notifier = (*notifier)(nil)
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.Notify(&peerpb.NotifyRequest{}, fakeServer)
+	}()
+	cancel()
 
-func newNotifier(subCallback func(nh node.Handler), nodes []types.Node) *notifier {
-	return &notifier{
-		nodes:       nodes,
-		subscribers: make(map[node.Handler]struct{}),
-		cb:          subCallback,
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Notify did not stop after its stream context was cancelled")
 	}
 }
 
-func (n *notifier) Subscribe(nh node.Handler) {
-	n.mu.Lock()
-	n.subscribers[nh] = struct{}{}
-	n.mu.Unlock()
-	for _, e := range n.nodes {
-		nh.NodeAdd(e)
-	}
-	if n.cb != nil {
-		n.cb(nh)
-	}
+type nodeTableFixture struct {
+	db    *statedb.DB
+	nodes statedb.RWTable[*node.Node]
 }
 
-func (n *notifier) Unsubscribe(nh node.Handler) {
-	n.mu.Lock()
-	delete(n.subscribers, nh)
-	n.mu.Unlock()
+func newNodeTableFixture(t testing.TB, nodes []types.Node) *nodeTableFixture {
+	t.Helper()
+	db := statedb.New()
+	table, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+
+	txn := db.WriteTxn(table)
+	for _, n := range nodes {
+		_, _, err := table.Insert(txn, &node.Node{Node: n})
+		require.NoError(t, err)
+	}
+	txn.Commit()
+
+	return &nodeTableFixture{db: db, nodes: table}
 }
 
-func (n *notifier) notifyAdd(e types.Node) {
-	n.mu.Lock()
-	for s := range n.subscribers {
-		s.NodeAdd(e)
-	}
-	n.mu.Unlock()
+func (f *nodeTableFixture) notifyAdd(t testing.TB, n types.Node) {
+	t.Helper()
+	txn := f.db.WriteTxn(f.nodes)
+	_, _, err := f.nodes.Insert(txn, &node.Node{Node: n})
+	require.NoError(t, err)
+	txn.Commit()
 }
 
-func (n *notifier) notifyDelete(e types.Node) {
-	n.mu.Lock()
-	for s := range n.subscribers {
-		s.NodeDelete(e)
-	}
-	n.mu.Unlock()
+func (f *nodeTableFixture) notifyDelete(t testing.TB, n types.Node) {
+	t.Helper()
+	txn := f.db.WriteTxn(f.nodes)
+	_, _, err := f.nodes.Delete(txn, &node.Node{Node: n})
+	require.NoError(t, err)
+	txn.Commit()
 }
 
-func (n *notifier) notifyUpdate(o, e types.Node) {
-	n.mu.Lock()
-	for s := range n.subscribers {
-		s.NodeUpdate(o, e)
+func (f *nodeTableFixture) notifyUpdate(t testing.TB, old, updated types.Node) {
+	t.Helper()
+	txn := f.db.WriteTxn(f.nodes)
+	if old.Fullname() != updated.Fullname() {
+		_, _, err := f.nodes.Delete(txn, &node.Node{Node: old})
+		require.NoError(t, err)
 	}
-	n.mu.Unlock()
+	_, _, err := f.nodes.Insert(txn, &node.Node{Node: updated})
+	require.NoError(t, err)
+	txn.Commit()
 }


### PR DESCRIPTION
Replace per-client NodeManager subscriptions with StateDB change iterators. Seed each stream from the initial table snapshot and retain previous node state to preserve add, update, and delete notifications while filtering changes that do not affect the peer address.

Rate-limit subsequent change batches to 50 milliseconds to reduce overhead. Remove the now-unused NodeManager dependency from the Hubble integration.

AIL:3
Related: https://github.com/cilium/cilium/issues/41744