### PR TITLE
neighbordiscovery: Observe node table for neighbor discovery

### DIFF
--- a/pkg/datapath/neighbor/forwardable_ip.go
+++ b/pkg/datapath/neighbor/forwardable_ip.go
@@ -5,6 +5,7 @@ package neighbor
 
 import (
 	"fmt"
+	"iter"
 	"net/netip"
 	"slices"
 	"strings"
@@ -90,6 +91,16 @@ var (
 		FromString: index.NetIPAddrString,
 		Unique:     true,
 	}
+
+	forwardableIPOwnerIndex = statedb.Index[*ForwardableIP, ForwardableIPOwner]{
+		Name: "owner",
+		FromObject: func(fip *ForwardableIP) index.KeySet {
+			return index.StringerSlice(fip.Owners)
+		},
+		FromKey:    index.Stringer[ForwardableIPOwner],
+		FromString: index.FromString,
+		Unique:     false,
+	}
 )
 
 // Return the read-only table for consumption, and the [ForwardableIPManager] for modification.
@@ -98,6 +109,7 @@ func newForwardableIPTable(db *statedb.DB, config *CommonConfig) (*ForwardableIP
 		db,
 		"forwardable-ip",
 		ForwardableIPIndex,
+		forwardableIPOwnerIndex,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -225,6 +237,65 @@ func (fim *ForwardableIPManager) Delete(ip netip.Addr, owner ForwardableIPOwner)
 
 	tx.Commit()
 
+	return nil
+}
+
+// Set replaces the set of forwardable IPs associated with owner. Changes to
+// all addresses are committed atomically and ownership by other owners is
+// preserved.
+func (fim *ForwardableIPManager) Set(owner ForwardableIPOwner, addresses iter.Seq[netip.Addr]) error {
+	if !fim.config.Enabled {
+		return fmt.Errorf("L2 neighbor discovery is not enabled")
+	}
+
+	desired := map[netip.Addr]struct{}{}
+	for address := range addresses {
+		desired[address] = struct{}{}
+	}
+
+	tx := fim.db.WriteTxn(fim.table)
+	defer tx.Abort()
+
+	current := map[netip.Addr]*ForwardableIP{}
+	for fip := range fim.table.List(tx, forwardableIPOwnerIndex.Query(owner)) {
+		current[fip.IP] = fip
+	}
+
+	for ip, fip := range current {
+		if _, found := desired[ip]; found {
+			delete(desired, ip)
+			continue
+		}
+
+		owners := slices.Clone(fip.Owners)
+		idx := slices.Index(owners, owner)
+		if idx < 0 {
+			continue
+		}
+		owners = slices.Delete(owners, idx, idx+1)
+		if len(owners) == 0 {
+			if _, _, err := fim.table.Delete(tx, fip); err != nil {
+				return err
+			}
+		} else {
+			updated := &ForwardableIP{IP: ip, Owners: owners}
+			if _, _, err := fim.table.Insert(tx, updated); err != nil {
+				return err
+			}
+		}
+	}
+
+	for ip := range desired {
+		fip := &ForwardableIP{IP: ip, Owners: []ForwardableIPOwner{owner}}
+		if _, _, err := fim.table.Modify(tx, fip, func(old, new *ForwardableIP) *ForwardableIP {
+			new.Owners = append(slices.Clone(old.Owners), owner)
+			return new
+		}); err != nil {
+			return err
+		}
+	}
+
+	tx.Commit()
 	return nil
 }
 

