### PR TITLE
fix(bpf): don't drop IPv6 RS/RAs when masquerading

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -17,6 +17,8 @@
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 #define ICMP6_ND_OPT_LEN 8
 
+#define ICMP6_RS_MSG_TYPE		133
+#define ICMP6_RA_MSG_TYPE		134
 #define ICMP6_NS_MSG_TYPE		135
 #define ICMP6_NA_MSG_TYPE		136
 #define ICMP6_RR_MSG_TYPE		138

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -2066,6 +2066,8 @@ snat_v6_nat(struct __ctx_buff *ctx, fraginfo_t fraginfo, int off, __s8 *ext_err)
 		switch (icmp6hdr.icmp6_type) {
 		case ICMPV6_ECHO_REPLY:
 		case ICMPV6_REDIRECT:
+		case ICMP6_RS_MSG_TYPE:
+		case ICMP6_RA_MSG_TYPE:
 		case ICMP6_NS_MSG_TYPE:
 		case ICMP6_NA_MSG_TYPE:
 			return NAT_PUNT_TO_STACK;

--- a/bpf/tests/host_bpf_masq_linklocal.c
+++ b/bpf/tests/host_bpf_masq_linklocal.c
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* BPF masquerade on a node whose only IPv6 address is a link-local.
+ *
+ * When no selected device has a global IPv6 address, the best IPv6 fallback
+ * node address is the link-local (fallbackAddresses.update() ranks addresses by
+ * public-vs-private and scope, and does not exclude link-locals), so that is
+ * what bpfMasqAddrs() hands the datapath as nat_ipv6_masquerade. Router
+ * Solicitations and Advertisements are sourced from that same link-local, which
+ * makes __snat_v6_needs_masquerade() answer NAT_NEEDED on its very first test,
+ * so snat_v6_nat() has to decide what to do with them.
+ */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6			1
+#define ENABLE_MASQUERADE_IPV6		1
+#define ENABLE_NODEPORT			1
+
+#define NODE_IP_V6			v6_node_one_ll
+
+/* Set port ranges to have deterministic source port selection */
+#include "nodeport_defaults.h"
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *server_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(union v6addr, nat_ipv6_masquerade, { .addr = v6_node_one_ll_addr})
+
+static __always_inline int check_not_masqueraded(const struct __ctx_buff *ctx)
+{
+	const __u8 expected_src[16] = v6_node_one_ll_addr;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	/* the packet must still carry the link-local source it was sent with */
+	if (memcmp(&l3->saddr, expected_src, 16) != 0)
+		test_fatal("src IP has been masqueraded");
+
+	test_finish();
+}
+
+/* Router Advertisements must reach the wire untranslated. Masquerading one
+ * would advertise the masquerade address as the router's link-local, and an
+ * ICMPv6 type that snat_v6_nat() does not recognise is dropped outright with
+ * DROP_NAT_UNSUPP_PROTO.
+ */
+PKTGEN(PROG_TYPE, "host_bpf_masq_ll_v6_1_icmp6_ra")
+int host_bpf_masq_ll_v6_1_icmp6_ra_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp;
+
+	pktgen__init(&builder, ctx);
+
+	icmp = pktgen__push_ipv6_icmp6_packet(&builder,
+					      (__u8 *)node_mac, (__u8 *)server_mac,
+					      (__u8 *)NODE_IP_V6,
+					      (__u8 *)v6_all_nodes_mcast,
+					      ICMP6_RA_MSG_TYPE);
+	if (!icmp)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "host_bpf_masq_ll_v6_1_icmp6_ra")
+int host_bpf_masq_ll_v6_1_icmp6_ra_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "host_bpf_masq_ll_v6_1_icmp6_ra")
+int host_bpf_masq_ll_v6_1_icmp6_ra_check(const struct __ctx_buff *ctx)
+{
+	return check_not_masqueraded(ctx);
+}
+
+/* Router Solicitations get the same treatment. */
+PKTGEN(PROG_TYPE, "host_bpf_masq_ll_v6_2_icmp6_rs")
+int host_bpf_masq_ll_v6_2_icmp6_rs_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp;
+
+	pktgen__init(&builder, ctx);
+
+	icmp = pktgen__push_ipv6_icmp6_packet(&builder,
+					      (__u8 *)node_mac, (__u8 *)server_mac,
+					      (__u8 *)NODE_IP_V6,
+					      (__u8 *)v6_all_routers_mcast,
+					      ICMP6_RS_MSG_TYPE);
+	if (!icmp)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "host_bpf_masq_ll_v6_2_icmp6_rs")
+int host_bpf_masq_ll_v6_2_icmp6_rs_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "host_bpf_masq_ll_v6_2_icmp6_rs")
+int host_bpf_masq_ll_v6_2_icmp6_rs_check(const struct __ctx_buff *ctx)
+{
+	return check_not_masqueraded(ctx);
+}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -119,6 +119,17 @@ volatile const __u8 v6_node_one[] = v6_node_one_addr;
 volatile const __u8 v6_node_two[] = v6_node_two_addr;
 volatile const __u8 v6_node_three[] = v6_node_three_addr;
 
