### PR TITLE
bpf: nat: fix ICMP csum in v4 SNAT path

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -814,7 +814,8 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx, fraginfo_t fraginfo, int l4_off
 #ifdef ENABLE_SNAT_ICMPV4
 static __always_inline __maybe_unused int
 snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
-			      struct ipv4_nat_entry **state)
+			      struct ipv4_nat_entry **state,
+			      __wsum *outer_csum_diff)
 {
 	__u32 inner_l3_off = (__u32)(off + sizeof(struct icmphdr));
 	struct ipv4_ct_tuple tuple = {};
@@ -824,6 +825,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	__u8 type;
 	int ret;
 	bool icmp_has_inner_l4_csum = true;
+	bool is_inner_l4_csum_enabled = true;
 	__u32 total_inner_len = (__u32)ctx_full_len(ctx) - inner_l3_off;
 
 	/* According to the RFC 5508, any networking equipment that is
@@ -887,6 +889,24 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + TCP_CSUM_SIZE)
 		icmp_has_inner_l4_csum = false;
 
+	/* For UDP, a checksum value of zero means that no checksum */
+	if (tuple.nexthdr == IPPROTO_UDP) {
+		__be16 l4_csum_be = 0;
+
+		if (ctx_load_bytes(ctx, inner_l4_off + offsetof(struct udphdr, check),
+				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
+			return DROP_INVALID;
+		if (l4_csum_be == 0)
+			is_inner_l4_csum_enabled = false;
+	}
+
+	/* Calculate the diff for the outer ICMP checksum. */
+	snat_v4_calc_icmp_error_csum_diff(tuple.saddr, (*state)->to_saddr,
+					  tuple.sport, (*state)->to_sport,
+					  icmp_has_inner_l4_csum &&
+					  is_inner_l4_csum_enabled,
+					  outer_csum_diff);
+
 	/* We found SNAT entry to NAT embedded packet. The destination addr
 	 * should be NATed according to the entry.
 	 */
@@ -907,7 +927,8 @@ static __always_inline int
 __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	      struct ipv4_nat_entry *state, fraginfo_t fraginfo,
 	      int l4_off, bool update_tuple, const struct ipv4_nat_target *target,
-	      __u16 port_off, struct trace_ctx *trace, __s8 *ext_err)
+	      __u16 port_off, __wsum outer_csum_diff,
+	      struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_nat_entry tmp;
 	__be16 to_sport = 0;
@@ -928,7 +949,7 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	ret = snat_v4_rewrite_headers(ctx, tuple->nexthdr, ETH_HLEN,
 				      ipfrag_has_l4_header(fraginfo), l4_off,
 				      tuple->saddr, state->to_saddr, IPV4_SADDR_OFF,
-				      tuple->sport, to_sport, port_off, 0);
+				      tuple->sport, to_sport, port_off, outer_csum_diff);
 
 	if (update_tuple) {
 		tuple->saddr = state->to_saddr;
@@ -945,6 +966,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_nat_entry *state = NULL;
+	__wsum outer_csum_diff = 0;
 	__u16 port_off = 0;
 	int ret;
 
@@ -1018,7 +1040,8 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			}
 
 nat_icmp_v4:
-			ret = snat_v4_nat_handle_icmp_error(ctx, off, &state);
+			ret = snat_v4_nat_handle_icmp_error(ctx, off, &state,
+							    &outer_csum_diff);
 			if (IS_ERR(ret))
 				return ret;
 
@@ -1034,7 +1057,7 @@ nat_icmp_v4:
 	};
 
 	return __snat_v4_nat(ctx, tuple, state, fraginfo, off, false, target,
-			     port_off, trace, ext_err);
+			     port_off, outer_csum_diff, trace, ext_err);
 }
 
 #ifdef ENABLE_SNAT_ICMPV4

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2537,7 +2537,7 @@ skip_source_lookup:
 		goto drop_err;
 
 	ret = __snat_v4_nat(ctx, &tuple, state, fraginfo, l4_off, true,
-			    &target, TCP_SPORT_OFF, &trace, &ext_err);
+			    &target, TCP_SPORT_OFF, 0, &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;
 

