### PR TITLE
[v1.19] BPF: Refactor nat tests to use scapy fixtures and add checksum coverage

### DIFF
--- a/bpf/tests/bpf_nat_icmp.h
+++ b/bpf/tests/bpf_nat_icmp.h
@@ -1,0 +1,187 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_MASQUERADE_IPV4		1
+
+#define EXT_IP  v4_ext_one
+#define NODE_IP v4_node_one
+#define POD_IP  v4_pod_one
+
+#define POD_SEC_IDENTITY 112233
+
+#include "lib/bpf_host.h"
+
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/nat.h>
+#include <lib/time.h>
+
+ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, { .be32 = NODE_IP })
+
+#include "bpf_nat_tuples.h"
+#include "scapy.h"
+
+#include "lib/endpoint.h"
+
+const __u8 icmp4_err_revnat_egress_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_egress_tcp)
+};
+const __u8 icmp4_err_revnat_egress_post_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_egress_post_tcp)
+};
+const __u8 icmp4_err_revnat_full_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_full_tcp)
+};
+const __u8 icmp4_err_revnat_full_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_full_tcp_after)
+};
+const __u8 icmp4_err_revnat_min_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_min_tcp)
+};
+const __u8 icmp4_err_revnat_min_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp4_err_revnat_min_tcp_after)
+};
+
+/*
+ * Push an egressing pod->external TCP packet through to-netdev and let the
+ * datapath set up nat mappings due to node ip masquerading. 
+ * Exploit the fact that tests are run in alphabetical order to ensure this
+ * happens before we check the icmp pmtud revSNAT mappings.
+ */
+PKTGEN(PROG_TYPE, "00_snat_v4_tcp_egress")
+int snat_v4_egress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_revnat_egress_tcp,
+			sizeof(icmp4_err_revnat_egress_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "00_snat_v4_tcp_egress")
+int snat_v4_egress_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(POD_IP, 0, 0, 0, POD_SEC_IDENTITY,
+			      0, (__u8 *)mac_one, (__u8 *)mac_one);
+
+	return netdev_send_packet(ctx);
+}
+
+/*
+ * Add a check prior to moving onto actual icmp pmtu icmp testing
+ * to quickly fail if priror steps did not setup expected nat state
+ */
+CHECK(PROG_TYPE, "00_snat_v4_tcp_egress")
+int snat_v4_egress_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	ASSERT_CTX_BUF_OFF("snat_v4_egress", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_revnat_egress_post_tcp,
+			   sizeof(icmp4_err_revnat_egress_post_tcp));
+
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = EXT_IP,
+		.dport   = tcp_src_two,
+		.sport   = tcp_dst_one,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = NAT_DIR_INGRESS,
+	};
+	struct ipv4_nat_entry *entry = map_lookup_elem(&cilium_snat_v4_external,
+						      &tuple);
+
+	if (!entry)
+		test_fatal("no revSNAT entry created by to-netdev");
+	if (entry->to_daddr != POD_IP)
+		test_fatal("revSNAT entry to_daddr is not the pod IP");
+	if (entry->to_dport != tcp_src_two)
+		test_fatal("revSNAT entry to_dport is not the pod source port");
+
+	test_finish();
+}
+
+/*
+ * Full inner TCP header + data payload variant.
+ */
+PKTGEN(PROG_TYPE, "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_revnat_full_tcp,
+			sizeof(icmp4_err_revnat_full_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_revnat_full_tcp_after,
+			   sizeof(icmp4_err_revnat_full_tcp_after));
+	test_finish();
+
+	return 0;
+}
+
+/*
+ * Minimal inner TCP (8 bytes: sport + dport + seq) variant.
+ * Tests that revSNAT handles the RFC 792 minimum embedded header correctly.
+ */
+PKTGEN(PROG_TYPE, "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_revnat_min_tcp,
+			sizeof(icmp4_err_revnat_min_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_pmtu_min_hdr", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_revnat_min_tcp_after,
+			   sizeof(icmp4_err_revnat_min_tcp_after));
+	test_finish();
+
+	return 0;
+}

