### PR TITLE
gateway-api: propgate listenerset status update errors

### DIFF
--- a/operator/pkg/gateway-api/status_listener.go
+++ b/operator/pkg/gateway-api/status_listener.go
@@ -118,7 +118,7 @@ func (m *ListenerStatusManager) SetListenerStatuses(ctx context.Context, gw *gat
 	}
 
 	if gatewayStatus != ListenersStatusNoneValid {
-		m.setListenerSetStatuses(
+		if err := m.setListenerSetStatuses(
 			ctx,
 			gw,
 			inputs.AttachedListenerSets,
@@ -131,7 +131,9 @@ func (m *ListenerStatusManager) SetListenerStatuses(ctx context.Context, gw *gat
 			inputs.UDPRoutes,
 			inputs.ReferenceGrants,
 			namespaceLabels,
-		)
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	return &ListenerStatusResult{
@@ -424,7 +426,7 @@ func (m *ListenerStatusManager) setListenerSetStatuses(
 	udpRoutes []gatewayv1.UDPRoute,
 	grants []gatewayv1.ReferenceGrant,
 	namespaceLabels helpers.NamespaceLabelIndex,
-) {
+) error {
 	gw.Status.AttachedListenerSets = nil
 
 	for i := range disallowedListenerSets {
@@ -435,8 +437,7 @@ func (m *ListenerStatusManager) setListenerSetStatuses(
 		setListenerSetProgrammed(ls, false, "ListenerSet is not allowed by the Gateway's allowedListeners policy", gatewayv1.ListenerSetReasonNotAllowed)
 
 		if err := m.updateListenerSetStatus(ctx, original, ls); err != nil {
-			m.logger.ErrorContext(ctx, "Unable to update ListenerSet status", logfields.Error, err,
-				logfields.Resource, client.ObjectKeyFromObject(ls).String())
+			return fmt.Errorf("failed to update ListenerSet status for %s: %w", client.ObjectKeyFromObject(ls).String(), err)
 		}
 	}
 	var validAttachedCount int32
@@ -531,14 +532,14 @@ func (m *ListenerStatusManager) setListenerSetStatuses(
 		}
 
 		if err := m.updateListenerSetStatus(ctx, original, ls); err != nil {
-			m.logger.ErrorContext(ctx, "Unable to update ListenerSet status", logfields.Error, err,
-				logfields.Resource, client.ObjectKeyFromObject(ls).String())
+			return fmt.Errorf("failed to update ListenerSet status for %s: %w", client.ObjectKeyFromObject(ls).String(), err)
 		}
 	}
 
 	if validAttachedCount > 0 {
 		gw.Status.AttachedListenerSets = &validAttachedCount
 	}
+	return nil
 }
 
 func (m *ListenerStatusManager) updateListenerSetStatus(ctx context.Context, original *gatewayv1.ListenerSet, new *gatewayv1.ListenerSet) error {


### PR DESCRIPTION
Propagate ListenerSet status update failures instead of logging and continuing inside `ListenerStatusManager`.

This changes `setListenerSetStatuses` to return an error and makes `SetListenerStatuses` bubble that failure up to the Gateway reconciler. Both `updateListenerSetStatus` callsites now return wrapped errors with the ListenerSet identity instead of emitting an error log and proceeding, so stale ListenerSet status updates are treated as reconcile failures rather than best-effort side effects.

This behavior was originally introduced as log-and-continue in b30034e0a8cecb90494157747be129252fcca9c9 (https://github.com/cilium/cilium/commit/b30034e0a8cecb90494157747be129252fcca9c9)

@asauber is this intentionally implemented like this?