--- a/bpf/tests/bpf_nat_icmp.h
+++ b/bpf/tests/bpf_nat_icmp.h
@@ -56,6 +56,22 @@ const __u8 icmp4_err_revnat_min_tcp_after[] = {
 	SCAPY_BUF_BYTES(icmp4_err_revnat_min_tcp_after)
 };
 
+const __u8 icmp4_tcp_ingress[] = {
+	SCAPY_BUF_BYTES(icmp4_tcp_ingress)
+};
+
+const __u8 icmp4_tcp_ingress_post_revnat[] = {
+	SCAPY_BUF_BYTES(icmp4_tcp_ingress_post_revnat)
+};
+
+const __u8 icmp4_err_nat_full_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nat_full_tcp)
+};
+
+const __u8 icmp4_err_nat_full_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nat_full_tcp_after)
+};
+
 /*
  * Push an egressing pod->external TCP packet through to-netdev and let the
  * datapath set up nat mappings due to node ip masquerading. 
@@ -182,6 +198,72 @@ int snat_v4_pmtu_min_hdr_check(const struct __ctx_buff *ctx)
 	ASSERT_CTX_BUF_OFF("snat_v4_tcp_pmtu_min_hdr", "Ether", ctx, sizeof(__u32),
 			   icmp4_err_revnat_min_tcp_after,
 			   sizeof(icmp4_err_revnat_min_tcp_after));
+	test_finish();
+
+	return 0;
+}
+
+/*
+ * Receive a packet and forward it to the pod. The pod rejects it, sends an ICMP error,
+ * ICMP error is fully NATed on the way out.
+ */
+PKTGEN(PROG_TYPE, "snat_v4_tcp_unreach_1")
+int snat_v4_tcp_unreach_1_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_tcp_ingress,
+			sizeof(icmp4_tcp_ingress));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "snat_v4_tcp_unreach_1")
+int snat_v4_tcp_unreach_1_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "snat_v4_tcp_unreach_1")
+int snat_v4_tcp_unreach_1_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_unreach_1", "Ether", ctx, sizeof(__u32),
+			   icmp4_tcp_ingress_post_revnat,
+			   sizeof(icmp4_tcp_ingress_post_revnat));
+	test_finish();
+
+	return 0;
+}
+
+PKTGEN(PROG_TYPE, "snat_v4_tcp_unreach_2")
+int snat_v4_tcp_unreach_2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_nat_full_tcp,
+			sizeof(icmp4_err_nat_full_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "snat_v4_tcp_unreach_2")
+int snat_v4_tcp_unreach_2_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "snat_v4_tcp_unreach_2")
+int snat_v4_tcp_unreach_2_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_unreach_2", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_nat_full_tcp_after,
+			   sizeof(icmp4_err_nat_full_tcp_after));
 	test_finish();
 
 	return 0;

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -75,6 +75,34 @@ icmp4_err_revnat_min_tcp_after = (
     Raw(_tcp_hdr_min_after)
 )
 
+icmp4_tcp_ingress = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_node_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_two) /
+    Raw(default_data)
+)
+
+icmp4_tcp_ingress_post_revnat = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_two) /
+    Raw(default_data)
+)
+
+icmp4_err_nat_full_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_one, dst=v4_ext_one) /
+    ICMP(type="dest-unreach", code="communication-prohibited") /
+    IPerror(bytes(icmp4_tcp_ingress_post_revnat[IP]))
+)
+
+icmp4_err_nat_full_tcp_after = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_ext_one) /
+    ICMP(type="dest-unreach", code="communication-prohibited") /
+    IPerror(bytes(icmp4_tcp_ingress[IP]))
+)
+
 # Shared header layers for the IPv6 egress flow, pre- and post-masquerade.
 _ip6_hdr_egress = IPv6(src=v6_pod_one, dst=v6_ext_node_one)
 _udp_hdr_egress = UDP(sport=tcp_src_two, dport=tcp_dst_one)


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/43196 fixed a bug
in the v4 RevSNAT path for ICMP error packets - when
rewriting the inner packet, this wasn't reflected in the
outer ICMP header's checksum field.

Now apply the same fix for the v4 SNAT path.

```release-note
Fix ICMP error packet handling by adding the missing checksum recalculation performed during NAT for SNATed load-balanced traffic.
```