--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -1,17 +1,23 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
 
-#define ENABLE_SCTP
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
+#define ENABLE_SCTP			1
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
 #define ENABLE_MASQUERADE_IPV6		1
 
-#include "lib/bpf_host.h"
+#define NODE_ONE6 { .addr = v6_node_one_addr }
+#define EXT_IP6 { .addr = v6_ext_node_one_addr }
+#define POD_IP6 { .addr = v6_pod_one_addr }
+
+#define POD6_SEC_IDENTITY 112244
 
 #include <bpf/config/node.h>
 
@@ -22,25 +28,13 @@
 #include <lib/nat.h>
 #include <lib/time.h>
 
-#include <bpf/helpers.h>
-#include <bpf/api.h>
+ASSIGN_CONFIG(union v6addr, nat_ipv6_masquerade, { .addr = v6_node_one_addr })
 
-#include <bpf/ctx/skb.h>
-#include <bpf/api.h>
-#include <bpf/config/node.h>
-
-#define DEBUG
-
-#include <lib/dbg.h>
-#include <lib/eps.h>
-#include <lib/nat.h>
-#include <lib/time.h>
+#include "scapy.h"
 
 #include "bpf_nat_tuples.h"
 
-#define NODE_ONE { .addr = v6_node_one_addr }
-#define EXT_IP { .addr = v6_ext_node_one_addr }
-#define POD_IP { .addr = v6_pod_one_addr }
+#include "lib/endpoint.h"
 
 /*
  * Input packet represents a device sending a PKT_TOO_BIG response ICMPv6
@@ -87,81 +81,144 @@
  *
  * Ref: https://datatracker.ietf.org/doc/html/rfc4443#section-3.2
  */
-__always_inline int gen_pmtu_pkt(struct pktgen *builder, int l4_type)
+const __u8 icmp6_err_revnat_egress_tcp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_egress_tcp)
+};
+const __u8 icmp6_err_revnat_egress_post_tcp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_egress_post_tcp)
+};
+const __u8 icmp6_err_revnat_egress_udp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_egress_udp)
+};
+const __u8 icmp6_err_revnat_egress_post_udp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_egress_post_udp)
+};
+const __u8 icmp6_err_revnat_full_tcp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_full_tcp)
+};
+const __u8 icmp6_err_revnat_full_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_full_tcp_after)
+};
+const __u8 icmp6_err_revnat_full_udp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_full_udp)
+};
+const __u8 icmp6_err_revnat_full_udp_after[] = {
+	SCAPY_BUF_BYTES(icmp6_err_revnat_full_udp_after)
+};
+
+/*
+ * Push an egressing pod->external TCP packet through to-netdev and let the
+ * datapath set up nat mappings due to node ip masquerading. 
+ * Exploit the fact that tests are run in alphabetical order to ensure this
+ * happens before we check the icmp pmtud revSNAT mappings.
+ */
+PKTGEN(PROG_TYPE, "00_snat_v6_tcp_egress")
+int snat_v6_egress_pktgen(struct __ctx_buff *ctx)
 {
-	struct ipv6hdr *inner_l3 = NULL;
-	struct icmp6hdr *l4 = NULL;
-	struct tcphdr *inner_l4 = NULL;
-	struct udphdr *inner_l4_udp = NULL; /* compiler complains if this isn't init to null? */
-	struct sctphdr *inner_l4_sctp = NULL;
-	void *data = NULL;
+	struct pktgen builder;
 
-	l4 = pktgen__push_ipv6_icmp6_packet(builder,
-					    (__u8 *)mac_one,
-					    (__u8 *)mac_two,
-					    (__u8 *)v6_ext_node_one,
-					    (__u8 *)v6_node_one,
-					    ICMPV6_PKT_TOOBIG);
-	if (!l4)
-		return TEST_FAIL;
-
-	inner_l3 = pktgen__push_default_ipv6hdr(builder);
-	if (!inner_l3)
-		return TEST_FAIL;
-
-	inner_l3->nexthdr = (__u8)l4_type;
-	ipv6hdr__set_addrs(inner_l3, (__u8 *)v6_node_one, (__u8 *)v6_ext_node_one);
-
-	switch (l4_type) {
-	case IPPROTO_TCP:
-		inner_l4 = pktgen__push_default_tcphdr(builder);
-		if (!inner_l4)
-			return TEST_FAIL;
-		/* original source */
-		inner_l4->dest = 1234;
-		inner_l4->source = 30001;
-		break;
-	case IPPROTO_UDP:
-		inner_l4_udp = pktgen__push_default_udphdr(builder);
-		if (!inner_l4_udp)
-			return TEST_FAIL;
-		inner_l4_udp->dest = 1234;
-		inner_l4_udp->source = 30001;
-		break;
-	case IPPROTO_SCTP:
-		inner_l4_sctp = pktgen__push_default_sctphdr(builder);
-		if (!inner_l4_udp)
-			return TEST_FAIL;
-		inner_l4_sctp->dest = 1234;
-		inner_l4_sctp->source = 30001;
-		break;
-	default:
-		return TEST_FAIL;
-	}
-
-	data = pktgen__push_data(builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_FAIL;
-
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp6_err_revnat_egress_tcp,
+			sizeof(icmp6_err_revnat_egress_tcp));
+	pktgen__finish(&builder);
 	return TEST_PASS;
 }
 
