### PR TITLE
hubble: resolve flow names from DNSZombies when DNSHistory has expired

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -1270,6 +1270,30 @@ func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.T
 type PrefixMatcherFunc func(ip netip.Addr) bool
 type NameMatcherFunc func(name string) bool
 
+// LookupIP returns the names associated with ip among zombies that are still
+// alive, i.e. whose IP is in use by a connection that outlived the DNS entry.
+// It returns nil when ip is unknown or its zombie is eligible for deletion.
+//
+// DNSHistory expires with the DNS TTL, so a long-lived connection loses its
+// name there long before it closes. Zombies exist precisely to retain that
+// mapping for the life of the connection, which makes them the correct source
+// for annotating flows on such connections.
+func (zombies *DNSZombieMappings) LookupIP(ip netip.Addr) (names []string) {
+	zombies.Lock()
+	defer zombies.Unlock()
+
+	zombie, ok := zombies.deletes[ip]
+	if !ok || !zombies.isConnectionAlive(zombie) {
+		return nil
+	}
+
+	// Sorted for the same reason as DNSCache.lookupIPByTime: zombie.Names is
+	// unordered, and callers such as Hubble use the result as a metric label.
+	names = slices.Clone(zombie.Names)
+	slices.Sort(names)
+	return names
+}
+
 // DumpAlive returns copies of still-alive zombies matching prefixMatcher.
 func (zombies *DNSZombieMappings) DumpAlive(prefixMatcher PrefixMatcherFunc) (alive []*DNSZombieMapping) {
 	zombies.Lock()

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1424,3 +1424,68 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 		})
 	}
 }
+
+// TestZombiesLookupIP covers the case Hubble relies on: a name that has
+// expired from DNSHistory is still resolvable while the connection using it
+// is alive, and stops resolving once the zombie is reaped.
+func TestZombiesLookupIP(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	now := time.Now()
+	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
+
+	ip := netip.MustParseAddr("1.1.1.1")
+	zombies.Upsert(now, ip, "test.com")
+
+	require.Equal(t, []string{"test.com"}, zombies.LookupIP(ip))
+
+	// Unknown addresses resolve to nothing rather than erroring.
+	require.Nil(t, zombies.LookupIP(netip.MustParseAddr("3.3.3.3")))
+
+	// Multiple names for one IP are all returned, sorted: zombie.Names is
+	// unordered, and callers use the result as a metric label.
+	zombies.Upsert(now, ip, "anotherthing.com")
+	require.Equal(t, []string{"anotherthing.com", "test.com"}, zombies.LookupIP(ip))
+
+	// Marking alive keeps the mapping resolvable across GC cycles, which is
+	// what a long-lived connection does via MarkDNSCTEntry.
+	now = now.Add(5 * time.Minute)
+	next := now.Add(5 * time.Minute)
+	zombies.MarkAlive(now, ip)
+	zombies.SetCTGCTime(now, next)
+	_, dead := zombies.GC()
+	require.Empty(t, dead)
+	require.Equal(t, []string{"anotherthing.com", "test.com"}, zombies.LookupIP(ip))
+
+	// Once the connection is gone the zombie is reaped and the name with it.
+	now = now.Add(10 * time.Minute)
+	zombies.SetCTGCTime(now, now.Add(5*time.Minute))
+	_, dead = zombies.GC()
+	require.NotEmpty(t, dead)
+	require.Nil(t, zombies.LookupIP(ip))
+}
+
+// TestZombiesLookupIPIsDisjointFromHistory documents why Hubble consults
+// DNSHistory before zombies rather than either alone: an entry is in exactly
+// one of the two, so only the pair covers a connection's whole life.
+func TestZombiesLookupIPIsDisjointFromHistory(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	now := time.Now()
+	ip := netip.MustParseAddr("1.1.1.1")
+
+	cache := NewDNSCache(0)
+	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
+
+	// A fresh lookup lives in history and is not yet a zombie, so resolving
+	// from zombies alone would report nothing for a new connection.
+	cache.Update(now, "test.com", []netip.Addr{ip}, 3)
+	require.Equal(t, []string{"test.com"}, cache.LookupIP(ip))
+	require.Nil(t, zombies.LookupIP(ip))
+
+	// Expiry moves it across: history goes quiet and the zombie takes over,
+	// which is the window where Hubble previously reported no name.
+	cache.GC(now.Add(5*time.Second), zombies)
+	require.Empty(t, cache.LookupIP(ip))
+	require.Equal(t, []string{"test.com"}, zombies.LookupIP(ip))
+}

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -152,6 +152,13 @@ func (h *payloadGetters) GetNamesOf(sourceEpID uint32, ip netip.Addr) []string {
 		return nil
 	}
 	names := ep.DNSHistory.LookupIP(ip)
+	if len(names) == 0 {
+		// DNSHistory expires with the DNS TTL. A connection that outlives it
+		// keeps its mapping in DNSZombies, which is held for exactly as long as
+		// the connection is in use, so fall back to it rather than reporting no
+		// name for the remainder of a long-lived connection.
+		names = ep.DNSZombies.LookupIP(ip)
+	}
 
 	for i := range names {
 		names[i] = strings.TrimSuffix(names[i], ".")


### PR DESCRIPTION
Hubble annotates SourceNames/DestinationNames using DNSHistory, which expires with the DNS TTL. The result is long-lived connections lose their name annotations in Hubble.

When an entry expires from DNSHistory but the connection is still active, it moves to DNSZombies. Fall back to DNSZombies when the DNSHistory record has expired.

```release-note
Long-lived connections keep their source/destination name annotations in Hubble after the DNS TTL expires.
```