### PR TITLE
gha: compute the ginkgo cache key once, before the matrix

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -153,6 +153,8 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build Ginkgo E2E
     timeout-minutes: 30
+    outputs:
+      ginkgo-cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       # If any of these steps are modified, please update the copy of these
       # steps further down under the 'setup-and-test' jobs.
@@ -167,13 +169,19 @@ jobs:
           # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
           allow-unsafe-pr-checkout: true
 
+      - name: Compute Ginkgo build cache key
+        id: cache-key
+        shell: bash
+        run: |
+          echo "key=${{ runner.os }}-ginkgo-e2e-${{ hashFiles('**/*.go') }}" >> $GITHUB_OUTPUT
+
       # Load Ginkgo build from GitHub
       - name: Load ginkgo E2E from GH cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache
         with:
           path: /tmp/.ginkgo-build/
-          key: ${{ runner.os }}-ginkgo-e2e-${{ hashFiles('**/*.go') }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Install Go
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -442,7 +450,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.ginkgo-build/
-          key: ${{ runner.os }}-ginkgo-e2e-${{ hashFiles('**/*.go') }}
+          key: ${{ needs.build-ginkgo-binary.outputs.ginkgo-cache-key }}
 
       # Re-build the tests if it was a cache miss.
       - name: Install Go


### PR DESCRIPTION
The E2E legs started failing with a template error before running any test:
hashFiles('**/*.go') couldn't finish within 120 seconds, at line 445.

hashFiles() runs on the runner under a 120s cap. The matrix jobs check out the
trusted context ref at the root and the pull request branch under untrusted/,
so the glob covers roughly 40k Go files instead of the 20k the tree has, and
the walk competes with the LVH VM and the kind cluster that are already
running. Hashing two trees also defeated the pre-build job, since the key saved
over one tree never matched the key restored over two and every leg rebuilt the
test binary that had just been built for it.

Compute the key once in build-ginkgo-binary, where the tree is checked out once
and the runner is idle, and hand it to the matrix as a job output.

This commit was prepared with AIL:3.

