### PR TITLE
bpf: loader: make AUX per-CPU offset branch-free via power-of-two sizing

### DIFF
--- a/bpf/lib/auxvars.h
+++ b/bpf/lib/auxvars.h
@@ -9,15 +9,18 @@
 #define DEFINE_AUX(typ, name) \
 	__section(".data.aux") typ __aux_##name;
 
-volatile const __section(".rodata.aux") __u64 _aux_stride;
-volatile const __section(".rodata.aux") __u64 _aux_max_off;
+volatile const __section(".rodata.aux") __u64 _aux_cpu_mask;
+volatile const __section(".rodata.aux") __u64 _aux_stride_shift;
 
-#define AUX(name) ({ \
-	__u32 cpuid = get_smp_processor_id(); \
-	void *aux_addr = (void *)&__aux_##name; \
-	__u64 offset = (_aux_stride * cpuid); \
-	if (offset > _aux_max_off) \
-		offset = _aux_max_off; \
-	aux_addr += offset; \
-	(__typeof__(__aux_##name) *)(aux_addr); \
-})
+/*
+ * The AUX macro is used to access per-CPU auxiliary variables. It calculates
+ * the address of the variable for the current CPU by adding an offset based on
+ * the CPU ID and a stride shift value.
+ *
+ * Once the minimum kernel version supported is v6.6, let's replace this and
+ * switch back to the previous implementation to avoid the memory overhead.
+ * (see https://github.com/cilium/cilium/issues/48301)
+ */
+#define AUX(name) \
+	((__typeof__(__aux_##name) *)((void *)&__aux_##name + \
+	 ((get_smp_processor_id() & _aux_cpu_mask) << _aux_stride_shift)))

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/bits"
 	"os"
 	"path"
 	"strings"
@@ -446,42 +447,53 @@ func modifyAuxData(spec *ebpf.CollectionSpec) error {
 		return nil
 	}
 
-	// Make collections of per-CPU values cache line aligned to prevent false sharing between CPUs.
+	// Round the per-CPU slot size up to a power of two (at least one cache line).
 	cacheLineSize := uint64(unsafe.Sizeof(cpu.CacheLinePad{}))
-	stride := uint64(auxData.ValueSize)
-	if stride%cacheLineSize != 0 {
-		stride += cacheLineSize - (stride % cacheLineSize)
+	strideShift := uint64(bits.Len64(uint64(auxData.ValueSize) - 1))
+	if minShift := uint64(bits.Len64(cacheLineSize - 1)); strideShift < minShift {
+		strideShift = minShift
 	}
+	stride := uint64(1) << strideShift
 
-	// Communicate the stride to the BPF programs so it can calculate the offset from any variable in the map
-	// to the value for the current CPU.
-	auxStride, found := spec.Variables["_aux_stride"]
+	// Communicate the shift to the BPF programs so it can calculate the offset from any
+	// variable in the map to the value for the current CPU.
+	auxStrideShift, found := spec.Variables["_aux_stride_shift"]
 	if !found {
-		return fmt.Errorf("missing _aux_stride variable for .data.aux map")
+		return fmt.Errorf("missing _aux_stride_shift variable for .data.aux map")
 	}
-	err := auxStride.Set(stride)
+	err := auxStrideShift.Set(strideShift)
 	if err != nil {
-		return fmt.Errorf("setting _aux_stride: %w", err)
+		return fmt.Errorf("setting _aux_stride_shift: %w", err)
 	}
 
-	// Resize the map so it has a copy of the values for each possible CPU.
+	// Resize the map so it has a copy of the values for each possible CPU, rounded
+	// up to the next power of two.
 	cpus := ebpf.MustPossibleCPU()
-	valueSize := uint32(cpus) * uint32(stride)
+	cpuSlots := nextPow2(uint64(cpus))
+	valueSize := uint32(cpuSlots) * uint32(stride)
 	auxData.Contents[0] = ebpf.MapKV{Key: uint32(0), Value: make([]byte, valueSize)}
 	auxData.ValueSize = valueSize
 
-	// Communicate the maximum offset of any variable in the map, used to make the verifier happy that we will never
-	// read or write past the end of the map value.
-	auxMaxOff, found := spec.Variables["_aux_max_off"]
+	// Communicate the CPU mask to the BPF programs, used to bound the per-CPU offset
+	// without a branch in the BPF code.
+	auxCPUMask, found := spec.Variables["_aux_cpu_mask"]
 	if !found {
-		return fmt.Errorf("missing _aux_max_off variable for .data.aux map")
+		return fmt.Errorf("missing _aux_cpu_mask variable for .data.aux map")
 	}
-	err = auxMaxOff.Set(uint64(valueSize) - stride)
+	err = auxCPUMask.Set(cpuSlots - 1)
 	if err != nil {
-		return fmt.Errorf("setting _aux_max_off: %w", err)
+		return fmt.Errorf("setting _aux_cpu_mask: %w", err)
 	}
 
 	return nil
+}
+
+// nextPow2 returns the smallest power of two that is >= n, or 1 if n == 0.
+func nextPow2(n uint64) uint64 {
+	if n <= 1 {
+		return 1
+	}
+	return 1 << bits.Len64(n-1)
 }
 
 func patchPrograms(coll *ebpf.CollectionSpec, patches map[string]func(asm.Instructions) (asm.Instructions, error)) error {


### PR DESCRIPTION
AUX() bounded the per-CPU offset with a runtime compare-and-clamp (`if offset > _aux_max_off`) after a multiply. The verifier can fold the clamp fine, but it can't propagate a bound through the multiply itself (`stride * cpuid` stays unbounded even with one exact operand), so this relied entirely on the clamp branch to stay safe. For now it is good, given we're using 1 AUX() at most in each codepath, but if we introduce new AUX() variables in the same codepaths this leads to doubling the verifier complexity to verify the program.

Therefore, this commit rounds both `possible_cpus()` and the aux section's per-CPU `stride` up to the next power of two, and replace the multiply+clamp with a mask + shift operation. AND/SHL by a constant are tracked exactly by the verifier, so the offset is provably bounded with no branch and no multiply.

This should give us a lot of advantage in terms of verifier complexity when using multiple AUX() calls/variables in the same BPF program, as the verifier can now reason about the offset of each AUX() independently, without needing to branch on the previous one.
However, the major tradeoff is the memory. Padding both `possible_cpus()` and `stride` to their next power of two can cost up to ~2x `.data.aux` in the worst case (e.g. a struct total just above a power-of-two boundary, or CPU counts like 96/48/24 rounding up).

I've evaluated an alternative solution, which consists in computing once per-BPF program/function the offset wrt the current CPU, and pass it down to each inner inlined function needing to use AUX(). Using a new helper `AUX_AT(offset, name)` would work still with less benefits in terms of verifier complexity (depending on where in the code it is computed first), but requires a lot of code changes and to propagate the offset wherever AUX() is used. That solution would not lead to memory waste though.

Other ideas are very welcomed!