### PR TITLE
node: Derive cluster-size intervals from table

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -476,13 +476,13 @@ func kvstoreExtraOptions(in struct {
 
 	Logger *slog.Logger
 
-	NodeManager nodeManager.NodeManager
-	ClientSet   k8sClient.Clientset
-	Resolver    dial.Resolver
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
+	ClientSet                    k8sClient.Clientset
+	Resolver                     dial.Resolver
 },
 ) kvstore.ExtraOptions {
 	goopts := kvstore.ExtraOptions{
-		ClusterSizeDependantInterval: in.NodeManager.ClusterSizeDependantInterval,
+		ClusterSizeDependantInterval: in.ClusterSizeDependantInterval,
 	}
 
 	// If K8s is enabled we can do the service translation automagically by

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/ipcache"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
@@ -39,8 +38,10 @@ var Cell = cell.Module(
 
 	// Convert concrete objects into more restricted interfaces used by clustermesh.
 	cell.ProvidePrivate(func(ipcache *ipcache.IPCache) ipcache.IPCacher { return ipcache }),
-	cell.ProvidePrivate(func(mgr nodemanager.NodeManager) (nodeStore.NodeManager, kvstore.ClusterSizeDependantIntervalFunc) {
-		return mgr, mgr.ClusterSizeDependantInterval
+	cell.ProvidePrivate(func(
+		mgr nodemanager.NodeManager,
+	) nodeStore.NodeManager {
+		return mgr
 	}),
 	cell.ProvidePrivate(idsMgrProvider),
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -60,7 +61,7 @@ type Configuration struct {
 	IPCache ipcache.IPCacher
 
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
-	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 
 	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
 	ServiceResolver dial.Resolver

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -15,9 +15,9 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/dial"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 type StatusFunc func() *models.RemoteCluster
@@ -40,7 +40,7 @@ type Configuration struct {
 	NewRemoteCluster RemoteClusterCreatorFunc
 
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
-	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 
 	// Resolvers, if provided, are used to create a custom dialer to connect to etcd.
 	Resolvers []dial.Resolver

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 var (
@@ -54,7 +55,7 @@ type remoteCluster struct {
 	configPath string
 
 	// clusterSizeDependantInterval allows to calculate intervals based on cluster size.
-	clusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+	clusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 
 	// resolvers are the set of resolvers used to create the custom dialer.
 	resolvers []dial.Resolver

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -28,8 +29,6 @@ type backendOption struct {
 
 type backendOptions map[string]*backendOption
 
-type ClusterSizeDependantIntervalFunc func(baseInterval time.Duration) time.Duration
-
 // ExtraOptions represents any options that can not be represented in a textual
 // format and need to be set programmatically.
 type ExtraOptions struct {
@@ -37,7 +36,7 @@ type ExtraOptions struct {
 
 	// ClusterSizeDependantInterval defines the function to calculate
 	// intervals based on cluster size
-	ClusterSizeDependantInterval ClusterSizeDependantIntervalFunc
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 
 	// NoLockQuorumCheck disables the lock acquisition quorum check
 	NoLockQuorumCheck bool

--- a/pkg/node/cluster_size.go
+++ b/pkg/node/cluster_size.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// ClusterSizeDependantIntervalFunc returns a time.Duration that is dependent on
+// the cluster size, i.e. the number of nodes that have been discovered. This
+// can be used to control sync intervals of shared or centralized resources to
+// avoid overloading these resources as the cluster grows.
+//
+// Example sync interval with baseInterval = 1 * time.Minute
+//
+// nodes | sync interval
+// ------+-----------------
+// 1     |   41.588830833s
+// 2     | 1m05.916737320s
+// 4     | 1m36.566274746s
+// 8     | 2m11.833474640s
+// 16    | 2m49.992800643s
+// 32    | 3m29.790453687s
+// 64    | 4m10.463236193s
+// 128   | 4m51.588744261s
+// 256   | 5m32.944565093s
+// 512   | 6m14.416550710s
+// 1024  | 6m55.946873494s
+// 2048  | 7m37.506428894s
+// 4096  | 8m19.080616652s
+// 8192  | 9m00.662124608s
+// 16384 | 9m42.247293667s
+type ClusterSizeDependantIntervalFunc func(time.Duration) time.Duration
+
+// NewClusterSizeDependantInterval returns a function that computes intervals
+// from the current size of the node table.
+func NewClusterSizeDependantInterval(
+	db *statedb.DB,
+	nodes statedb.Table[*Node],
+) ClusterSizeDependantIntervalFunc {
+	return func(baseInterval time.Duration) time.Duration {
+		return backoff.ClusterSizeDependantInterval(
+			baseInterval,
+			nodes.NumObjects(db.ReadTxn()),
+		)
+	}
+}

--- a/pkg/node/cluster_size_test.go
+++ b/pkg/node/cluster_size_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestClusterSizeDependantInterval(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	interval := NewClusterSizeDependantInterval(db, nodes)
+	base := time.Minute
+
+	require.Equal(t, base, interval(base))
+
+	txn := db.WriteTxn(nodes)
+	for _, name := range []string{"node-1", "node-2", "node-3"} {
+		_, _, err := nodes.Insert(txn, &Node{Node: nodeTypes.Node{Name: name}})
+		require.NoError(t, err)
+	}
+	txn.Commit()
+
+	require.Equal(
+		t,
+		backoff.ClusterSizeDependantInterval(base, 3),
+		interval(base),
+	)
+}

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -42,6 +42,7 @@ var LocalNodeStoreCell = cell.Module(
 
 	cell.ProvidePrivate(NewNodeTable),
 	cell.Provide(NewNodeTableAndLocalNodeStore),
+	cell.Provide(NewClusterSizeDependantInterval),
 )
 
 const (

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/time"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -70,12 +69,6 @@ type NodeManager interface {
 	// MeshNodeSync is called when the store completes the initial nodes listing including meshed nodes
 	MeshNodeSync()
 
-	// ClusterSizeDependantInterval returns a time.Duration that is dependent on
-	// the cluster size, i.e. the number of nodes that have been discovered. This
-	// can be used to control sync intervals of shared or centralized resources to
-	// avoid overloading these resources as the cluster grows.
-	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
-
 	// SetPrefixClusterMutatorFn allows to inject a custom prefix cluster mutator.
 	// The mutator may then be applied to the PrefixCluster(s) using cmtypes.PrefixClusterFrom.
 	SetPrefixClusterMutatorFn(mutator func(*types.Node) []cmtypes.PrefixClusterOpts)
@@ -83,20 +76,21 @@ type NodeManager interface {
 
 func newAllNodeManager(in struct {
 	cell.In
-	Logger      *slog.Logger
-	ClusterInfo cmtypes.ClusterInfo
-	TunnelConf  tunnel.Config
-	Lifecycle   cell.Lifecycle
-	IPCache     *ipcache.IPCache
-	IPSetMgr    ipset.Manager
-	IPSetFilter IPSetFilterFn `optional:"true"`
-	NodeMetrics *nodeMetrics
-	Health      cell.Health
-	JobGroup    job.Group
-	DB          *statedb.DB
-	Devices     statedb.Table[*tables.Device]
-	WGConfig    wgTypes.Config
-	Nodes       statedb.Table[*node.Node]
+	Logger                       *slog.Logger
+	ClusterInfo                  cmtypes.ClusterInfo
+	TunnelConf                   tunnel.Config
+	Lifecycle                    cell.Lifecycle
+	IPCache                      *ipcache.IPCache
+	IPSetMgr                     ipset.Manager
+	IPSetFilter                  IPSetFilterFn `optional:"true"`
+	NodeMetrics                  *nodeMetrics
+	Health                       cell.Health
+	JobGroup                     job.Group
+	DB                           *statedb.DB
+	Devices                      statedb.Table[*tables.Device]
+	WGConfig                     wgTypes.Config
+	Nodes                        statedb.Table[*node.Node]
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 },
 ) (NodeManager, error) {
 
@@ -106,7 +100,7 @@ func newAllNodeManager(in struct {
 	// here.
 	nodeTable := in.Nodes.(statedb.RWTable[*node.Node])
 
-	mngr, err := New(in.Logger, option.Config, in.ClusterInfo, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, nodeTable)
+	mngr, err := New(in.Logger, option.Config, in.ClusterInfo, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, nodeTable, in.ClusterSizeDependantInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -26,7 +26,6 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/time/rate"
 
-	"github.com/cilium/cilium/pkg/backoff"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
@@ -135,6 +134,9 @@ type manager struct {
 
 	// group of jobs, tied to the lifecycle of the manager
 	jobGroup job.Group
+	// clusterSizeDependantInterval computes background sync intervals from the
+	// current size of the node table.
+	clusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 
 	// metrics to track information about the node manager
 	metrics *nodeMetrics
@@ -288,32 +290,34 @@ func New(
 	devices statedb.Table[*tables.Device],
 	wgCfg types.Config,
 	nodeTable statedb.RWTable[*node.Node],
+	clusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc,
 ) (*manager, error) {
 	if ipsetFilter == nil {
 		ipsetFilter = func(*nodeTypes.Node) bool { return false }
 	}
 
 	m := &manager{
-		logger:                 logger,
-		nodes:                  map[nodeTypes.Identity]*nodeEntry{},
-		nodeTable:              nodeTable,
-		restoredNodes:          map[nodeTypes.Identity]*nodeTypes.Node{},
-		conf:                   c,
-		clusterInfo:            clusterInfo,
-		underlay:               tunnelConf.UnderlayProtocol(),
-		controllerManager:      controller.NewManager(),
-		nodeHandlers:           map[node.Handler]struct{}{},
-		ipcache:                ipCache,
-		ipsetMgr:               ipsetMgr,
-		ipsetInitializer:       ipsetMgr.NewInitializer(),
-		ipsetFilter:            ipsetFilter,
-		metrics:                nodeMetrics,
-		health:                 health,
-		jobGroup:               jobGroup,
-		db:                     db,
-		devices:                devices,
-		prefixClusterMutatorFn: func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
-		wgConfig:               wgCfg,
+		logger:                       logger,
+		nodes:                        map[nodeTypes.Identity]*nodeEntry{},
+		nodeTable:                    nodeTable,
+		restoredNodes:                map[nodeTypes.Identity]*nodeTypes.Node{},
+		conf:                         c,
+		clusterInfo:                  clusterInfo,
+		underlay:                     tunnelConf.UnderlayProtocol(),
+		controllerManager:            controller.NewManager(),
+		nodeHandlers:                 map[node.Handler]struct{}{},
+		ipcache:                      ipCache,
+		ipsetMgr:                     ipsetMgr,
+		ipsetInitializer:             ipsetMgr.NewInitializer(),
+		ipsetFilter:                  ipsetFilter,
+		metrics:                      nodeMetrics,
+		health:                       health,
+		jobGroup:                     jobGroup,
+		clusterSizeDependantInterval: clusterSizeDependantInterval,
+		db:                           db,
+		devices:                      devices,
+		prefixClusterMutatorFn:       func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
+		wgConfig:                     wgCfg,
 	}
 
 	if nodeTable != nil {
@@ -374,47 +378,11 @@ func (m *manager) Stop(cell.HookContext) error {
 	return nil
 }
 
-// ClusterSizeDependantInterval returns a time.Duration that is dependant on
-// the cluster size, i.e. the number of nodes that have been discovered. This
-// can be used to control sync intervals of shared or centralized resources to
-// avoid overloading these resources as the cluster grows.
-//
-// Example sync interval with baseInterval = 1 * time.Minute
-//
-// nodes | sync interval
-// ------+-----------------
-// 1     |   41.588830833s
-// 2     | 1m05.916737320s
-// 4     | 1m36.566274746s
-// 8     | 2m11.833474640s
-// 16    | 2m49.992800643s
-// 32    | 3m29.790453687s
-// 64    | 4m10.463236193s
-// 128   | 4m51.588744261s
-// 256   | 5m32.944565093s
-// 512   | 6m14.416550710s
-// 1024  | 6m55.946873494s
-// 2048  | 7m37.506428894s
-// 4096  | 8m19.080616652s
-// 8192  | 9m00.662124608s
-// 16384 | 9m42.247293667s
-func (m *manager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
-	m.mutex.RLock()
-	numNodes := len(m.nodes)
-	m.mutex.RUnlock()
-
-	return backoff.ClusterSizeDependantInterval(baseInterval, numNodes)
-}
-
-func (m *manager) backgroundSyncInterval() time.Duration {
-	return m.ClusterSizeDependantInterval(baseBackgroundSyncInterval)
-}
-
 // backgroundSync ensures that local node has a valid datapath in-place for
 // each node in the cluster. See NodeValidateImplementation().
 func (m *manager) backgroundSync(ctx context.Context, health cell.Health) error {
 	for {
-		syncInterval := m.backgroundSyncInterval()
+		syncInterval := m.clusterSizeDependantInterval(baseBackgroundSyncInterval)
 		startWaiting := time.After(syncInterval)
 		m.logger.Debug(
 			"Starting new iteration of background sync",

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -56,6 +56,10 @@ type nodeEvent struct {
 	metadata ipcache.IPMetadata
 }
 
+func testClusterSizeDependantInterval(interval time.Duration) time.Duration {
+	return interval
+}
+
 type ipcacheMock struct {
 	events chan nodeEvent
 }
@@ -252,7 +256,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -349,7 +353,7 @@ func TestNodeLabels(t *testing.T) {
 		Source:  source.Unspec,
 	}
 
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	mngr.NodeUpdated(nRemote)
@@ -436,7 +440,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -520,7 +524,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(b)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -537,39 +541,13 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	b.StopTimer()
 }
 
-func TestClusterSizeDependantInterval(t *testing.T) {
-	logger := hivetest.Logger(t)
-
-	ipcacheMock := newIPcacheMock()
-	dp := fakenode.NewHandler()
-	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
-	require.NoError(t, err)
-	mngr.Subscribe(dp)
-	defer mngr.Stop(context.TODO())
-
-	prevInterval := time.Nanosecond
-
-	for i := range 1000 {
-		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local, IPAddresses: []nodeTypes.Address{
-			{
-				Type: addressing.NodeInternalIP,
-				IP:   net.ParseIP("10.0.0.1"),
-			},
-		}}
-		mngr.NodeUpdated(n)
-		newInterval := mngr.ClusterSizeDependantInterval(time.Minute)
-		assert.Greater(t, newInterval, prevInterval)
-	}
-}
-
 func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -639,7 +617,7 @@ func TestIpcache(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -784,7 +762,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -831,7 +809,7 @@ func TestNodeEncryption(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		EncryptNode: true,
-	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -955,7 +933,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1094,6 +1072,9 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		cell.Provide(tables.NewDeviceTable),
 		cell.Provide(statedb.RWTable[*tables.Device].ToTable),
 		cell.Provide(node.NewNodeTable),
+		cell.Provide(func() node.ClusterSizeDependantIntervalFunc {
+			return func(interval time.Duration) time.Duration { return interval }
+		}),
 		cell.Module("node_manager", "Node Manager", cell.Provide(New)),
 		cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.DefaultClusterInfo }),
 		cell.Invoke(fn),
@@ -1217,7 +1198,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1318,7 +1299,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1498,7 +1479,7 @@ func TestNodesStartupPruning(t *testing.T) {
 		h, _ := cell.NewSimpleHealth()
 		mngr, err := New(logger, &option.DaemonConfig{
 			StateDir: stateDir,
-		}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+		}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			mngr.Stop(context.TODO())
@@ -1634,7 +1615,7 @@ func TestNodeTableMirroring(t *testing.T) {
 
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, db, nil, fakewireguard.Config{}, nodeTable)
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, db, nil, fakewireguard.Config{}, nodeTable, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 
 	initialized, initWatch := nodeTable.Initialized(db.ReadTxn())
@@ -1759,6 +1740,7 @@ func TestNodeTableInitializersCompleteInEitherOrder(t *testing.T) {
 				nil,
 				fakewireguard.Config{},
 				nodeTable,
+				testClusterSizeDependantInterval,
 			)
 			require.NoError(t, err)
 

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -34,7 +34,7 @@ var fakeConfig = &option.DaemonConfig{
 func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	logger := hivetest.Logger(tb)
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(logger, fakeConfig, cmtypes.DefaultClusterInfo, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil)
+	nm, err := New(logger, fakeConfig, cmtypes.DefaultClusterInfo, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{

--- a/pkg/status/cell.go
+++ b/pkg/status/cell.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
-	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
@@ -101,7 +100,9 @@ type statusParams struct {
 	MaglevConfig     maglev.Config
 	MonitorAgent     monitoragent.Agent
 	NodeLocalStore   *node.LocalNodeStore
-	NodeManager      nodemanager.NodeManager
+
+	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
+
 	PolicyMapFactory policymap.Factory
 	TunnelConfig     tunnel.Config
 	WireguardAgent   wgTypes.Agent

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -704,7 +704,7 @@ func (d *statusCollector) getProbes() []Probe {
 				// 2048  | 1m15s
 				// 8192  | 1m30s
 				// 16384 | 1m32s
-				return d.statusParams.NodeManager.ClusterSizeDependantInterval(10 * time.Second)
+				return d.statusParams.ClusterSizeDependantInterval(10 * time.Second)
 			},
 			Probe: func(ctx context.Context) (any, error) {
 				return d.getK8sStatus(), nil


### PR DESCRIPTION
Provide a cluster-size-dependent interval function backed by the current number of objects in Table[*node.Node].

Use it for KVStore, ClusterMesh, and status intervals, removing the public NodeManager dependency while retaining the manager private calculation for its temporary background validation loop.

AIL:3
Related: https://github.com/cilium/cilium/issues/41744