### PR TITLE
cilium-cli: keep connectivity perf usable without Cilium

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -409,11 +409,12 @@ func (ct *ConnectivityTest) setupAndValidatePerf(ctx context.Context, _ SetupHoo
 		return err
 	}
 
-	if err := ct.initCiliumPods(ctx); err != nil {
+	// The perf suite is also run without Cilium, to collect baseline numbers.
+	if err := ct.initCiliumPods(ctx); errors.Is(err, errNoCiliumPods) {
+		ct.Warnf("Skipping Cilium version detection: %s", err)
+	} else if err != nil {
 		return err
-	}
-
-	if err := ct.detectCiliumVersion(ctx); err != nil {
+	} else if err := ct.detectCiliumVersion(ctx); err != nil {
 		return err
 	}
 
@@ -978,6 +979,11 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	return nil
 }
 
+// errNoCiliumPods is returned by initCiliumPods when a cluster runs no Cilium
+// agent, so that callers which tolerate this can tell it apart from a failure
+// to reach the Kubernetes API.
+var errNoCiliumPods = errors.New("no cilium agent pods found")
+
 // initCiliumPods fetches the Cilium agent pod information from all clients
 func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
 	for _, client := range ct.clients.clients() {
@@ -986,7 +992,7 @@ func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
 			return fmt.Errorf("unable to list Cilium pods: %w", err)
 		}
 		if len(ciliumPods.Items) == 0 {
-			return fmt.Errorf("no cilium agent pods found in -n %s -l %s", ct.params.CiliumNamespace, ct.params.AgentPodSelector)
+			return fmt.Errorf("%w in -n %s -l %s", errNoCiliumPods, ct.params.CiliumNamespace, ct.params.AgentPodSelector)
 		}
 		for _, ciliumPod := range ciliumPods.Items {
 			// TODO: Can Cilium pod names collide across clusters?


### PR DESCRIPTION
The net-perf-gke baseline matrix job deliberately installs no Cilium: it runs cilium connectivity perf against a bare GKE cluster to produce the reference numbers the Cilium matrix jobs are compared against. Since ce7f9b264b, which detects the Cilium version in the perf setup path so the banner stops printing 0.0.0, that job fails within a second with "no cilium agent pods found in -n kube-system -l k8s-app=cilium", because initCiliumPods treats an empty pod list as fatal.

Seen in https://github.com/cilium/cilium/actions/runs/32434777663

Let the perf setup tolerate a cluster with no agent. initCiliumPods now wraps a sentinel error for the empty case so the perf path can tell it apart from a failure to reach the Kubernetes API, which stays fatal, and version detection is skipped when there is no agent to ask. The Cilium matrix jobs are unaffected and keep reporting the real version.

Verified in https://github.com/cilium/cilium/actions/runs/32474694911, where all seven matrix jobs passed. The baseline one logged "Skipping Cilium version detection: no cilium agent pods found in -n kube-system -l k8s-app=cilium" and then produced a full perf summary, while the native one still reported Cilium version 1.21.0.

Fixes: ce7f9b264b ("cilium-cli/connectivity: detect Cilium version in connectivity perf setup")

This PR was prepared with AIL:3.