-int snat_v6_insert_ct_nat(__u8 proto)
+SETUP(PROG_TYPE, "00_snat_v6_tcp_egress")
+int snat_v6_egress_setup(struct __ctx_buff *ctx)
 {
-	struct ipv6_nat_entry entry = {
-		.to_daddr = POD_IP,
-	};
-	entry.to_sport = 0;
-	entry.to_dport = 20;
+	union v6addr pod_ip = POD_IP6;
+
+	endpoint_v6_add_entry(&pod_ip, 0, 0, 0, POD6_SEC_IDENTITY,
+			      (__u8 *)mac_one, (__u8 *)mac_one);
+
+	return netdev_send_packet(ctx);
+}
+
+/*
+ * Add a check prior to moving onto actual icmp pmtu icmp testing
+ * to quickly fail if priror steps did not setup expected nat state
+ */
+CHECK(PROG_TYPE, "00_snat_v6_tcp_egress")
+int snat_v6_egress_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	ASSERT_CTX_BUF_OFF("snat_v6_egress", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_revnat_egress_post_tcp,
+			   sizeof(icmp6_err_revnat_egress_post_tcp));
+
+	union v6addr pod_ip = POD_IP6;
 	struct ipv6_ct_tuple tuple = {
-		.daddr   = NODE_ONE,
-		.saddr   = EXT_IP,
-		.dport   = 30001, /* SNAT remapped port */
-		.sport   = 1234,
-		.nexthdr = proto,
-		.flags = TUPLE_F_IN,
+		.daddr   = NODE_ONE6,
+		.saddr   = EXT_IP6,
+		.dport   = tcp_src_two,
+		.sport   = tcp_dst_one,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = NAT_DIR_INGRESS,
 	};
