### PR TITLE
auth: Observe node table for map cleanup

### DIFF
--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -16,9 +19,9 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
-	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -27,11 +30,14 @@ type authMapGarbageCollector struct {
 	authmap         authMap
 	nodeIDHandler   node.IDHandler
 	authTypeFetcher authTypeFetcher
+	db              *statedb.DB
+	nodes           statedb.Table[*node.Node]
 
-	ciliumNodesMutex      lock.Mutex
-	ciliumNodesDiscovered map[uint16]struct{}
-	ciliumNodesSynced     bool
-	ciliumNodesDeleted    map[uint16]struct{}
+	ciliumNodesMutex   lock.Mutex
+	ciliumNodesSynced  bool
+	ciliumNodesChanged bool
+	activeNodeIDs      map[uint16]struct{}
+	activeNodeIDsReady bool
 
 	ciliumIdentitiesMutex      lock.RWMutex
 	ciliumIdentitiesDiscovered map[identity.NumericIdentity]struct{}
@@ -43,27 +49,28 @@ type authMapGarbageCollector struct {
 	endpointsCacheMutex  lock.RWMutex
 }
 
-func (r *authMapGarbageCollector) Name() string {
-	return "authmap-gc"
-}
-
 // authTypeFetcher returns the AuthTypes required by the policy between two
 // identities. Today this is satisfied by the policy compute cell.
 type authTypeFetcher interface {
 	GetAuthTypes(localID, remoteID identity.NumericIdentity) policyTypes.AuthTypes
 }
 
-func newAuthMapGC(logger *slog.Logger, authmap authMap, nodeIDHandler node.IDHandler, authTypeFetcher authTypeFetcher) *authMapGarbageCollector {
+func newAuthMapGC(
+	logger *slog.Logger,
+	authmap authMap,
+	nodeIDHandler node.IDHandler,
+	authTypeFetcher authTypeFetcher,
+	db *statedb.DB,
+	nodes statedb.Table[*node.Node],
+) *authMapGarbageCollector {
 	return &authMapGarbageCollector{
 		logger:          logger,
 		authmap:         authmap,
 		nodeIDHandler:   nodeIDHandler,
 		authTypeFetcher: authTypeFetcher,
+		db:              db,
+		nodes:           nodes,
 
-		ciliumNodesDiscovered: map[uint16]struct{}{
-			0: {}, // Local node 0 is always available
-		},
-		ciliumNodesDeleted:         map[uint16]struct{}{},
 		ciliumIdentitiesDiscovered: map[identity.NumericIdentity]struct{}{},
 		ciliumIdentitiesDeleted:    map[identity.NumericIdentity]struct{}{},
 	}
@@ -95,58 +102,88 @@ func (r *authMapGarbageCollector) cleanup(ctx context.Context) error {
 
 // Nodes
 
-func (r *authMapGarbageCollector) subscribeToNodeEvents(nodeManager manager.NodeManager) {
-	nodeManager.Subscribe(r)
+func (r *authMapGarbageCollector) observeNodeChanges(ctx context.Context) error {
+	_, initialized := r.nodes.Initialized(r.db.ReadTxn())
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-initialized:
+	}
 
+	nodeSet, activeNodeIDs, activeNodeIDsReady, watch := r.nodeStateWatch()
+	r.ciliumNodesMutex.Lock()
 	r.logger.Debug("Nodes synced")
 	r.ciliumNodesSynced = true
+	r.ciliumNodesChanged = true
+	r.activeNodeIDs = activeNodeIDs
+	r.activeNodeIDsReady = activeNodeIDsReady
+	r.ciliumNodesMutex.Unlock()
+
+	// Coalesce bursts of node updates before comparing the current node set.
+	limiter := rate.NewLimiter(50*time.Millisecond, 1)
+	defer limiter.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-watch:
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+		newNodeSet, newActiveNodeIDs, newActiveNodeIDsReady, newWatch := r.nodeStateWatch()
+		watch = newWatch
+		if maps.Equal(nodeSet, newNodeSet) {
+			if !activeNodeIDsReady && newActiveNodeIDsReady {
+				activeNodeIDs = newActiveNodeIDs
+				activeNodeIDsReady = true
+				r.ciliumNodesMutex.Lock()
+				r.activeNodeIDs = activeNodeIDs
+				r.activeNodeIDsReady = true
+				r.ciliumNodesMutex.Unlock()
+			}
+			continue
+		}
+		nodeSet = newNodeSet
+		activeNodeIDs = newActiveNodeIDs
+		activeNodeIDsReady = newActiveNodeIDsReady
+		r.ciliumNodesMutex.Lock()
+		r.ciliumNodesChanged = true
+		r.activeNodeIDs = activeNodeIDs
+		r.activeNodeIDsReady = activeNodeIDsReady
+		r.ciliumNodesMutex.Unlock()
+	}
 }
 
-func (r *authMapGarbageCollector) NodeAdd(newNode nodeTypes.Node) error {
-	r.ciliumNodesMutex.Lock()
-	defer r.ciliumNodesMutex.Unlock()
-
-	if r.ciliumNodesDiscovered != nil {
-		remoteNodeIDs := r.remoteNodeIDs(newNode)
-		r.logger.Debug("Node discovered - mark to keep",
-			logfields.Name, newNode.Identity().Name,
-			logfields.ClusterName, newNode.Identity().Cluster,
-			logfields.NodeIDs, remoteNodeIDs,
-		)
-		for _, rID := range remoteNodeIDs {
-			r.ciliumNodesDiscovered[rID] = struct{}{}
+func (r *authMapGarbageCollector) nodeStateWatch() (
+	map[nodeTypes.Identity]struct{},
+	map[uint16]struct{},
+	bool,
+	<-chan struct{},
+) {
+	nodes, watch := r.nodes.AllWatch(r.db.ReadTxn())
+	nodeSet := map[nodeTypes.Identity]struct{}{}
+	activeNodeIDs := map[uint16]struct{}{0: {}} // Local node 0 is always available.
+	activeNodeIDsReady := true
+	for n := range nodes {
+		nodeSet[n.Identity()] = struct{}{}
+		if n.IsLocal() {
+			continue
+		}
+		for _, addr := range n.IPAddresses {
+			if addr.Type != addressing.NodeInternalIP {
+				continue
+			}
+			nodeID, exists := r.nodeIDHandler.GetNodeID(addr.IP)
+			if !exists {
+				activeNodeIDsReady = false
+				continue
+			}
+			activeNodeIDs[nodeID] = struct{}{}
 		}
 	}
-
-	return nil
-}
-
-func (r *authMapGarbageCollector) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
-	return nil
-}
-
-func (r *authMapGarbageCollector) NodeDelete(deletedNode nodeTypes.Node) error {
-	r.ciliumNodesMutex.Lock()
-	defer r.ciliumNodesMutex.Unlock()
-
-	remoteNodeIDs := r.remoteNodeIDs(deletedNode)
-	r.logger.Debug("Node deleted - mark for deletion",
-		logfields.Name, deletedNode.Identity().Name,
-		logfields.ClusterName, deletedNode.Identity().Cluster,
-		logfields.NodeIDs, remoteNodeIDs,
-	)
-	for _, rID := range remoteNodeIDs {
-		r.ciliumNodesDeleted[rID] = struct{}{}
-	}
-
-	return nil
-}
-
-func (r *authMapGarbageCollector) AllNodeValidateImplementation() {
-}
-
-func (r *authMapGarbageCollector) NodeValidateImplementation(node nodeTypes.Node) error {
-	return nil
+	return nodeSet, activeNodeIDs, activeNodeIDsReady, watch
 }
 
 func (r *authMapGarbageCollector) cleanupNodes(_ context.Context) error {
@@ -159,37 +196,20 @@ func (r *authMapGarbageCollector) cleanupNodes(_ context.Context) error {
 		r.logger.Debug("Skipping nodes cleanup - not synced yet")
 		return nil
 	}
-
-	if err := r.cleanupMissingNodes(); err != nil {
-		return fmt.Errorf("failed to cleanup missing nodes: %w", err)
-	}
-
-	if err := r.cleanupDeletedNodes(); err != nil {
-		return fmt.Errorf("failed to cleanup deleted nodes: %w", err)
-	}
-
-	return nil
-}
-
-func (r *authMapGarbageCollector) cleanupDeletedNodes() error {
-	for nodeID := range r.ciliumNodesDeleted {
-		if err := r.cleanupDeletedNode(nodeID); err != nil {
-			// keep entry and try to delete it during the next gc execution
-			return fmt.Errorf("failed to cleanup deleted node: %w", err)
-		}
-		delete(r.ciliumNodesDeleted, nodeID)
-	}
-
-	return nil
-}
-
-func (r *authMapGarbageCollector) cleanupMissingNodes() error {
-	if r.ciliumNodesDiscovered == nil {
+	if !r.ciliumNodesChanged {
 		return nil
 	}
 
+	if !r.activeNodeIDsReady {
+		_, r.activeNodeIDs, r.activeNodeIDsReady, _ = r.nodeStateWatch()
+		if !r.activeNodeIDsReady {
+			r.logger.Debug("Node IDs not ready, deferring auth map cleanup")
+			return nil
+		}
+	}
+
 	err := r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
-		if _, ok := r.ciliumNodesDiscovered[key.remoteNodeID]; !ok {
+		if _, ok := r.activeNodeIDs[key.remoteNodeID]; !ok {
 			r.logger.Debug("Deleting entry due to removed remote node", logfields.RemoteNodeID, key.remoteNodeID)
 			return true
 		}
@@ -197,43 +217,11 @@ func (r *authMapGarbageCollector) cleanupMissingNodes() error {
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to cleanup missing nodes: %w", err)
 	}
 
-	r.ciliumNodesDiscovered = nil
-
-	return err
-}
-
-func (r *authMapGarbageCollector) cleanupDeletedNode(nodeID uint16) error {
-	return r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
-		if key.remoteNodeID == nodeID {
-			r.logger.Debug("Deleting entry due to removed node", logfields.NodeID, nodeID)
-			return true
-		}
-		return false
-	})
-}
-
-func (r *authMapGarbageCollector) remoteNodeIDs(node nodeTypes.Node) []uint16 {
-	var remoteNodeIDs []uint16
-
-	for _, addr := range node.IPAddresses {
-		if addr.Type == addressing.NodeInternalIP {
-			nodeID, exists := r.nodeIDHandler.GetNodeID(addr.IP)
-			if !exists {
-				// This might be the case at startup, when new nodes aren't yet known to the nodehandler
-				// and therefore no node id has been assigned to them.
-				r.logger.Debug("No node ID available for node IP - skipping",
-					logfields.NodeName, node.Name,
-					logfields.IPAddr, addr.IP)
-				continue
-			}
-			remoteNodeIDs = append(remoteNodeIDs, nodeID)
-		}
-	}
-
-	return remoteNodeIDs
+	r.ciliumNodesChanged = false
+	return nil
 }
 
 // Identities

--- a/pkg/auth/authmap_gc_test.go
+++ b/pkg/auth/authmap_gc_test.go
@@ -6,16 +6,19 @@ package auth
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
@@ -33,7 +36,7 @@ func Test_authMapGarbageCollector_cleanupIdentities(t *testing.T) {
 			{localIdentity: 11, remoteIdentity: 12, remoteNodeID: 0, authType: policyTypes.AuthTypeAlwaysFail}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil, nil, nil)
 
 	assert.Len(t, authMap.entries, 5)
 	assert.Empty(t, gc.ciliumIdentitiesDiscovered)
@@ -96,8 +99,6 @@ func Test_authMapGarbageCollector_cleanupIdentities(t *testing.T) {
 }
 
 func Test_authMapGarbageCollector_cleanupNodes(t *testing.T) {
-	ctx := context.TODO()
-
 	authMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
 			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policyTypes.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
@@ -107,72 +108,68 @@ func Test_authMapGarbageCollector_cleanupNodes(t *testing.T) {
 			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 4, authType: policyTypes.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
+	db, nodes := newTestNodeTable(t,
+		ciliumNodeEvent("172.18.0.1"),
+		ciliumNodeEvent("172.18.0.2"),
+	)
 	gc := newAuthMapGC(hivetest.Logger(t), authMap, newFakeNodeIDHandler(map[uint16]string{
 		1: "172.18.0.1",
 		2: "172.18.0.2",
 		3: "172.18.0.3",
 		4: "172.18.0.4",
 		5: "172.18.0.5",
-	}), nil)
+	}), nil, db, nodes)
 
 	assert.Len(t, authMap.entries, 5)
-	assert.Len(t, gc.ciliumNodesDiscovered, 1, "Local node 0 is always present")
-	assert.Empty(t, gc.ciliumNodesDeleted)
 	assert.False(t, gc.ciliumNodesSynced)
 
-	err := gc.NodeAdd(ciliumNodeEvent("172.18.0.1"))
-	assert.NoError(t, err, "Handling a node event should never result in an error")
-	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
-	assert.Len(t, gc.ciliumNodesDiscovered, 2, "Discovered nodes should be kept in the internal state")
-
-	err = gc.NodeAdd(ciliumNodeEvent("172.18.0.2"))
-	assert.NoError(t, err, "Handling a node event should never result in an error")
-	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
-	assert.Len(t, gc.ciliumNodesDiscovered, 3, "Discovered nodes should be kept in the internal state")
-
-	err = gc.cleanupIdentities(ctx)
+	err := gc.cleanupNodes(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, authMap.entries, 5, "GC run before the initial sync should not delete any entries from the auth map")
-	assert.Len(t, gc.ciliumNodesDiscovered, 3, "GC run before the initial sync should not delete the discovered nodes")
 
-	gc.ciliumNodesSynced = true // Node sync event will mark the nodes as synced
+	gc.ciliumNodesSynced = true
+	gc.ciliumNodesChanged = true
+	deleteTestNode(t, db, nodes, ciliumNodeEvent("172.18.0.2"))
+	insertTestNode(t, db, nodes, ciliumNodeEvent("172.18.0.3"))
 
-	err = gc.NodeDelete(ciliumNodeEvent("172.18.0.2"))
-	assert.NoError(t, err, "Handling a node event should never result in an error")
-	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
-	assert.Len(t, gc.ciliumNodesDeleted, 1, "Deleted nodes after the sync and before the initial GC run should already be kept")
-
-	err = gc.NodeAdd(ciliumNodeEvent("172.18.0.3"))
-	assert.NoError(t, err, "Handling a node event should never result in an error")
-	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
-	assert.Len(t, gc.ciliumNodesDiscovered, 4, "Discovered nodes after the sync event should be kept until the first GC run")
-
-	err = gc.cleanupNodes(ctx)
+	err = gc.cleanupNodes(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, authMap.entries, 3, "GC run after the initial sync should delete all entries which belong to deleted or non-discovered nodes")
 	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policyTypes.AuthTypeSpire})
 	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: policyTypes.AuthTypeSpire})
 	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 3, authType: policyTypes.AuthTypeSpire})
