### PR TITLE
l2announcer: make leader-election Lease name collision-free

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -5,6 +5,8 @@ package l2announcer
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -290,6 +292,10 @@ func (l2a *L2Announcer) leaseGC(ctx context.Context, health cell.Health) error {
 	}
 
 	for _, lease := range list.Items {
+		// leaseName keeps leasePrefix at the start of every Lease name, so this
+		// prefix scan matches Leases created under both the current hashed
+		// scheme and the older "<prefix>-<namespace>-<name>" scheme, letting
+		// orphaned pre-upgrade Leases get collected here as well.
 		if !strings.HasPrefix(lease.Name, leasePrefix) {
 			continue
 		}
@@ -846,11 +852,35 @@ func (l2a *L2Announcer) leaseNamespace() string {
 
 const leasePrefix = "cilium-l2announce"
 
+// leaseName returns the leader-election Lease name for a Service.
+//
+// The namespace and Service name cannot simply be concatenated with a hyphen:
+// '-' is legal inside both a namespace (a DNS-1123 label) and a Service name (a
+// DNS-1035 label), so distinct pairs collapse onto the same string. Namespace
+// "foo" + Service "bar-baz" and namespace "foo-bar" + Service "baz" would both
+// render as "cilium-l2announce-foo-bar-baz" and share a single leader election.
+//
+// To make the mapping injective we append a short deterministic hash of the
+// canonical "namespace/name" key. Neither half may contain '/', so that key is
+// itself unambiguous, and the hash therefore differs for any distinct pair even
+// when the readable "<namespace>-<name>" part collides.
+//
+// The readable part is retained so the Lease stays recognisable in
+// `kubectl get leases`, and the name still begins with leasePrefix so the
+// leaseGC prefix scan keeps matching both new Leases and pre-upgrade Leases
+// created under the old scheme. The result stays a valid DNS-1123 subdomain and
+// well within the 253-character limit (namespace + name are each <= 63 chars).
+func leaseName(namespace, name string) string {
+	sum := sha256.Sum256([]byte(namespace + "/" + name))
+	hash := hex.EncodeToString(sum[:8])
+	return fmt.Sprintf("%s-%s-%s-%s", leasePrefix, namespace, name, hash)
+}
+
 func (l2a *L2Announcer) newLeaseLock(svc *loadbalancer.Service) *resourcelock.LeaseLock {
 	return &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
 			Namespace: l2a.leaseNamespace(),
-			Name:      fmt.Sprintf("%s-%s-%s", leasePrefix, svc.Name.Namespace(), svc.Name.Name()),
+			Name:      leaseName(svc.Name.Namespace(), svc.Name.Name()),
 		},
 		Client: l2a.params.Clientset.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -1191,3 +1191,34 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+// TestLeaseNameNoCollision verifies that leaseName maps distinct
+// (namespace, name) pairs onto distinct Lease names, in particular the
+// hyphen-boundary collision from GitHub issue #48084: namespace "foo" +
+// Service "bar-baz" and namespace "foo-bar" + Service "baz" both used to
+// render as "cilium-l2announce-foo-bar-baz" and share a single leader
+// election.
+func TestLeaseNameNoCollision(t *testing.T) {
+	a := leaseName("foo", "bar-baz")
+	b := leaseName("foo-bar", "baz")
+
+	// The two previously-colliding Services must now get different Leases.
+	assert.NotEqual(t, a, b, "distinct (namespace, name) pairs must not collide onto one Lease")
+
+	// leaseGC scans by prefix, so every name must keep leasePrefix at the
+	// start for both new and pre-upgrade Leases to be collectable.
+	assert.True(t, strings.HasPrefix(a, leasePrefix), "%q must start with %q", a, leasePrefix)
+	assert.True(t, strings.HasPrefix(b, leasePrefix), "%q must start with %q", b, leasePrefix)
+
+	// The readable "<prefix>-<namespace>-<name>" part is retained.
+	assert.True(t, strings.HasPrefix(a, leasePrefix+"-foo-bar-baz-"), "unexpected name %q", a)
+	assert.True(t, strings.HasPrefix(b, leasePrefix+"-foo-bar-baz-"), "unexpected name %q", b)
+
+	// The function is deterministic for a given pair.
+	assert.Equal(t, a, leaseName("foo", "bar-baz"), "leaseName must be deterministic")
+
+	// Stay within the Kubernetes 253-char object-name limit even for the
+	// maximum-length namespace and Service name (63 chars each).
+	long := leaseName(strings.Repeat("n", 63), strings.Repeat("s", 63))
+	assert.LessOrEqual(t, len(long), 253, "lease name %q exceeds the 253-char limit", long)
+}


### PR DESCRIPTION
The L2 announcer built the per-Service leader-election Lease name by concatenating the namespace and Service name onto a prefix with a hyphen:

```go
fmt.Sprintf("%s-%s-%s", leasePrefix, svc.Name.Namespace(), svc.Name.Name())
```

A hyphen is legal inside both a namespace (a DNS-1123 label) and a Service name (a DNS-1035 label), so this mapping is **not injective**. Namespace `foo` + Service `bar-baz` and namespace `foo-bar` + Service `baz` both render as `cilium-l2announce-foo-bar-baz`, so the two unrelated Services end up sharing a single Lease and one leader election. The `leaseGC` scan only prefix-matches, so it cannot disambiguate them either. This is silent when it happens and the symptom points at the L2 policy rather than at a name collision (most likely in multi-tenant clusters that use hyphenated namespace prefixes such as `team-a` / `team-a-staging`).

**Fix:** make the mapping injective by appending a short deterministic hash (first 8 bytes of SHA-256, hex-encoded) of the canonical `namespace/name` key to the existing readable name. Neither half can contain `/`, so the key is unambiguous and the hash differs for any distinct pair even when the readable `<namespace>-<name>` part collides.

The readable part is retained so Leases stay recognisable in `kubectl get leases`, and the name still begins with `leasePrefix`, so:

- the `leaseGC` prefix scan keeps matching **both** new Leases and orphaned pre-upgrade Leases, and
- the result remains a valid DNS-1123 subdomain, well within the 253-character object-name limit (namespace and Service name are each ≤ 63 chars).

I considered the `%s-%s.%s` dotted-separator alternative suggested in the issue; it is more readable, but the hash approach does not depend on the "labels never contain `.`" invariant and gives a hard uniqueness guarantee, so I went with the hash.

**Backward compatibility:** the Lease name changes on upgrade, which orphans Leases created under the old scheme. Those are released on agent shutdown (`ReleaseOnCancel`), which empties the holder identity, and `leaseGC` already deletes prefix-matching Leases with an empty holder — and the old names still start with `leasePrefix` — so they clean themselves up. I have not verified this end-to-end on a live cluster; found and fixed by source inspection, matching the issue.

**Testing:** added `TestLeaseNameNoCollision` proving the `foo`/`bar-baz` vs `foo-bar`/`baz` case now yields distinct names, that both still start with `leasePrefix` (so GC matches), that the function is deterministic, and that the maximum-length case stays within 253 chars.

```
$ go build ./pkg/l2announcer/...   # ok
$ go test ./pkg/l2announcer/...    # ok  (3.774s)
```

Fixes: #48084

```release-note
Fix L2 announcements leader-election Lease name collision where two Services whose namespace/name differed only at a hyphen boundary could share a single Lease.
```

---

Disclosure per the [Cilium AI Policy]: this PR was prepared with AI assistance at **AIL:3** (AI-authored under detailed human direction). I specified the fix approach, the collision case to cover, the GC/backward-compatibility constraints, and reviewed the diff, the build, and the test results before submitting.

[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
