### PR TITLE
docs/ipam: Fix multi-pool annotation name in examples

### DIFF
--- a/Documentation/network/kubernetes/ipam-multi-pool.rst
+++ b/Documentation/network/kubernetes/ipam-multi-pool.rst
@@ -95,7 +95,7 @@ Validate installation
        mars      7s
 
 #. Create two deployments with two pods each. One allocating from the ``default`` pool and one
-   allocating from the ``mars`` pool by way of the ``ipam.cilium.io/ipam-pool: mars`` annotation:
+   allocating from the ``mars`` pool by way of the ``ipam.cilium.io/ip-pool: mars`` annotation:
 
    .. code-block:: shell-session
 
@@ -162,7 +162,7 @@ Validate installation
        $ kubectl exec pod/nginx-default-79885c7f58-fdfgf -- curl -s -o /dev/null -w "%{http_code}" http://10.20.0.37
        200
 
-#. Alternatively, the ``ipam.cilium.io/ipam-pool`` annotation can also be applied to a namespace:
+#. Alternatively, the ``ipam.cilium.io/ip-pool`` annotation can also be applied to a namespace:
 
    .. code-block:: shell-session
 


### PR DESCRIPTION
When I was testing out multi-pool ipam, I noticed how the annotation documented in the tutorial for CRD-backed multi-pool ipam is wrong in some places.
In some parts, it is written as `ipam.cilium.io/ipam-pool`. The correct annotation is `ipam.cilium.io/ip-pool` as defined here: https://github.com/cilium/cilium/blob/30b51ec8b7b9f62cf25e010d8aea2dfc2f6b040e/pkg/annotation/k8s.go#L250-L252

AIL:1

```release-note
docs/ipam: Fix incorrect multi-pool IPAM annotation name in documentation
```