-	assert.Nil(t, gc.ciliumNodesDiscovered, "First GC run after the initial sync should reset the option to discover nodes")
-	assert.Empty(t, gc.ciliumNodesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted nodes")
+	assert.False(t, gc.ciliumNodesChanged)
 
-	err = gc.NodeAdd(ciliumNodeEvent("172.18.0.5"))
-	assert.NoError(t, err, "Handling a node should never result in an error")
-	assert.Len(t, authMap.entries, 3, "Node should never modify the map directly")
-	assert.Nil(t, gc.ciliumNodesDiscovered, "Discovered nodes after the first GC run should no longer be of any interest")
+	deleteTestNode(t, db, nodes, ciliumNodeEvent("172.18.0.3"))
+	_, gc.activeNodeIDs, gc.activeNodeIDsReady, _ = gc.nodeStateWatch()
+	gc.ciliumNodesChanged = true
 
-	err = gc.NodeDelete(ciliumNodeEvent("172.18.0.3"))
-	assert.NoError(t, err, "Handling a node event should never result in an error")
-	assert.Len(t, authMap.entries, 3, "Node events should never modify the map directly")
-	assert.Len(t, gc.ciliumNodesDeleted, 1, "Deleted nodes should be kept for the next GC run")
-
-	err = gc.cleanupNodes(ctx)
+	err = gc.cleanupNodes(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, authMap.entries, 2, "GC runs should delete all entries which belong to deleted nodes")
 	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policyTypes.AuthTypeSpire})
 	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: policyTypes.AuthTypeSpire})
