### PR TITLE
bgp: Move bgp config flags to bgp cell

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,6 +30,7 @@ cilium-agent [flags]
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
       --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                              Kubernetes namespace to get BGP control plane secrets from
       --bpf-auth-map-max int                                      Maximum number of entries in auth map (default 524288)
       --bpf-conntrack-accounting                                  Enable CT accounting for packets and bytes (default false)
       --bpf-ct-global-any-max int                                 Maximum number of entries in non-TCP CT table (default 262144)
@@ -118,7 +119,7 @@ cilium-agent [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
-      --enable-bgp-control-plane                                  Enable the BGP control plane.
+      --enable-bgp-control-plane                                  Enable the BGP control plane
       --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
       --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-bpf-clock-probe                                    Enable BPF clock source probing for more efficient tick retrieval

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -21,6 +21,9 @@ cilium-agent hive [flags]
       --alibabacloud-vswitches strings                            List of VSwitches to use for ENI and IP allocation at the node level
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
+      --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                              Kubernetes namespace to get BGP control plane secrets from
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")
@@ -67,6 +70,8 @@ cilium-agent hive [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
+      --enable-bgp-control-plane                                  Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
       --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-bpf-stats                                          Enable BPF statistics collection
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -27,6 +27,9 @@ cilium-agent hive dot-graph [flags]
       --alibabacloud-vswitches strings                            List of VSwitches to use for ENI and IP allocation at the node level
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
+      --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                              Kubernetes namespace to get BGP control plane secrets from
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")
@@ -73,6 +76,8 @@ cilium-agent hive dot-graph [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
+      --enable-bgp-control-plane                                  Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
       --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-bpf-stats                                          Enable BPF statistics collection
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])

--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -22,6 +22,12 @@ cilium-dbg preflight migrate-identity [flags]
 ### Options
 
 ```
+      --bgp-router-id-allocation-ip-pool string     IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string        BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                Kubernetes namespace to get BGP control plane secrets from
+      --enable-bgp-control-plane                    Enable the BGP control plane
+      --enable-bgp-control-plane-status-report      Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute          Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-k8s                                  Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for migrate-identity

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -13,6 +13,9 @@ cilium-operator-alibabacloud [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -36,6 +39,9 @@ cilium-operator-alibabacloud [flags]
   -D, --debug                                                      Enable debugging mode
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -13,6 +13,9 @@ cilium-operator-alibabacloud hive [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -33,6 +36,9 @@ cilium-operator-alibabacloud hive [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -19,6 +19,9 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -39,6 +42,9 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -14,6 +14,9 @@ cilium-operator-aws [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces, DescribeSecurityGroups and GetSecurityGroupsForVpc. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -38,6 +41,9 @@ cilium-operator-aws [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -14,6 +14,9 @@ cilium-operator-aws hive [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces, DescribeSecurityGroups and GetSecurityGroupsForVpc. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -35,6 +38,9 @@ cilium-operator-aws hive [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -20,6 +20,9 @@ cilium-operator-aws hive dot-graph [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces, DescribeSecurityGroups and GetSecurityGroupsForVpc. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -41,6 +44,9 @@ cilium-operator-aws hive dot-graph [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -15,6 +15,9 @@ cilium-operator-azure [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -38,6 +41,9 @@ cilium-operator-azure [flags]
   -D, --debug                                                      Enable debugging mode
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -15,6 +15,9 @@ cilium-operator-azure hive [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -35,6 +38,9 @@ cilium-operator-azure hive [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -21,6 +21,9 @@ cilium-operator-azure hive dot-graph [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -41,6 +44,9 @@ cilium-operator-azure hive dot-graph [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -12,6 +12,9 @@ cilium-operator-generic [flags]
 
 ```
       --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -39,6 +42,9 @@ cilium-operator-generic [flags]
   -D, --debug                                                      Enable debugging mode
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -12,6 +12,9 @@ cilium-operator-generic hive [flags]
 
 ```
       --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -36,6 +39,9 @@ cilium-operator-generic hive [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -18,6 +18,9 @@ cilium-operator-generic hive dot-graph [flags]
 
 ```
       --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -42,6 +45,9 @@ cilium-operator-generic hive dot-graph [flags]
       --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -21,6 +21,9 @@ cilium-operator [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -49,6 +52,9 @@ cilium-operator [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -21,6 +21,9 @@ cilium-operator hive [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -46,6 +49,9 @@ cilium-operator hive [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -27,6 +27,9 @@ cilium-operator hive dot-graph [flags]
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
+      --bgp-router-id-allocation-ip-pool string                    IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                       BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                               Kubernetes namespace to get BGP control plane secrets from
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
@@ -52,6 +55,9 @@ cilium-operator hive dot-graph [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-bgp-control-plane                                   Enable the BGP control plane
+      --enable-bgp-control-plane-status-report                     Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -15,6 +15,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
@@ -36,7 +37,6 @@ import (
 const opTimeout = 30 * time.Second
 
 func migrateIdentityCmd() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "migrate-identity",
 		Short: "Migrate KVStore-backed identities to kubernetes CRD-backed identities",
@@ -52,10 +52,11 @@ func migrateIdentityCmd() *cobra.Command {
 
 	hive := hive.New(
 		k8sClient.Cell,
-		cell.Invoke(func(lc cell.Lifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
+		cell.Config(bgpConfig.DefaultConfig),
+		cell.Invoke(func(lc cell.Lifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner, bgpCfg bgpConfig.BGPConfig) {
 			lc.Append(cell.Hook{
 				OnStart: func(ctx cell.HookContext) error {
-					return migrateIdentities(ctx, clientset, shutdowner)
+					return migrateIdentities(ctx, clientset, shutdowner, bgpCfg)
 				},
 			})
 		}),
@@ -90,7 +91,7 @@ func migrateIdentityCmd() *cobra.Command {
 //
 // NOTE: It is assumed that the migration is from k8s to k8s installations. The
 // key labels different when running in non-k8s mode.
-func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) error {
+func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shutdowner hive.Shutdowner, bgpCfg bgpConfig.BGPConfig) error {
 	defer shutdowner.Shutdown()
 
 	// This allows us to initialize a CRD allocator
@@ -100,7 +101,7 @@ func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shut
 	initCtx, initCancel := context.WithTimeout(ctx, opTimeout)
 	kvstoreBackend := initKVStore(ctx, initCtx)
 
-	crdBackend, crdAllocator := initK8s(initCtx, clientset)
+	crdBackend, crdAllocator := initK8s(initCtx, clientset, bgpCfg)
 	initCancel()
 
 	log.Info("Listing identities in kvstore")
@@ -208,11 +209,11 @@ func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shut
 
 // initK8s connects to k8s with a allocator.Backend and an initialized
 // allocator.Allocator, using the k8s config passed into the command.
-func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend allocator.Backend, crdAllocator *allocator.Allocator) {
+func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfig.BGPConfig) (crdBackend allocator.Backend, crdAllocator *allocator.Allocator) {
 	log.Info("Setting up kubernetes client")
 
 	// Update CRDs to ensure ciliumIdentity is present
-	ciliumClient.RegisterCRDs(log, clientset)
+	ciliumClient.RegisterCRDs(log, clientset, bgpCfg)
 
 	// Create a CRD Backend
 	crdBackend, err := identitybackend.NewCRDBackend(log, identitybackend.CRDBackendConfiguration{

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgp"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bpf/stats"
 	cgroup "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/ciliumenvoyconfig"
@@ -172,8 +173,8 @@ var (
 		store.Cell,
 
 		// Provide CRD resource names for 'k8sSynced.CRDSyncCell' below.
-		cell.Provide(func() k8sSynced.CRDSyncResourceNamesOut {
-			return k8sSynced.NewCRDSyncResourceNamesOut(k8sSynced.AgentCRDResourceNames()...)
+		cell.Provide(func(bgpCfg bgpConfig.BGPConfig) k8sSynced.CRDSyncResourceNamesOut {
+			return k8sSynced.NewCRDSyncResourceNamesOut(k8sSynced.AgentCRDResourceNames(bgpCfg)...)
 		}),
 
 		// CRDSyncCell provides a promise that is resolved as soon as CRDs used by the
@@ -352,7 +353,11 @@ var (
 		natStats.Cell,
 
 		// Provide resource groups to watch.
-		cell.Provide(func() watchers.ResourceGroupFunc { return allResourceGroups }),
+		cell.Provide(func(bgpCfg bgpConfig.BGPConfig) watchers.ResourceGroupFunc {
+			return func(logger *slog.Logger, cfg watchers.WatcherConfiguration) (resourceGroups, waitForCachesOnly []string) {
+				return allResourceGroups(logger, cfg, bgpCfg)
+			}
+		}),
 
 		// K8s Watcher provides the core k8s watchers
 		watchers.Cell,
@@ -449,7 +454,7 @@ var pprofConfig = pprof.Config{
 
 // resourceGroups are all of the core Kubernetes and Cilium resource groups
 // which the Cilium agent watches to implement CNI functionality.
-func allResourceGroups(logger *slog.Logger, cfg watchers.WatcherConfiguration) (resourceGroups, waitForCachesOnly []string) {
+func allResourceGroups(logger *slog.Logger, cfg watchers.WatcherConfiguration, bgpCfg bgpConfig.BGPConfig) (resourceGroups, waitForCachesOnly []string) {
 	k8sGroups := []string{
 		// Pods can contain labels which are essential for endpoints
 		// being restored to have the right identity.
@@ -464,7 +469,7 @@ func allResourceGroups(logger *slog.Logger, cfg watchers.WatcherConfiguration) (
 		waitForCachesOnly = append(waitForCachesOnly, resources.K8sAPIGroupNetworkingV1Core)
 	}
 
-	ciliumGroups, waitOnlyList := watchers.GetGroupsForCiliumResources(logger, k8sSynced.AgentCRDResourceNames())
+	ciliumGroups, waitOnlyList := watchers.GetGroupsForCiliumResources(logger, k8sSynced.AgentCRDResourceNames(bgpCfg))
 	waitForCachesOnly = append(waitForCachesOnly, waitOnlyList...)
 
 	return append(k8sGroups, ciliumGroups...), waitForCachesOnly

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -748,18 +748,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.TCFilterPriority)
 	option.BindEnv(vp, option.TCFilterPriority)
 
-	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
-	option.BindEnv(vp, option.EnableBGPControlPlane)
-
-	flags.Bool(option.EnableBGPControlPlaneStatusReport, true, "Enable the BGP control plane status reporting")
-	option.BindEnv(vp, option.EnableBGPControlPlaneStatusReport)
-
-	flags.String(option.BGPRouterIDAllocationMode, option.BGPRouterIDAllocationModeDefault, "BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool'")
-	option.BindEnv(vp, option.BGPRouterIDAllocationMode)
-
-	flags.String(option.BGPRouterIDAllocationIPPool, "", "IP pool to allocate the BGP router-id from when the mode is 'ip-pool'")
-	option.BindEnv(vp, option.BGPRouterIDAllocationIPPool)
-
 	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
 	option.BindEnv(vp, option.EnablePMTUDiscovery)
 

--- a/operator/pkg/bgp/cell.go
+++ b/operator/pkg/bgp/cell.go
@@ -7,33 +7,36 @@ import (
 	"github.com/cilium/hive/cell"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var Cell = cell.Module(
 	"bgp-cp-operator",
 	"BGP Control Plane Operator",
+
+	cell.Config(config.DefaultConfig),
+
 	cell.ProvidePrivate(newSecretResource),
 	cell.Invoke(registerBGPResourceManager),
 	cell.Invoke(registerPeerConfigStatusReconciler),
 	metrics.Metric(NewBGPOperatorMetrics),
 )
 
-func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
+func newSecretResource(lc cell.Lifecycle, c client.Clientset, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
 	// Secret is only used for status reporting (MissingAuthSecret condition)
-	if !c.IsEnabled() || !dc.BGPControlPlaneEnabled() || !dc.EnableBGPControlPlaneStatusReport {
+	if !c.IsEnabled() || !bc.BGPControlPlaneEnabled() || !bc.EnableStatusReport {
 		return nil
 	}
-	if dc.BGPSecretsNamespace == "" {
+	if bc.SecretsNamespace == "" {
 		return nil
 	}
 	return resource.New[*slim_core_v1.Secret](
 		lc, utils.ListerWatcherFromTyped[*slim_core_v1.SecretList](
-			c.Slim().CoreV1().Secrets(dc.BGPSecretsNamespace),
+			c.Slim().CoreV1().Secrets(bc.SecretsNamespace),
 		), mp)
 }

--- a/operator/pkg/bgp/cluster_test.go
+++ b/operator/pkg/bgp/cluster_test.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -129,11 +129,10 @@ var (
 			},
 		},
 	}
-	defaultDaemonConfig = &option.DaemonConfig{
-		EnableBGPControlPlane:             true,
-		Debug:                             true,
-		BGPSecretsNamespace:               "kube-system",
-		EnableBGPControlPlaneStatusReport: true,
+	defaultBGPConfig = config.BGPConfig{
+		Enable:             true,
+		SecretsNamespace:   "kube-system",
+		EnableStatusReport: true,
 	}
 )
 
@@ -303,7 +302,7 @@ func Test_NodeLabels(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 			defer cancel()
 
-			f, watcherReady := newFixture(t, ctx, req, defaultDaemonConfig)
+			f, watcherReady := newFixture(t, ctx, req, defaultBGPConfig)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -339,7 +338,6 @@ func Test_NodeLabels(t *testing.T) {
 
 				assert.True(c, isSameOwner(tt.expectedNodeConfig.GetOwnerReferences(), nodeConfig.GetOwnerReferences()))
 				assert.Equal(c, tt.expectedNodeConfig.Spec, nodeConfig.Spec)
-
 			}, TestTimeout, 50*time.Millisecond)
 		})
 	}
@@ -618,7 +616,7 @@ func Test_ClusterConfigSteps(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	defer cancel()
 
-	f, watchersReady := newFixture(t, ctx, require.New(t), defaultDaemonConfig)
+	f, watchersReady := newFixture(t, ctx, require.New(t), defaultBGPConfig)
 
 	tlog := hivetest.Logger(t)
 	f.hive.Start(tlog, ctx)
@@ -879,7 +877,7 @@ func TestClusterConfigConditions(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 			defer cancel()
 
-			f, watchersReady := newFixture(t, ctx, require.New(t), defaultDaemonConfig)
+			f, watchersReady := newFixture(t, ctx, require.New(t), defaultBGPConfig)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -1118,7 +1116,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 			defer cancel()
 
-			f, watchersReady := newFixture(t, ctx, require.New(t), defaultDaemonConfig)
+			f, watchersReady := newFixture(t, ctx, require.New(t), defaultBGPConfig)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -1232,13 +1230,12 @@ func TestDisableClusterConfigStatusReport(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	defer cancel()
 
-	daemonConfigStatusFalse := &option.DaemonConfig{
-		EnableBGPControlPlane:             true,
-		Debug:                             true,
-		BGPSecretsNamespace:               "kube-system",
-		EnableBGPControlPlaneStatusReport: false,
+	configStatusFalse := config.BGPConfig{
+		Enable:             true,
+		SecretsNamespace:   "kube-system",
+		EnableStatusReport: false,
 	}
-	f, watchersReady := newFixture(t, ctx, require.New(t), daemonConfigStatusFalse)
+	f, watchersReady := newFixture(t, ctx, require.New(t), configStatusFalse)
 
 	tlog := hivetest.Logger(t)
 	f.hive.Start(tlog, ctx)
@@ -1279,13 +1276,12 @@ func TestDisableClusterConfigStatusReport(t *testing.T) {
 }
 
 func TestRouterIDAllocation(t *testing.T) {
-	daemonConfigBGPRouterID := &option.DaemonConfig{
-		EnableBGPControlPlane:             true,
-		Debug:                             true,
-		BGPSecretsNamespace:               "kube-system",
-		EnableBGPControlPlaneStatusReport: true,
-		BGPRouterIDAllocationMode:         option.BGPRouterIDAllocationModeIPPool,
-		BGPRouterIDAllocationIPPool:       "10.0.0.0/24",
+	configBGPRouterID := config.BGPConfig{
+		Enable:                   true,
+		SecretsNamespace:         "kube-system",
+		EnableStatusReport:       true,
+		RouterIDAllocationMode:   config.BGPRouterIDAllocationModeIPPool,
+		RouterIDAllocationIPPool: "10.0.0.0/24",
 	}
 	tests := []struct {
 		name                       string
@@ -1563,7 +1559,7 @@ func TestRouterIDAllocation(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 			defer cancel()
 
-			f, watchersReady := newFixture(t, ctx, require.New(t), daemonConfigBGPRouterID)
+			f, watchersReady := newFixture(t, ctx, require.New(t), configBGPRouterID)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)

--- a/operator/pkg/bgp/fixture_test.go
+++ b/operator/pkg/bgp/fixture_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/hive"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -27,9 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var (
-	TestTimeout = 5 * time.Second
-)
+var TestTimeout = 5 * time.Second
 
 type fixture struct {
 	hive          *hive.Hive
@@ -43,7 +42,7 @@ type fixture struct {
 	bgpnClient cilium_client_v2.CiliumBGPNodeConfigInterface
 }
 
-func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *option.DaemonConfig) (*fixture, func()) {
+func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, bgpCfg config.BGPConfig) (*fixture, func()) {
 	rws := map[string]*struct {
 		once    sync.Once
 		watchCh chan any
@@ -141,7 +140,9 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 		}),
 
 		cell.Provide(func() *option.DaemonConfig {
-			return dc
+			return &option.DaemonConfig{
+				Debug: true,
+			}
 		}),
 
 		cell.Provide(func() k8sClient.Clientset {
@@ -150,6 +151,15 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 
 		Cell,
 	)
+
+	hive.AddConfigOverride(f.hive, func(dst *config.BGPConfig) {
+		dst.EnableLegacyOriginAttribute = bgpCfg.EnableLegacyOriginAttribute
+		dst.SecretsNamespace = bgpCfg.SecretsNamespace
+		dst.Enable = bgpCfg.Enable
+		dst.EnableStatusReport = bgpCfg.EnableStatusReport
+		dst.RouterIDAllocationMode = bgpCfg.RouterIDAllocationMode
+		dst.RouterIDAllocationIPPool = bgpCfg.RouterIDAllocationIPPool
+	})
 
 	return f, watchersReadyFn
 }

--- a/operator/pkg/bgp/manager.go
+++ b/operator/pkg/bgp/manager.go
@@ -16,31 +16,29 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cilium/cilium/operator/pkg/lbipam"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/ipalloc"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var (
-	// maxErrorLen is the maximum length of error message to be logged.
-	maxErrorLen = 140
-)
+// maxErrorLen is the maximum length of error message to be logged.
+var maxErrorLen = 140
 
 type BGPParams struct {
 	cell.In
 
-	Logger       *slog.Logger
-	LC           cell.Lifecycle
-	Clientset    k8s_client.Clientset
-	DaemonConfig *option.DaemonConfig
-	JobGroup     job.Group
-	Health       cell.Health
-	Metrics      *BGPOperatorMetrics
+	Logger    *slog.Logger
+	LC        cell.Lifecycle
+	Clientset k8s_client.Clientset
+	BGPConfig config.BGPConfig
+	JobGroup  job.Group
+	Health    cell.Health
+	Metrics   *BGPOperatorMetrics
 
 	// resource tracking
 	ClusterConfigResource      resource.Resource[*v2.CiliumBGPClusterConfig]
@@ -86,7 +84,7 @@ type BGPResourceManager struct {
 
 // registerBGPResourceManager creates a new BGPResourceManager operator instance.
 func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
-	if !p.DaemonConfig.BGPControlPlaneEnabled() {
+	if !p.BGPConfig.BGPControlPlaneEnabled() {
 		return nil
 	}
 
@@ -106,10 +104,10 @@ func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
 		nodeConfig:            p.NodeConfigResource,
 		peerConfig:            p.PeerConfigResource,
 		ciliumNode:            p.NodeResource,
-		enableStatusReporting: p.DaemonConfig.EnableBGPControlPlaneStatusReport,
+		enableStatusReporting: p.BGPConfig.EnableStatusReport,
 	}
-	if p.DaemonConfig.BGPRouterIDAllocationMode == option.BGPRouterIDAllocationModeIPPool {
-		ipnet, err := netip.ParsePrefix(p.DaemonConfig.BGPRouterIDAllocationIPPool)
+	if p.BGPConfig.RouterIDAllocationMode == config.BGPRouterIDAllocationModeIPPool {
+		ipnet, err := netip.ParsePrefix(p.BGPConfig.RouterIDAllocationIPPool)
 		if err != nil {
 			err = fmt.Errorf("failed to parse BGP router ID IP pool: %w", err)
 			b.logger.Error(err.Error())
@@ -123,7 +121,7 @@ func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
 
 		from, to := lbipam.RangeFromPrefix(ipnet)
 		// 50 router IDs as the initial size is enough for hash map since we don't expect more than too many nodes
-		//to run BGP with upstream routers and it can still grow if needed.
+		// to run BGP with upstream routers and it can still grow if needed.
 		b.bgpRouterIDIPPool, err = ipalloc.NewHashAllocator[string](from, to, 50)
 		if err != nil {
 			err = fmt.Errorf("failed to create router ID IP pool: %w", err)

--- a/operator/pkg/bgp/peer.go
+++ b/operator/pkg/bgp/peer.go
@@ -16,11 +16,11 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/resiliency"
 )
 
@@ -38,27 +38,27 @@ type peerConfigStatusReconciler struct {
 type peerConfigStatusReconcilerIn struct {
 	cell.In
 
-	Clientset    k8s_client.Clientset
-	DaemonConfig *option.DaemonConfig
-	JobGroup     job.Group
+	Clientset k8s_client.Clientset
+	BGPConfig config.BGPConfig
+	JobGroup  job.Group
 
 	SecretResource     resource.Resource[*slim_core_v1.Secret]
 	PeerConfigResource resource.Resource[*v2.CiliumBGPPeerConfig]
 }
 
 func registerPeerConfigStatusReconciler(in peerConfigStatusReconcilerIn) {
-	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+	if !in.BGPConfig.BGPControlPlaneEnabled() {
 		return
 	}
 
 	u := &peerConfigStatusReconciler{
 		cs:                 in.Clientset,
-		secretNamespace:    in.DaemonConfig.BGPSecretsNamespace,
+		secretNamespace:    in.BGPConfig.SecretsNamespace,
 		secretResource:     in.SecretResource,
 		peerConfigResource: in.PeerConfigResource,
 	}
 
-	if !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+	if !in.BGPConfig.EnableStatusReport {
 		// Register a job to cleanup the conditions from the existing
 		// PeerConfig resources. This is needed for the case that the
 		// status report was enabled previously and some conditions

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -22,6 +22,7 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/health"
 	healthTypes "github.com/cilium/cilium/pkg/hive/health/types"
@@ -31,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type peerConfigTestFixture struct {
@@ -101,11 +101,11 @@ func newPeerConfigTestFixture(t *testing.T, ctx context.Context, enableStatusRep
 				k8sClient.NewFakeClientset,
 				newSecretResource,
 				k8s.CiliumBGPPeerConfigResource,
-				func() *option.DaemonConfig {
-					return &option.DaemonConfig{
-						EnableBGPControlPlane:             true,
-						BGPSecretsNamespace:               "kube-system",
-						EnableBGPControlPlaneStatusReport: enableStatusReport,
+				func() config.BGPConfig {
+					return config.BGPConfig{
+						Enable:             true,
+						SecretsNamespace:   "kube-system",
+						EnableStatusReport: enableStatusReport,
 					}
 				},
 			),

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -48,6 +49,7 @@ type lbipamCellParams struct {
 	SvcResource  resource.Resource[*slim_core_v1.Service]
 
 	DaemonConfig *option.DaemonConfig
+	BGPConfig    bgpConfig.BGPConfig
 
 	Metrics *ipamMetrics
 
@@ -62,7 +64,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 	}
 
 	var lbClasses []string
-	if params.DaemonConfig.EnableBGPControlPlane {
+	if params.BGPConfig.BGPControlPlaneEnabled() {
 		lbClasses = append(lbClasses, cilium_api_v2alpha1.BGPLoadBalancerClass)
 	}
 

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -22,6 +22,7 @@ import (
 
 	operator_k8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
 
@@ -869,7 +870,6 @@ func TestServiceDelete(t *testing.T) {
 	}
 	ipsUsed = getPoolStatusCount(fixture.GetPool("pool-a"), ciliumPoolIPsUsedCondition)
 	require.Equal(t, "0", ipsUsed)
-
 }
 
 // TestReallocOnInit tests the edge case where an existing service has an IP assigned for which there is no IP Pool.
@@ -2906,8 +2906,11 @@ func TestLBIPAMStartupRestartShutdown(t *testing.T) {
 			// Dependencies
 			k8sFakeClient.FakeClientCell(),
 			cell.Provide(func() *option.DaemonConfig {
-				return &option.DaemonConfig{
-					EnableBGPControlPlane: true,
+				return &option.DaemonConfig{}
+			}),
+			cell.Provide(func() config.BGPConfig {
+				return config.BGPConfig{
+					Enable: true,
 				}
 			}),
 			cell.Provide(k8s.DefaultServiceWatchConfig),
@@ -3050,6 +3053,9 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{}
 		}),
+		cell.Provide(func() config.BGPConfig {
+			return config.BGPConfig{}
+		}),
 		cell.Config(k8s.DefaultConfig),
 		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Provide(
@@ -3148,6 +3154,9 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 		}),
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{}
+		}),
+		cell.Provide(func() config.BGPConfig {
+			return config.BGPConfig{}
 		}),
 		cell.Config(k8s.DefaultConfig),
 		cell.Provide(k8s.DefaultServiceWatchConfig),

--- a/pkg/bgp/agent/controller.go
+++ b/pkg/bgp/agent/controller.go
@@ -15,20 +15,18 @@ import (
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/hive"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var (
-	// ErrBGPControlPlaneDisabled is set when the BGP control plane is disabled
-	ErrBGPControlPlaneDisabled = fmt.Errorf("BGP control plane is disabled")
-)
+// ErrBGPControlPlaneDisabled is set when the BGP control plane is disabled
+var ErrBGPControlPlaneDisabled = fmt.Errorf("BGP control plane is disabled")
 
 // Controller is the agent side BGP Control Plane controller.
 //
@@ -71,7 +69,7 @@ type ControllerParams struct {
 	Sig                     *signaler.BGPCPSignaler
 	RouteMgr                BGPRouterManager
 	BGPNodeConfigStore      store.BGPCPResourceStore[*v2.CiliumBGPNodeConfig]
-	DaemonConfig            *option.DaemonConfig
+	BGPConfig               config.BGPConfig
 	LocalCiliumNodeResource daemon_k8s.LocalCiliumNodeResource
 }
 
@@ -86,7 +84,7 @@ type ControllerParams struct {
 func NewController(params ControllerParams) (*Controller, error) {
 	// If the BGP control plane is disabled, just return nil. This way the hive dependency graph is always static
 	// regardless of config. The lifecycle has not been appended so no work will be done.
-	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+	if !params.BGPConfig.BGPControlPlaneEnabled() {
 		return nil, nil
 	}
 

--- a/pkg/bgp/cell.go
+++ b/pkg/bgp/cell.go
@@ -81,9 +81,9 @@ var Cell = cell.Module(
 	cell.Provide(
 		tables.NewBGPReconcileErrorTable,
 		tables.NewDesiredRoutePoliciesTable,
-		func(t statedb.RWTable[*tables.DesiredRoutePolicy], dc *option.DaemonConfig) statedb.Table[*tables.DesiredRoutePolicy] {
+		func(t statedb.RWTable[*tables.DesiredRoutePolicy], bc config.BGPConfig) statedb.Table[*tables.DesiredRoutePolicy] {
 			// Do not create this resource if BGP Control Plane is disabled.
-			if !dc.BGPControlPlaneEnabled() {
+			if !bc.BGPControlPlaneEnabled() {
 				return nil
 			}
 
@@ -115,12 +115,12 @@ var Cell = cell.Module(
 	metrics.Metric(manager.NewBGPManagerMetrics),
 )
 
-func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumPodIPPool] {
+func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumPodIPPool] {
 	// Do not create this resource if:
 	//   1. The BGP Control Plane is disabled.
 	//   2. Kubernetes support is disabled and the clientset cannot be used.
 	//   3. Multi-pool IPAM is disabled.
-	if !dc.BGPControlPlaneEnabled() || !c.IsEnabled() || dc.IPAM != ipam_option.IPAMMultiPool {
+	if !bc.BGPControlPlaneEnabled() || !c.IsEnabled() || dc.IPAM != ipam_option.IPAMMultiPool {
 		return nil
 	}
 
@@ -130,9 +130,9 @@ func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *optio
 		), mp, resource.WithMetric("CiliumPodIPPool"))
 }
 
-func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
+func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientset, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
 	// Do not create this resource if the BGP Control Plane is disabled
-	if !dc.BGPControlPlaneEnabled() {
+	if !bc.BGPControlPlaneEnabled() {
 		return nil
 	}
 
@@ -141,20 +141,20 @@ func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientse
 	}
 
 	// Do not create this resource if the BGP namespace is not set
-	if dc.BGPSecretsNamespace == "" {
+	if bc.SecretsNamespace == "" {
 		logger.Warn("bgp-secrets-namespace not set, will not be able to use BGP control plane auth secrets")
 		return nil
 	}
 
 	return resource.New[*slim_core_v1.Secret](
 		lc, utils.ListerWatcherFromTyped[*slim_core_v1.SecretList](
-			c.Slim().CoreV1().Secrets(dc.BGPSecretsNamespace),
+			c.Slim().CoreV1().Secrets(bc.SecretsNamespace),
 		), mp)
 }
 
-func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPNodeConfig] {
+func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPNodeConfig] {
 	// Do not create this resource if the BGP Control Plane is disabled
-	if !dc.BGPControlPlaneEnabled() {
+	if !bc.BGPControlPlaneEnabled() {
 		return nil
 	}
 
@@ -168,9 +168,9 @@ func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.
 		), mp, resource.WithMetric("CiliumBGPNodeConfig"))
 }
 
-func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPPeerConfig] {
+func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPPeerConfig] {
 	// Do not create this resource if the BGP Control Plane is disabled
-	if !dc.BGPControlPlaneEnabled() {
+	if !bc.BGPControlPlaneEnabled() {
 		return nil
 	}
 
@@ -184,9 +184,9 @@ func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.
 		), mp, resource.WithMetric("CiliumBGPPeerConfig"))
 }
 
-func newBGPAdvertisementResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPAdvertisement] {
+func newBGPAdvertisementResource(lc cell.Lifecycle, c client.Clientset, bc config.BGPConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPAdvertisement] {
 	// Do not create this resource if the BGP Control Plane is disabled
-	if !dc.BGPControlPlaneEnabled() {
+	if !bc.BGPControlPlaneEnabled() {
 		return nil
 	}
 

--- a/pkg/bgp/cell.go
+++ b/pkg/bgp/cell.go
@@ -15,13 +15,13 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgp/api"
 	"github.com/cilium/cilium/pkg/bgp/commands"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/gobgp"
 	"github.com/cilium/cilium/pkg/bgp/manager"
 	"github.com/cilium/cilium/pkg/bgp/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
 	bgp_metrics "github.com/cilium/cilium/pkg/bgp/metrics"
-	bgp_option "github.com/cilium/cilium/pkg/bgp/option"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -37,7 +37,7 @@ var Cell = cell.Module(
 	"BGP Control Plane",
 
 	// Provide config so that other cells can access it
-	cell.Config(bgp_option.DefaultConfig),
+	cell.Config(config.DefaultConfig),
 
 	// Main BGP CP components
 	cell.Provide(

--- a/pkg/bgp/config/config.go
+++ b/pkg/bgp/config/config.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package option
+package config
 
 import "github.com/spf13/pflag"
 
@@ -14,13 +14,13 @@ const (
 
 type BGPConfig struct {
 	// Enables LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
-	EnableBGPLegacyOriginAttribute bool
+	EnableLegacyOriginAttribute bool `mapstructure:"enable-bgp-legacy-origin-attribute"`
 }
 
 var DefaultConfig = BGPConfig{
-	EnableBGPLegacyOriginAttribute: false,
+	EnableLegacyOriginAttribute: false,
 }
 
 func (def BGPConfig) Flags(flags *pflag.FlagSet) {
-	flags.Bool(EnableBGPLegacyOriginAttribute, def.EnableBGPLegacyOriginAttribute, "Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE")
+	flags.Bool(EnableBGPLegacyOriginAttribute, def.EnableLegacyOriginAttribute, "Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE")
 }

--- a/pkg/bgp/config/config.go
+++ b/pkg/bgp/config/config.go
@@ -3,24 +3,70 @@
 
 package config
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 const (
+	// Flag to enable BGP control plane features
+	EnableBGPControlPlane = "enable-bgp-control-plane"
+
+	// EnableBGPControlPlaneStatusReport enables BGP Control Plane CRD status reporting
+	EnableBGPControlPlaneStatusReport = "enable-bgp-control-plane-status-report"
+
 	// Enables advertising LoadBalancerIP routes with the BGP ORIGIN
 	// attribute set to INCOMPLETE (2), matching MetalLB’s legacy behavior,
 	// instead of the default IGP (0).
 	EnableBGPLegacyOriginAttribute = "enable-bgp-legacy-origin-attribute"
+
+	// BGPSecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
+	BGPSecretsNamespace = "bgp-secrets-namespace"
+
+	// BGP router-id allocation mode
+	BGPRouterIDAllocationMode = "bgp-router-id-allocation-mode"
+
+	// BGP router-id allocation IP pool
+	BGPRouterIDAllocationIPPool = "bgp-router-id-allocation-ip-pool"
 )
 
 type BGPConfig struct {
+	// Enables BGP control plane features.
+	Enable bool `mapstructure:"enable-bgp-control-plane"`
+
+	// Enables BGP control plane status reporting.
+	EnableStatusReport bool `mapstructure:"enable-bgp-control-plane-status-report"`
+
 	// Enables LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
 	EnableLegacyOriginAttribute bool `mapstructure:"enable-bgp-legacy-origin-attribute"`
+
+	// SecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
+	SecretsNamespace string `mapstructure:"bgp-secrets-namespace"`
+
+	// RouterIDAllocationMode is the mode to allocate the BGP router-id.
+	RouterIDAllocationMode BGPRouterIDAllocationModeType `mapstructure:"bgp-router-id-allocation-mode"`
+
+	// RouterIDAllocationIPPool is the IP pool to allocate the BGP router-id from.
+	RouterIDAllocationIPPool string `mapstructure:"bgp-router-id-allocation-ip-pool"`
 }
 
 var DefaultConfig = BGPConfig{
 	EnableLegacyOriginAttribute: false,
+	SecretsNamespace:            "",
+	Enable:                      false,
+	EnableStatusReport:          true,
+	RouterIDAllocationMode:      BGPRouterIDAllocationModeDefault,
+	RouterIDAllocationIPPool:    "",
 }
 
 func (def BGPConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableBGPLegacyOriginAttribute, def.EnableLegacyOriginAttribute, "Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE")
+	flags.Bool(EnableBGPControlPlane, def.Enable, "Enable the BGP control plane")
+	flags.Bool(EnableBGPControlPlaneStatusReport, def.EnableStatusReport, "Enable the BGP control plane status reporting")
+	flags.Var(&(def.RouterIDAllocationMode), BGPRouterIDAllocationMode, "BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool'")
+	flags.String(BGPRouterIDAllocationIPPool, def.RouterIDAllocationIPPool, "IP pool to allocate the BGP router-id from when the mode is 'ip-pool'")
+	flags.String(BGPSecretsNamespace, def.SecretsNamespace, "Kubernetes namespace to get BGP control plane secrets from")
+}
+
+func (def BGPConfig) BGPControlPlaneEnabled() bool {
+	return def.Enable
 }

--- a/pkg/bgp/config/types.go
+++ b/pkg/bgp/config/types.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+const (
+	// BGPRouterIDAllocationModeDefault means the router-id is allocated per node
+	BGPRouterIDAllocationModeDefault BGPRouterIDAllocationModeType = "default"
+
+	// BGPRouterIDAllocationModeIPPool means the router-id is allocated per IP pool
+	BGPRouterIDAllocationModeIPPool BGPRouterIDAllocationModeType = "ip-pool"
+)
+
+type BGPRouterIDAllocationModeType string
+
+func (t *BGPRouterIDAllocationModeType) Set(value string) error {
+	*t = BGPRouterIDAllocationModeType(value)
+
+	return nil
+}
+
+func (t *BGPRouterIDAllocationModeType) String() string {
+	return string(*t)
+}
+
+func (t *BGPRouterIDAllocationModeType) Type() string {
+	return "string"
+}

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -32,7 +32,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -45,7 +44,7 @@ type bgpRouterManagerParams struct {
 	Logger              *slog.Logger
 	Lifecycle           cell.Lifecycle
 	JobGroup            job.Group
-	DaemonConfig        *option.DaemonConfig
+	BGPConfig           config.BGPConfig
 	Metrics             *BGPManagerMetrics
 	DB                  *statedb.DB
 	ReconcileErrorTable statedb.RWTable[*tables.BGPReconcileError]
@@ -122,7 +121,7 @@ type BGPRouterManager struct {
 	DB                  *statedb.DB
 	ReconcileErrorTable statedb.RWTable[*tables.BGPReconcileError]
 
-	BGPRouterIDAllocationMode config.BGPRouterIDAllocationModeType
+	BGPConfig config.BGPConfig
 
 	// running is set when the manager is running, and unset when it is stopped.
 	running bool
@@ -140,7 +139,7 @@ type BGPRouterManager struct {
 
 // NewBGPRouterManager constructs a new BGPRouterManager.
 func NewBGPRouterManager(params bgpRouterManagerParams) agent.BGPRouterManager {
-	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+	if !params.BGPConfig.BGPControlPlaneEnabled() {
 		return &BGPRouterManager{}
 	}
 
@@ -158,7 +157,7 @@ func NewBGPRouterManager(params bgpRouterManagerParams) agent.BGPRouterManager {
 		DB:                  params.DB,
 		ReconcileErrorTable: params.ReconcileErrorTable,
 
-		BGPRouterIDAllocationMode: config.BGPRouterIDAllocationModeType(params.DaemonConfig.BGPRouterIDAllocationMode),
+		BGPConfig: params.BGPConfig,
 
 		// By default, do not destroy the GobGP router on Stop() as that causes sending Cease notification to peers,
 		// which terminates Graceful Restart progress. We set this to true only for tests, where GR is not needed
@@ -506,7 +505,7 @@ func (m *BGPRouterManager) ReconcileInstances(ctx context.Context,
 
 	// use a reconcileDiff to compute which BgpServers must be created, removed
 	// and reconciled.
-	rd := newReconcileDiff(ciliumNode, m.BGPRouterIDAllocationMode)
+	rd := newReconcileDiff(ciliumNode, m.BGPConfig)
 
 	if nodeObj == nil {
 		m.withdrawAll(ctx, rd)
@@ -591,7 +590,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	routerID, err := getRouterID(c, ciliumNode, m.BGPRouterIDAllocationMode)
+	routerID, err := getRouterID(c, ciliumNode, m.BGPConfig)
 	if err != nil {
 		return err
 	}
@@ -932,13 +931,13 @@ func calcRouterIDFromMacAddress() (string, error) {
 // be returned. Otherwise, the router ID will be resolved from the ciliumnode annotations. If the router ID is not
 // defined in the annotations, the node IP from cilium node will be returned. If the node IP is not available, the
 // router ID will be calculated from the MAC address.
-func getRouterID(cfg *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, mode config.BGPRouterIDAllocationModeType) (string, error) {
+func getRouterID(cfg *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, bgpCfg config.BGPConfig) (string, error) {
 	if cfg.RouterID != nil {
 		return *cfg.RouterID, nil
 	}
 
 	// If there are no annotations about router-id, router-id will be allocated based on the allocation mode
-	switch mode {
+	switch bgpCfg.RouterIDAllocationMode {
 	case config.BGPRouterIDAllocationModeDefault:
 		if nodeIP := ciliumNode.GetIP(false); nodeIP != nil {
 			return nodeIP.String(), nil
@@ -955,7 +954,7 @@ func getRouterID(cfg *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, mode 
 		}
 		return routerID, nil
 	default:
-		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", mode, config.BGPRouterIDAllocationModeDefault, config.BGPRouterIDAllocationModeIPPool)
+		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", bgpCfg.RouterIDAllocationMode, config.BGPRouterIDAllocationModeDefault, config.BGPRouterIDAllocationModeIPPool)
 	}
 }
 

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -22,6 +22,7 @@ import (
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/pkg/bgp/agent"
 	"github.com/cilium/cilium/pkg/bgp/api"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
@@ -121,6 +122,8 @@ type BGPRouterManager struct {
 	DB                  *statedb.DB
 	ReconcileErrorTable statedb.RWTable[*tables.BGPReconcileError]
 
+	BGPRouterIDAllocationMode config.BGPRouterIDAllocationModeType
+
 	// running is set when the manager is running, and unset when it is stopped.
 	running bool
 
@@ -154,6 +157,8 @@ func NewBGPRouterManager(params bgpRouterManagerParams) agent.BGPRouterManager {
 		// statedb
 		DB:                  params.DB,
 		ReconcileErrorTable: params.ReconcileErrorTable,
+
+		BGPRouterIDAllocationMode: config.BGPRouterIDAllocationModeType(params.DaemonConfig.BGPRouterIDAllocationMode),
 
 		// By default, do not destroy the GobGP router on Stop() as that causes sending Cease notification to peers,
 		// which terminates Graceful Restart progress. We set this to true only for tests, where GR is not needed
@@ -494,13 +499,14 @@ func (m *BGPRouterManager) DestroyRouterOnStop(destroy bool) {
 // reconciled.
 func (m *BGPRouterManager) ReconcileInstances(ctx context.Context,
 	nodeObj *v2.CiliumBGPNodeConfig,
-	ciliumNode *v2.CiliumNode) error {
+	ciliumNode *v2.CiliumNode,
+) error {
 	m.Lock()
 	defer m.Unlock()
 
 	// use a reconcileDiff to compute which BgpServers must be created, removed
 	// and reconciled.
-	rd := newReconcileDiff(ciliumNode)
+	rd := newReconcileDiff(ciliumNode, m.BGPRouterIDAllocationMode)
 
 	if nodeObj == nil {
 		m.withdrawAll(ctx, rd)
@@ -571,8 +577,8 @@ func (m *BGPRouterManager) register(ctx context.Context, rd *reconcileDiff) erro
 // BGPInstance
 func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 	c *v2.CiliumBGPNodeInstance,
-	ciliumNode *v2.CiliumNode) error {
-
+	ciliumNode *v2.CiliumNode,
+) error {
 	l := m.logger.With(types.InstanceLogField, c.Name)
 
 	l.Info("Registering BGP instance")
@@ -585,7 +591,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	routerID, err := getRouterID(c, ciliumNode)
+	routerID, err := getRouterID(c, ciliumNode, m.BGPRouterIDAllocationMode)
 	if err != nil {
 		return err
 	}
@@ -644,8 +650,8 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 func (m *BGPRouterManager) reconcileBGPConfig(ctx context.Context,
 	i *instance.BGPInstance,
 	newc *v2.CiliumBGPNodeInstance,
-	ciliumNode *v2.CiliumNode) error {
-
+	ciliumNode *v2.CiliumNode,
+) error {
 	reconcileStart := time.Now()
 
 	var reconcileErrs []error
@@ -878,9 +884,9 @@ func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) err
 // getLocalASN returns the local ASN for the given BGP instance. If the local ASN is defined in the desired config, it
 // will be returned. Currently, we do not support auto-ASN assignment, so if the local ASN is not defined in the
 // desired config, an error will be returned.
-func getLocalASN(config *v2.CiliumBGPNodeInstance) (int64, error) {
-	if config.LocalASN != nil {
-		return *config.LocalASN, nil
+func getLocalASN(cfg *v2.CiliumBGPNodeInstance) (int64, error) {
+	if cfg.LocalASN != nil {
+		return *cfg.LocalASN, nil
 	}
 	// NOTE: for now we require a local ASN to be specified
 	// remove this check once we support auto-ASN assignment.
@@ -926,30 +932,30 @@ func calcRouterIDFromMacAddress() (string, error) {
 // be returned. Otherwise, the router ID will be resolved from the ciliumnode annotations. If the router ID is not
 // defined in the annotations, the node IP from cilium node will be returned. If the node IP is not available, the
 // router ID will be calculated from the MAC address.
-func getRouterID(config *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode) (string, error) {
-	if config.RouterID != nil {
-		return *config.RouterID, nil
+func getRouterID(cfg *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, mode config.BGPRouterIDAllocationModeType) (string, error) {
+	if cfg.RouterID != nil {
+		return *cfg.RouterID, nil
 	}
 
 	// If there are no annotations about router-id, router-id will be allocated based on the allocation mode
-	switch option.Config.BGPRouterIDAllocationMode {
-	case option.BGPRouterIDAllocationModeDefault:
+	switch mode {
+	case config.BGPRouterIDAllocationModeDefault:
 		if nodeIP := ciliumNode.GetIP(false); nodeIP != nil {
 			return nodeIP.String(), nil
 		} else {
 			return calcRouterIDFromMacAddress()
 		}
-	case option.BGPRouterIDAllocationModeIPPool:
-		if config.RouterID == nil {
+	case config.BGPRouterIDAllocationModeIPPool:
+		if cfg.RouterID == nil {
 			return "", fmt.Errorf("can't find the router-id in the CiliumBGPNodeInstance")
 		}
-		routerID := *config.RouterID
+		routerID := *cfg.RouterID
 		if net.ParseIP(routerID).To4() == nil {
 			return "", fmt.Errorf("the router-id %s is not a valid IPv4 address", routerID)
 		}
 		return routerID, nil
 	default:
-		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", option.Config.BGPRouterIDAllocationMode, option.BGPRouterIDAllocationModeDefault, option.BGPRouterIDAllocationModeIPPool)
+		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", mode, config.BGPRouterIDAllocationModeDefault, config.BGPRouterIDAllocationModeIPPool)
 	}
 }
 
@@ -958,9 +964,9 @@ func getRouterID(config *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode) (s
 // defined in the annotations, -1 will be returned.
 //
 // In gobgp, with -1 as the local port, bgp instance will start in non-listening mode.
-func getLocalPort(config *v2.CiliumBGPNodeInstance) (int32, error) {
-	if config.LocalPort != nil {
-		return *config.LocalPort, nil
+func getLocalPort(cfg *v2.CiliumBGPNodeInstance) (int32, error) {
+	if cfg.LocalPort != nil {
+		return *cfg.LocalPort, nil
 	}
 	return int32(-1), nil
 }

--- a/pkg/bgp/manager/reconciler/crd_status.go
+++ b/pkg/bgp/manager/reconciler/crd_status.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
@@ -35,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -69,7 +69,7 @@ type StatusReconcilerIn struct {
 
 	DB                  *statedb.DB
 	ReconcileErrorTable statedb.RWTable[*tables.BGPReconcileError]
-	DaemonConfig        *option.DaemonConfig
+	BGPConfig           config.BGPConfig
 	Job                 job.Group
 	ClientSet           k8s_client.Clientset
 	LocalNode           daemon_k8s.LocalCiliumNodeResource
@@ -83,7 +83,7 @@ type StatusReconcilerOut struct {
 }
 
 func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
-	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+	if !in.BGPConfig.BGPControlPlaneEnabled() {
 		return StatusReconcilerOut{}
 	}
 	// CRD Status reconciler is disabled if there is no kubernetes support
@@ -106,7 +106,7 @@ func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
 	// If the status reporting is disabled, schedule a job to cleanup
 	// status field. Otherwise, users may see the stale status that
 	// previously reported.
-	if !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+	if !in.BGPConfig.EnableStatusReport {
 		in.Job.Add(job.OneShot(
 			"bgp-crd-status-cleanup",
 			r.cleanupStatus,

--- a/pkg/bgp/manager/reconciler/crd_status_test.go
+++ b/pkg/bgp/manager/reconciler/crd_status_test.go
@@ -22,6 +22,7 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
 	"github.com/cilium/cilium/pkg/hive"
@@ -30,7 +31,6 @@ import (
 	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -97,10 +97,10 @@ func newCRDStatusFixture(ctx context.Context, req *require.Assertions, l *slog.L
 	f.hive = hive.New(
 		daemon_k8s.ResourcesCell,
 		cell.Provide(
-			func() *option.DaemonConfig {
-				return &option.DaemonConfig{
-					EnableBGPControlPlane:             true,
-					EnableBGPControlPlaneStatusReport: true,
+			func() config.BGPConfig {
+				return config.BGPConfig{
+					Enable:             true,
+					EnableStatusReport: true,
 				}
 			},
 			tables.NewBGPReconcileErrorTable,
@@ -129,7 +129,7 @@ func newCRDStatusFixture(ctx context.Context, req *require.Assertions, l *slog.L
 }
 
 func TestCRDConditions(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name               string
 		statedbData        []*tables.BGPReconcileError
 		initNodeConfig     *v2.CiliumBGPNodeConfig
@@ -353,10 +353,10 @@ func TestDisableStatusReport(t *testing.T) {
 	hive := hive.New(
 		daemon_k8s.ResourcesCell,
 		cell.Provide(
-			func() *option.DaemonConfig {
-				return &option.DaemonConfig{
-					EnableBGPControlPlane:             true,
-					EnableBGPControlPlaneStatusReport: false,
+			func() config.BGPConfig {
+				return config.BGPConfig{
+					Enable:             true,
+					EnableStatusReport: false,
 				}
 			},
 			k8sFakeClient.NewFakeClientset,

--- a/pkg/bgp/manager/reconciler/default_gateway.go
+++ b/pkg/bgp/manager/reconciler/default_gateway.go
@@ -16,12 +16,12 @@ import (
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // DefaultGatewayReconciler is a ConfigReconciler which handles auto-discovery
@@ -43,13 +43,13 @@ type DefaultGatewayReconcilerOut struct {
 type DefaultGatewayReconcilerIn struct {
 	cell.In
 
-	Logger       *slog.Logger
-	DaemonConfig *option.DaemonConfig
-	DB           *statedb.DB
-	JobGroup     job.Group
-	Signaler     *signaler.BGPCPSignaler
-	RouteTable   statedb.Table[*tables.Route]
-	DeviceTable  statedb.Table[*tables.Device]
+	Logger      *slog.Logger
+	BGPConfig   config.BGPConfig
+	DB          *statedb.DB
+	JobGroup    job.Group
+	Signaler    *signaler.BGPCPSignaler
+	RouteTable  statedb.Table[*tables.Route]
+	DeviceTable statedb.Table[*tables.Device]
 }
 
 var (
@@ -58,7 +58,7 @@ var (
 )
 
 func NewDefaultGatewayReconciler(p DefaultGatewayReconcilerIn) DefaultGatewayReconcilerOut {
-	if !p.DaemonConfig.BGPControlPlaneEnabled() {
+	if !p.BGPConfig.BGPControlPlaneEnabled() {
 		return DefaultGatewayReconcilerOut{}
 	}
 

--- a/pkg/bgp/manager/reconciler/interface_test.go
+++ b/pkg/bgp/manager/reconciler/interface_test.go
@@ -16,13 +16,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 func Test_InterfaceAdvertisement(t *testing.T) {
@@ -423,10 +423,8 @@ func Test_InterfaceAdvertisement(t *testing.T) {
 	db := statedb.New()
 	deviceTable, err := tables.NewDeviceTable(db)
 	req.NoError(err)
-	dc := &option.DaemonConfig{
-		EnableBGPControlPlane: true,
-	}
-	desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
+	bgpCfg := config.BGPConfig{Enable: true}
+	desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, bgpCfg)
 	req.NoError(err)
 
 	// initialize reconciler

--- a/pkg/bgp/manager/reconciler/neighbor.go
+++ b/pkg/bgp/manager/reconciler/neighbor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/statedb"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/types"
@@ -22,19 +23,18 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // NeighborReconciler is a ConfigReconciler which reconciles the peers of the
 // provided BGP server with the provided CiliumBGPVirtualRouter.
 type NeighborReconciler struct {
-	logger       *slog.Logger
-	SecretStore  store.BGPCPResourceStore[*slim_corev1.Secret]
-	PeerConfig   store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
-	DB           *statedb.DB
-	DeviceTable  statedb.Table[*tables.Device]
-	DaemonConfig *option.DaemonConfig
-	metadata     map[string]NeighborReconcilerMetadata
+	logger      *slog.Logger
+	SecretStore store.BGPCPResourceStore[*slim_corev1.Secret]
+	PeerConfig  store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
+	DB          *statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
+	BGPConfig   config.BGPConfig
+	metadata    map[string]NeighborReconcilerMetadata
 }
 
 type NeighborReconcilerOut struct {
@@ -45,12 +45,12 @@ type NeighborReconcilerOut struct {
 
 type NeighborReconcilerIn struct {
 	cell.In
-	Logger       *slog.Logger
-	SecretStore  store.BGPCPResourceStore[*slim_corev1.Secret]
-	PeerConfig   store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
-	DB           *statedb.DB
-	DeviceTable  statedb.Table[*tables.Device]
-	DaemonConfig *option.DaemonConfig
+	Logger      *slog.Logger
+	SecretStore store.BGPCPResourceStore[*slim_corev1.Secret]
+	PeerConfig  store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
+	DB          *statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
+	BGPConfig   config.BGPConfig
 }
 
 func NewNeighborReconciler(params NeighborReconcilerIn) NeighborReconcilerOut {
@@ -58,13 +58,13 @@ func NewNeighborReconciler(params NeighborReconcilerIn) NeighborReconcilerOut {
 
 	return NeighborReconcilerOut{
 		Reconciler: &NeighborReconciler{
-			logger:       logger,
-			SecretStore:  params.SecretStore,
-			PeerConfig:   params.PeerConfig,
-			DaemonConfig: params.DaemonConfig,
-			DB:           params.DB,
-			DeviceTable:  params.DeviceTable,
-			metadata:     make(map[string]NeighborReconcilerMetadata),
+			logger:      logger,
+			SecretStore: params.SecretStore,
+			PeerConfig:  params.PeerConfig,
+			BGPConfig:   params.BGPConfig,
+			DB:          params.DB,
+			DeviceTable: params.DeviceTable,
+			metadata:    make(map[string]NeighborReconcilerMetadata),
 		},
 	}
 	// NOTE: there is no need to trigger reconciliation upon Device table changes,
@@ -353,7 +353,7 @@ func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, 
 	if r.SecretStore == nil {
 		return nil, false, fmt.Errorf("SecretsNamespace not configured")
 	}
-	item, ok, err := r.SecretStore.GetByKey(resource.Key{Namespace: r.DaemonConfig.BGPSecretsNamespace, Name: name})
+	item, ok, err := r.SecretStore.GetByKey(resource.Key{Namespace: r.BGPConfig.SecretsNamespace, Name: name})
 	if err != nil || !ok {
 		if errors.Is(err, store.ErrStoreUninitialized) {
 			err = errors.Join(err, ErrAbortReconcile)

--- a/pkg/bgp/manager/reconciler/neighbor_test.go
+++ b/pkg/bgp/manager/reconciler/neighbor_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/types"
@@ -22,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -228,11 +228,10 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 			// setup initial neighbors
 			neighborReconciler := NeighborReconcilerOut{
 				Reconciler: &NeighborReconciler{
-					logger:       params.Logger,
-					SecretStore:  params.SecretStore,
-					PeerConfig:   params.PeerConfig,
-					DaemonConfig: params.DaemonConfig,
-					metadata:     make(map[string]NeighborReconcilerMetadata),
+					logger:      params.Logger,
+					SecretStore: params.SecretStore,
+					PeerConfig:  params.PeerConfig,
+					metadata:    make(map[string]NeighborReconcilerMetadata),
 				},
 			}.Reconciler
 			neighborReconciler.Init(testInstance)
@@ -411,12 +410,11 @@ func TestNeighborReconciler_SourceInterfaceAddress(t *testing.T) {
 	peerConfigStore := store.NewMockBGPCPResourceStore[*v2.CiliumBGPPeerConfig]()
 
 	neighborReconciler := NewNeighborReconciler(NeighborReconcilerIn{
-		Logger:       hivetest.Logger(t),
-		SecretStore:  nil,
-		PeerConfig:   peerConfigStore,
-		DaemonConfig: &option.DaemonConfig{},
-		DB:           db,
-		DeviceTable:  deviceTable,
+		Logger:      hivetest.Logger(t),
+		SecretStore: nil,
+		PeerConfig:  peerConfigStore,
+		DB:          db,
+		DeviceTable: deviceTable,
 	}).Reconciler.(*NeighborReconciler)
 
 	// initialize test instance
@@ -526,10 +524,10 @@ func setupNeighbors(t *testing.T, peers []PeerData) (NeighborReconcilerIn, *v2.C
 	secretStore := store.InitMockStore[*slim_corev1.Secret](secretObjs)
 
 	return NeighborReconcilerIn{
-		Logger:       hivetest.Logger(t),
-		SecretStore:  secretStore,
-		PeerConfig:   peerConfigStore,
-		DaemonConfig: &option.DaemonConfig{BGPSecretsNamespace: "bgp-secrets"},
+		Logger:      hivetest.Logger(t),
+		SecretStore: secretStore,
+		PeerConfig:  peerConfigStore,
+		BGPConfig:   config.BGPConfig{SecretsNamespace: "bgp-secrets"},
 	}, nodeConfig
 }
 

--- a/pkg/bgp/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr_test.go
@@ -15,6 +15,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
@@ -449,10 +450,8 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			db := statedb.New()
-			dc := &option.DaemonConfig{
-				EnableBGPControlPlane: true,
-			}
-			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
+			bgpCfg := config.BGPConfig{Enable: true}
+			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, bgpCfg)
 			req.NoError(err)
 
 			// initialize pod cidr reconciler

--- a/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
+++ b/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
@@ -14,6 +14,7 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
@@ -23,7 +24,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -603,10 +603,8 @@ func Test_PodIPPoolAdvertisements(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			db := statedb.New()
-			dc := &option.DaemonConfig{
-				EnableBGPControlPlane: true,
-			}
-			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
+			bgpCfg := config.BGPConfig{Enable: true}
+			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, bgpCfg)
 			req.NoError(err)
 
 			params := PodIPPoolReconcilerIn{

--- a/pkg/bgp/manager/reconciler/route_policy.go
+++ b/pkg/bgp/manager/reconciler/route_policy.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cilium/statedb"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
 	"github.com/cilium/cilium/pkg/bgp/types"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type RoutePolicyReconcilerOut struct {
@@ -32,7 +32,7 @@ type RoutePolicyReconcilerIn struct {
 	Logger                  *slog.Logger
 	DB                      *statedb.DB
 	DesiredRoutePolicyTable statedb.Table[*tables.DesiredRoutePolicy]
-	DaemonConfig            *option.DaemonConfig
+	BGPConfig               config.BGPConfig
 }
 
 type RoutePolicyReconciler struct {
@@ -51,7 +51,7 @@ type RoutePolicyReconcilerMetadata struct {
 
 func NewRoutePolicyReconciler(params RoutePolicyReconcilerIn) RoutePolicyReconcilerOut {
 	// Do not create this resource if BGP Control Plane is disabled.
-	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+	if !params.BGPConfig.BGPControlPlaneEnabled() {
 		return RoutePolicyReconcilerOut{}
 	}
 

--- a/pkg/bgp/manager/reconciler/route_policy_test.go
+++ b/pkg/bgp/manager/reconciler/route_policy_test.go
@@ -16,11 +16,11 @@ import (
 
 	"github.com/cilium/cilium/pkg/bgp/agent"
 	bgpcommands "github.com/cilium/cilium/pkg/bgp/commands"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
 	bgpmock "github.com/cilium/cilium/pkg/bgp/mock"
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type routePolicyTestFixture struct {
@@ -62,10 +62,8 @@ func newRoutePolicyTestFixture(t testing.TB) *routePolicyTestFixture {
 	}
 	f.hive = ciliumhive.New(
 		cell.Provide(
-			func() *option.DaemonConfig {
-				return &option.DaemonConfig{
-					EnableBGPControlPlane: true,
-				}
+			func() config.BGPConfig {
+				return config.BGPConfig{Enable: true}
 			},
 			bgpTables.NewDesiredRoutePoliciesTable,
 			statedb.RWTable[*bgpTables.DesiredRoutePolicy].ToTable,

--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
-	"github.com/cilium/cilium/pkg/bgp/option"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -45,7 +45,7 @@ type ServiceReconcilerIn struct {
 	JobGroup job.Group
 
 	PeerAdvert   *CiliumPeerAdvertisement
-	Config       option.BGPConfig
+	Config       config.BGPConfig
 	DaemonConfig *ciliumoption.DaemonConfig
 	Signaler     *signaler.BGPCPSignaler
 
@@ -86,7 +86,7 @@ func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
 	r := &ServiceReconciler{
 		logger:                       in.Logger,
 		peerAdvert:                   in.PeerAdvert,
-		legacyOriginAttributeEnabled: in.Config.EnableBGPLegacyOriginAttribute,
+		legacyOriginAttributeEnabled: in.Config.EnableLegacyOriginAttribute,
 		signaler:                     in.Signaler,
 		db:                           in.DB,
 		frontends:                    in.Frontends,

--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -27,7 +27,6 @@ import (
 	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	ciliumoption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/svcrouteconfig"
 	"github.com/cilium/cilium/pkg/time"
@@ -44,10 +43,9 @@ type ServiceReconcilerIn struct {
 	Logger   *slog.Logger
 	JobGroup job.Group
 
-	PeerAdvert   *CiliumPeerAdvertisement
-	Config       config.BGPConfig
-	DaemonConfig *ciliumoption.DaemonConfig
-	Signaler     *signaler.BGPCPSignaler
+	PeerAdvert *CiliumPeerAdvertisement
+	Config     config.BGPConfig
+	Signaler   *signaler.BGPCPSignaler
 
 	DB                      *statedb.DB
 	Frontends               statedb.Table[*loadbalancer.Frontend]
@@ -80,7 +78,7 @@ type ServiceReconcilerMetadata struct {
 }
 
 func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
-	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+	if !in.Config.BGPControlPlaneEnabled() {
 		return ServiceReconcilerOut{}
 	}
 	r := &ServiceReconciler{

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/fake"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
-	"github.com/cilium/cilium/pkg/bgp/option"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
@@ -33,7 +33,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	ciliumoption "github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/svcrouteconfig"
 )
@@ -805,15 +804,15 @@ var (
 		Address: "10.10.10.1",
 	}
 
-	bgpConfig = func() option.BGPConfig {
-		config := option.DefaultConfig
-		return config
+	bgpConfig = func() config.BGPConfig {
+		cfg := config.DefaultConfig
+		return cfg
 	}
 
-	bgpConfigWithLegacyOriginAttrEnabled = func() option.BGPConfig {
-		config := option.DefaultConfig
-		config.EnableBGPLegacyOriginAttribute = true
-		return config
+	bgpConfigWithLegacyOriginAttrEnabled = func() config.BGPConfig {
+		cfg := config.DefaultConfig
+		cfg.EnableLegacyOriginAttribute = true
+		return cfg
 	}
 )
 
@@ -2702,9 +2701,9 @@ func Test_ServiceAdvertisementWithPeerIPChange(t *testing.T) {
 	})
 }
 
-func runServiceTests(t *testing.T, config option.BGPConfig, steps []svcTestStep) {
+func runServiceTests(t *testing.T, bgpCfg config.BGPConfig, steps []svcTestStep) {
 	// start the test hive
-	f := newServiceTestFixture(t, config)
+	f := newServiceTestFixture(t, bgpCfg)
 	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 	err := f.hive.Start(log, context.Background())
 	require.NoError(t, err)
@@ -2793,7 +2792,7 @@ func runServiceTests(t *testing.T, config option.BGPConfig, steps []svcTestStep)
 	}
 }
 
-func newServiceTestFixture(t *testing.T, config option.BGPConfig) *svcTestFixture {
+func newServiceTestFixture(t *testing.T, bgpCfg config.BGPConfig) *svcTestFixture {
 	f := &svcTestFixture{
 		PeerConfigStore: store.NewMockBGPCPResourceStore[*v2.CiliumBGPPeerConfig](),
 		AdvertStore:     store.NewMockBGPCPResourceStore[*v2.CiliumBGPAdvertisement](),
@@ -2815,13 +2814,10 @@ func newServiceTestFixture(t *testing.T, config option.BGPConfig) *svcTestFixtur
 							AdvertStore:     f.AdvertStore,
 						})
 				},
-				func() *ciliumoption.DaemonConfig {
-					return &ciliumoption.DaemonConfig{
-						EnableBGPControlPlane: true,
-					}
-				},
-				func() option.BGPConfig {
-					return config
+				func() config.BGPConfig {
+					bgpCfg.Enable = true
+
+					return bgpCfg
 				},
 				func() loadbalancer.Config {
 					return loadbalancer.Config{}
@@ -2839,9 +2835,7 @@ func newServiceTestFixture(t *testing.T, config option.BGPConfig) *svcTestFixtur
 					Logger:                  p.Logger,
 					DB:                      f.svcReconciler.db,
 					DesiredRoutePolicyTable: f.svcReconciler.desiredRoutePolicyTable,
-					DaemonConfig: &ciliumoption.DaemonConfig{
-						EnableBGPControlPlane: true,
-					},
+					BGPConfig:               config.BGPConfig{Enable: true},
 				}).Reconciler.(*RoutePolicyReconciler)
 			}),
 		),

--- a/pkg/bgp/manager/tables/route_policies.go
+++ b/pkg/bgp/manager/tables/route_policies.go
@@ -9,9 +9,9 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -230,9 +230,9 @@ func DesiredRoutePoliciesByInstanceOwnerResource(instance string, owner string, 
 	})
 }
 
-func NewDesiredRoutePoliciesTable(db *statedb.DB, dc *option.DaemonConfig) (statedb.RWTable[*DesiredRoutePolicy], error) {
+func NewDesiredRoutePoliciesTable(db *statedb.DB, bc config.BGPConfig) (statedb.RWTable[*DesiredRoutePolicy], error) {
 	// Do not create this resource if BGP Control Plane is disabled.
-	if !dc.BGPControlPlaneEnabled() {
+	if !bc.BGPControlPlaneEnabled() {
 		return nil, nil
 	}
 

--- a/pkg/bgp/manager/workdiff.go
+++ b/pkg/bgp/manager/workdiff.go
@@ -6,6 +6,7 @@ package manager
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -13,7 +14,8 @@ import (
 type reconcileDiff struct {
 	seen map[string]*v2.CiliumBGPNodeInstance
 
-	ciliumNode *v2.CiliumNode
+	ciliumNode                *v2.CiliumNode
+	bgpRouterIDAllocationMode config.BGPRouterIDAllocationModeType
 
 	register  []string
 	withdraw  []string
@@ -22,13 +24,14 @@ type reconcileDiff struct {
 
 // newReconcileDiff constructs a new *reconcileDiff with all internal structures
 // initialized.
-func newReconcileDiff(ciliumNode *v2.CiliumNode) *reconcileDiff {
+func newReconcileDiff(ciliumNode *v2.CiliumNode, bgpRouterIDAllocationMode config.BGPRouterIDAllocationModeType) *reconcileDiff {
 	return &reconcileDiff{
-		seen:       make(map[string]*v2.CiliumBGPNodeInstance),
-		ciliumNode: ciliumNode,
-		register:   []string{},
-		withdraw:   []string{},
-		reconcile:  []string{},
+		seen:                      make(map[string]*v2.CiliumBGPNodeInstance),
+		ciliumNode:                ciliumNode,
+		bgpRouterIDAllocationMode: bgpRouterIDAllocationMode,
+		register:                  []string{},
+		withdraw:                  []string{},
+		reconcile:                 []string{},
 	}
 }
 
@@ -107,7 +110,7 @@ func (wd *reconcileDiff) requiresRecreate(existing *instance.BGPInstance, desire
 		return false, fmt.Errorf("failed to get local port for instance %v: %w", desiredConfig.Name, err)
 	}
 
-	routerID, err := getRouterID(desiredConfig, wd.ciliumNode)
+	routerID, err := getRouterID(desiredConfig, wd.ciliumNode, wd.bgpRouterIDAllocationMode)
 	if err != nil {
 		return false, fmt.Errorf("failed to get router ID for instance %v: %w", desiredConfig.Name, err)
 	}

--- a/pkg/bgp/manager/workdiff.go
+++ b/pkg/bgp/manager/workdiff.go
@@ -14,8 +14,8 @@ import (
 type reconcileDiff struct {
 	seen map[string]*v2.CiliumBGPNodeInstance
 
-	ciliumNode                *v2.CiliumNode
-	bgpRouterIDAllocationMode config.BGPRouterIDAllocationModeType
+	ciliumNode *v2.CiliumNode
+	bgpConfig  config.BGPConfig
 
 	register  []string
 	withdraw  []string
@@ -24,14 +24,14 @@ type reconcileDiff struct {
 
 // newReconcileDiff constructs a new *reconcileDiff with all internal structures
 // initialized.
-func newReconcileDiff(ciliumNode *v2.CiliumNode, bgpRouterIDAllocationMode config.BGPRouterIDAllocationModeType) *reconcileDiff {
+func newReconcileDiff(ciliumNode *v2.CiliumNode, bgpConfig config.BGPConfig) *reconcileDiff {
 	return &reconcileDiff{
-		seen:                      make(map[string]*v2.CiliumBGPNodeInstance),
-		ciliumNode:                ciliumNode,
-		bgpRouterIDAllocationMode: bgpRouterIDAllocationMode,
-		register:                  []string{},
-		withdraw:                  []string{},
-		reconcile:                 []string{},
+		seen:       make(map[string]*v2.CiliumBGPNodeInstance),
+		ciliumNode: ciliumNode,
+		bgpConfig:  bgpConfig,
+		register:   []string{},
+		withdraw:   []string{},
+		reconcile:  []string{},
 	}
 }
 
@@ -110,7 +110,7 @@ func (wd *reconcileDiff) requiresRecreate(existing *instance.BGPInstance, desire
 		return false, fmt.Errorf("failed to get local port for instance %v: %w", desiredConfig.Name, err)
 	}
 
-	routerID, err := getRouterID(desiredConfig, wd.ciliumNode, wd.bgpRouterIDAllocationMode)
+	routerID, err := getRouterID(desiredConfig, wd.ciliumNode, wd.bgpConfig)
 	if err != nil {
 		return false, fmt.Errorf("failed to get router ID for instance %v: %w", desiredConfig.Name, err)
 	}

--- a/pkg/bgp/metrics/metrics.go
+++ b/pkg/bgp/metrics/metrics.go
@@ -13,10 +13,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/bgp/agent"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -32,7 +32,7 @@ type collectorIn struct {
 	cell.In
 
 	Logger        *slog.Logger
-	DaemonConfig  *option.DaemonConfig
+	BGPConfig     config.BGPConfig
 	Registry      *metrics.Registry
 	RouterManager agent.BGPRouterManager
 }
@@ -47,7 +47,7 @@ type collectorIn struct {
 // MustRegister interface. We may want to revisit this in the future.
 func RegisterCollector(in collectorIn) {
 	// Don't provide the collector if BGP control plane is disabled
-	if !in.DaemonConfig.EnableBGPControlPlane {
+	if !in.BGPConfig.BGPControlPlaneEnabled() {
 		return
 	}
 	in.Registry.MustRegister(&collector{

--- a/pkg/bgp/test/script_test.go
+++ b/pkg/bgp/test/script_test.go
@@ -26,6 +26,7 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bgp"
 	"github.com/cilium/cilium/pkg/bgp/agent"
+	"github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bgp/manager"
 	"github.com/cilium/cilium/pkg/bgp/test/commands"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -144,12 +145,9 @@ func TestPrivilegedScript(t *testing.T) {
 			cell.Provide(
 				func() *option.DaemonConfig {
 					option.Config = &option.DaemonConfig{
-						EnableBGPControlPlane:     true,
-						BGPSecretsNamespace:       testSecretsNamespace,
-						BGPRouterIDAllocationMode: option.BGPRouterIDAllocationModeDefault,
-						IPAM:                      *ipam,
-						EnableIPv4:                true,
-						EnableIPv6:                true,
+						IPAM:       *ipam,
+						EnableIPv4: true,
+						EnableIPv6: true,
 					}
 					return option.Config
 				},
@@ -169,6 +167,14 @@ func TestPrivilegedScript(t *testing.T) {
 				lbWriter = w
 			}),
 		)
+
+		hive.AddConfigOverride(
+			h,
+			func(cfg *config.BGPConfig) {
+				cfg.Enable = true
+				cfg.SecretsNamespace = testSecretsNamespace
+				cfg.RouterIDAllocationMode = config.BGPRouterIDAllocationModeDefault
+			})
 
 		hive.AddConfigOverride(
 			h,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -54,10 +54,10 @@ const (
 	RuntimePath = "/var/run/cilium"
 
 	// RuntimePathRights are the default access rights of the RuntimePath directory
-	RuntimePathRights = 0775
+	RuntimePathRights = 0o775
 
 	// StateDirRights are the default access rights of the state directory
-	StateDirRights = 0770
+	StateDirRights = 0o770
 
 	// StateDir is the default path for the state directory relative to RuntimePath
 	StateDir = "state"
@@ -475,9 +475,6 @@ const (
 	// EnableVTEP enables VXLAN Tunnel Endpoint (VTEP) Integration
 	EnableVTEP     = false
 	MaxVTEPDevices = 8
-
-	// Enable BGP control plane features.
-	EnableBGPControlPlane = false
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = true

--- a/pkg/k8s/apis/cell.go
+++ b/pkg/k8s/apis/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
@@ -86,8 +87,10 @@ type RegisterCRDsFuncOut struct {
 	Func RegisterCRDsFunc `group:"register-crd-funcs"`
 }
 
-func newCiliumGroupCRDs() RegisterCRDsFuncOut {
+func newCiliumGroupCRDs(bc bgpConfig.BGPConfig) RegisterCRDsFuncOut {
 	return RegisterCRDsFuncOut{
-		Func: client.RegisterCRDs,
+		Func: func(l *slog.Logger, c k8sClient.Clientset) error {
+			return client.RegisterCRDs(l, c, bc)
+		},
 	}
 }

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -13,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/cilium/cilium/pkg/bgp/config"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconstv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -213,10 +215,10 @@ func CustomResourceDefinitionList() map[string]*CRDList {
 
 // CreateCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
-func CreateCustomResourceDefinitions(logger *slog.Logger, clientset apiextensionsclient.Interface) error {
+func CreateCustomResourceDefinitions(logger *slog.Logger, clientset apiextensionsclient.Interface, bgpCfg bgpConfig.BGPConfig) error {
 	crds := CustomResourceDefinitionList()
 
-	for _, r := range synced.AllCiliumCRDResourceNames() {
+	for _, r := range synced.AllCiliumCRDResourceNames(bgpCfg) {
 		if crd, ok := crds[r]; ok {
 			if err := createCRD(logger, clientset, crd.Name, crd.FullName); err != nil {
 				return err
@@ -431,8 +433,8 @@ func constructV1CRD(
 }
 
 // RegisterCRDs registers all CRDs with the K8s apiserver.
-func RegisterCRDs(logger *slog.Logger, clientset client.Clientset) error {
-	if err := CreateCustomResourceDefinitions(logger, clientset); err != nil {
+func RegisterCRDs(logger *slog.Logger, clientset client.Clientset, bgpCfg config.BGPConfig) error {
+	if err := CreateCustomResourceDefinitions(logger, clientset, bgpCfg); err != nil {
 		return fmt.Errorf("Unable to create custom resource definition: %w", err)
 	}
 

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -40,7 +41,7 @@ func CRDResourceName(crd string) string {
 	return "crd:" + crd
 }
 
-func agentCRDResourceNames() []string {
+func agentCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
 	result := []string{
 		CRDResourceName(v2.CIDName),
 		CRDResourceName(v2alpha1.CPIPName),
@@ -79,7 +80,7 @@ func agentCRDResourceNames() []string {
 		result = append(result, CRDResourceName(v2.CCECName))
 		result = append(result, CRDResourceName(v2.CECName))
 	}
-	if option.Config.EnableBGPControlPlane {
+	if bgpCfg.Enable {
 		result = append(result, CRDResourceName(v2.BGPCCName))
 		result = append(result, CRDResourceName(v2.BGPAName))
 		result = append(result, CRDResourceName(v2.BGPPCName))
@@ -101,8 +102,8 @@ func agentCRDResourceNames() []string {
 
 // AgentCRDResourceNames returns a list of all CRD resource names the Cilium
 // agent needs to wait to be registered before initializing any k8s watchers.
-func AgentCRDResourceNames() []string {
-	return agentCRDResourceNames()
+func AgentCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
+	return agentCRDResourceNames(bgpCfg)
 }
 
 // ClusterMeshAPIServerResourceNames returns a list of all CRD resource names the
@@ -127,8 +128,8 @@ func GatewayAPIResourceNames() []string {
 
 // AllCiliumCRDResourceNames returns a list of all Cilium CRD resource names
 // that the cilium operator or testsuite may register.
-func AllCiliumCRDResourceNames() []string {
-	res := append(AgentCRDResourceNames(), GatewayAPIResourceNames()...)
+func AllCiliumCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
+	res := append(AgentCRDResourceNames(bgpCfg), GatewayAPIResourceNames()...)
 	res = append(res,
 		CRDResourceName(v2.CNCName),
 	)

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/datapath/connector"
@@ -103,6 +104,7 @@ type featuresParams struct {
 	WgConfig            wgTypes.Config
 	IPsecConfig         ipsec.Config
 	ConnectorConfig     connector.Config
+	BGPConfig           bgpConfig.BGPConfig
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.EncapProtocol {

--- a/pkg/metrics/features/features.go
+++ b/pkg/metrics/features/features.go
@@ -25,7 +25,7 @@ func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featu
 		if err != nil {
 			return fmt.Errorf("failed to get agent config: %w", err)
 		}
-		m.update(&params, agentConfig, params.LBConfig, params.KPRConfig, params.WgConfig, params.IPsecConfig)
+		m.update(&params, agentConfig, params.LBConfig, params.KPRConfig, params.WgConfig, params.IPsecConfig, params.BGPConfig)
 		return nil
 	}))
 

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
@@ -972,11 +973,11 @@ func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 }
 
 type featureMetrics interface {
-	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.Config, ipsecCfg ipsec.Config)
+	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.Config, ipsecCfg ipsec.Config, bgpCfg bgpConfig.BGPConfig)
 	toGatherer() (prometheus.Gatherer, error)
 }
 
-func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.Config, ipsecCfg ipsec.Config) {
+func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.Config, ipsecCfg ipsec.Config, bgpCfg bgpConfig.BGPConfig) {
 	networkMode := networkModeDirectRouting
 	if config.TunnelingEnabled() {
 		switch params.TunnelProtocol() {
@@ -1069,7 +1070,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 
 	m.ACLBNodePortConfig.WithLabelValues(lbConfig.LBMode, lbConfig.LBAlgorithm, config.NodePortAcceleration).Set(1)
 
-	if config.EnableBGPControlPlane {
+	if bgpCfg.Enable {
 		m.ACLBBGPEnabled.Set(1)
 	}
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	fakeconnector "github.com/cilium/cilium/pkg/datapath/connector/fake"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
@@ -139,7 +140,7 @@ func TestUpdateNetworkMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultNetworkModes {
@@ -191,7 +192,7 @@ func TestUpdateIPAMMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultIPAMModes {
@@ -243,7 +244,7 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 				CNIChainingMode: tt.chainingMode,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultChainingModes {
@@ -305,7 +306,7 @@ func TestUpdateInternetProtocol(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultChainingModes {
@@ -356,7 +357,7 @@ func TestUpdateIdentityAllocationMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultIdentityAllocationModes {
@@ -412,7 +413,7 @@ func TestUpdateCiliumEndpointSlices(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.CPCiliumEndpointSlicesEnabled.Get()
 
@@ -484,7 +485,7 @@ func TestUpdateDeviceMode(t *testing.T) {
 				ConnectorConfig: fakeconnector.NewConfig(tt.configuredMode, tt.operationalMode),
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode counters are incremented
 			for _, configuredMode := range defaultConfiguredDatapathModes {
@@ -543,7 +544,7 @@ func TestUpdateHostFirewall(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.NPHostFirewallEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableHostFirewall, counterValue)
@@ -588,7 +589,7 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.NPLocalRedirectPolicyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableLRP, counterValue)
@@ -634,7 +635,7 @@ func TestUpdateMutualAuth(t *testing.T) {
 				MutualAuth:      tt.enableMutualAuth,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.NPMutualAuthEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableMutualAuth, counterValue)
@@ -680,7 +681,7 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.NPNonDefaultDenyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableNonDefaultDeny, counterValue)
@@ -723,7 +724,7 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultCIDRPolicies {
@@ -847,7 +848,7 @@ func TestUpdateEncryptionMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{EnableWireguard: tt.enableWireguard}, fakeipsec.Config{EnableIPsec: tt.enableIPSec})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{EnableWireguard: tt.enableWireguard}, fakeipsec.Config{EnableIPsec: tt.enableIPSec}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, encMode := range defaultEncryptionModes {
@@ -908,7 +909,7 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{KubeProxyReplacement: tt.enableKubeProxyReplacement}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{KubeProxyReplacement: tt.enableKubeProxyReplacement}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBKubeProxyReplacementEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableKubeProxyReplacement, counterValue)
@@ -964,7 +965,7 @@ func TestUpdateNodePortConfig(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, portMode := range defaultNodePortModes {
@@ -1014,7 +1015,6 @@ func TestUpdateBGP(t *testing.T) {
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultConfiguredDatapathMode,
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
-				EnableBGPControlPlane:  tt.bgpControlPlane,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
@@ -1025,7 +1025,7 @@ func TestUpdateBGP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{Enable: tt.bgpControlPlane})
 
 			counterValue := metrics.ACLBBGPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for bgpControlPlane: %t, got %.f", tt.expected, tt.bgpControlPlane, counterValue)
@@ -1071,7 +1071,7 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBEgressGatewayEnabled.Get()
 
@@ -1118,7 +1118,7 @@ func TestUpdateBandwidthManager(t *testing.T) {
 				BandwidthManager: tt.enableBandwidthManager,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBBandwidthManagerEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableBandwidthManager, counterValue)
@@ -1164,7 +1164,7 @@ func TestUpdateSCTP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBSCTPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableSCTP, counterValue)
@@ -1210,7 +1210,7 @@ func TestUpdateVTEP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBVTEPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableVTEP, counterValue)
@@ -1256,7 +1256,7 @@ func TestUpdateEnvoyConfig(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBCiliumEnvoyConfigEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableEnvoyConfig, counterValue)
@@ -1312,7 +1312,7 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 				},
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultBigTCPAddressFamilies {
@@ -1368,7 +1368,7 @@ func TestUpdateL2Announcements(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBL2LBEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2Announcements, counterValue)
@@ -1414,7 +1414,7 @@ func TestUpdateL2PodAnnouncements(t *testing.T) {
 				L2PodAnnouncement: tt.enableL2PodAnnouncements,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBL2PodAnnouncementEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2PodAnnouncements, counterValue)
@@ -1460,7 +1460,7 @@ func TestUpdateExtEnvoyProxyMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultExternalEnvoyProxyModes {
@@ -1516,13 +1516,14 @@ func TestUpdateDynamicNodeConfig(t *testing.T) {
 				isDynamicConfigSourceKindNodeConfig: tt.enableDynamicNodeConfig,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counterValue := metrics.ACLBCiliumNodeConfigEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableDynamicNodeConfig, counterValue)
 		})
 	}
 }
+
 func TestUpdateKernelVersion(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1564,7 +1565,7 @@ func TestUpdateKernelVersion(t *testing.T) {
 				KernelVersionString: "3.2.1",
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakewireguard.Config{}, fakeipsec.Config{}, bgpConfig.BGPConfig{})
 
 			counter, err := metrics.DPKernelVersion.GetMetricWithLabelValues(params.KernelVersion())
 			assert.NoError(t, err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -886,9 +886,6 @@ const (
 	// delegated IPAM plugin.
 	InstallUplinkRoutesForDelegatedIPAM = "install-uplink-routes-for-delegated-ipam"
 
-	// BGPSecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
-	BGPSecretsNamespace = "bgp-secrets-namespace"
-
 	// VLANBPFBypass instructs Cilium to bypass bpf logic for vlan tagged packets
 	VLANBPFBypass = "vlan-bpf-bypass"
 
@@ -912,18 +909,6 @@ const (
 	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
 	// filters to be inserted prior to the cilium filter.
 	TCFilterPriority = "bpf-filter-priority"
-
-	// Flag to enable BGP control plane features
-	EnableBGPControlPlane = "enable-bgp-control-plane"
-
-	// EnableBGPControlPlaneStatusReport enables BGP Control Plane CRD status reporting
-	EnableBGPControlPlaneStatusReport = "enable-bgp-control-plane-status-report"
-
-	// BGP router-id allocation mode
-	BGPRouterIDAllocationMode = "bgp-router-id-allocation-mode"
-
-	// BGP router-id allocation IP pool
-	BGPRouterIDAllocationIPPool = "bgp-router-id-allocation-ip-pool"
 
 	// EnablePMTUDiscovery enables path MTU discovery to send ICMP
 	// fragmentation-needed replies to the client (when needed).
@@ -1079,14 +1064,6 @@ const (
 	// IdentityManagementModeBoth means cilium-agent and cilium-operator both manage identities
 	// (used only during migration between "agent" and "operator").
 	IdentityManagementModeBoth = "both"
-)
-
-const (
-	// BGPRouterIDAllocationModeDefault means the router-id is allocated per node
-	BGPRouterIDAllocationModeDefault = "default"
-
-	// BGPRouterIDAllocationModeIPPool means the router-id is allocated per IP pool
-	BGPRouterIDAllocationModeIPPool = "ip-pool"
 )
 
 // IPSec-related options.
@@ -1757,9 +1734,6 @@ type DaemonConfig struct {
 	// the provided comma-separated list of ports in the container network namespace
 	ContainerIPLocalReservedPorts string
 
-	// BGPSecretsNamespace is the Kubernetes namespace to get BGP control plane secrets from.
-	BGPSecretsNamespace string
-
 	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature.
 	EnableCiliumEndpointSlice bool
 
@@ -1786,18 +1760,6 @@ type DaemonConfig struct {
 	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
 	// filters to be inserted prior to the cilium filter.
 	TCFilterPriority uint16
-
-	// Enables BGP control plane features.
-	EnableBGPControlPlane bool
-
-	// Enables BGP control plane status reporting.
-	EnableBGPControlPlaneStatusReport bool
-
-	// BGPRouterIDAllocationMode is the mode to allocate the BGP router-id.
-	BGPRouterIDAllocationMode string
-
-	// BGPRouterIDAllocationIPPool is the IP pool to allocate the BGP router-id from.
-	BGPRouterIDAllocationIPPool string
 
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
@@ -1891,69 +1853,66 @@ type DaemonConfig struct {
 	EnableDatapathPlugins bool
 }
 
-var (
-	// Config represents the daemon configuration
-	Config = &DaemonConfig{
-		CreationTime:                    time.Now(),
-		Opts:                            NewIntOptions(&DaemonOptionLibrary),
-		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
-		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
-		IPAMDefaultIPPool:               defaults.IPAMDefaultIPPool,
-		EnableHealthChecking:            defaults.EnableHealthChecking,
-		EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
-		HealthCheckICMPFailureThreshold: defaults.HealthCheckICMPFailureThreshold,
-		EnableIPv4:                      defaults.EnableIPv4,
-		EnableIPv6:                      defaults.EnableIPv6,
-		PreferIpv6:                      defaults.PreferIpv6,
-		EnableIPv6NDP:                   defaults.EnableIPv6NDP,
-		EnableSCTP:                      defaults.EnableSCTP,
-		EnableL7Proxy:                   defaults.EnableL7Proxy,
-		ToFQDNsMaxIPsPerHost:            defaults.ToFQDNsMaxIPsPerHost,
-		IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
-		CiliumIdentityMaxJitter:         defaults.CiliumIdentityMaxJitter,
-		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriodK8s,
-		FixedIdentityMapping:            make(map[string]string),
-		LogOpt:                          make(map[string]string),
-		EnableEndpointRoutes:            defaults.EnableEndpointRoutes,
-		AnnotateK8sNode:                 defaults.AnnotateK8sNode,
-		AutoCreateCiliumNodeResource:    defaults.AutoCreateCiliumNodeResource,
-		IdentityAllocationMode:          IdentityAllocationModeKVstore,
-		AllowICMPFragNeeded:             defaults.AllowICMPFragNeeded,
-		AllocatorListTimeout:            defaults.AllocatorListTimeout,
-		EnableICMPRules:                 defaults.EnableICMPRules,
-		DatapathMode:                    defaults.DatapathMode,
+// Config represents the daemon configuration
+var Config = &DaemonConfig{
+	CreationTime:                    time.Now(),
+	Opts:                            NewIntOptions(&DaemonOptionLibrary),
+	IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
+	IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
+	IPAMDefaultIPPool:               defaults.IPAMDefaultIPPool,
+	EnableHealthChecking:            defaults.EnableHealthChecking,
+	EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
+	HealthCheckICMPFailureThreshold: defaults.HealthCheckICMPFailureThreshold,
+	EnableIPv4:                      defaults.EnableIPv4,
+	EnableIPv6:                      defaults.EnableIPv6,
+	PreferIpv6:                      defaults.PreferIpv6,
+	EnableIPv6NDP:                   defaults.EnableIPv6NDP,
+	EnableSCTP:                      defaults.EnableSCTP,
+	EnableL7Proxy:                   defaults.EnableL7Proxy,
+	ToFQDNsMaxIPsPerHost:            defaults.ToFQDNsMaxIPsPerHost,
+	IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
+	CiliumIdentityMaxJitter:         defaults.CiliumIdentityMaxJitter,
+	IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriodK8s,
+	FixedIdentityMapping:            make(map[string]string),
+	LogOpt:                          make(map[string]string),
+	EnableEndpointRoutes:            defaults.EnableEndpointRoutes,
+	AnnotateK8sNode:                 defaults.AnnotateK8sNode,
+	AutoCreateCiliumNodeResource:    defaults.AutoCreateCiliumNodeResource,
+	IdentityAllocationMode:          IdentityAllocationModeKVstore,
+	AllowICMPFragNeeded:             defaults.AllowICMPFragNeeded,
+	AllocatorListTimeout:            defaults.AllocatorListTimeout,
+	EnableICMPRules:                 defaults.EnableICMPRules,
+	DatapathMode:                    defaults.DatapathMode,
 
-		EnableVTEP:                           defaults.EnableVTEP,
-		EnableBGPControlPlane:                defaults.EnableBGPControlPlane,
-		EnableK8sNetworkPolicy:               defaults.EnableK8sNetworkPolicy,
-		EnableK8sClusterNetworkPolicy:        defaults.EnableK8sClusterNetworkPolicy,
-		EnableCiliumNetworkPolicy:            defaults.EnableCiliumNetworkPolicy,
-		EnableCiliumClusterwideNetworkPolicy: defaults.EnableCiliumClusterwideNetworkPolicy,
-		PolicyCIDRMatchMode:                  defaults.PolicyCIDRMatchMode,
-		MaxConnectedClusters:                 defaults.MaxConnectedClusters,
+	EnableVTEP:                           defaults.EnableVTEP,
+	EnableK8sNetworkPolicy:               defaults.EnableK8sNetworkPolicy,
+	EnableK8sClusterNetworkPolicy:        defaults.EnableK8sClusterNetworkPolicy,
+	EnableCiliumNetworkPolicy:            defaults.EnableCiliumNetworkPolicy,
+	EnableCiliumClusterwideNetworkPolicy: defaults.EnableCiliumClusterwideNetworkPolicy,
+	PolicyCIDRMatchMode:                  defaults.PolicyCIDRMatchMode,
+	MaxConnectedClusters:                 defaults.MaxConnectedClusters,
 
-		BPFDistributedLRU:             defaults.BPFDistributedLRU,
-		BPFEventsDropEnabled:          defaults.BPFEventsDropEnabled,
-		BPFEventsPolicyVerdictEnabled: defaults.BPFEventsPolicyVerdictEnabled,
-		BPFEventsTraceEnabled:         defaults.BPFEventsTraceEnabled,
-		BPFConntrackAccounting:        defaults.BPFConntrackAccounting,
-		EnableEnvoyConfig:             defaults.EnableEnvoyConfig,
+	BPFDistributedLRU:             defaults.BPFDistributedLRU,
+	BPFEventsDropEnabled:          defaults.BPFEventsDropEnabled,
+	BPFEventsPolicyVerdictEnabled: defaults.BPFEventsPolicyVerdictEnabled,
+	BPFEventsTraceEnabled:         defaults.BPFEventsTraceEnabled,
+	BPFConntrackAccounting:        defaults.BPFConntrackAccounting,
+	EnableEnvoyConfig:             defaults.EnableEnvoyConfig,
 
-		EnableNonDefaultDenyPolicies: defaults.EnableNonDefaultDenyPolicies,
+	EnableNonDefaultDenyPolicies: defaults.EnableNonDefaultDenyPolicies,
 
-		EnableSourceIPVerification: defaults.EnableSourceIPVerification,
+	EnableSourceIPVerification: defaults.EnableSourceIPVerification,
 
-		ConnectivityProbeFrequencyRatio: defaults.ConnectivityProbeFrequencyRatio,
+	ConnectivityProbeFrequencyRatio: defaults.ConnectivityProbeFrequencyRatio,
 
-		IPTracingOptionType: defaults.IPTracingOptionType,
+	IPTracingOptionType: defaults.IPTracingOptionType,
 
-		EnableCiliumNodeCRD: defaults.EnableCiliumNodeCRD,
+	EnableCiliumNodeCRD: defaults.EnableCiliumNodeCRD,
 
-		PolicyAccounting: defaults.PolicyAccounting,
+	PolicyAccounting: defaults.PolicyAccounting,
 
-		EnableDatapathPlugins: defaults.EnableDatapathPlugins,
-	}
-)
+	EnableDatapathPlugins: defaults.EnableDatapathPlugins,
+}
 
 // IsExcludedLocalAddress returns true if the specified IP matches one of the
 // excluded local IP ranges
@@ -2531,7 +2490,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LoadBalancerIPIPSockMark = vp.GetBool(LoadBalancerIPIPSockMark)
 	c.InstallNoConntrackIptRules = vp.GetBool(InstallNoConntrackIptRules)
 	c.ContainerIPLocalReservedPorts = vp.GetString(ContainerIPLocalReservedPorts)
-	c.BGPSecretsNamespace = vp.GetString(BGPSecretsNamespace)
 	c.EnableNat46X64Gateway = vp.GetBool(EnableNat46X64Gateway)
 	c.EnableRemoteNodeMasquerade = vp.GetBool(EnableRemoteNodeMasquerade)
 	c.EnableIPv4Masquerade = vp.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
@@ -2875,16 +2833,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	// VTEP integration enable option
 	c.EnableVTEP = vp.GetBool(EnableVTEP)
 
-	// Enable BGP control plane features
-	c.EnableBGPControlPlane = vp.GetBool(EnableBGPControlPlane)
-
-	// Enable BGP control plane status reporting
-	c.EnableBGPControlPlaneStatusReport = vp.GetBool(EnableBGPControlPlaneStatusReport)
-
-	// BGP router-id allocation mode
-	c.BGPRouterIDAllocationMode = vp.GetString(BGPRouterIDAllocationMode)
-	c.BGPRouterIDAllocationIPPool = vp.GetString(BGPRouterIDAllocationIPPool)
-
 	// Support failure-mode for policy map overflow
 	c.EnableEndpointLockdownOnPolicyOverflow = vp.GetBool(EnableEndpointLockdownOnPolicyOverflow)
 
@@ -3130,8 +3078,8 @@ func (c *DaemonConfig) SetMapElementSizes(
 	sizeofCTElement,
 	sizeofNATElement,
 	sizeofNeighElement,
-	sizeofSockRevElement int) {
-
+	sizeofSockRevElement int,
+) {
 	c.SizeofCTElement = sizeofCTElement
 	c.SizeofNATElement = sizeofNATElement
 	c.SizeofNeighElement = sizeofNeighElement
@@ -3216,16 +3164,14 @@ func (c *DaemonConfig) calculateDynamicBPFMapSizes(logger *slog.Logger, vp *vipe
 		logger.Debug(fmt.Sprintf("option %s set by user to %v", CTMapEntriesGlobalTCPName, c.CTMapEntriesGlobalTCP))
 	}
 	if !vp.IsSet(CTMapEntriesGlobalAnyName) {
-		c.CTMapEntriesGlobalAny =
-			getEntries(CTMapEntriesGlobalAnyDefault, LimitTableAutoGlobalAnyMin, LimitTableMax)
+		c.CTMapEntriesGlobalAny = getEntries(CTMapEntriesGlobalAnyDefault, LimitTableAutoGlobalAnyMin, LimitTableMax)
 		logger.Info(fmt.Sprintf("option %s set by dynamic sizing to %v",
 			CTMapEntriesGlobalAnyName, c.CTMapEntriesGlobalAny))
 	} else {
 		logger.Debug(fmt.Sprintf("option %s set by user to %v", CTMapEntriesGlobalAnyName, c.CTMapEntriesGlobalAny))
 	}
 	if !vp.IsSet(NATMapEntriesGlobalName) {
-		c.NATMapEntriesGlobal =
-			getEntries(NATMapEntriesGlobalDefault, LimitTableAutoNatGlobalMin, LimitTableMax)
+		c.NATMapEntriesGlobal = getEntries(NATMapEntriesGlobalDefault, LimitTableAutoNatGlobalMin, LimitTableMax)
 		logger.Info(fmt.Sprintf("option %s set by dynamic sizing to %v",
 			NATMapEntriesGlobalName, c.NATMapEntriesGlobal))
 		if c.NATMapEntriesGlobal > c.CTMapEntriesGlobalTCP+c.CTMapEntriesGlobalAny {
@@ -3408,10 +3354,6 @@ func (c *DaemonConfig) diffFromFile() error {
 			cmpopts.IgnoreTypes(&OptionLibrary{}))
 	}
 	return fmt.Errorf("Config differs:\n%s", diff)
-}
-
-func (c *DaemonConfig) BGPControlPlaneEnabled() bool {
-	return c.EnableBGPControlPlane
 }
 
 func (c *DaemonConfig) IsDualStack() bool {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -32,6 +32,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	cnpv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/test/config"
@@ -4030,7 +4031,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"role":               "cilium-config-agent",
 		}
 
-		crdsToDelete = synced.AllCiliumCRDResourceNames()
+		crdsToDelete = synced.AllCiliumCRDResourceNames(bgpConfig.DefaultConfig)
 	)
 
 	wg.Add(len(resourcesToDelete))


### PR DESCRIPTION
Thanks to @dvachaiev for getting this worked on! They did the majority of the work, just getting it over the finish line (original pr #46748) (rebased on 'main' and split out of the original commit)

Decoupled BGP CP cell from the common daemon infra, moved bgp config flags from the common DaemonConfig to BGPConfig.

The BGP flags - `enable-bgp-control-plane`, `enable-bgp-control-plane-status-report`, `bgp-secrets-namespace`, `bgp-router-id-allocation-mode` and `bgp-router-id-allocation-ip-pool` - are now declared by the BGPConfig cell config in `pkg/bgp/config` instead of DaemonConfig.

Fixes: #45352 

```release-note
bgp: Move bgp config flags to bgp cell
```
