### PR TITLE
node: Add NodeWriter and use it in NodeManager

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -41,6 +41,7 @@ var LocalNodeStoreCell = cell.Module(
 	"Provides LocalNodeStore for observing and updating local node info",
 
 	cell.ProvidePrivate(NewNodeTable),
+	cell.Provide(NewWriter),
 	cell.Provide(NewNodeTableAndLocalNodeStore),
 	cell.Provide(NewClusterSizeDependantInterval),
 )

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -86,17 +86,10 @@ func newAllNodeManager(in struct {
 	DB                           *statedb.DB
 	Devices                      statedb.Table[*tables.Device]
 	WGConfig                     wgTypes.Config
-	Nodes                        statedb.Table[*node.Node]
+	Writer                       *node.Writer
 	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 },
 ) (NodeManager, error) {
-
-	// We want to restrict access to RWTable[*Node] until the
-	// migration away from NodeManager is complete (#41744),
-	// hence we only have access to Table[*Node] and cast it
-	// here.
-	nodeTable := in.Nodes.(statedb.RWTable[*node.Node])
-
 	mngr, err := New(
 		in.Logger,
 		option.Config,
@@ -109,7 +102,7 @@ func newAllNodeManager(in struct {
 		in.DB,
 		in.Devices,
 		in.WGConfig,
-		nodeTable,
+		in.Writer,
 		in.ClusterSizeDependantInterval,
 	)
 	if err != nil {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -167,8 +167,8 @@ type manager struct {
 	// The devices table
 	devices statedb.Table[*tables.Device]
 
-	// nodeTable holds the nodes
-	nodeTable statedb.RWTable[*node.Node]
+	// writer owns all remote-node table access.
+	writer *node.Writer
 
 	// clusterNodeTableInit and meshNodeTableInit mark their respective node
 	// sources initialized. The node table is initialized after both complete.
@@ -276,13 +276,13 @@ func New(
 	db *statedb.DB,
 	devices statedb.Table[*tables.Device],
 	wgCfg types.Config,
-	nodeTable statedb.RWTable[*node.Node],
+	writer *node.Writer,
 	clusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc,
 ) (*manager, error) {
 	m := &manager{
 		logger:                       logger,
 		nodes:                        map[nodeTypes.Identity]*nodeEntry{},
-		nodeTable:                    nodeTable,
+		writer:                       writer,
 		restoredNodes:                map[nodeTypes.Identity]*nodeTypes.Node{},
 		conf:                         c,
 		clusterInfo:                  clusterInfo,
@@ -300,13 +300,14 @@ func New(
 		wgConfig:                     wgCfg,
 	}
 
-	if nodeTable != nil {
+	if writer != nil {
+		nodeTable := writer.Table()
 		wtxn := db.WriteTxn(nodeTable)
-		clusterInitDone := nodeTable.RegisterInitializer(
+		clusterInitDone := m.writer.RegisterInitializer(
 			wtxn,
 			ClusterNodeTableInitializerName,
 		)
-		meshInitDone := nodeTable.RegisterInitializer(
+		meshInitDone := m.writer.RegisterInitializer(
 			wtxn,
 			MeshNodeTableInitializerName,
 		)
@@ -573,8 +574,8 @@ func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
 
 func (m *manager) nodeAddressHasEncryptKey() bool {
 	optOut := false
-	if m.nodeTable != nil && m.db != nil {
-		if localNode, _, found := m.nodeTable.Get(m.db.ReadTxn(), node.LocalNodeQuery); found {
+	if m.writer != nil && m.db != nil {
+		if localNode, _, found := m.writer.Table().Get(m.db.ReadTxn(), node.LocalNodeQuery); found {
 			optOut = localNode.Local.OptOutNodeEncryption
 		}
 	}
@@ -892,39 +893,21 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 }
 
 func (m *manager) upsertToNodeTable(n *nodeTypes.Node) {
-	if n.IsLocal() || m.nodeTable == nil {
+	if n.IsLocal() || m.writer == nil {
 		return
 	}
-	txn := m.db.WriteTxn(m.nodeTable)
-	old, _, found := m.nodeTable.Get(txn, node.NodeByName(n.Fullname()))
-	if found && old.Local != nil {
-		// Never touch the local node.
-		txn.Abort()
-		return
-	}
-	obj := &node.Node{Node: *n}
-	if found {
-		obj.Statuses = old.Statuses.Pending()
-	}
-	m.nodeTable.Insert(txn, obj)
+	txn := m.db.WriteTxn(m.writer.Table())
+	m.writer.Upsert(txn, n)
 	txn.Commit()
 }
 
-func (m *manager) deleteFromNodeTable(nodeId nodeTypes.Identity) {
-	if m.nodeTable == nil {
+func (m *manager) deleteFromNodeTable(src source.Source, nodeID nodeTypes.Identity) {
+	if m.writer == nil {
 		return
 	}
-	var n node.Node
-	n.Name = nodeId.Name
-	n.Cluster = nodeId.Cluster
-	txn := m.db.WriteTxn(m.nodeTable)
-	old, found, _ := m.nodeTable.Delete(txn, &n)
-	if found && old.Local != nil {
-		// Never touch the local node.
-		txn.Abort()
-	} else {
-		txn.Commit()
-	}
+	txn := m.db.WriteTxn(m.writer.Table())
+	m.writer.Delete(txn, src, nodeID)
+	txn.Commit()
 }
 
 func (m *manager) cidrsToPrefixesCluster(n *nodeTypes.Node, prefixes ...netip.Prefix) iter.Seq[cmtypes.PrefixCluster] {
@@ -1136,7 +1119,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 
 	entry.mutex.Lock()
 	delete(m.nodes, nodeIdentifier)
-	m.deleteFromNodeTable(nodeIdentifier)
+	m.deleteFromNodeTable(n.Source, nodeIdentifier)
 	if m.nodeCheckpointer != nil {
 		m.nodeCheckpointer.TriggerWithReason("NodeDeleted")
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1014,6 +1014,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		cell.Provide(tables.NewDeviceTable),
 		cell.Provide(statedb.RWTable[*tables.Device].ToTable),
 		cell.Provide(node.NewNodeTable),
+		cell.Provide(node.NewWriter),
 		cell.Provide(func() node.ClusterSizeDependantIntervalFunc {
 			return func(interval time.Duration) time.Duration { return interval }
 		}),
@@ -1403,10 +1404,25 @@ func TestNodeTableMirroring(t *testing.T) {
 	db := statedb.New()
 	nodeTable, err := node.NewNodeTable(db)
 	require.NoError(t, err)
+	writer := node.NewWriter(logger, db, nodeTable)
 
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, db, nil, fakewireguard.Config{}, nodeTable, testClusterSizeDependantInterval)
+	mngr, err := New(
+		logger,
+		&option.DaemonConfig{},
+		cmtypes.ClusterInfo{Name: "c1"},
+		tunnel.Config{},
+		ipcacheMock,
+		NewNodeMetrics(),
+		h,
+		nil,
+		db,
+		nil,
+		fakewireguard.Config{},
+		writer,
+		testClusterSizeDependantInterval,
+	)
 	require.NoError(t, err)
 
 	initialized, initWatch := nodeTable.Initialized(db.ReadTxn())
@@ -1469,6 +1485,25 @@ func TestNodeTableMirroring(t *testing.T) {
 	requireNode(t, n1)
 	requireNode(t, n2)
 
+	// NodeManager delegates table conflict resolution to node.Writer. For
+	// equal-priority address owners the latest update wins.
+	n3 := n2.DeepCopy()
+	n3.Name = "node3"
+	mngr.NodeUpdated(*n3)
+	requireNode(t, n1)
+	requireNoNode(t, n2)
+	requireNode(t, *n3)
+
+	// Deleting the displaced node must not delete the current address owner.
+	mngr.NodeDeleted(n2)
+	requireNoNode(t, n2)
+	requireNode(t, *n3)
+
+	mngr.NodeUpdated(n2)
+	requireNode(t, n1)
+	requireNode(t, n2)
+	requireNoNode(t, *n3)
+
 	select {
 	case <-initWatch:
 		t.Fatal("node table initialized before NodeSync")
@@ -1514,6 +1549,7 @@ func TestNodeTableInitializersCompleteInEitherOrder(t *testing.T) {
 			db := statedb.New()
 			nodeTable, err := node.NewNodeTable(db)
 			require.NoError(t, err)
+			writer := node.NewWriter(hivetest.Logger(t), db, nodeTable)
 
 			health, _ := cell.NewSimpleHealth()
 			mngr, err := New(
@@ -1528,7 +1564,7 @@ func TestNodeTableInitializersCompleteInEitherOrder(t *testing.T) {
 				db,
 				nil,
 				fakewireguard.Config{},
-				nodeTable,
+				writer,
 				testClusterSizeDependantInterval,
 			)
 			require.NoError(t, err)

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -142,6 +142,35 @@ var (
 	}
 	NodeByName = NodeNameIndex.Query
 
+	// NodeAddressIndex indexes every address of the node. Writer enforces single
+	// ownership and resolves conflicts prior to insertion according to source
+	// priority.
+	NodeAddressIndex = statedb.Index[*Node, netip.Addr]{
+		Name: "address",
+		FromObject: func(obj *Node) index.KeySet {
+			keys := make([]index.Key, 0, len(obj.IPAddresses)+4)
+			appendAddr := func(addr netip.Addr) {
+				if addr.IsValid() {
+					keys = append(keys, index.NetIPAddr(addr.Unmap()))
+				}
+			}
+			for _, address := range obj.IPAddresses {
+				if addr, ok := netip.AddrFromSlice(address.IP); ok {
+					appendAddr(addr)
+				}
+			}
+			appendAddr(obj.IPv4HealthIP.Addr)
+			appendAddr(obj.IPv6HealthIP.Addr)
+			appendAddr(obj.IPv4IngressIP.Addr)
+			appendAddr(obj.IPv6IngressIP.Addr)
+			return index.NewKeySet(keys...)
+		},
+		FromKey:    index.NetIPAddr,
+		FromString: index.NetIPAddrString,
+		Unique:     true,
+	}
+	NodeByAddress = NodeAddressIndex.Query
+
 	NodeLocalIndex = statedb.Index[*Node, bool]{
 		Name: "local",
 		FromObject: func(obj *LocalNode) index.KeySet {
@@ -166,5 +195,6 @@ func NewNodeTable(db *statedb.DB) (statedb.RWTable[*Node], error) {
 		NodeTableName,
 		NodeNameIndex,
 		NodeLocalIndex,
+		NodeAddressIndex,
 	)
 }

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"slices"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// Writer provides source-aware write access to the node table.
+type Writer struct {
+	log   *slog.Logger
+	db    *statedb.DB
+	nodes statedb.RWTable[*Node]
+}
+
+// NewWriter constructs a node table writer.
+func NewWriter(log *slog.Logger, db *statedb.DB, nodes statedb.RWTable[*Node]) *Writer {
+	return &Writer{log: log, db: db, nodes: nodes}
+}
+
+// Table returns read-only access to the node table.
+func (w *Writer) Table() statedb.Table[*Node] { return w.nodes }
+
+// RegisterInitializer registers a producer that must finish its initial node
+// listing before the table is considered initialized.
+func (w *Writer) RegisterInitializer(txn statedb.WriteTxn, name string) func(statedb.WriteTxn) {
+	return w.nodes.RegisterInitializer(txn, name)
+}
+
+// Refresh marks every node pending and waits for all currently known node
+// reconcilers to successfully process them.
+func (w *Writer) Refresh(ctx context.Context) error {
+	txn := w.db.WriteTxn(w.nodes)
+	targets := []string{}
+	for n := range w.nodes.All(txn) {
+		targets = append(targets, n.Fullname())
+		updated := *n
+		updated.Statuses = updated.Statuses.Pending()
+		if _, _, err := w.nodes.Insert(txn, &updated); err != nil {
+			txn.Abort()
+			return fmt.Errorf("marking node %s pending: %w", updated.Fullname(), err)
+		}
+	}
+	txn.Commit()
+
+	rtxn := w.db.ReadTxn()
+	for _, fullname := range targets {
+		for {
+			n, _, watch, found := w.nodes.GetWatch(rtxn, NodeByName(fullname))
+			if !found {
+				break
+			}
+
+			finished := true
+			for _, status := range n.Statuses.All() {
+				if status.Kind != reconciler.StatusKindDone &&
+					status.Kind != reconciler.StatusKindError {
+					finished = false
+					break
+				}
+			}
+			if finished {
+				break
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-watch:
+				rtxn = w.db.ReadTxn()
+			}
+		}
+	}
+	return nil
+}
+
+// Upsert takes ownership of n and inserts or updates it if its source is
+// allowed to overwrite the current owner. The caller must not modify n after
+// calling Upsert. It reports whether the table changed. Conflicting weaker
+// objects are not retained, so their producer must upsert them again if the
+// winning object is later deleted.
+func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
+	obj := &Node{Node: *n}
+
+	old, _, found := w.nodes.Get(txn, NodeByName(obj.Fullname()))
+	if found {
+		if old.Local != nil || !source.AllowOverwrite(old.Source, obj.Source) {
+			w.log.Warn("Ignoring node update from lower priority source",
+				logfields.Node, obj.Fullname(),
+				logfields.Source, old.Source,
+				logfields.NodeOwner, obj.Source,
+			)
+			return false
+		}
+		if old.Node.DeepEqual(&obj.Node) {
+			return false
+		}
+	}
+
+	// Resolve all address conflicts before changing the table. This keeps the
+	// operation atomic when an incoming node overlaps multiple existing nodes:
+	// a single stronger owner rejects the update without deleting weaker ones.
+	conflicts := map[string]*Node{}
+	for _, addr := range conflictAddresses(n) {
+		candidate, _, found := w.nodes.Get(txn, NodeByAddress(addr))
+		if !found || candidate.Fullname() == obj.Fullname() {
+			continue
+		}
+		w.log.Warn("Node address conflicts with another node",
+			logfields.IPAddr, addr,
+			logfields.Node, obj.Fullname(),
+			logfields.Source, obj.Source,
+			logfields.ConflictingResource, candidate.Fullname(),
+			logfields.NodeOwner, candidate.Source,
+		)
+		conflicts[candidate.Fullname()] = candidate
+	}
+	for _, candidate := range conflicts {
+		if candidate.Local != nil || !source.AllowOverwrite(candidate.Source, obj.Source) {
+			return false
+		}
+	}
+
+	for _, candidate := range conflicts {
+		if _, _, err := w.nodes.Delete(txn, candidate); err != nil {
+			w.log.Error("Failed to delete node with conflicting address",
+				logfields.Error, err,
+				logfields.Node, candidate.Name,
+				logfields.Source, candidate.Source,
+			)
+			return false
+		}
+	}
+
+	if found {
+		obj.Statuses = old.Statuses.Pending()
+	}
+
+	if _, _, err := w.nodes.Insert(txn, obj); err != nil {
+		w.log.Error("Failed to write node to table",
+			logfields.Error, err,
+			logfields.Node, obj.Name,
+			logfields.Source, obj.Source,
+		)
+		return false
+	}
+	return true
+}
+
+// conflictAddresses returns the normalized addresses whose ownership used to
+// gate NodeManager datapath updates. IPv4-mapped IPv6 addresses are normalized
+// to IPv4 so both representations conflict with one another.
+func conflictAddresses(n *nodeTypes.Node) []netip.Addr {
+	addrs := make([]netip.Addr, 0, len(n.IPAddresses)+4)
+	appendAddr := func(addr netip.Addr) {
+		if addr.IsValid() {
+			addrs = append(addrs, addr.Unmap())
+		}
+	}
+
+	for _, address := range n.IPAddresses {
+		if addr, ok := netip.AddrFromSlice(address.IP); ok {
+			appendAddr(addr)
+		}
+	}
+	appendAddr(n.IPv4HealthIP.Addr)
+	appendAddr(n.IPv6HealthIP.Addr)
+	appendAddr(n.IPv4IngressIP.Addr)
+	appendAddr(n.IPv6IngressIP.Addr)
+
+	slices.SortFunc(addrs, netip.Addr.Compare)
+	return slices.Compact(addrs)
+}
+
+// Delete removes a remote node if this writer's source still owns it. It
+// reports whether the table changed.
+func (w *Writer) Delete(txn statedb.WriteTxn, src source.Source, identity nodeTypes.Identity) bool {
+	old, _, found := w.nodes.Get(txn, NodeByName(identity.String()))
+	if !found {
+		return false
+	}
+	if old.Local != nil || old.Source != src {
+		w.log.Warn("Ignoring node deletion from source that does not own node",
+			logfields.Node, identity.Name,
+			logfields.Source, src,
+			logfields.NodeOwner, old.Source,
+		)
+		return false
+	}
+	if _, _, err := w.nodes.Delete(txn, old); err != nil {
+		w.log.Error("Failed to delete node from table",
+			logfields.Error, err,
+			logfields.Node, identity.Name,
+			logfields.Source, src,
+		)
+		return false
+	}
+	return true
+}

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/stretchr/testify/require"
+
+	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+func TestSourceWriter(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+	upsert := func(n *types.Node) bool {
+		txn := db.WriteTxn(nodes)
+		defer txn.Commit()
+		return w.Upsert(txn, n)
+	}
+	deleteNode := func(src source.Source, identity types.Identity) bool {
+		txn := db.WriteTxn(nodes)
+		defer txn.Commit()
+		return w.Delete(txn, src, identity)
+	}
+
+	n := &types.Node{Name: "node-1", Source: source.Kubernetes}
+	require.True(t, upsert(n))
+
+	txn := db.ReadTxn()
+	got, _, found := nodes.Get(txn, NodeByName("node-1"))
+	require.True(t, found)
+	require.Equal(t, source.Kubernetes, got.Source)
+
+	got = got.DeepCopy()
+	got.Statuses = got.Statuses.Set("test", reconciler.StatusDone())
+	wtxn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(wtxn, got)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	// An identical update preserves the completed status and table revision.
+	revision := nodes.Revision(db.ReadTxn())
+	require.False(t, upsert(n))
+	require.Equal(t, revision, nodes.Revision(db.ReadTxn()))
+
+	// A weaker source cannot replace or delete the object.
+	weakNode := n.DeepCopy()
+	weakNode.Source = source.ClusterMesh
+	weakNode.Labels = map[string]string{"source": "mesh"}
+	revision = nodes.Revision(db.ReadTxn())
+	require.False(t, upsert(weakNode))
+	require.False(t, deleteNode(weakNode.Source, weakNode.Identity()))
+	require.Equal(t, revision, nodes.Revision(db.ReadTxn()))
+
+	// A stronger source takes ownership and resets reconciliation statuses.
+	strongNode := n.DeepCopy()
+	strongNode.Source = source.KVStore
+	strongNode.Labels = map[string]string{"source": "kvstore"}
+	require.True(t, upsert(strongNode))
+	got, _, found = nodes.Get(db.ReadTxn(), NodeByName("node-1"))
+	require.True(t, found)
+	require.Equal(t, source.KVStore, got.Source)
+	require.Equal(t, reconciler.StatusKindPending, got.Statuses.Get("test").Kind)
+
+	require.False(t, deleteNode(n.Source, n.Identity()))
+	require.True(t, deleteNode(strongNode.Source, strongNode.Identity()))
+	_, _, found = nodes.Get(db.ReadTxn(), NodeByName("node-1"))
+	require.False(t, found)
+}
+
+func TestSourceWriterDoesNotOverwriteLocalNode(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	local := &Node{
+		Node: types.Node{
+			Name:        "local",
+			Source:      source.Local,
+			IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+		},
+		Local: &LocalNodeInfo{},
+	}
+	txn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, local)
+	require.NoError(t, err)
+	txn.Commit()
+
+	remote := &types.Node{Name: "local", Source: source.KubeAPIServer}
+	txn = db.WriteTxn(nodes)
+	require.False(t, w.Upsert(txn, remote))
+	require.False(t, w.Delete(txn, source.Local, remote.Identity()))
+	txn.Commit()
+	got, _, found := nodes.Get(db.ReadTxn(), NodeByName("local"))
+	require.True(t, found)
+	require.NotNil(t, got.Local)
+
+	// The local row also owns its addresses regardless of source priority.
+	remote = &types.Node{
+		Name:        "remote",
+		Source:      source.KubeAPIServer,
+		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+	}
+	txn = db.WriteTxn(nodes)
+	require.False(t, w.Upsert(txn, remote))
+	txn.Commit()
+	_, _, found = nodes.Get(db.ReadTxn(), NodeByName("remote"))
+	require.False(t, found)
+}
+
+func TestWriterAddressConflicts(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	upsert := func(n *types.Node) bool {
+		txn := db.WriteTxn(nodes)
+		defer txn.Commit()
+		return w.Upsert(txn, n)
+	}
+	requireNode := func(name string) *Node {
+		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.True(t, found, name)
+		return n
+	}
+	requireNoNode := func(name string) {
+		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.False(t, found, name)
+	}
+	newNode := func(name string, src source.Source, addresses ...string) *types.Node {
+		n := &types.Node{Name: name, Source: src}
+		for _, address := range addresses {
+			n.IPAddresses = append(n.IPAddresses, types.Address{IP: net.ParseIP(address)})
+		}
+		return n
+	}
+
+	// A stronger source takes the address and removes the weaker node.
+	require.True(t, upsert(newNode("mesh", source.ClusterMesh, "10.0.0.1")))
+	require.True(t, upsert(newNode("k8s", source.Kubernetes, "10.0.0.1")))
+	requireNoNode("mesh")
+	require.Equal(t, source.Kubernetes, requireNode("k8s").Source)
+
+	// A weaker source cannot take an address from its current owner.
+	require.False(t, upsert(newNode("weaker", source.ClusterMesh, "10.0.0.1")))
+	requireNoNode("weaker")
+	requireNode("k8s")
+
+	// At equal priority the latest update wins.
+	require.True(t, upsert(newNode("latest", source.Kubernetes, "10.0.0.1")))
+	requireNoNode("k8s")
+	requireNode("latest")
+
+	// Health and ingress addresses participate in the same ownership checks.
+	health := newNode("health", source.Kubernetes)
+	health.IPv4HealthIP = iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))
+	require.True(t, upsert(health))
+	require.True(t, upsert(newNode("health-latest", source.Kubernetes, "10.0.0.4")))
+	requireNoNode("health")
+	requireNode("health-latest")
+
+	ingress := newNode("ingress", source.Kubernetes)
+	ingress.IPv4IngressIP = iputil.AddrFrom(netip.MustParseAddr("10.0.0.5"))
+	require.True(t, upsert(ingress))
+	require.True(t, upsert(newNode("ingress-latest", source.Kubernetes, "10.0.0.5")))
+	requireNoNode("ingress")
+	requireNode("ingress-latest")
+
+	// Four-byte IPv4 and IPv4-mapped IPv6 representations are equivalent.
+	mapped := newNode("mapped", source.Kubernetes)
+	mapped.IPAddresses = []types.Address{{IP: net.IP{10, 0, 0, 6}}}
+	require.True(t, upsert(mapped))
+	require.True(t, upsert(newNode("mapped-latest", source.Kubernetes, "10.0.0.6")))
+	requireNoNode("mapped")
+	requireNode("mapped-latest")
+
+	// Check all conflicts before deleting anything. This update could replace
+	// the mesh node, but is rejected because it cannot replace the KVStore node.
+	require.True(t, upsert(newNode("mesh-2", source.ClusterMesh, "10.0.0.2")))
+	require.True(t, upsert(newNode("kvstore", source.KVStore, "10.0.0.3")))
+	require.False(t, upsert(newNode(
+		"mixed", source.Kubernetes, "10.0.0.2", "10.0.0.3",
+	)))
+	requireNode("mesh-2")
+	requireNode("kvstore")
+	requireNoNode("mixed")
+}
+
+func TestWriterRefresh(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	n := &Node{Node: types.Node{Name: "node-1", Source: source.Kubernetes}}
+	n.Statuses = n.Statuses.Set("test", reconciler.StatusDone())
+	txn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, n)
+	require.NoError(t, err)
+	txn.Commit()
+
+	done := make(chan error, 1)
+	go func() { done <- w.Refresh(context.Background()) }()
+
+	require.Eventually(t, func() bool {
+		n, _, found := nodes.Get(db.ReadTxn(), NodeByName("node-1"))
+		return found && n.Statuses.Get("test").Kind == reconciler.StatusKindPending
+	}, time.Second, 10*time.Millisecond)
+
+	txn = db.WriteTxn(nodes)
+	n, _, found := nodes.Get(txn, NodeByName("node-1"))
+	require.True(t, found)
+	n = n.DeepCopy()
+	n.Statuses = n.Statuses.Set("test", reconciler.StatusDone())
+	_, _, err = nodes.Insert(txn, n)
+	require.NoError(t, err)
+	txn.Commit()
+	require.NoError(t, <-done)
+}


### PR DESCRIPTION
This introduces the `node.Writer` for controlled writes into the Table[Node]. On `Upsert` we check for conflicts with existing nodes. If a node exists with the same name, but different source then the highest priority source wins, and if a node exists with a different name that holds any of the addresses of the new node we check for source priority and if source is equal or higher the new node replaces the old node. As with NodeManager we don't set aside the losing nodes and restore them later. In other words, this aims to keep the same exact semantics as before.

AIL:3
Related: https://github.com/cilium/cilium/issues/41744