-	assert.Nil(t, gc.ciliumNodesDiscovered)
-	assert.Empty(t, gc.ciliumNodesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted nodes")
+	assert.False(t, gc.ciliumNodesChanged)
+}
+
+func Test_authMapGarbageCollector_cleanupNodesDefersUntilNodeIDsReady(t *testing.T) {
+	authMap := &fakeAuthMap{entries: map[authKey]authInfo{
+		{remoteNodeID: 1}: {},
+	}}
+	db, nodes := newTestNodeTable(t, ciliumNodeEvent("172.18.0.1"))
+	nodeIDs := newFakeNodeIDHandler(map[uint16]string{})
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, nodeIDs, nil, db, nodes)
+	gc.ciliumNodesSynced = true
+	gc.ciliumNodesChanged = true
+
+	require.NoError(t, gc.cleanupNodes(t.Context()))
+	assert.Len(t, authMap.entries, 1, "cleanup must not remove entries while active node IDs are unavailable")
+	assert.True(t, gc.ciliumNodesChanged, "cleanup should be retried")
+
+	nodeIDs.nodeIdMappings[1] = "172.18.0.1"
+	require.NoError(t, gc.cleanupNodes(t.Context()))
+	assert.Len(t, authMap.entries, 1)
+	assert.False(t, gc.ciliumNodesChanged)
 }
 
 func Test_authMapGarbageCollector_cleanupPolicies(t *testing.T) {
@@ -198,6 +195,8 @@ func Test_authMapGarbageCollector_cleanupPolicies(t *testing.T) {
 				},
 			},
 		},