+/* Link-local address of a node's native device, and the Neighbor Discovery
+ * multicast destinations.
+ */
+#define v6_node_one_ll_addr {0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+#define v6_all_nodes_mcast_addr {0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+#define v6_all_routers_mcast_addr {0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+
+volatile const __u8 v6_node_one_ll[] = v6_node_one_ll_addr;
+volatile const __u8 v6_all_nodes_mcast[] = v6_all_nodes_mcast_addr;
+volatile const __u8 v6_all_routers_mcast[] = v6_all_routers_mcast_addr;
+
 /* IPv6 addresses for services in the cluster */
 #define v6_svc_one_addr {0xfd, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 #define v6_svc_two_addr {0xfd, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

`snat_v6_nat()` punts ICMPv6 echo replies, redirects and NS/NA to the stack but
returns `DROP_NAT_UNSUPP_PROTO` for every other type, so Router Solicitations and
Advertisements do not survive the egress masquerade path:

```
xx drop (Unsupported protocol for NAT masquerade, -1) flow 0x0 ,
   file nodeport_egress.h:152, identity host->unknown:
   fe80::bae9:24ff:fe80:ebfe -> ff02::1 icmp RouterAdvertisement
```

This hits a node whose only IPv6 address is a link-local. RS/RA are always
sourced from a link-local, and when no selected device has a global IPv6 address
the best IPv6 fallback node address is the link-local itself —
`fallbackAddresses.update()` ranks candidates by public-vs-private and scope, and
does not exclude link-locals — so `bpfMasqAddrs()` hands that address to the
datapath as `nat_ipv6_masquerade`. `__snat_v6_needs_masquerade()` then matches
such a packet on its very first test, source equals the masquerade address, and
answers `NAT_NEEDED`. That leaves `snat_v6_nat()` nothing but the ICMPv6 type to
go on: it only consults `snat_v6_nat_can_skip()` for TCP/UDP/SCTP.

Neighbor Discovery is link-local by definition and must never be masqueraded —
rewriting an RA's source would advertise the masquerade address as the router's
link-local. RFC 4890 section 4.4, which 5244b68c1468 ("bpf: Hande icmpv6 in host
firewall") cites when it added the NS/NA punt, lists RS/RA in the same
must-not-be-dropped group. Punt them to the stack alongside NS/NA, and cover both
types with a BPF masquerade test for a node whose masquerade address is a
link-local.

Split out of #47394 so it can be reviewed and merged on its own; it is a
standalone datapath fix that does not depend on the rest of that series.

Fixes: #48093

```release-note
Fix IPv6 Router Solicitations and Router Advertisements being dropped with
"Unsupported protocol for NAT masquerade" on nodes whose BPF masquerade address
is a link-local address.
```

This PR was prepared with AIL:2. I personally wrote or checked all code and
validated the behavior end-to-end against a live cluster and DPU (on a v1.19.x
backport).