### PR TITLE
aws/ipam: Stop reporting prefixes as individual IPs to release

### DIFF
--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -314,23 +314,32 @@ func (n *Node) GetAttachedCIDRs() []netip.Prefix {
 
 	var attached []netip.Prefix
 	for _, eni := range n.enis {
+		prefixes := make([]netip.Prefix, 0, len(eni.Prefixes)+len(eni.IPv6Prefixes))
 		for _, prefix := range eni.Prefixes {
 			if prefix.IsValid() {
-				attached = append(attached, prefix.Prefix)
+				prefixes = append(prefixes, prefix.Prefix)
 			}
 		}
 		for _, prefix := range eni.IPv6Prefixes {
 			if prefix.IsValid() {
-				attached = append(attached, prefix.Prefix)
+				prefixes = append(prefixes, prefix.Prefix)
 			}
 		}
+		attached = append(attached, prefixes...)
+
 		for _, addr := range eni.Addresses {
-			if addr.IsValid() {
-				attached = append(attached, netip.PrefixFrom(addr.Addr, addr.BitLen()))
+			if !addr.IsValid() || prefixContains(prefixes, addr.Addr) {
+				continue
 			}
+			attached = append(attached, netip.PrefixFrom(addr.Addr, addr.BitLen()))
 		}
 	}
 	return attached
+}
+
+// prefixContains reports whether addr falls inside any of the prefixes.
+func prefixContains(prefixes []netip.Prefix, addr netip.Addr) bool {
+	return slices.ContainsFunc(prefixes, func(p netip.Prefix) bool { return p.Contains(addr) })
 }
 
 // PrepareCIDRRelease maps released CIDRs back to their source ENIs

--- a/pkg/aws/ipam/node_test.go
+++ b/pkg/aws/ipam/node_test.go
@@ -4,6 +4,7 @@
 package ipam
 
 import (
+	"fmt"
 	"net/netip"
 	"testing"
 
@@ -322,6 +323,46 @@ func TestGetAttachedCIDRs(t *testing.T) {
 			netip.MustParsePrefix("10.0.0.16/28"),
 			netip.MustParsePrefix("2001:db8::1/128"),
 			netip.MustParsePrefix("2001:db8:1::/80"),
+		}, n.GetAttachedCIDRs())
+	})
+
+	t.Run("addresses expanded from a delegated prefix are not reported individually", func(t *testing.T) {
+		// The EC2 layer expands every delegated prefix into eni.Addresses.
+		// Only the prefix itself is attached as far as the release path is
+		// concerned, since the agent records only the prefix in
+		// Spec.IPAM.Pools.Allocated.
+		addrs := []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.1.5"))}
+		for i := range 16 {
+			addrs = append(addrs, iputil.AddrFrom(netip.MustParseAddr(fmt.Sprintf("10.0.0.%d", 16+i))))
+		}
+
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: addrs,
+				Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+			},
+		})
+
+		require.ElementsMatch(t, []netip.Prefix{
+			netip.MustParsePrefix("10.0.0.16/28"),
+			netip.MustParsePrefix("10.0.1.5/32"),
+		}, n.GetAttachedCIDRs())
+	})
+
+	t.Run("addresses covered by an IPv6 prefix are not reported individually", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []iputil.Addr{
+					iputil.AddrFrom(netip.MustParseAddr("2001:db8:1::5")),
+					iputil.AddrFrom(netip.MustParseAddr("2001:db8:2::1")),
+				},
+				IPv6Prefixes: []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("2001:db8:1::/80"))},
+			},
+		})
+
+		require.ElementsMatch(t, []netip.Prefix{
+			netip.MustParsePrefix("2001:db8:1::/80"),
+			netip.MustParsePrefix("2001:db8:2::1/128"),
 		}, n.GetAttachedCIDRs())
 	})
 }


### PR DESCRIPTION
This fixes a bug where the ENI IPAM operator would try to release prefix IPs as individual IPs even when they were in use.

The v1.20 IPAM ENI operator introduced a bug when using prefix delegation where prefixes were considered both as prefixes and as individual IPs when it came to IP release. The issue is that the operator was filling its array of attached CIDRs using both the ENI's prefixes and addresses fields. However, IPv4 prefixes are expanded into individual IPs in the addresses field which caused the problem.

With this the operator would see the individual IPs of the prefix as separate attachments and since the agent was only reporting the prefix as a whole as being used, the operator would start trying to release the individual IPs and fail due to the EC2 API rejecting the request.

Covering the IPv6 case is not strictly necessary, but I included it to keep uniformity between how both IP families are handled.

```release-note
aws/ipam: Fixed a bug where the operator in ENI IPAM mode would try to release prefix IPs as individual IPs even when they were in use.
```