+		nil,
+		nil,
 	)
 
 	assert.Len(t, authMap.entries, 3)
@@ -217,7 +216,7 @@ func Test_authMapGarbageCollector_cleanupExpired(t *testing.T) {
 			{localIdentity: 1, remoteIdentity: 3, remoteNodeID: 0, authType: policyTypes.AuthTypeSpire}: {expiration: time.Now().Add(-5 * time.Minute)},
 		},
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil, nil, nil)
 
 	assert.Len(t, authMap.entries, 2)
 
@@ -242,6 +241,7 @@ func Test_authMapGarbageCollector_cleanup(t *testing.T) {
 		},
 	}
 
+	db, nodes := newTestNodeTable(t, ciliumNodeEvent("172.18.0.2"))
 	gc := newAuthMapGC(hivetest.Logger(t), authMap,
 		newFakeNodeIDHandler(map[uint16]string{
 			1: "172.18.0.1",
@@ -269,14 +269,14 @@ func Test_authMapGarbageCollector_cleanup(t *testing.T) {
 				},
 			},
 		},
+		db,
+		nodes,
 	)
 
 	assert.Len(t, authMap.entries, 7)
 
-	require.NoError(t, gc.NodeAdd(ciliumNodeEvent("172.18.0.1")))
-	require.NoError(t, gc.NodeAdd(ciliumNodeEvent("172.18.0.2")))
 	gc.ciliumNodesSynced = true
