### PR TITLE
CLI: add toleration for a single etcd container restart 

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -170,7 +170,6 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		errorMsgsWithExceptions: errorMsgsWithExceptions,
 		thresholdExceptions:     warningThresholdExceptions,
 		ScenarioBase:            check.NewScenarioBase(),
-		ciliumVersion:           ciliumVersion,
 		startTime:               startTime,
 	}
 }
@@ -180,7 +179,6 @@ type noErrorsInLogs struct {
 
 	errorMsgsWithExceptions map[string][]logMatcher
 	thresholdExceptions     thresholdExceptions
-	ciliumVersion           semver.Version
 	mostCommonFailureLog    string
 	mostCommonFailureCount  int
 	startTime               time.Time
@@ -236,8 +234,7 @@ func (n *noErrorsInLogs) Run(ctx context.Context, t *check.Test) {
 		for container, restarts := range info.containers {
 			id := fmt.Sprintf("%s/%s/%s (%s)", pod.Cluster, pod.Namespace, pod.Name, container)
 			t.NewGenericAction(n, id).Run(func(a *check.Action) {
-				// Do not check for container restarts for Cilium v1.16 and earlier.
-				ignore := n.ciliumVersion.LT(semver.MustParse("1.17.0"))
+				var ignore bool
 
 				// Ignore Cilium operator restarts for the moment, as they can
 				// legitimately happen in case it loses the leader election due

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -256,6 +256,25 @@ func (n *noErrorsInLogs) Run(ctx context.Context, t *check.Test) {
 				// such restart, but only on GKE where it has been observed.
 				ignore = ignore || (isGKE && restarts == 1 && container == "config")
 
+				// Each pod is associated with a single /etc/hosts file that is
+				// mounted inside each container of the pod, and the kubelet
+				// enforces its content again every time that a container is
+				// started, through [os.WriteFile] [1]. However, this leaves a
+				// tiny race condition window in which an already started
+				// container may observe a truncated version of the hosts file.
+				// No race condition is small enough to escape our CI, and we
+				// witnessed the etcd container fail to resolve the localhost
+				// hostname when configuring the peer listeners, and exit [2],
+				// eventually tripping this restart check. Ideally, we'd not
+				// rely on a hostname there, but that's easier said than done,
+				// because a direct use of either 127.0.0.1 or [::1] would not
+				// work if the corresponding IP family is disabled. For the
+				// moment, let's tolerate a possible restart of this container.
+				//
+				// [1]: https://github.com/kubernetes/kubernetes/blob/65bca7cd12f0/pkg/kubelet/kubelet_pods.go#L491-L515
+				// [2]: [...] "msg":"creating peer listener failed","error":"listen tcp: lookup localhost on 10.245.0.10:53: no such host"
+				ignore = ignore || (restarts == 1 && container == "etcd")
+
 				var logs bytes.Buffer
 				err := client.GetLogs(ctx, pod.Namespace, pod.Name, container, opts, &logs)
 				if err != nil {


### PR DESCRIPTION
Each pod is associated with a single `/etc/hosts` file that is mounted inside each container of the pod, and the kubelet enforces its content again every time that a container is started, through [os.WriteFile] [1]. However, this leaves a tiny race condition window in which an already started container may observe a truncated version of the hosts file. 

No race condition is small enough to escape our CI, and we witnessed the etcd container fail to resolve the localhost hostname when configuring the peer listeners, and exit [2], eventually tripping this restart check. Ideally, we'd not rely on a hostname there, but that's easier said than done, because a direct use of either 127.0.0.1 or [::1] would not work if the corresponding IP family is disabled. For the moment, let's tolerate a possible restart of this container.

\[1]: https://github.com/kubernetes/kubernetes/blob/65bca7cd12f0/pkg/kubelet/kubelet_pods.go#L491-L515
\[2]: [...] "msg":"creating peer listener failed","error":"listen tcp: lookup localhost on 10.245.0.10:53: no such host"

AIL: 0 for the creation of the patch (although I leveraged AI to help with the investigation of the flake)
