### PR TITLE
Hide statedb table indexes behind query helpers

### DIFF
--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -119,7 +119,7 @@ func statusDaemon() {
 		}
 		if healthEnabled {
 			table := newRemoteTable[types.Status]("health")
-			iter, errChan := table.LowerBound(context.Background(), health.PrimaryIndex.Query("agent"))
+			iter, errChan := table.LowerBound(context.Background(), health.StatusByID("agent"))
 			ss := statedb.Collect(iter)
 			if err := <-errChan; err != nil {
 				Fatalf("Failed while streaming remote health data table: %s", err)

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -326,7 +326,7 @@ func TestDisablePeerConfigStatusReport(t *testing.T) {
 
 				rtxn := f.db.ReadTxn()
 
-				_, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
+				_, _, found := f.healthTable.Get(rtxn, health.StatusByID(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
 				assert.False(ct, found, "expected job to be done")
 			}, time.Second*3, time.Millisecond*100)
 		})

--- a/operator/pkg/ztunnel/reconciler/reconciler.go
+++ b/operator/pkg/ztunnel/reconciler/reconciler.go
@@ -22,7 +22,7 @@ import (
 // will re-reconcile it on transient SPIRE failures.
 func requeueNamespace(db *statedb.DB, enrolledTbl statedb.RWTable[*table.EnrolledNamespace], namespace string) {
 	txn := db.WriteTxn(enrolledTbl)
-	ns, _, found := enrolledTbl.Get(txn, table.EnrolledNamespacesNameIndex.Query(namespace))
+	ns, _, found := enrolledTbl.Get(txn, table.EnrolledNamespaceByName(namespace))
 	if found {
 		clone := ns.Clone()
 		clone.Status = reconciler.StatusPending()
@@ -198,7 +198,7 @@ func (ops *EnrollmentReconciler) Start(cell.HookContext) error {
 					}
 				} else {
 					ops.logger.Debug("ServiceAccount added/updated", logfields.Name, sa.Name)
-					_, _, found := ops.enrolledNamespaceTable.Get(ops.db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query(sa.Namespace))
+					_, _, found := ops.enrolledNamespaceTable.Get(ops.db.ReadTxn(), table.EnrolledNamespaceByName(sa.Namespace))
 					if !found {
 						ops.logger.Debug("Namespace not enrolled for mTLS", logfields.K8sNamespace, sa.Namespace)
 						continue

--- a/operator/pkg/ztunnel/reconciler/reconciler_test.go
+++ b/operator/pkg/ztunnel/reconciler/reconciler_test.go
@@ -428,7 +428,7 @@ func TestEnrollmentReconciler_Start_ErrorMetricsAndRequeue(t *testing.T) {
 
 		// Verify the namespace was requeued to pending for re-reconciliation.
 		require.Eventually(t, func() bool {
-			ns, _, found := enrolledTbl.Get(db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query("enrolled-ns"))
+			ns, _, found := enrolledTbl.Get(db.ReadTxn(), table.EnrolledNamespaceByName("enrolled-ns"))
 			return found && ns.Status.Kind == reconciler.StatusKindPending
 		}, 5*time.Second, 10*time.Millisecond)
 	case <-time.After(5 * time.Second):

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -726,7 +726,7 @@ func (m *BGPRouterManager) updateReconcilerErrors(instance string, newErrors []e
 func (m *BGPRouterManager) getErrorsFromTable(txn statedb.WriteTxn, instance string) []error {
 	// get existing errors for this instance from the table
 	var reconcileErrs []*tables.BGPReconcileError
-	iter := m.ReconcileErrorTable.List(txn, tables.BGPReconcileErrorInstance.Query(instance))
+	iter := m.ReconcileErrorTable.List(txn, tables.BGPReconcileErrorsByInstance(instance))
 	for instanceErr := range iter {
 		reconcileErrs = append(reconcileErrs, instanceErr.DeepCopy())
 	}
@@ -742,7 +742,7 @@ func (m *BGPRouterManager) getErrorsFromTable(txn statedb.WriteTxn, instance str
 }
 
 func (m *BGPRouterManager) deleteErrorsFromTable(txn statedb.WriteTxn, instance string) error {
-	iter := m.ReconcileErrorTable.List(txn, tables.BGPReconcileErrorInstance.Query(instance))
+	iter := m.ReconcileErrorTable.List(txn, tables.BGPReconcileErrorsByInstance(instance))
 	for instanceErr := range iter {
 		_, _, err := m.ReconcileErrorTable.Delete(txn, instanceErr)
 		if err != nil {

--- a/pkg/bgp/manager/tables/errors.go
+++ b/pkg/bgp/manager/tables/errors.go
@@ -59,7 +59,7 @@ func (k BGPReconcileErrorKey) Key() index.Key {
 }
 
 var (
-	BGPReconcileErrorIndex = statedb.Index[*BGPReconcileError, BGPReconcileErrorKey]{
+	bgpReconcileErrorIndex = statedb.Index[*BGPReconcileError, BGPReconcileErrorKey]{
 		Name: "key",
 		FromObject: func(obj *BGPReconcileError) index.KeySet {
 			return index.NewKeySet(
@@ -72,7 +72,7 @@ var (
 		FromKey: BGPReconcileErrorKey.Key,
 		Unique:  true,
 	}
-	BGPReconcileErrorInstance = statedb.Index[*BGPReconcileError, string]{
+	bgpReconcileErrorInstanceIndex = statedb.Index[*BGPReconcileError, string]{
 		Name: "Instance",
 		FromObject: func(obj *BGPReconcileError) index.KeySet {
 			return index.NewKeySet(index.String(obj.Instance))
@@ -81,13 +81,16 @@ var (
 		FromString: index.FromString,
 		Unique:     false,
 	}
+
+	// BGPReconcileErrorsByInstance queries the BGP reconcile error table by instance.
+	BGPReconcileErrorsByInstance = bgpReconcileErrorInstanceIndex.Query
 )
 
 func NewBGPReconcileErrorTable(db *statedb.DB) (statedb.RWTable[*BGPReconcileError], error) {
 	return statedb.NewTable(
 		db,
 		"bgp-reconcile-errors",
-		BGPReconcileErrorIndex,
-		BGPReconcileErrorInstance,
+		bgpReconcileErrorIndex,
+		bgpReconcileErrorInstanceIndex,
 	)
 }

--- a/pkg/datapath/iptables/ipset/ipset.go
+++ b/pkg/datapath/iptables/ipset/ipset.go
@@ -98,7 +98,7 @@ func (m *manager) AddToIPSet(name string, family Family, addrs ...netip.Addr) {
 			Name: name,
 			Addr: addr,
 		}
-		if _, _, found := m.table.Get(txn, tables.IPSetEntryIndex.Query(key)); found {
+		if _, _, found := m.table.Get(txn, tables.IPSetEntryByKey(key)); found {
 			continue
 		}
 		_, _, _ = m.table.Insert(txn, &tables.IPSetEntry{
@@ -126,7 +126,7 @@ func (m *manager) RemoveFromIPSet(name string, addrs ...netip.Addr) {
 			Name: name,
 			Addr: addr,
 		}
-		obj, _, found := m.table.Get(txn, tables.IPSetEntryIndex.Query(key))
+		obj, _, found := m.table.Get(txn, tables.IPSetEntryByKey(key))
 		if !found {
 			continue
 		}

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -378,7 +378,7 @@ func TestOpsPruneEnabled(t *testing.T) {
 	fakeLogger := slog.New(slog.DiscardHandler)
 
 	db := statedb.New()
-	table, _ := statedb.NewTable(db, "ipsets", tables.IPSetEntryIndex)
+	table, _ := tables.NewIPSetTable(db)
 
 	txn := db.WriteTxn(table)
 	table.Insert(txn, &tables.IPSetEntry{
@@ -487,7 +487,7 @@ func TestOpsRetry(t *testing.T) {
 	txn.Commit()
 
 	for {
-		queryObj, _, watch, found := table.GetWatch(db.ReadTxn(), tables.IPSetEntryIndex.QueryFromObject(obj))
+		queryObj, _, watch, found := table.GetWatch(db.ReadTxn(), tables.IPSetEntryByKey(tables.IPSetEntryKey{Name: obj.Name, Addr: obj.Addr}))
 		require.True(t, found)
 
 		if queryObj.Status.Kind == reconciler.StatusKindDone {

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -154,7 +154,7 @@ func (m *manager) ensureHostEndpointQoS(txn statedb.WriteTxn) {
 func (m *manager) DeleteBandwidthLimit(epID uint16) {
 	if m.enabled {
 		txn := m.params.DB.WriteTxn(m.params.EdtTable)
-		obj, _, found := m.params.EdtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		obj, _, found := m.params.EdtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: epID,
 			Direction:  DirectionEgress,
 		}))
@@ -179,7 +179,7 @@ func (m *manager) UpdateIngressBandwidthLimit(epID uint16, bytesPerSecond uint64
 func (m *manager) DeleteIngressBandwidthLimit(epID uint16) {
 	if m.enabled {
 		txn := m.params.DB.WriteTxn(m.params.EdtTable)
-		obj, _, found := m.params.EdtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		obj, _, found := m.params.EdtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: epID,
 			Direction:  DirectionIngress,
 		}))

--- a/pkg/datapath/linux/bandwidth/bandwidth_test.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth_test.go
@@ -38,14 +38,14 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Verify host endpoint was NOT inserted (template ID should be skipped)
 		txn := db.ReadTxn()
-		_, _, found := edtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		_, _, found := edtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 0xffff,
 			Direction:  DirectionEgress,
 		}))
 		assert.False(t, found, "Host endpoint with template ID should not be inserted")
 
 		// Verify the pod entry was still inserted
-		_, _, found = edtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		_, _, found = edtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 100,
 			Direction:  DirectionEgress,
 		}))
@@ -67,7 +67,7 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Verify host endpoint was inserted with Guaranteed QoS
 		txn := db.ReadTxn()
-		hostEntry, _, found := edtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		hostEntry, _, found := edtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 42,
 			Direction:  DirectionEgress,
 		}))
@@ -76,7 +76,7 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 		assert.Equal(t, uint64(0), hostEntry.BytesPerSecond, "Host endpoint should have no bandwidth limit")
 
 		// Verify the pod entry was also inserted
-		podEntry, _, found := edtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		podEntry, _, found := edtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 100,
 			Direction:  DirectionEgress,
 		}))
@@ -100,7 +100,7 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Manually delete the host endpoint entry to verify it's not re-added
 		wtxn := db.WriteTxn(edtTable)
-		hostEntry, _, found := edtTable.Get(wtxn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		hostEntry, _, found := edtTable.Get(wtxn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 42,
 			Direction:  DirectionEgress,
 		}))
@@ -110,7 +110,7 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Verify host endpoint is deleted
 		rtxn := db.ReadTxn()
-		_, _, found = edtTable.Get(rtxn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		_, _, found = edtTable.Get(rtxn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 42,
 			Direction:  DirectionEgress,
 		}))
@@ -121,14 +121,14 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Verify host endpoint is still NOT present (proves we skipped setup)
 		rtxn2 := db.ReadTxn()
-		_, _, found = edtTable.Get(rtxn2, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		_, _, found = edtTable.Get(rtxn2, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 42,
 			Direction:  DirectionEgress,
 		}))
 		assert.False(t, found, "Host endpoint should NOT be re-added on subsequent calls")
 
 		// Verify the second pod entry was inserted
-		_, _, found = edtTable.Get(rtxn2, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		_, _, found = edtTable.Get(rtxn2, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 101,
 			Direction:  DirectionEgress,
 		}))
@@ -155,7 +155,7 @@ func TestEnsureHostEndpointQoS(t *testing.T) {
 
 		// Verify host endpoint was inserted
 		txn := db.ReadTxn()
-		hostEntry, _, found := edtTable.Get(txn, bwmap.EdtIDIndex.Query(bwmap.EdtIDKey{
+		hostEntry, _, found := edtTable.Get(txn, bwmap.EDTByID(bwmap.EdtIDKey{
 			EndpointID: 42,
 			Direction:  DirectionEgress,
 		}))

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -590,7 +590,7 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 			}
 			// Remove all neighbors for the device. For a deleted device netlink does not
 			// always send complete set of neighbor delete messages.
-			neighbors := dc.params.NeighborTable.List(txn, tables.NeighborLinkIndex.Query(d.Index))
+			neighbors := dc.params.NeighborTable.List(txn, tables.NeighborsByLinkIndex(d.Index))
 			for n := range neighbors {
 				dc.params.NeighborTable.Delete(txn, n)
 			}

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -584,7 +584,7 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 
 			// Remove all routes for the device. For a deleted device netlink does not
 			// send complete set of route delete messages.
-			routes := dc.params.RouteTable.List(txn, tables.RouteLinkIndex.Query(d.Index))
+			routes := dc.params.RouteTable.List(txn, tables.RoutesByLinkIndex(d.Index))
 			for r := range routes {
 				dc.params.RouteTable.Delete(txn, r)
 			}
@@ -715,7 +715,7 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 }
 
 func hasGlobalRoute(devIndex int, tbl statedb.Table[*tables.Route], rxn statedb.ReadTxn) bool {
-	routes := tbl.List(rxn, tables.RouteLinkIndex.Query(devIndex))
+	routes := tbl.List(rxn, tables.RoutesByLinkIndex(devIndex))
 	hasGlobal := false
 	for r := range routes {
 		if r.Dst.Addr().IsGlobalUnicast() {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -129,7 +129,7 @@ func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, rx statedb.ReadTxn, rou
 	for _, r := range gwRoutes {
 		// See if they already exist.
 		cidr, _ := r.Dst.Mask.Size()
-		_, _, watch, found := routes.GetWatch(rx, tables.RouteIDIndex.Query(tables.RouteID{
+		_, _, watch, found := routes.GetWatch(rx, tables.RouteByID(tables.RouteID{
 			Table:     tables.RouteTable(r.Table),
 			LinkIndex: r.LinkIndex,
 			Dst:       netip.PrefixFrom(netipx.MustFromStdIP(r.Dst.IP), cidr),

--- a/pkg/datapath/linux/sysctl/sysctl.go
+++ b/pkg/datapath/linux/sysctl/sysctl.go
@@ -327,7 +327,7 @@ func (sysctl *reconcilingSysctl) waitForReconciliation(name []string) error {
 
 	var err error
 	for {
-		obj, _, watch, _ := sysctl.settings.GetWatch(sysctl.db.ReadTxn(), tables.SysctlNameIndex.Query(strings.Join(name, ".")))
+		obj, _, watch, _ := sysctl.settings.GetWatch(sysctl.db.ReadTxn(), tables.SysctlByName(strings.Join(name, ".")))
 		if obj.Status.Kind == reconciler.StatusKindDone {
 			// already reconciled
 			return nil

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -105,7 +105,7 @@ func TestWaitForReconciliation(t *testing.T) {
 
 	// fake a successful reconciliation
 	txn := db.WriteTxn(settings)
-	old, _, found := settings.Get(txn, tables.SysctlNameIndex.Query(paramName))
+	old, _, found := settings.Get(txn, tables.SysctlByName(paramName))
 	_, exist, err := settings.Insert(txn, old.Clone().SetStatus(reconciler.StatusDone()))
 	txn.Commit()
 

--- a/pkg/datapath/neighbor/forwardable_ip.go
+++ b/pkg/datapath/neighbor/forwardable_ip.go
@@ -82,7 +82,7 @@ func (fip *ForwardableIP) TableRow() []string {
 }
 
 var (
-	ForwardableIPIndex = statedb.Index[*ForwardableIP, netip.Addr]{
+	forwardableIPIndex = statedb.Index[*ForwardableIP, netip.Addr]{
 		Name: "id",
 		FromObject: func(d *ForwardableIP) index.KeySet {
 			return index.NewKeySet(index.NetIPAddr(d.IP))
@@ -108,7 +108,7 @@ func newForwardableIPTable(db *statedb.DB, config *CommonConfig) (*ForwardableIP
 	tbl, err := statedb.NewTable(
 		db,
 		"forwardable-ip",
-		ForwardableIPIndex,
+		forwardableIPIndex,
 		forwardableIPOwnerIndex,
 	)
 	if err != nil {
@@ -206,7 +206,7 @@ func (fim *ForwardableIPManager) Delete(ip netip.Addr, owner ForwardableIPOwner)
 	tx := fim.db.WriteTxn(fim.table)
 	defer tx.Abort()
 
-	fi, _, found := fim.table.Get(tx, ForwardableIPIndex.Query(ip))
+	fi, _, found := fim.table.Get(tx, forwardableIPIndex.Query(ip))
 	if !found {
 		return nil
 	}

--- a/pkg/datapath/neighbor/neighbor_reconciler.go
+++ b/pkg/datapath/neighbor/neighbor_reconciler.go
@@ -92,7 +92,7 @@ type ops struct {
 func (ops *ops) Update(ctx context.Context, rx statedb.ReadTxn, _ statedb.Revision, neighbor *DesiredNeighbor) error {
 	ops.metrics.NeighborEntryInsertCount.Inc()
 
-	_, _, isNew := ops.neighbors.Get(rx, tables.NeighborIDIndex.Query(tables.NeighborID{
+	_, _, isNew := ops.neighbors.Get(rx, tables.NeighborByID(tables.NeighborID{
 		IPAddr:    neighbor.IP,
 		LinkIndex: neighbor.IfIndex,
 	}))
@@ -158,7 +158,7 @@ func (ops *ops) Update(ctx context.Context, rx statedb.ReadTxn, _ statedb.Revisi
 
 // Delete gets called with a deleted desired neighbor.
 func (ops *ops) Delete(ctx context.Context, rx statedb.ReadTxn, _ statedb.Revision, neighbor *DesiredNeighbor) error {
-	neigh, _, found := ops.neighbors.Get(rx, tables.NeighborIDIndex.Query(tables.NeighborID{
+	neigh, _, found := ops.neighbors.Get(rx, tables.NeighborByID(tables.NeighborID{
 		IPAddr:    neighbor.IP,
 		LinkIndex: neighbor.IfIndex,
 	}))

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -93,7 +93,7 @@ func newLocalNodeConfig(
 
 	nativeDevices, devsWatch := tables.SelectedDevices(devices, txn)
 	nodeAddrsIter, addrsWatch := nodeAddresses.AllWatch(txn)
-	mtuRoute, _, mtuWatch, _ := mtuTbl.GetWatch(txn, mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4))
+	mtuRoute, _, mtuWatch, _ := mtuTbl.GetWatch(txn, mtu.MTURouteByPrefix(mtu.DefaultPrefixV4))
 
 	watchChans := []<-chan struct{}{devsWatch, addrsWatch, mtuWatch}
 	var directRoutingDevice *tables.Device

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -138,7 +138,7 @@ func newOrchestrator(params orchestratorParams) *orchestrator {
 		OnStart: func(ctx cell.HookContext) error {
 			for {
 				rxt := params.DB.ReadTxn()
-				mtuRoute, _, watch, found := params.MTU.GetWatch(rxt, mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4))
+				mtuRoute, _, watch, found := params.MTU.GetWatch(rxt, mtu.MTURouteByPrefix(mtu.DefaultPrefixV4))
 				if !found {
 					select {
 					case <-ctx.Done():

--- a/pkg/datapath/tables/ipset.go
+++ b/pkg/datapath/tables/ipset.go
@@ -23,7 +23,7 @@ func (k IPSetEntryKey) Key() index.Key {
 	return append(index.NetIPAddr(k.Addr), []byte(k.Name)...)
 }
 
-var IPSetEntryIndex = statedb.Index[*IPSetEntry, IPSetEntryKey]{
+var ipSetEntryIndex = statedb.Index[*IPSetEntry, IPSetEntryKey]{
 	Name: IPSetsTableName,
 	FromObject: func(s *IPSetEntry) index.KeySet {
 		return index.NewKeySet(IPSetEntryKey{s.Name, s.Addr}.Key())
@@ -44,11 +44,14 @@ var IPSetEntryIndex = statedb.Index[*IPSetEntry, IPSetEntryKey]{
 	Unique: true,
 }
 
+// IPSetEntryByKey queries the ipsets table by name and address.
+var IPSetEntryByKey = ipSetEntryIndex.Query
+
 func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSetEntry], error) {
 	return statedb.NewTable(
 		db,
 		IPSetsTableName,
-		IPSetEntryIndex,
+		ipSetEntryIndex,
 	)
 }
 

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -41,7 +41,7 @@ func (pne *L2AnnounceEntry) DeepCopy() *L2AnnounceEntry {
 }
 
 var (
-	L2AnnounceIDIndex = statedb.Index[*L2AnnounceEntry, L2AnnounceKey]{
+	l2AnnounceIDIndex = statedb.Index[*L2AnnounceEntry, L2AnnounceKey]{
 		Name: "id",
 		FromObject: func(b *L2AnnounceEntry) index.KeySet {
 			return index.NewKeySet(b.Key())
@@ -58,7 +58,7 @@ var (
 		Unique: true,
 	}
 
-	L2AnnounceOriginIndex = statedb.Index[*L2AnnounceEntry, types.NamespacedName]{
+	l2AnnounceOriginIndex = statedb.Index[*L2AnnounceEntry, types.NamespacedName]{
 		Name: "origin",
 		FromObject: func(b *L2AnnounceEntry) index.KeySet {
 			return index.StringerSlice(b.Origins)
@@ -66,14 +66,20 @@ var (
 		FromKey:    index.Stringer[types.NamespacedName],
 		FromString: index.FromString,
 	}
+
+	// L2AnnounceByID queries the L2 announce table by entry key.
+	L2AnnounceByID = l2AnnounceIDIndex.Query
+
+	// L2AnnouncesByOrigin queries the L2 announce table by origin.
+	L2AnnouncesByOrigin = l2AnnounceOriginIndex.Query
 )
 
 func NewL2AnnounceTable(db *statedb.DB) (statedb.RWTable[*L2AnnounceEntry], error) {
 	return statedb.NewTable(
 		db,
 		"l2-announce",
-		L2AnnounceIDIndex,
-		L2AnnounceOriginIndex,
+		l2AnnounceIDIndex,
+		l2AnnounceOriginIndex,
 	)
 }
 

--- a/pkg/datapath/tables/neighbor.go
+++ b/pkg/datapath/tables/neighbor.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	NeighborIDIndex = statedb.Index[*Neighbor, NeighborID]{
+	neighborIDIndex = statedb.Index[*Neighbor, NeighborID]{
 		Name: "ID",
 		FromObject: func(n *Neighbor) index.KeySet {
 			return index.NewKeySet(
@@ -56,7 +56,7 @@ var (
 		Unique: true,
 	}
 
-	NeighborLinkIndex = statedb.Index[*Neighbor, int]{
+	neighborLinkIndex = statedb.Index[*Neighbor, int]{
 		Name: "LinkIndex",
 		FromObject: func(n *Neighbor) index.KeySet {
 			return index.NewKeySet(index.Int(n.LinkIndex))
@@ -65,7 +65,7 @@ var (
 		FromString: index.IntString,
 	}
 
-	NeighborIPAddrIndex = statedb.Index[*Neighbor, netip.Addr]{
+	neighborIPAddrIndex = statedb.Index[*Neighbor, netip.Addr]{
 		Name: "IPAddr",
 		FromObject: func(n *Neighbor) index.KeySet {
 			return index.NewKeySet(index.NetIPAddr(n.IPAddr))
@@ -73,15 +73,24 @@ var (
 		FromKey:    index.NetIPAddr,
 		FromString: index.NetIPAddrString,
 	}
+
+	// NeighborByID queries the neighbors table by neighbor ID.
+	NeighborByID = neighborIDIndex.Query
+
+	// NeighborsByLinkIndex queries the neighbors table by link index.
+	NeighborsByLinkIndex = neighborLinkIndex.Query
+
+	// NeighborByIPAddr queries the neighbors table by IP address.
+	NeighborByIPAddr = neighborIPAddrIndex.Query
 )
 
 func NewNeighborTable(db *statedb.DB) (statedb.RWTable[*Neighbor], error) {
 	return statedb.NewTable(
 		db,
 		"neighbors",
-		NeighborIDIndex,
-		NeighborLinkIndex,
-		NeighborIPAddrIndex,
+		neighborIDIndex,
+		neighborLinkIndex,
+		neighborIPAddrIndex,
 	)
 }
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -285,7 +285,7 @@ func (n *nodeAddressController) reconcile(health cell.Health) *statedb.WatchSet 
 	// Get iterators for the current state and new watch channels.
 	allDevices, devicesWatch := n.Devices.AllWatch(rtxn)
 	ws.Add(devicesWatch)
-	localRoutes, routesWatch := n.Routes.PrefixWatch(rtxn, RouteIDIndex.Query(RouteID{Table: RT_TABLE_LOCAL}))
+	localRoutes, routesWatch := n.Routes.PrefixWatch(rtxn, RouteByID(RouteID{Table: RT_TABLE_LOCAL}))
 	ws.Add(routesWatch)
 
 	// A map to hold the desired state of node addresses, keyed by device name.

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -107,11 +107,7 @@ func (k NodeAddressKey) Key() index.Key {
 }
 
 var (
-	// NodeAddressIndex is the primary index for node addresses:
-	//
-	//   var nodeAddresses Table[NodeAddress]
-	//   nodeAddresses.First(txn, NodeAddressIndex.Query(netip.MustParseAddr("1.2.3.4")))
-	NodeAddressIndex = statedb.Index[NodeAddress, NodeAddressKey]{
+	nodeAddressIndex = statedb.Index[NodeAddress, NodeAddressKey]{
 		Name: "id",
 		FromObject: func(a NodeAddress) index.KeySet {
 			return index.NewKeySet(NodeAddressKey{a.Addr, a.DeviceName}.Key())
@@ -128,7 +124,7 @@ var (
 		Unique: true,
 	}
 
-	NodeAddressDeviceNameIndex = statedb.Index[NodeAddress, string]{
+	nodeAddressDeviceNameIndex = statedb.Index[NodeAddress, string]{
 		Name: "name",
 		FromObject: func(a NodeAddress) index.KeySet {
 			return index.NewKeySet(index.String(a.DeviceName))
@@ -138,7 +134,7 @@ var (
 		Unique:     false,
 	}
 
-	NodeAddressNodePortIndex = statedb.Index[NodeAddress, bool]{
+	nodeAddressNodePortIndex = statedb.Index[NodeAddress, bool]{
 		Name: "node-port",
 		FromObject: func(a NodeAddress) index.KeySet {
 			return index.NewKeySet(index.Bool(a.NodePort))
@@ -147,6 +143,15 @@ var (
 		FromString: index.BoolString,
 		Unique:     false,
 	}
+
+	// NodeAddressByKey queries the node addresses table by address and device.
+	NodeAddressByKey = nodeAddressIndex.Query
+
+	// NodeAddressesByDeviceName queries the node addresses table by device name.
+	NodeAddressesByDeviceName = nodeAddressDeviceNameIndex.Query
+
+	// NodeAddressesByNodePort queries the node addresses table by NodePort eligibility.
+	NodeAddressesByNodePort = nodeAddressNodePortIndex.Query
 
 	NodeAddressTableName statedb.TableName = "node-addresses"
 
@@ -173,9 +178,9 @@ func NewNodeAddressTable(db *statedb.DB) (statedb.RWTable[NodeAddress], error) {
 	return statedb.NewTable(
 		db,
 		NodeAddressTableName,
-		NodeAddressIndex,
-		NodeAddressDeviceNameIndex,
-		NodeAddressNodePortIndex,
+		nodeAddressIndex,
+		nodeAddressDeviceNameIndex,
+		nodeAddressNodePortIndex,
 	)
 }
 
@@ -409,7 +414,7 @@ func (n *nodeAddressController) update(txn statedb.WriteTxn, new []NodeAddress, 
 	// Gather the set of currently existing addresses for this device.
 	current := sets.New(statedb.Collect(
 		statedb.Map(
-			n.NodeAddresses.List(txn, NodeAddressDeviceNameIndex.Query(device)),
+			n.NodeAddresses.List(txn, NodeAddressesByDeviceName(device)),
 			func(addr NodeAddress) netip.Addr {
 				return addr.Addr
 			}))...)
@@ -417,7 +422,7 @@ func (n *nodeAddressController) update(txn statedb.WriteTxn, new []NodeAddress, 
 	// Update the new set of addresses for this device. We try to avoid insertions when nothing has changed
 	// to avoid unnecessary wakeups to watchers of the table.
 	for _, addr := range new {
-		old, _, hadOld := n.NodeAddresses.Get(txn, NodeAddressIndex.Query(NodeAddressKey{Addr: addr.Addr, DeviceName: device}))
+		old, _, hadOld := n.NodeAddresses.Get(txn, NodeAddressByKey(NodeAddressKey{Addr: addr.Addr, DeviceName: device}))
 		if !hadOld || old != addr {
 			updated = true
 			n.NodeAddresses.Insert(txn, addr)

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -766,7 +766,7 @@ func TestNodeAddressNodeIPChange(t *testing.T) {
 	txn.Commit()
 	<-watch // wait for propagation
 
-	iter, watch := nodeAddrs.ListWatch(db.ReadTxn(), NodeAddressNodePortIndex.Query(true))
+	iter, watch := nodeAddrs.ListWatch(db.ReadTxn(), NodeAddressesByNodePort(true))
 	addrs := statedb.Collect(iter)
 	if assert.Len(t, addrs, 1) {
 		assert.Equal(t, testNodeIPv4, addrs[0].Addr)
@@ -780,7 +780,7 @@ func TestNodeAddressNodeIPChange(t *testing.T) {
 	<-watch
 
 	// The new node IP should now be preferred for NodePort.
-	iter = nodeAddrs.List(db.ReadTxn(), NodeAddressNodePortIndex.Query(true))
+	iter = nodeAddrs.List(db.ReadTxn(), NodeAddressesByNodePort(true))
 	addrs = statedb.Collect(iter)
 	if assert.Len(t, addrs, 1) {
 		assert.Equal(t, "10.0.0.1", addrs[0].Addr.String())

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	RouteIDIndex = statedb.Index[*Route, RouteID]{
+	routeIDIndex = statedb.Index[*Route, RouteID]{
 		Name: "id",
 		FromObject: func(r *Route) index.KeySet {
 			return index.NewKeySet(
@@ -57,7 +57,7 @@ var (
 		Unique: true,
 	}
 
-	RouteLinkIndex = statedb.Index[*Route, int]{
+	routeLinkIndex = statedb.Index[*Route, int]{
 		Name: "LinkIndex",
 		FromObject: func(r *Route) index.KeySet {
 			return index.NewKeySet(index.Int(r.LinkIndex))
@@ -65,14 +65,20 @@ var (
 		FromKey:    index.Int,
 		FromString: index.IntString,
 	}
+
+	// RouteByID queries the routes table by route ID.
+	RouteByID = routeIDIndex.Query
+
+	// RoutesByLinkIndex queries the routes table by link index.
+	RoutesByLinkIndex = routeLinkIndex.Query
 )
 
 func NewRouteTable(db *statedb.DB) (statedb.RWTable[*Route], error) {
 	return statedb.NewTable(
 		db,
 		"routes",
-		RouteIDIndex,
-		RouteLinkIndex,
+		routeIDIndex,
+		routeLinkIndex,
 	)
 }
 
@@ -170,7 +176,7 @@ func HasDefaultRoute(tbl statedb.Table[*Route], rxn statedb.ReadTxn, linkIndex i
 	// Device has a default route when a route exists in the main table
 	// with a zero destination.
 	for _, prefix := range []netip.Prefix{zeroPrefixV4, zeroPrefixV6} {
-		r, _, _ := tbl.Get(rxn, RouteIDIndex.Query(RouteID{
+		r, _, _ := tbl.Get(rxn, RouteByID(RouteID{
 			RT_TABLE_MAIN,
 			linkIndex,
 			prefix,

--- a/pkg/datapath/tables/sysctl.go
+++ b/pkg/datapath/tables/sysctl.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	SysctlNameIndex = statedb.Index[*Sysctl, string]{
+	sysctlNameIndex = statedb.Index[*Sysctl, string]{
 		Name: "name",
 		FromObject: func(s *Sysctl) index.KeySet {
 			return index.NewKeySet(index.String(strings.Join(s.Name, ".")))
@@ -22,6 +22,9 @@ var (
 		Unique:     true,
 	}
 
+	// SysctlByName queries the sysctl table by parameter name.
+	SysctlByName = sysctlNameIndex.Query
+
 	SysctlTableName = "sysctl"
 )
 
@@ -29,7 +32,7 @@ func NewSysctlTable(db *statedb.DB) (statedb.RWTable[*Sysctl], error) {
 	tbl, err := statedb.NewTable(
 		db,
 		SysctlTableName,
-		SysctlNameIndex,
+		sysctlNameIndex,
 	)
 	return tbl, err
 }

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -176,7 +176,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 func deviceGetPrimaryAddresses(manager *Manager, iface string) (netip.Addr, netip.Addr) {
 	var primaryIP4, primaryIP6 netip.Addr
 
-	addrs := manager.nodeAddrTable.List(manager.db.ReadTxn(), tables.NodeAddressDeviceNameIndex.Query(iface))
+	addrs := manager.nodeAddrTable.List(manager.db.ReadTxn(), tables.NodeAddressesByDeviceName(iface))
 	for addr := range addrs {
 		if !addr.Primary {
 			continue

--- a/pkg/hive/health/cell.go
+++ b/pkg/hive/health/cell.go
@@ -15,7 +15,7 @@ import (
 var Cell = cell.Module(
 	"health",
 	"Modular Health Provider V2",
-	cell.ProvidePrivate(newTablesPrivate),
+	cell.ProvidePrivate(NewTable),
 	cell.Provide(
 		newHealthV2Provider,
 		statedb.RWTable[types.Status].ToTable,
@@ -32,7 +32,7 @@ var Cell = cell.Module(
 var HistoryCell = cell.Provide(newHealthHistory)
 
 var (
-	PrimaryIndex = statedb.Index[types.Status, types.HealthID]{
+	primaryIndex = statedb.Index[types.Status, types.HealthID]{
 		Name: "identifier",
 		FromObject: func(s types.Status) index.KeySet {
 			return index.NewKeySet([]byte(s.ID.String()))
@@ -41,7 +41,7 @@ var (
 		FromString: index.FromString,
 		Unique:     true,
 	}
-	LevelIndex = statedb.Index[types.Status, types.Level]{
+	levelIndex = statedb.Index[types.Status, types.Level]{
 		Name: "level",
 		FromObject: func(s types.Status) index.KeySet {
 			return index.NewKeySet(index.Stringer(s.Level))
@@ -50,12 +50,19 @@ var (
 		FromString: index.FromString,
 		Unique:     false,
 	}
+
+	// StatusByID queries the health status table by reporter ID.
+	StatusByID = primaryIndex.Query
+
+	// StatusByLevel queries the health status table by health level.
+	StatusByLevel = levelIndex.Query
 )
 
-func newTablesPrivate(db *statedb.DB) (statedb.RWTable[types.Status], error) {
+// NewTable creates the health status table.
+func NewTable(db *statedb.DB) (statedb.RWTable[types.Status], error) {
 	return statedb.NewTable(
 		db,
 		TableName,
-		PrimaryIndex,
-		LevelIndex)
+		primaryIndex,
+		levelIndex)
 }

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -105,7 +105,7 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 
 func getHealth(db *statedb.DB, table statedb.Table[types.Status], prefix, match string, levels []string) []types.Status {
 	tx := db.ReadTxn()
-	results := table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix)))
+	results := table.Prefix(tx, StatusByID(types.HealthID(prefix)))
 	ss := []types.Status{}
 	for status := range results {
 		if match != "" && !strings.Contains(status.ID.String(), match) {

--- a/pkg/hive/health/metrics_test.go
+++ b/pkg/hive/health/metrics_test.go
@@ -36,7 +36,7 @@ func Test_Metrics(t *testing.T) {
 		statedb.Cell,
 		job.Cell,
 
-		cell.ProvidePrivate(newTablesPrivate),
+		cell.ProvidePrivate(NewTable),
 		cell.Provide(
 			newHealthHistory,
 			func() HistoryDir {

--- a/pkg/hive/health/provider.go
+++ b/pkg/hive/health/provider.go
@@ -68,7 +68,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			}
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
-			old, _, found := p.statusTable.Get(tx, PrimaryIndex.QueryFromObject(s))
+			old, _, found := p.statusTable.Get(tx, StatusByID(s.ID.HealthID()))
 			if found && !old.Stopped.IsZero() {
 				return fmt.Errorf("reporting for %q has been stopped", s.ID)
 			}
@@ -107,7 +107,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
-			q := PrimaryIndex.Query(types.HealthID(i.String()))
+			q := StatusByID(i.HealthID())
 			iter := p.statusTable.Prefix(tx, q)
 			numDeleted := 0
 			for o := range iter {
@@ -136,7 +136,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			}
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
-			old, _, found := p.statusTable.Get(tx, PrimaryIndex.Query(i.HealthID()))
+			old, _, found := p.statusTable.Get(tx, StatusByID(i.HealthID()))
 			if !found {
 				// Nothing to do.
 				return nil

--- a/pkg/hive/health/provider_test.go
+++ b/pkg/hive/health/provider_test.go
@@ -21,7 +21,7 @@ func allStatus(db *statedb.DB, statusTable statedb.RWTable[types.Status]) []type
 }
 
 func byLevel(db *statedb.DB, statusTable statedb.RWTable[types.Status], l types.Level) []types.Status {
-	return statedb.Collect(statusTable.List(db.ReadTxn(), LevelIndex.Query(l)))
+	return statedb.Collect(statusTable.List(db.ReadTxn(), StatusByLevel(l)))
 }
 
 func TestProvider(t *testing.T) {
@@ -30,7 +30,7 @@ func TestProvider(t *testing.T) {
 		statedb.Cell,
 		cell.Provide(newHealthV2Provider),
 		cell.Provide(newHealthHistory),
-		cell.ProvidePrivate(newTablesPrivate),
+		cell.ProvidePrivate(NewTable),
 		cell.Provide(func() HistoryDir {
 			return HistoryDir(t.TempDir())
 		}),

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -977,7 +977,7 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 
 	svcKey := serviceKey(ss.svc)
 
-	entriesIter := tbl.List(txn, tables.L2AnnounceOriginIndex.Query(svcKey))
+	entriesIter := tbl.List(txn, tables.L2AnnouncesByOrigin(svcKey))
 
 	// If we are not the leader, we should not have any proxy entries for the service.
 	if !ss.currentlyLeader {
@@ -1056,7 +1056,7 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 		}
 
 		entry := desiredEntries[key]
-		existing, _, _ := tbl.Get(txn, tables.L2AnnounceIDIndex.Query(tables.L2AnnounceKey{
+		existing, _, _ := tbl.Get(txn, tables.L2AnnounceByID(tables.L2AnnounceKey{
 			IP:               entry.IP,
 			NetworkInterface: entry.NetworkInterface,
 		}))

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -200,7 +200,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 					if !is4 {
 						beAddr = netip.IPv6Unspecified()
 					}
-					for addr := range s.params.NodeAddresses.List(wtxn, tables.NodeAddressNodePortIndex.Query(true)) {
+					for addr := range s.params.NodeAddresses.List(wtxn, tables.NodeAddressesByNodePort(true)) {
 						if is4 && addr.Addr.Is4() {
 							beAddr = addr.Addr
 							break

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -754,7 +754,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 	if isDatapathCandidate {
 		isLocalAddr := func(addr netip.Addr) bool {
 			k := tables.NodeAddressKey{Addr: addr}
-			for range ops.nodeAddrs.Prefix(txn, tables.NodeAddressIndex.Query(k)) {
+			for range ops.nodeAddrs.Prefix(txn, tables.NodeAddressByKey(k)) {
 				return true
 			}
 			return false
@@ -791,7 +791,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 		// empty so any previously expanded frontends are withdrawn below.
 		var nodePortAddrs []netip.Addr
 		if isDatapathCandidate {
-			for na := range ops.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
+			for na := range ops.nodeAddrs.List(txn, tables.NodeAddressesByNodePort(true)) {
 				if na.Addr.Is6() != fe.Address.IsIPv6() {
 					continue
 				}

--- a/pkg/loadbalancer/writer/node_addr_reconciler.go
+++ b/pkg/loadbalancer/writer/node_addr_reconciler.go
@@ -65,7 +65,7 @@ type nodePortAddrReconciler struct {
 }
 
 func (r *nodePortAddrReconciler) getAddrs(txn statedb.ReadTxn) ([]netip.Addr, <-chan struct{}) {
-	iter, watch := r.nodeAddrs.ListWatch(txn, tables.NodeAddressNodePortIndex.Query(true))
+	iter, watch := r.nodeAddrs.ListWatch(txn, tables.NodeAddressesByNodePort(true))
 	return statedb.Collect(
 		statedb.Map(iter, func(addr tables.NodeAddress) netip.Addr { return addr.Addr }),
 	), watch

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -300,7 +300,7 @@ func (w *Writer) isNodePortConflict(txn statedb.ReadTxn, addr loadbalancer.L3n4A
 		return false
 	}
 	ip := addr.AddrCluster().Addr()
-	for na := range w.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
+	for na := range w.nodeAddrs.List(txn, tables.NodeAddressesByNodePort(true)) {
 		if na.Addr == ip {
 			return true
 		}

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -50,26 +50,31 @@ func (k EdtIDKey) Key() index.Key {
 	return key
 }
 
-var EdtIDIndex = statedb.Index[Edt, EdtIDKey]{
-	Name: "endpoint-id",
-	FromObject: func(t Edt) index.KeySet {
-		return index.NewKeySet(t.Key())
-	},
-	FromKey: EdtIDKey.Key,
-	FromString: func(key string) (index.Key, error) {
-		epS, directionS, _ := strings.Cut(key, "+")
-		ep, err := strconv.ParseUint(epS, 10, 16)
-		if err != nil {
-			return index.Key{}, err
-		}
-		direction, err := strconv.ParseUint(directionS, 10, 16)
-		if err != nil {
-			return index.Key{}, err
-		}
-		return EdtIDKey{EndpointID: uint16(ep), Direction: uint8(direction)}.Key(), nil
-	},
-	Unique: true,
-}
+var (
+	edtIDIndex = statedb.Index[Edt, EdtIDKey]{
+		Name: "endpoint-id",
+		FromObject: func(t Edt) index.KeySet {
+			return index.NewKeySet(t.Key())
+		},
+		FromKey: EdtIDKey.Key,
+		FromString: func(key string) (index.Key, error) {
+			epS, directionS, _ := strings.Cut(key, "+")
+			ep, err := strconv.ParseUint(epS, 10, 16)
+			if err != nil {
+				return index.Key{}, err
+			}
+			direction, err := strconv.ParseUint(directionS, 10, 16)
+			if err != nil {
+				return index.Key{}, err
+			}
+			return EdtIDKey{EndpointID: uint16(ep), Direction: uint8(direction)}.Key(), nil
+		},
+		Unique: true,
+	}
+
+	// EDTByID queries the EDT table by endpoint ID and direction.
+	EDTByID = edtIDIndex.Query
+)
 
 func NewEdt(endpointID uint16, direction uint8, bytesPerSecond uint64, prio uint32) Edt {
 	return Edt{
@@ -88,7 +93,7 @@ func NewEdtTable(db *statedb.DB) (statedb.RWTable[Edt], error) {
 	return statedb.NewTable(
 		db,
 		EdtTableName,
-		EdtIDIndex,
+		edtIDIndex,
 	)
 }
 

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -204,13 +204,13 @@ type LatestMTUGetter struct {
 
 func (m *LatestMTUGetter) GetDeviceMTU() int {
 	rtx := m.db.ReadTxn()
-	mtu, _, _ := m.tbl.Get(rtx, MTURouteIndex.Query(DefaultPrefixV4))
+	mtu, _, _ := m.tbl.Get(rtx, MTURouteByPrefix(DefaultPrefixV4))
 	return mtu.DeviceMTU
 }
 
 func (m *LatestMTUGetter) GetRouteMTU() int {
 	rtx := m.db.ReadTxn()
-	mtu, _, _ := m.tbl.Get(rtx, MTURouteIndex.Query(DefaultPrefixV4))
+	mtu, _, _ := m.tbl.Get(rtx, MTURouteByPrefix(DefaultPrefixV4))
 	return mtu.RouteMTU
 }
 

--- a/pkg/mtu/manager.go
+++ b/pkg/mtu/manager.go
@@ -78,7 +78,7 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 		changed := false
 
 		// Update the IPv4 default route MTU if it has changed
-		existing, _, found := m.MTUTable.Get(txn, MTURouteIndex.Query(DefaultPrefixV4))
+		existing, _, found := m.MTUTable.Get(txn, MTURouteByPrefix(DefaultPrefixV4))
 		if !found || existing.DeviceMTU != routeMTU.DeviceMTU {
 			routeMTU.Prefix = DefaultPrefixV4
 			_, _, err := m.MTUTable.Insert(txn, routeMTU)
@@ -90,7 +90,7 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 		}
 
 		// Update the IPv6 default route MTU if it has changed
-		existing, _, found = m.MTUTable.Get(txn, MTURouteIndex.Query(DefaultPrefixV6))
+		existing, _, found = m.MTUTable.Get(txn, MTURouteByPrefix(DefaultPrefixV6))
 		if !found || existing.DeviceMTU != routeMTU.DeviceMTU {
 			routeMTU.Prefix = DefaultPrefixV6
 			_, _, err := m.MTUTable.Insert(txn, routeMTU)

--- a/pkg/mtu/table.go
+++ b/pkg/mtu/table.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	MTURouteIndex = statedb.Index[RouteMTU, netip.Prefix]{
+	mtuRouteIndex = statedb.Index[RouteMTU, netip.Prefix]{
 		Name: "cidr",
 		FromObject: func(rm RouteMTU) index.KeySet {
 			return index.NewKeySet(index.NetIPPrefix(rm.Prefix))
@@ -21,13 +21,16 @@ var (
 		FromString: index.NetIPPrefixString,
 		Unique:     true,
 	}
+
+	// MTURouteByPrefix queries the MTU table by route prefix.
+	MTURouteByPrefix = mtuRouteIndex.Query
 )
 
 func NewMTUTable(db *statedb.DB) (statedb.RWTable[RouteMTU], error) {
 	return statedb.NewTable(
 		db,
 		"mtu",
-		MTURouteIndex,
+		mtuRouteIndex,
 	)
 }
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1089,7 +1089,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		}
 
 		rx := db.ReadTxn()
-		ss, _, watch, found := statusTable.GetWatch(rx, health.PrimaryIndex.Query(id.HealthID()))
+		ss, _, watch, found := statusTable.GetWatch(rx, health.StatusByID(id.HealthID()))
 		if !found {
 			_, watch = statusTable.AllWatch(rx)
 		}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -279,7 +279,7 @@ func (a *Agent) init() error {
 	// Without this, the kernel defaults to 1500 - 80 = 1420, ignoring alignment padding.
 	// Worst case we set 1500 - 95 = 1405; the mtuReconciler will adjust once the MTU table is populated.
 	deviceMTU := mtu.EthernetMTU
-	if mtuRoute, _, _, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4)); found {
+	if mtuRoute, _, _, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteByPrefix(mtu.DefaultPrefixV4)); found {
 		deviceMTU = mtuRoute.DeviceMTU
 	}
 	linkMTU := deviceMTU - mtu.WireguardOverhead
@@ -338,7 +338,7 @@ func (a *Agent) mtuReconciler(ctx context.Context, health cell.Health) error {
 	retryTimer := backoff.Exponential{Logger: a.logger, Min: 100 * time.Millisecond, Max: 1 * time.Minute}
 	retry := false
 	for {
-		mtuRoute, _, watch, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4))
+		mtuRoute, _, watch, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteByPrefix(mtu.DefaultPrefixV4))
 		if found {
 			link, err := safenetlink.LinkByName(types.IfaceName)
 			if err != nil {

--- a/pkg/ztunnel/reconciler/reconciler.go
+++ b/pkg/ztunnel/reconciler/reconciler.go
@@ -228,7 +228,7 @@ func (ops *EnrollmentReconciler) Start(ctx cell.HookContext) error {
 		}
 		// Check if namespace is enrolled
 		txn := ops.db.ReadTxn()
-		_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespacesNameIndex.Query(epNamespace))
+		_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespaceByName(epNamespace))
 		if !found {
 			ops.logger.Info("Skipping enrollment of endpoint in unenrolled namespace",
 				logfields.K8sNamespace, epNamespace,
@@ -257,7 +257,7 @@ func (ops *EnrollmentReconciler) EndpointCreated(ep *endpoint.Endpoint) {
 	}
 	// Check if namespace is enrolled
 	txn := ops.db.ReadTxn()
-	_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespacesNameIndex.Query(epNamespace))
+	_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespaceByName(epNamespace))
 	if !found {
 		ops.logger.Debug("Skipping enrollment of endpoint in unenrolled namespace",
 			logfields.K8sNamespace, epNamespace,
@@ -283,7 +283,7 @@ func (ops *EnrollmentReconciler) EndpointDeleted(ep *endpoint.Endpoint, _ endpoi
 	}
 	// Check if namespace is enrolled
 	txn := ops.db.ReadTxn()
-	_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespacesNameIndex.Query(epNamespace))
+	_, _, found := ops.enrolledNamespaceTable.Get(txn, table.EnrolledNamespaceByName(epNamespace))
 	if !found {
 		ops.logger.Debug("Skipping disenrollment of endpoint in unenrolled namespace",
 			logfields.K8sNamespace, epNamespace,

--- a/pkg/ztunnel/table/enrolled_namespaces.go
+++ b/pkg/ztunnel/table/enrolled_namespaces.go
@@ -47,21 +47,25 @@ func (ns *EnrolledNamespace) Clone() *EnrolledNamespace {
 	return &e
 }
 
-// EnrolledNamespacesNameIndex allows looking up EnrolledNamespace by its name.
-var EnrolledNamespacesNameIndex = statedb.Index[*EnrolledNamespace, string]{
-	Name: "name",
-	FromObject: func(ns *EnrolledNamespace) index.KeySet {
-		return index.NewKeySet(index.String(ns.Name))
-	},
-	FromKey: index.String,
-	Unique:  true,
-}
+var (
+	enrolledNamespacesNameIndex = statedb.Index[*EnrolledNamespace, string]{
+		Name: "name",
+		FromObject: func(ns *EnrolledNamespace) index.KeySet {
+			return index.NewKeySet(index.String(ns.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+
+	// EnrolledNamespaceByName queries the enrolled namespaces table by name.
+	EnrolledNamespaceByName = enrolledNamespacesNameIndex.Query
+)
 
 func NewEnrolledNamespacesTable(db *statedb.DB) (statedb.RWTable[*EnrolledNamespace], error) {
 	return statedb.NewTable(
 		db,
 		"mtls-enrolled-namespaces",
-		EnrolledNamespacesNameIndex,
+		enrolledNamespacesNameIndex,
 	)
 }
 

--- a/pkg/ztunnel/xds/stream_processor.go
+++ b/pkg/ztunnel/xds/stream_processor.go
@@ -82,7 +82,7 @@ func NewEndpointSource(k *watchers.K8sCiliumEndpointsWatcher, sp *StreamProcesso
 // isNamespaceEnrolled checks if the given namespace is enrolled for ztunnel processing.
 func (es *EndpointSource) isNamespaceEnrolled(namespace string) bool {
 	txn := es.sp.db.ReadTxn()
-	_, _, found := es.sp.enrolledNamespaceTable.Get(txn, table.EnrolledNamespacesNameIndex.Query(namespace))
+	_, _, found := es.sp.enrolledNamespaceTable.Get(txn, table.EnrolledNamespaceByName(namespace))
 	return found
 }
 


### PR DESCRIPTION
Across several packages using statedb tables, the `statedb.Index` values were exported directly. This let callers depend on the index definitions rather than a stable query API. This PR unexports those index values in favor of small query helper functions (e.g. `NodeAddressByAddr`, `RouteByTableIndex`, `NeighborByIP`) that construct the query on the caller's behalf.

This reduces the package API surface and keeps the underlying index implementation (name, key encoding, etc.) as an internal implementation detail that can't be depended on or modified by users of the package.

AIL: 3. I instructed Claude to find candidate indexes to unexport and to suggest query helpers. I manually verified each replacement manually.