-	return map_update_elem(&cilium_snat_v6_external, &tuple, &entry, BPF_ANY);
+	struct ipv6_nat_entry *entry = map_lookup_elem(&cilium_snat_v6_external,
+						      &tuple);
+
+	if (!entry)
+		test_fatal("no revSNAT entry created by to-netdev");
+	if (!ipv6_addr_equals(&entry->to_daddr, &pod_ip))
+		test_fatal("revSNAT entry to_daddr is not the pod IP");
+	if (entry->to_dport != tcp_src_two)
+		test_fatal("revSNAT entry to_dport is not the pod source port");
+
+	test_finish();
+}
+
+PKTGEN(PROG_TYPE, "01_snat_v6_udp_egress")
+int snat_v6_egress_udp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp6_err_revnat_egress_udp,
+			sizeof(icmp6_err_revnat_egress_udp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP(PROG_TYPE, "01_snat_v6_udp_egress")
+int snat_v6_egress_udp_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "01_snat_v6_udp_egress")
+int snat_v6_egress_udp_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	ASSERT_CTX_BUF_OFF("snat_v6_egress_udp", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_revnat_egress_post_udp,
+			   sizeof(icmp6_err_revnat_egress_post_udp));
+
+	union v6addr pod_ip = POD_IP6;
+	struct ipv6_ct_tuple tuple = {
+		.daddr   = NODE_ONE6,
+		.saddr   = EXT_IP6,
+		.dport   = tcp_src_two,
+		.sport   = tcp_dst_one,
+		.nexthdr = IPPROTO_UDP,
+		.flags   = NAT_DIR_INGRESS,
+	};
+	struct ipv6_nat_entry *entry = map_lookup_elem(&cilium_snat_v6_external,
+						      &tuple);
+
+	if (!entry)
+		test_fatal("no revSNAT entry created by to-netdev");
+	if (!ipv6_addr_equals(&entry->to_daddr, &pod_ip))
+		test_fatal("revSNAT entry to_daddr is not the pod IP");
+	if (entry->to_dport != tcp_src_two)
+		test_fatal("revSNAT entry to_dport is not the pod source port");
+
+	test_finish();
 }
 
 int do_icmp6_pkt_too_big_check(const struct __ctx_buff *ctx)
@@ -200,9 +257,9 @@ int do_icmp6_pkt_too_big_check(const struct __ctx_buff *ctx)
 	l4 = (void *)(data + sizeof(__u32) +
 		sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
 		sizeof(struct icmp6hdr) + sizeof(struct ipv6hdr));
-	if (*((__u16 *)l4) != 20)
+	if (*((__u16 *)l4) != bpf_htons(20))
 		return TEST_FAIL;
-	if (*((__u16 *)(l4 + sizeof(__u16))) != 1234)
+	if (*((__u16 *)(l4 + sizeof(__u16))) != bpf_htons(1234))
 		return TEST_FAIL;
 	return 0;
 }
@@ -213,7 +270,9 @@ int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 	struct pktgen builder;
 
 	pktgen__init(&builder, ctx);
-	gen_pmtu_pkt(&builder, IPPROTO_TCP);
+	scapy_push_data(&builder,
+			icmp6_err_revnat_full_tcp,
+			sizeof(icmp6_err_revnat_full_tcp));
 	pktgen__finish(&builder);
 	return TEST_PASS;
 }
@@ -221,12 +280,6 @@ int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_setup(struct __ctx_buff *ctx)
 {
-	int ret;
-
-	ret = snat_v6_insert_ct_nat(IPPROTO_TCP);
-	if (ret < 0)
-		return TEST_FAIL;
-
 	return netdev_receive_packet(ctx);
 }
 