-	require.NoError(t, gc.NodeDelete(ciliumNodeEvent("172.18.0.1")))
+	gc.ciliumNodesChanged = true
 	for i := 1; i < 15; i++ {
 		require.NoError(t, gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, identity.NumericIdentity(i))))
 	}
@@ -300,7 +300,7 @@ func Test_authMapGarbageCollector_cleanupEndpoints(t *testing.T) {
 			{localIdentity: 3, remoteIdentity: 1, remoteNodeID: 100, authType: policyTypes.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil, nil, nil)
 	gc.endpointsCache = map[uint16]*endpoint.Endpoint{
 		1: {
 			SecurityIdentity: &identity.Identity{
@@ -340,7 +340,7 @@ func Test_authMapGarbageCollector_cleanupEndpointsNoopCase(t *testing.T) {
 			{localIdentity: 3, remoteIdentity: 1, remoteNodeID: 100, authType: policyTypes.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil, nil, nil)
 	gc.endpointsCache = map[uint16]*endpoint.Endpoint{
 		1: {
 			SecurityIdentity: &identity.Identity{
@@ -379,23 +379,18 @@ func Test_authMapGarbageCollector_cleanupEndpointsNoopCase(t *testing.T) {
 	assert.Len(t, authMap.entries, 3, "GC runs should not have deleted entries when all secrity IDs were stil in the endpoint map")
 }
 
-func Test_authMapGarbageCollector_HandleNodeEventError(t *testing.T) {
+func Test_authMapGarbageCollector_cleanupNodesError(t *testing.T) {
 	authMap := &fakeAuthMap{
 		entries:    map[authKey]authInfo{},
 		failDelete: true,
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, newFakeNodeIDHandler(map[uint16]string{10: "172.18.0.3"}), nil)
-
-	event := ciliumNodeEvent("172.18.0.3")
-	err := gc.NodeAdd(event)
-	assert.NoError(t, err)
-	err = gc.NodeDelete(event)
-	assert.NoError(t, err)
+	db, nodes := newTestNodeTable(t)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, newFakeNodeIDHandler(map[uint16]string{10: "172.18.0.3"}), nil, db, nodes)
 
 	gc.ciliumNodesSynced = true
-	gc.ciliumNodesDiscovered = nil
-	err = gc.cleanupNodes(context.Background())
-	assert.ErrorContains(t, err, "failed to cleanup deleted node: failed to delete entry")
+	gc.ciliumNodesChanged = true
+	err := gc.cleanupNodes(context.Background())
+	assert.ErrorContains(t, err, "failed to cleanup missing nodes: failed to delete entry")
 }
 
 func Test_authMapGarbageCollector_HandleIdentityEventError(t *testing.T) {
@@ -403,7 +398,7 @@ func Test_authMapGarbageCollector_HandleIdentityEventError(t *testing.T) {
 		entries:    map[authKey]authInfo{},
 		failDelete: true,
 	}
-	gc := newAuthMapGC(hivetest.Logger(t), authMap, newFakeNodeIDHandler(map[uint16]string{}), nil)
+	gc := newAuthMapGC(hivetest.Logger(t), authMap, newFakeNodeIDHandler(map[uint16]string{}), nil, nil, nil)
 
 	event := ciliumIdentityEvent(cache.IdentityChangeDelete, 4)
 	err := gc.handleIdentityChange(context.Background(), event)
@@ -415,9 +410,86 @@ func Test_authMapGarbageCollector_HandleIdentityEventError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to cleanup deleted identity: failed to delete entry")
 }
 
+func Test_authMapGarbageCollector_observeNodeChanges(t *testing.T) {
+	db, nodes := newTestNodeTable(t)
+	gc := newAuthMapGC(hivetest.Logger(t), &fakeAuthMap{}, newFakeNodeIDHandler(nil), nil, db, nodes)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- gc.observeNodeChanges(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		gc.ciliumNodesMutex.Lock()
+		defer gc.ciliumNodesMutex.Unlock()
+		return gc.ciliumNodesSynced
+	}, time.Second, time.Millisecond)
+
+	gc.ciliumNodesMutex.Lock()
+	gc.ciliumNodesChanged = false
+	gc.ciliumNodesMutex.Unlock()
+	insertTestNode(t, db, nodes, ciliumNodeEvent("172.18.0.1"))
+
+	require.Eventually(t, func() bool {
+		gc.ciliumNodesMutex.Lock()
+		defer gc.ciliumNodesMutex.Unlock()
+		return gc.ciliumNodesChanged
+	}, time.Second, time.Millisecond)
+
+	gc.ciliumNodesMutex.Lock()
+	gc.ciliumNodesChanged = false
+	gc.ciliumNodesMutex.Unlock()
+	updated := ciliumNodeEvent("172.18.0.1")
+	updated.EncryptionKey = 1
+	insertTestNode(t, db, nodes, updated)
+	require.Never(t, func() bool {
+		gc.ciliumNodesMutex.Lock()
+		defer gc.ciliumNodesMutex.Unlock()
+		return gc.ciliumNodesChanged
+	}, 150*time.Millisecond, time.Millisecond, "node updates should not trigger cleanup")
+
+	insertTestNode(t, db, nodes, ciliumNodeEvent("172.18.0.2"))
+	require.Eventually(t, func() bool {
+		gc.ciliumNodesMutex.Lock()
+		defer gc.ciliumNodesMutex.Unlock()
+		return gc.ciliumNodesChanged
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func newTestNodeTable(t testing.TB, initial ...nodeTypes.Node) (*statedb.DB, statedb.RWTable[*node.Node]) {
+	t.Helper()
+	db := statedb.New()
+	nodes, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+	for _, n := range initial {
+		insertTestNode(t, db, nodes, n)
+	}
+	return db, nodes
+}
+
+func insertTestNode(t testing.TB, db *statedb.DB, nodes statedb.RWTable[*node.Node], n nodeTypes.Node) {
+	t.Helper()
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Insert(txn, &node.Node{Node: n})
+	require.NoError(t, err)
+	txn.Commit()
+}
+
+func deleteTestNode(t testing.TB, db *statedb.DB, nodes statedb.RWTable[*node.Node], n nodeTypes.Node) {
+	t.Helper()
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Delete(txn, &node.Node{Node: n})
+	require.NoError(t, err)
+	txn.Commit()
+}
+
 func ciliumNodeEvent(nodeInternalIP string) nodeTypes.Node {
 	return nodeTypes.Node{
-		Name:    "test-node",
+		Name:    "test-node-" + strings.ReplaceAll(nodeInternalIP, ".", "-"),
 		Cluster: "test-cluster",
 		IPAddresses: []nodeTypes.Address{
 			{

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -4,12 +4,14 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
@@ -19,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/time"
@@ -96,8 +97,9 @@ type authManagerParams struct {
 
 	SignalManager   signal.SignalManager
 	NodeIDHandler   node.IDHandler
+	DB              *statedb.DB
+	Nodes           statedb.Table[*node.Node]
 	IdentityChanges stream.Observable[cache.IdentityChange]
-	NodeManager     nodeManager.NodeManager
 	EndpointManager endpointmanager.EndpointManager
 	PolicyComputer  compute.PolicyRecomputer
 }
@@ -123,7 +125,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 		return nil, fmt.Errorf("failed to create auth manager: %w", err)
 	}
 
-	mapGC := newAuthMapGC(params.Logger, mapCache, params.NodeIDHandler, params.PolicyComputer)
+	mapGC := newAuthMapGC(params.Logger, mapCache, params.NodeIDHandler, params.PolicyComputer, params.DB, params.Nodes)
 
 	// Register auth components to lifecycle hooks & jobs
 
@@ -141,7 +143,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 		return nil, fmt.Errorf("failed to register signal authentication job: %w", err)
 	}
 	registerReAuthenticationJob(params.JobGroup, mgr, params.AuthHandlers)
-	registerGCJobs(params.JobGroup, params.Lifecycle, mapGC, params.Config, params.NodeManager, params.EndpointManager, params.IdentityChanges)
+	registerGCJobs(params.JobGroup, params.Lifecycle, mapGC, params.Config, params.EndpointManager, params.IdentityChanges)
 
 	return mgr, nil
 }
@@ -168,20 +170,21 @@ func registerSignalAuthenticationJob(jobGroup job.Group, mgr *AuthManager, sm si
 	return nil
 }
 
-func registerGCJobs(jobGroup job.Group, lifecycle cell.Lifecycle, mapGC *authMapGarbageCollector, cfg config, nodeManager nodeManager.NodeManager, endpointManager endpointmanager.EndpointManager, identityChanges stream.Observable[cache.IdentityChange]) {
+func registerGCJobs(jobGroup job.Group, lifecycle cell.Lifecycle, mapGC *authMapGarbageCollector, cfg config, endpointManager endpointmanager.EndpointManager, identityChanges stream.Observable[cache.IdentityChange]) {
 	lifecycle.Append(cell.Hook{
 		OnStart: func(hookContext cell.HookContext) error {
-			mapGC.subscribeToNodeEvents(nodeManager)
 			mapGC.subscribeToEndpointEvents(endpointManager)
 			return nil
 		},
 		OnStop: func(hookContext cell.HookContext) error {
-			nodeManager.Unsubscribe(mapGC)
 			endpointManager.Unsubscribe(mapGC)
 			return nil
 		},
 	})
 
+	jobGroup.Add(job.OneShot("auth-gc-node-events", func(ctx context.Context, _ cell.Health) error {
+		return mapGC.observeNodeChanges(ctx)
+	}))
 	jobGroup.Add(job.Observer("auth-gc-identity-events", mapGC.handleIdentityChange, identityChanges))
 	jobGroup.Add(job.Timer("auth-gc-cleanup", mapGC.cleanup, cfg.MeshAuthGCInterval))
 }


### PR DESCRIPTION
Replace the auth-map garbage collector's NodeManager subscription with a rate-limited node-table root watch. Track node membership and active datapath node IDs in one table traversal, and schedule cleanup only when the node set changes.

Wait for node-table initialization before enabling cleanup and defer destructive map updates while an active node ID is unavailable. Update the auth cell wiring and tests for node additions, removals, ordinary updates, and delayed node-ID allocation.

AIL:3
Related: https://github.com/cilium/cilium/issues/41744