--- a/pkg/datapath/neighbor/forwardable_ip_test.go
+++ b/pkg/datapath/neighbor/forwardable_ip_test.go
@@ -5,6 +5,7 @@ package neighbor
 
 import (
 	"net/netip"
+	"slices"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -105,6 +106,46 @@ func TestForwardableIPManager(t *testing.T) {
 	// Delete ip1:nodeOwner, should remove the node owner from the existing entry
 	// but keep the entry in the table
 	err = fim.Delete(ip1, nodeOwner)
+	require.NoError(t, err)
+	fis = statedb.Collect(fip.All(db.ReadTxn()))
+	require.ElementsMatch(t, fis, []*ForwardableIP{
+		{
+			IP:     ip1,
+			Owners: []ForwardableIPOwner{serviceOwner},
+		},
+	})
+
+	// Set atomically replaces all IPs for one owner while retaining ownership
+	// by others.
+	err = fim.Set(nodeOwner, slices.Values([]netip.Addr{ip1, ip2}))
+	require.NoError(t, err)
+	fis = statedb.Collect(fip.All(db.ReadTxn()))
+	require.ElementsMatch(t, fis, []*ForwardableIP{
+		{
+			IP:     ip1,
+			Owners: []ForwardableIPOwner{serviceOwner, nodeOwner},
+		},
+		{
+			IP:     ip2,
+			Owners: []ForwardableIPOwner{nodeOwner},
+		},
+	})
+
+	err = fim.Set(nodeOwner, slices.Values([]netip.Addr{ip2}))
+	require.NoError(t, err)
+	fis = statedb.Collect(fip.All(db.ReadTxn()))
+	require.ElementsMatch(t, fis, []*ForwardableIP{
+		{
+			IP:     ip1,
+			Owners: []ForwardableIPOwner{serviceOwner},
+		},
+		{
+			IP:     ip2,
+			Owners: []ForwardableIPOwner{nodeOwner},
+		},
+	})
+
+	err = fim.Set(nodeOwner, slices.Values([]netip.Addr{}))
 	require.NoError(t, err)
 	fis = statedb.Collect(fip.All(db.ReadTxn()))
 	require.ElementsMatch(t, fis, []*ForwardableIP{

--- a/pkg/node/neighbordiscovery/node_neighbor_discovery.go
+++ b/pkg/node/neighbordiscovery/node_neighbor_discovery.go
@@ -4,202 +4,171 @@
 package neighbordiscovery
 
 import (
+	"context"
 	"fmt"
+	"iter"
+	"maps"
 	"net/netip"
+	"sync"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/manager"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var Cell = cell.Module(
 	"node-neighbor-discovery",
-	"A node handler that manages forwardable IPs for nodes in the cluster",
-	cell.Invoke(NewNodeNeighborHandler),
+	"Observes nodes to manage forwardable IPs for the cluster",
+	cell.Invoke(registerNodeNeighborDiscovery),
 )
 
-var (
-	_ node.Handler         = (*nodeNeighborHandler)(nil)
-	_ config.ChangeHandler = (*nodeNeighborHandler)(nil)
-)
+const changeRateLimit = 50 * time.Millisecond
 
-// NewNodeNeighborHandler initializes the node neighbor handler and
-// subscribes it to the node manager if L2 neighbor discovery is enabled.
-// It will add forwardable IPs for all nodes in the cluster to the
-func NewNodeNeighborHandler(
-	nodeManger manager.NodeManager,
+type forwardableIPManager interface {
+	Set(neighbor.ForwardableIPOwner, iter.Seq[netip.Addr]) error
+	FinishInitializer(neighbor.ForwardableIPInitializer)
+}
+
+// registerNodeNeighborDiscovery observes the node table if L2 neighbor
+// discovery is enabled and maintains the node-owned forwardable IPs.
+func registerNodeNeighborDiscovery(
+	db *statedb.DB,
+	jobs job.Group,
+	nodes statedb.Table[*node.Node],
 	forwardableIPManager *neighbor.ForwardableIPManager,
 	nodeConfigNotifier *manager.NodeConfigNotifier,
-) {
-	// If the forwardable IP manager is not enabled, then there is no point to
-	// doing any work here.
+) error {
 	if !forwardableIPManager.Enabled() {
-		return
+		return nil
 	}
 
-	nnh := &nodeNeighborHandler{
-		forwardableIPManager: forwardableIPManager,
-		initializer:          forwardableIPManager.RegisterInitializer("node-neighbor-discovery"),
+	initializer := forwardableIPManager.RegisterInitializer("node-neighbor-discovery")
+	observer, err := newNodeNeighborObserver(db, nodes, forwardableIPManager, initializer)
+	if err != nil {
+		return fmt.Errorf("creating node change iterator: %w", err)
 	}
 
-	nodeManger.Subscribe(nnh)
-	nodeConfigNotifier.Subscribe(nnh)
+	nodeConfigNotifier.Subscribe(observer)
+	jobs.Add(
+		job.OneShot("node-neighbor-discovery", observer.run),
+	)
+	return nil
 }
 
-type nodeNeighborHandler struct {
-	forwardableIPManager *neighbor.ForwardableIPManager
+type nodeNeighborObserver struct {
+	db                   *statedb.DB
+	nodes                statedb.Table[*node.Node]
+	changes              statedb.ChangeIterator[*node.Node]
+	forwardableIPManager forwardableIPManager
 	initializer          neighbor.ForwardableIPInitializer
+
+	configInitialized chan struct{}
+	configInitOnce    sync.Once
 }
 
-// Name identifies the handler, this is used in logging/reporting handler
-// reconciliation errors.
-func (nnh *nodeNeighborHandler) Name() string {
-	return "node-neighbor-handler"
+var _ config.ChangeHandler = (*nodeNeighborObserver)(nil)
+
+func newNodeNeighborObserver(
+	db *statedb.DB,
+	nodes statedb.Table[*node.Node],
+	forwardableIPManager forwardableIPManager,
+	initializer neighbor.ForwardableIPInitializer,
+) (*nodeNeighborObserver, error) {
+	wtxn := db.WriteTxn(nodes)
+	changes, err := nodes.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodeNeighborObserver{
+		db:                   db,
+		nodes:                nodes,
+		changes:              changes,
+		forwardableIPManager: forwardableIPManager,
+		initializer:          initializer,
+		configInitialized:    make(chan struct{}),
+	}, nil
 }
 
-// NodeAdd is called when a node is discovered for the first time.
-func (nnh *nodeNeighborHandler) NodeAdd(newNode nodeTypes.Node) error {
-	// We only want to add forwardable IPs for nodes that are not local.
-	if newNode.IsLocal() {
-		return nil
-	}
+func (o *nodeNeighborObserver) run(ctx context.Context, _ cell.Health) error {
+	defer o.changes.Close()
 
-	if newNode.GetNodeIP(false).To4() != nil {
-		ipv4, ok := netip.AddrFromSlice(newNode.GetNodeIP(false).To4())
-		if ok {
-			err := nnh.forwardableIPManager.Insert(
-				ipv4,
-				neighbor.ForwardableIPOwner{
-					Type: neighbor.ForwardableIPOwnerNode,
-					ID:   newNode.Identity().String(),
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to insert forwardable IP for node %s: %w", newNode.Name, err)
+	limiter := rate.NewLimiter(changeRateLimit, 1)
+	defer limiter.Stop()
+
+	txn := o.db.ReadTxn()
+	_, initWatch := o.nodes.Initialized(txn)
+	configWatch := o.configInitialized
+	initDone := false
+
+	for {
+		changes, watch := o.changes.Next(txn)
+		for change := range changes {
+			if err := o.apply(change); err != nil {
+				return err
 			}
 		}
-	}
 
-	if newNode.GetNodeIP(true).To16() != nil {
-		ipv6, ok := netip.AddrFromSlice(newNode.GetNodeIP(true).To16())
-		if ok {
-			err := nnh.forwardableIPManager.Insert(
-				ipv6,
-				neighbor.ForwardableIPOwner{
-					Type: neighbor.ForwardableIPOwnerNode,
-					ID:   newNode.Identity().String(),
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to insert forwardable IP for node %s: %w", newNode.Name, err)
-			}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		case <-initWatch:
+			initWatch = nil
+		case <-configWatch:
+			configWatch = nil
 		}
+
+		if !initDone && initWatch == nil && configWatch == nil {
+			initDone = true
+			o.forwardableIPManager.FinishInitializer(o.initializer)
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			return nil
+		}
+
+		txn = o.db.ReadTxn()
+	}
+}
+
+func (o *nodeNeighborObserver) apply(change statedb.Change[*node.Node]) error {
+	n := change.Object
+	id := n.Identity()
+	ips := nodeIPs(n)
+	if change.Deleted || n.Local != nil {
+		ips = nil
 	}
 
+	owner := neighbor.ForwardableIPOwner{
+		Type: neighbor.ForwardableIPOwnerNode,
+		ID:   id.String(),
+	}
+	if err := o.forwardableIPManager.Set(owner, maps.Keys(ips)); err != nil {
+		return fmt.Errorf("setting forwardable IPs for node %s: %w", id, err)
+	}
 	return nil
 }
 
-// NodeUpdate is called when a node definition changes. Both the old
-// and new node definition is provided. NodeUpdate() is never called
-// before NodeAdd() is called for a particular node.
-func (nnh *nodeNeighborHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
-	// We only want to add forwardable IPs for nodes that are not local.
-	if oldNode.IsLocal() {
-		return nil
-	}
-
-	// We only care if the node name or IP address has changed.
-	if oldNode.Identity().String() != newNode.Identity().String() ||
-		!oldNode.GetNodeIP(false).To4().Equal(newNode.GetNodeIP(false).To4()) ||
-		!oldNode.GetNodeIP(true).To16().Equal(newNode.GetNodeIP(true).To16()) {
-
-		if err := nnh.NodeDelete(oldNode); err != nil {
-			return fmt.Errorf("failed to delete old node %s: %w", oldNode.Name, err)
-		}
-
-		if err := nnh.NodeAdd(newNode); err != nil {
-			return fmt.Errorf("failed to add new node %s: %w", newNode.Name, err)
+func nodeIPs(n *node.Node) map[netip.Addr]struct{} {
+	ips := map[netip.Addr]struct{}{}
+	for _, ipv6 := range []bool{false, true} {
+		if ip, ok := netip.AddrFromSlice(n.GetNodeIP(ipv6)); ok {
+			ips[ip.Unmap()] = struct{}{}
 		}
 	}
-
-	return nil
+	return ips
 }
 
-// NodeDelete is called after a node has been deleted
-func (nnh *nodeNeighborHandler) NodeDelete(node nodeTypes.Node) error {
-	// We only want to add forwardable IPs for nodes that are not local.
-	if node.IsLocal() {
-		return nil
-	}
-
-	if node.GetNodeIP(false).To4() != nil {
-		ipv4, ok := netip.AddrFromSlice(node.GetNodeIP(false).To4())
-		if ok {
-			err := nnh.forwardableIPManager.Delete(
-				ipv4,
-				neighbor.ForwardableIPOwner{
-					Type: neighbor.ForwardableIPOwnerNode,
-					ID:   node.Name,
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to delete forwardable IP for node %s: %w", node.Name, err)
-			}
-		}
-	}
-
-	if node.GetNodeIP(true).To16() != nil {
-		ipv6, ok := netip.AddrFromSlice(node.GetNodeIP(true).To16())
-		if ok {
-			err := nnh.forwardableIPManager.Delete(
-				ipv6,
-				neighbor.ForwardableIPOwner{
-					Type: neighbor.ForwardableIPOwnerNode,
-					ID:   node.Name,
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to delete forwardable IP for node %s: %w", node.Name, err)
-			}
-		}
-	}
-
-	return nil
-}
-
-// AllNodeValidateImplementation is called to validate the implementation
-// of all nodes in the node cache.
-func (nnh *nodeNeighborHandler) AllNodeValidateImplementation() {
-	// This is a no-op for the node neighbor handler.
-}
-
-// NodeValidateImplementation is called to validate the implementation of
-// the node in the datapath. This function is intended to be run on an
-// interval to ensure that the datapath is consistently converged.
-func (nnh *nodeNeighborHandler) NodeValidateImplementation(node nodeTypes.Node) error {
-	// We only want to add forwardable IPs for nodes that are not local.
-	if node.IsLocal() {
-		return nil
-	}
-
-	// [nodeNeighborHandler.NodeAdd] is idempotent, so a forwardable IP already exists
-	// this is a no-op. If the forwardable IP does not exist, it will be created.
-	return nnh.NodeAdd(node)
-}
-
-// NodeConfigurationChanged is called when the local node configuration
-// has changed
-func (nnh *nodeNeighborHandler) NodeConfigurationChanged(config config.Config) error {
-
-	// `NodeConfigurationChanged` is called by the loader when the datapath is initialized.
-	// We use this event as a signal that `NodeAdd` should have been called for all nodes
-	// we should know about and that we can consider our entries in the forwardable IP manager
-	// as initialized.
-	nnh.forwardableIPManager.FinishInitializer(nnh.initializer)
-
+func (o *nodeNeighborObserver) NodeConfigurationChanged(config.Config) error {
+	o.configInitOnce.Do(func() { close(o.configInitialized) })
 	return nil
 }

--- a/pkg/node/neighbordiscovery/node_neighbor_discovery_test.go
+++ b/pkg/node/neighbordiscovery/node_neighbor_discovery_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package neighbordiscovery
+
+import (
+	"context"
+	"iter"
+	"maps"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/datapath/config"
+	"github.com/cilium/cilium/pkg/datapath/neighbor"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type fakeForwardableIPManager struct {
+	mu          lock.Mutex
+	entries     map[netip.Addr]neighbor.ForwardableIPOwner
+	insertCount int
+	deleteCount int
+	initialized chan struct{}
+	initOnce    sync.Once
+}
+
+func newFakeForwardableIPManager() *fakeForwardableIPManager {
+	return &fakeForwardableIPManager{
+		entries:     map[netip.Addr]neighbor.ForwardableIPOwner{},
+		initialized: make(chan struct{}),
+	}
+}
+
+func (m *fakeForwardableIPManager) Set(
+	owner neighbor.ForwardableIPOwner,
+	addresses iter.Seq[netip.Addr],
+) error {
+	desired := map[netip.Addr]struct{}{}
+	for ip := range addresses {
+		desired[ip] = struct{}{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for ip, currentOwner := range m.entries {
+		if currentOwner == owner {
+			if _, found := desired[ip]; found {
+				delete(desired, ip)
+				continue
+			}
+			delete(m.entries, ip)
+			m.deleteCount++
+		}
+	}
+	for ip := range desired {
+		m.entries[ip] = owner
+		m.insertCount++
+	}
+	return nil
+}
+
+func (m *fakeForwardableIPManager) FinishInitializer(neighbor.ForwardableIPInitializer) {
+	m.initOnce.Do(func() { close(m.initialized) })
+}
+
+func (m *fakeForwardableIPManager) snapshot() (map[netip.Addr]neighbor.ForwardableIPOwner, int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return maps.Clone(m.entries), m.insertCount, m.deleteCount
+}
+
+func TestNodeNeighborObserver(t *testing.T) {
+	db := statedb.New()
+	nodes, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(nodes)
+	initialNodesDone := nodes.RegisterInitializer(wtxn, "test")
+	wtxn.Commit()
+
+	manager := newFakeForwardableIPManager()
+	observer, err := newNodeNeighborObserver(
+		db,
+		nodes,
+		manager,
+		neighbor.ForwardableIPInitializer{},
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- observer.run(ctx, nil) }()
+
+	n1 := &node.Node{
+		Node: nodeTypes.Node{
+			Name:    "node-1",
+			Cluster: "cluster-1",
+			Source:  source.CustomResource,
+			IPAddresses: []nodeTypes.Address{
+				{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")},
+				{Type: addressing.NodeInternalIP, IP: net.ParseIP("2001:db8::1")},
+			},
+		},
+	}
+	local := &node.Node{
+		Node: nodeTypes.Node{
+			Name:    "local",
+			Cluster: "cluster-1",
+			Source:  source.Local,
+			IPAddresses: []nodeTypes.Address{
+				{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.2")},
+			},
+		},
+		Local: &node.LocalNodeInfo{},
+	}
+
+	wtxn = db.WriteTxn(nodes)
+	nodes.Insert(wtxn, n1)
+	nodes.Insert(wtxn, local)
+	wtxn.Commit()
+
+	wantOwner := neighbor.ForwardableIPOwner{
+		Type: neighbor.ForwardableIPOwnerNode,
+		ID:   n1.Identity().String(),
+	}
+	require.Eventually(t, func() bool {
+		entries, _, _ := manager.snapshot()
+		return maps.Equal(entries, map[netip.Addr]neighbor.ForwardableIPOwner{
+			netip.MustParseAddr("10.0.0.1"):    wantOwner,
+			netip.MustParseAddr("2001:db8::1"): wantOwner,
+		})
+	}, time.Second, time.Millisecond)
+
+	// Neither readiness signal is sufficient on its own.
+	require.NoError(t, observer.NodeConfigurationChanged(config.Config{}))
+	select {
+	case <-manager.initialized:
+		t.Fatal("initializer finished before the node table was initialized")
+	default:
+	}
+
+	wtxn = db.WriteTxn(nodes)
+	initialNodesDone(wtxn)
+	wtxn.Commit()
+	select {
+	case <-manager.initialized:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwardable-IP initialization")
+	}
+
+	// An update unrelated to node IPs must not touch the forwardable-IP set.
+	_, insertsBefore, deletesBefore := manager.snapshot()
+	n1WithLabel := &node.Node{Node: n1.Node}
+	n1WithLabel.Labels = map[string]string{"unrelated": "label"}
+	wtxn = db.WriteTxn(nodes)
+	nodes.Insert(wtxn, n1WithLabel)
+	wtxn.Commit()
+	require.Never(t, func() bool {
+		_, inserts, deletes := manager.snapshot()
+		return inserts != insertsBefore || deletes != deletesBefore
+	}, 2*changeRateLimit, time.Millisecond)
+
+	// Changing an address removes only the old address and inserts the new one.
+	n1Updated := &node.Node{
+		Node: nodeTypes.Node{
+			Name:    n1.Name,
+			Cluster: n1.Cluster,
+			Source:  n1.Source,
+			IPAddresses: []nodeTypes.Address{
+				{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.3")},
+				{Type: addressing.NodeInternalIP, IP: net.ParseIP("2001:db8::1")},
+			},
+		},
+	}
+	wtxn = db.WriteTxn(nodes)
+	nodes.Insert(wtxn, n1Updated)
+	wtxn.Commit()
+	require.Eventually(t, func() bool {
+		entries, inserts, deletes := manager.snapshot()
+		return inserts == insertsBefore+1 && deletes == deletesBefore+1 &&
+			maps.Equal(entries, map[netip.Addr]neighbor.ForwardableIPOwner{
+				netip.MustParseAddr("10.0.0.3"):    wantOwner,
+				netip.MustParseAddr("2001:db8::1"): wantOwner,
+			})
+	}, time.Second, time.Millisecond)
+
+	// Deletion uses the same clustered identity as insertion.
+	wtxn = db.WriteTxn(nodes)
+	nodes.Delete(wtxn, n1Updated)
+	wtxn.Commit()
+	require.Eventually(t, func() bool {
+		entries, _, _ := manager.snapshot()
+		return len(entries) == 0
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-runErr)
+}


### PR DESCRIPTION
Replace the NodeManager handler with a rate-limited StateDB change observer. Track each node's current IP set so unrelated updates do not rewrite forwardable IP entries and use the full node identity for both insertion and deletion.

Keep the forwardable IP table uninitialized until the node table snapshot has been consumed and datapath configuration is available.

AIL:3
Related: https://github.com/cilium/cilium/issues/41744