@@ -234,7 +287,9 @@ CHECK("tc", "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_check(const struct __ctx_buff *ctx)
 {
 	test_init();
-	assert(do_icmp6_pkt_too_big_check(ctx) == 0);
+	ASSERT_CTX_BUF_OFF("snat_v6_tcp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_revnat_full_tcp_after,
+			   sizeof(icmp6_err_revnat_full_tcp_after));
 	test_finish();
 
 	return 0;
@@ -246,7 +301,9 @@ int snat_v6_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 	struct pktgen builder;
 
 	pktgen__init(&builder, ctx);
-	gen_pmtu_pkt(&builder, IPPROTO_UDP);
+	scapy_push_data(&builder,
+			icmp6_err_revnat_full_udp,
+			sizeof(icmp6_err_revnat_full_udp));
 	pktgen__finish(&builder);
 	return TEST_PASS;
 }
@@ -254,12 +311,6 @@ int snat_v6_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_setup(struct __ctx_buff *ctx)
 {
-	int ret;
-
-	ret = snat_v6_insert_ct_nat(IPPROTO_UDP);
-	if (ret < 0)
-		return TEST_FAIL;
-
 	return netdev_receive_packet(ctx);
 }
 
@@ -267,7 +318,9 @@ CHECK("tc", "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_check(const struct __ctx_buff *ctx)
 {
 	test_init();
-	assert(do_icmp6_pkt_too_big_check(ctx) == 0);
+	ASSERT_CTX_BUF_OFF("snat_v6_udp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_revnat_full_udp_after,
+			   sizeof(icmp6_err_revnat_full_udp_after));
 	test_finish();
 
 	return 0;

--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -221,49 +221,6 @@ int snat_v6_egress_udp_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-int do_icmp6_pkt_too_big_check(const struct __ctx_buff *ctx)
-{
-	struct ipv6hdr *l3 = NULL;
-	struct ipv6hdr *inner_l3 = NULL;
-	void *l4 = NULL;
-	void *data = (void *)(long)ctx->data;
-	void *data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
-		sizeof(struct icmp6hdr) + sizeof(struct ipv6hdr) +
-		2 * sizeof(__u16) > data_end)
-		return TEST_FAIL;
-
-	l3 = (struct ipv6hdr *)(data + sizeof(__u32) + sizeof(struct ethhdr));
-	if (memcmp(&l3->daddr, (void *)v6_pod_one, 16) > 0)
-		return TEST_FAIL;
-
-	if (memcmp(&l3->saddr, (void *)v6_ext_node_one, 16) > 0)
-		return TEST_FAIL;
-
-	if (l3->nexthdr != IPPROTO_ICMPV6)
-		return TEST_FAIL;
-
-	inner_l3 = (struct ipv6hdr *)(data + sizeof(__u32) +
-		sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
-		sizeof(struct icmp6hdr));
-
-	if (memcmp(&inner_l3->daddr, (void *)v6_ext_node_one, 16) > 0)
-		return TEST_FAIL;
-
-	if (memcmp(&inner_l3->saddr, (void *)v6_pod_one, 16) > 0)
-		return TEST_FAIL;
-
-	l4 = (void *)(data + sizeof(__u32) +
-		sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
-		sizeof(struct icmp6hdr) + sizeof(struct ipv6hdr));
-	if (*((__u16 *)l4) != bpf_htons(20))
-		return TEST_FAIL;
-	if (*((__u16 *)(l4 + sizeof(__u16))) != bpf_htons(1234))
-		return TEST_FAIL;
-	return 0;
-}
-
 PKTGEN("tc", "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 {

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 static __always_inline void
 endpoint_add_entry(struct endpoint_key *key, __u32 ifindex, __u16 lxc_id, __u32 flags, __u32 sec_id,
 		   __u32 parent_ifindex, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -5,6 +5,76 @@ from scapy.all import *
 
 from pkt_defs_common import *
 
+# Shared header layers for the egress TCP flow, pre- and post-masquerade.
+_ip_hdr_egress = IP(src=v4_pod_one, dst=v4_ext_one, flags="DF")
+_tcp_hdr_egress = TCP(sport=tcp_src_two, dport=tcp_dst_one, seq=tcp_default_seq)
+
+# Pod -> external host as goes into to-netdev host device (pre-masquerading).
+# pod_ip:33440 -> ext_ip:22331
+# The intention is that this should setup the correct nat entries for
+# testing revSNAT.
+# We use tcp_src_two=33440 which is above the nodeport minimum default value
+# meaning that, assuming a empty nat map, the SNAT mapping can reuse the same
+# port.
+icmp4_err_revnat_egress_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip_hdr_egress /
+    _tcp_hdr_egress /
+    Raw(default_data)
+)
+
+# Post-masquerade: saddr rewritten to node IP. Ports are unchanged because
+# tcp_src_two (33440) > NODEPORT_PORT_MIN_NAT so the same source port is reused.
+_ip_hdr_egress_post = IP(src=v4_node_one, dst=v4_ext_one, flags="DF")
+_tcp_hdr_egress_post = TCP(sport=tcp_src_two, dport=tcp_dst_one, seq=tcp_default_seq)
+icmp4_err_revnat_egress_post_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip_hdr_egress_post /
+    _tcp_hdr_egress_post /
+    Raw(default_data)
+)
+
+# Full inner TCP header + complete data payload
+icmp4_err_revnat_full_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_node_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IPerror(**_ip_hdr_egress_post.fields) /
+    TCPerror(**_tcp_hdr_egress_post.fields) /
+    Raw(default_data)
+)
+
+# After revSNAT: outer daddr -> pod_ip, inner saddr -> pod_ip. The ports are
+# unchanged because the SNAT preserved the source port (see above).
+icmp4_err_revnat_full_tcp_after = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IPerror(**_ip_hdr_egress.fields) /
+    TCPerror(**_tcp_hdr_egress.fields) /
+    Raw(default_data)
+)
+
+# Inner TCP truncated to first 8 bytes: sport + dport + seq (RFC 792 minimum)
+_tcp_hdr_min = bytes(TCP(sport=tcp_src_two, dport=tcp_dst_one, seq=tcp_default_seq))[:8]
+icmp4_err_revnat_min_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_node_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IPerror(src=v4_node_one, dst=v4_ext_one, flags="DF", proto=6) /
+    Raw(_tcp_hdr_min)
+)
+
+# After revSNAT (min TCP): outer daddr -> pod_ip, inner saddr -> pod_ip
+_tcp_hdr_min_after = bytes(TCP(sport=tcp_src_two, dport=tcp_dst_one, seq=tcp_default_seq))[:8]
+icmp4_err_revnat_min_tcp_after = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IPerror(src=v4_pod_one, dst=v4_ext_one, flags="DF", proto=6) /
+    Raw(_tcp_hdr_min_after)
+)
+
 # outer IPv4 (pod_two -> pod_one), ICMP Destination Unreachable / Fragmentation Needed,
 # embedded original IPv4 + TCP with SNAT'd port
 icmp4_err_frag_needed_for_revnat = (
@@ -14,7 +84,6 @@ icmp4_err_frag_needed_for_revnat = (
     IP(src=v4_pod_one, dst=v4_pod_two, flags="DF") /
     TCP(sport=32768, dport=80)  # NODEPORT_PORT_MIN_NAT (SNAT'd port)
 )
-
 
 # After rev-NAT: pod_two -> node_one, with original port restored
 icmp4_err_frag_needed_after_revnat = (

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -75,6 +75,83 @@ icmp4_err_revnat_min_tcp_after = (
     Raw(_tcp_hdr_min_after)
 )
 
+# Shared header layers for the IPv6 egress flow, pre- and post-masquerade.
+_ip6_hdr_egress = IPv6(src=v6_pod_one, dst=v6_ext_node_one)
+_udp_hdr_egress = UDP(sport=tcp_src_two, dport=tcp_dst_one)
+
+# Pod -> external host as goes into to-netdev host device (pre-masquerading).
+# pod_ip6:33440 -> ext_ip6:22331
+# Same idea as icmp4_err_revnat_egress_tcp: let the to-netdev datapath
+# build the revSNAT state. 
+icmp6_err_revnat_egress_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip6_hdr_egress /
+    _tcp_hdr_egress /
+    Raw(default_data)
+)
+
+icmp6_err_revnat_egress_udp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip6_hdr_egress /
+    _udp_hdr_egress /
+    Raw(default_data)
+)
+
+# Post-masquerade: saddr rewritten to node IP. Ports are unchanged because
+# tcp_src_two (33440) > NODEPORT_PORT_MIN_NAT so the same source port is reused.
+_ip6_hdr_egress_post = IPv6(src=v6_node_one, dst=v6_ext_node_one)
+icmp6_err_revnat_egress_post_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip6_hdr_egress_post /
+    _tcp_hdr_egress /
+    Raw(default_data)
+)
+
+icmp6_err_revnat_egress_post_udp = (
+    Ether(src=mac_one, dst=mac_two) /
+    _ip6_hdr_egress_post /
+    _udp_hdr_egress /
+    Raw(default_data)
+)
+
+def _icmp6_revnat_pkt(inner_l4):
+    """Outer ICMPv6 PKT_TOO_BIG wrapper (pre-revSNAT): ext -> node, inner node -> ext."""
+    return (
+        Ether(src=mac_one, dst=mac_two) /
+        IPv6(src=v6_ext_node_one, dst=v6_node_one) /
+        ICMPv6PacketTooBig(mtu=1500) /
+        _ip6_hdr_egress_post /
+        inner_l4
+    )
+
+def _icmp6_revnat_after_pkt(inner_l4):
+    """Outer ICMPv6 PKT_TOO_BIG wrapper (post-revSNAT): ext -> pod, inner pod -> ext."""
+    return (
+        Ether(src=mac_one, dst=mac_two) /
+        IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+        ICMPv6PacketTooBig(mtu=1500) /
+        _ip6_hdr_egress /
+        inner_l4
+    )
+
+icmp6_err_revnat_full_tcp = _icmp6_revnat_pkt(
+    _tcp_hdr_egress / Raw(default_data)
+)
+
+# After revSNAT: outer daddr -> pod_ip6, inner saddr -> pod_ip6. The ports are
+# unchanged because the SNAT preserved the source port (see above).
+icmp6_err_revnat_full_tcp_after = _icmp6_revnat_after_pkt(
+    _tcp_hdr_egress / Raw(default_data)
+)
+
+icmp6_err_revnat_full_udp = _icmp6_revnat_pkt(
+    _udp_hdr_egress / Raw(default_data)
+)
+
+icmp6_err_revnat_full_udp_after = _icmp6_revnat_after_pkt(
+    _udp_hdr_egress / Raw(default_data)
+)
+
 # outer IPv4 (pod_two -> pod_one), ICMP Destination Unreachable / Fragmentation Needed,
 # embedded original IPv4 + TCP with SNAT'd port
 icmp4_err_frag_needed_for_revnat = (

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -80,6 +80,10 @@ tcp_svc_one   = 80
 tcp_svc_two   = 443
 tcp_svc_three = 53
 
+# Other default properties for TCP
+tcp_default_seq = 123456
+tcp_default_win = 65535
+
 # Default payload data for tests. Note this includes a trailing
 # NUL-terminating byte for consistency with the C macro. This is
 # to ensure consistency in things like IP checksum values.

--- a/bpf/tests/tc_icmp_snat.c
+++ b/bpf/tests/tc_icmp_snat.c
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#define ENABLE_DSR		1
-#define ENCAP_IFINDEX		1
+#undef TUNNEL_MODE
 
 #define ENABLE_IPV4			1
 #define ENABLE_IPV6			1

--- a/bpf/tests/tc_icmp_snat_hostfw.c
+++ b/bpf/tests/tc_icmp_snat_hostfw.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_HOST_FIREWALL
+
+#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_icmp_snat_hostfw.c
+++ b/bpf/tests/tc_icmp_snat_hostfw.c
@@ -3,4 +3,12 @@
 
 #define ENABLE_HOST_FIREWALL
 
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_SCTP			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_MASQUERADE_IPV4		1
+#define ENABLE_MASQUERADE_IPV6		1
+
+#include "bpf_nat_icmp.h"
 #include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_icmp_snat_tunnel.c
+++ b/bpf/tests/tc_icmp_snat_tunnel.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_DSR 1
+#define ENCAP_IFINDEX 1
+
+#include "bpf_nat_icmp.h"

--- a/bpf/tests/tc_nodeport_icmp4_snat.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat.c
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#undef TUNNEL_MODE
-
-#include "tc_nodeport_icmp4_snat.h"
-

--- a/bpf/tests/tc_nodeport_icmp4_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat_hostfw.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_HOST_FIREWALL
-
-#include "tc_nodeport_icmp4_snat.h"

--- a/bpf/tests/tc_nodeport_icmp4_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat_tunnel.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_TUNNEL
-
-#include "tc_nodeport_icmp4_snat.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#undef TUNNEL_MODE
-
-#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_HOST_FIREWALL
-
-#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_DSR
-#define ENCAP_IFINDEX 1
-
-#include "bpf_nat_icmp6.h"


### PR DESCRIPTION
Backport
* [ ] #47222 (minor adjustments for missing test infrastructure in `v1.19`)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47222
```