### PR TITLE
devcontainer: Update to work with new ubuntu 26.04 base and skip redundant nested container exec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,11 @@
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker": {}
+    // Ubuntu 26.04 (resolute) has no moby-* packages, so install Docker CE
+    // instead: the feature hard-fails with moby enabled on that distribution.
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "moby": false
+    }
   },
   "mounts": [
     // To enable kernel modules for devcontainer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
   "image": "quay.io/cilium/cilium-builder:2db810de99c504c5eb4c51baf7e836acb38d0050@sha256:8e62d9e0921c81ba4cd7f3a01ef736ae34c002fe0ab3f670e61585e46b2bbf9f",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
+  // This container is based on the cilium-builder image, so contrib/scripts/builder.sh can run commands
+  // in place instead of spawning another builder nested container.
+  "containerEnv": {
+    "IN_CILIUM_BUILDER_CONTAINER": "1"
+  },
   "features": {
     // Ubuntu 26.04 (resolute) has no moby-* packages, so install Docker CE
     // instead: the feature hard-fails with moby enabled on that distribution.

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -9,6 +9,11 @@ fi
 
 cd "$(dirname "$0")/../.."
 
+# Don't spawn a nested cilium-builder container if we're already running in one.
+if [ "${IN_CILIUM_BUILDER_CONTAINER:-}" = "1" ]; then
+	exec "$@"
+fi
+
 CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
 
 GO="$(which go 2> /dev/null || :)"
@@ -128,4 +133,4 @@ else
 fi
 docker exec "$CONTAINER" mkdir -p /home/ubuntu/.cache
 docker exec "$CONTAINER" chown "${CHOWN_FLAGS[@]}" ubuntu:ubuntu /home/ubuntu/.cache
-docker exec "${USER_OPTION[@]}" ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"
+docker exec "${USER_OPTION[@]}" -e IN_CILIUM_BUILDER_CONTAINER=1 ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"


### PR DESCRIPTION
Two small fixes for the devcontainer, see each commit for details:

---

The cilium-builder image that is used as the base for the repository's
devcontainer is based on Ubuntu 26.04 since https://github.com/cilium/cilium/pull/47215. The docker-in-docker
devcontainer feature fails to install Moby on that release as the
package is not available in that ubuntu release.

See error:
```
$ devcontainer up --workspace-folder .
[...]
> [dev_containers_target_stage 5/5] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-in-docker_0,target=/tmp/build-features-src/docker-in-docker_0     cp -ar /tmp/build-features-src/docker-in-docker_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/docker-in-docker_0  && cd /tmp/dev-container-features/docker-in-docker_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/docker-in-docker_0:
  0.076 ===========================================================================
  0.076 Feature       : Docker (Docker-in-Docker)
  0.076 Description   : Create child containers inside a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
  0.076 Id            : ghcr.io/devcontainers/features/docker-in-docker
  0.076 Version       : 4.0.0
  0.076 Documentation : https://github.com/devcontainers/features/tree/main/src/docker-in-docker
  0.076 Options       :
  0.076     VERSION="latest"
  0.076     MOBY="true"
  0.076     MOBYBUILDXVERSION="latest"
  0.076     DOCKERDASHCOMPOSEVERSION="latest"
  0.076     AZUREDNSAUTODETECTION="true"
  0.076     DOCKERDEFAULTADDRESSPOOL=""
  0.076     INSTALLDOCKERBUILDX="true"
  0.076     INSTALLDOCKERCOMPOSESWITCH="false"
  0.076     DISABLEIP6TABLES="false"
  0.076     IPTABLESSWITCHATRUNTIME="true"
  0.076 ===========================================================================
  0.082 (!) The 'moby' option is not supported on ubuntu 'resolute' because 'moby-cli' and related system packages are not available in that distribution.
  0.082 (!) To continue, either set the feature option '"moby": false' or use a different base image.
  0.082 ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/docker-in-docker for help troubleshooting this error.
```

After this patch:
```
$ devcontainer up --workspace-folder .
[...] # suceeds
$ devcontainer exec cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=26.04
DISTRIB_CODENAME=resolute
DISTRIB_DESCRIPTION="Ubuntu 26.04 LTS"
```

---

A lot of make targets use `contrib/scripts/builder.sh` to ensure they
get executed in the reproducible context of the cilium-builder image.
But when using a devcontainer that's itself already a container based on
the cilium-builder image, this lead today to spawning a nested builder
contanienr needlessly, making things slower than they need to be.

Additionnally, since the devcontainer runs as root by default, the
`builder.sh` script is currently broken there since https://github.com/cilium/cilium/pull/46652.

This PR sets a sentinel `IN_CILIUM_BUILDER_CONTAINER` env var in
devcontainers and updates `builder.sh` to detect that sentinel and skip
the nested container exec.

---
