### PR TITLE
Revert "cli: drop restarts exclusion for Cilium v1.16 and earlier"

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -170,6 +170,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		errorMsgsWithExceptions: errorMsgsWithExceptions,
 		thresholdExceptions:     warningThresholdExceptions,
 		ScenarioBase:            check.NewScenarioBase(),
+		ciliumVersion:           ciliumVersion,
 		startTime:               startTime,
 	}
 }
@@ -179,6 +180,7 @@ type noErrorsInLogs struct {
 
 	errorMsgsWithExceptions map[string][]logMatcher
 	thresholdExceptions     thresholdExceptions
+	ciliumVersion           semver.Version
 	mostCommonFailureLog    string
 	mostCommonFailureCount  int
 	startTime               time.Time
@@ -234,7 +236,8 @@ func (n *noErrorsInLogs) Run(ctx context.Context, t *check.Test) {
 		for container, restarts := range info.containers {
 			id := fmt.Sprintf("%s/%s/%s (%s)", pod.Cluster, pod.Namespace, pod.Name, container)
 			t.NewGenericAction(n, id).Run(func(a *check.Action) {
-				var ignore bool
+				// Do not check for container restarts for Cilium v1.16 and earlier.
+				ignore := n.ciliumVersion.LT(semver.MustParse("1.17.0"))
 
 				// Ignore Cilium operator restarts for the moment, as they can
 				// legitimately happen in case it loses the leader election due


### PR DESCRIPTION
This reverts commit f75e1d8ebe62e8b2ae0a73ed7f6cf9350da07afb.

It turns out I have spoken too early, as Julian pointed out that there may still be some workflows exercising v1.16 during the downgrade path, given that v1.17 has only been recently transitioned into EOL. Let's be conservative, and keep this logic around for a bit more to prevent surprises, given that it does no harm anyway.

Reported-by: Julian Wiedmann <jwi@isovalent.com>
