### PR TITLE
fix: skip deprecated IPv6 addresses in PreferredIPv6Address

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -406,8 +406,9 @@ func (dc *devicesController) processUpdates(
 
 func deviceAddressFromAddrUpdate(upd netlink.AddrUpdate) tables.DeviceAddress {
 	return tables.DeviceAddress{
-		Addr:      netipx.MustFromStdIP(upd.LinkAddress.IP),
-		Secondary: upd.Flags&unix.IFA_F_SECONDARY != 0,
+		Addr:       netipx.MustFromStdIP(upd.LinkAddress.IP),
+		Secondary:  upd.Flags&unix.IFA_F_SECONDARY != 0,
+		Deprecated: upd.Flags&0x20 != 0, // IFA_F_DEPRECATED (not exposed by golang.org/x/sys/unix)
 
 		// ifaddrmsg.ifa_scope is uint8, vishvananda/netlink has wrong type
 		Scope: tables.RouteScope(upd.Scope),

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -173,18 +173,20 @@ func (d *Device) TableRow() []string {
 
 // NOTE: Update DeepEqual() when changing this struct.
 type DeviceAddress struct {
-	Addr      netip.Addr
-	Secondary bool
-	Scope     RouteScope // Address scope, e.g. RT_SCOPE_LINK, RT_SCOPE_HOST etc.
+	Addr       netip.Addr
+	Secondary  bool
+	Deprecated bool // Address is deprecated (preferred_lft == 0); not preferred for new connections
+	Scope      RouteScope // Address scope, e.g. RT_SCOPE_LINK, RT_SCOPE_HOST etc.
 }
 
 func (d *DeviceAddress) String() string {
-	return fmt.Sprintf("%s (secondary=%v, scope=%d)", d.Addr, d.Secondary, d.Scope)
+	return fmt.Sprintf("%s (secondary=%v, deprecated=%v, scope=%d)", d.Addr, d.Secondary, d.Deprecated, d.Scope)
 }
 
 func (d *DeviceAddress) DeepEqual(other *DeviceAddress) bool {
 	return d.Addr == other.Addr &&
 		d.Secondary == other.Secondary &&
+		d.Deprecated == other.Deprecated &&
 		d.Scope == other.Scope
 }
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -609,17 +609,39 @@ func showAddresses(addrs []NodeAddress) string {
 
 // PreferredIPv6Address returns a non-link-local IPv6 address,
 // falling back to a link-local address when necessary.
+// Deprecated addresses (preferred_lft == 0) are only selected
+// when no non-deprecated global address is available.
 func PreferredIPv6Address(addrs []DeviceAddress) netip.Addr {
-	var ip netip.Addr
+	var global, globalDeprecated, linkLocal netip.Addr
 	for _, addr := range addrs {
-		if addr.Addr.Is6() && !addr.Addr.IsUnspecified() {
-			ip = addr.Addr
-			if !ip.IsLinkLocalUnicast() {
-				break
+		if !addr.Addr.Is6() || addr.Addr.IsUnspecified() {
+			continue
+		}
+		if addr.Addr.IsLinkLocalUnicast() {
+			if !linkLocal.IsValid() {
+				linkLocal = addr.Addr
 			}
+			continue
+		}
+		// Global (non-link-local) address.
+		if addr.Deprecated {
+			if !globalDeprecated.IsValid() {
+				globalDeprecated = addr.Addr
+			}
+			continue
+		}
+		// Non-deprecated global address - prefer this.
+		if !global.IsValid() {
+			global = addr.Addr
 		}
 	}
-	return ip
+	if global.IsValid() {
+		return global
+	}
+	if globalDeprecated.IsValid() {
+		return globalDeprecated
+	}
+	return linkLocal
 }
 
 // PreferredIPv4Address returns the first usable IPv4 address ordered by SortedAddresses.

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -1009,6 +1009,38 @@ func TestPreferredIPv6Address(t *testing.T) {
 			},
 			want: netip.MustParseAddr("2600:1900:4001:2a1:0:2::"),
 		},
+		{
+			name: "skip_deprecated_global",
+			addrs: []DeviceAddress{
+				{Addr: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"), Deprecated: true},
+				{Addr: netip.MustParseAddr("fdc1:e344:ba0a:8:10:2:8:81")},
+			},
+			want: netip.MustParseAddr("fdc1:e344:ba0a:8:10:2:8:81"),
+		},
+		{
+			name: "all_global_deprecated_fallback",
+			addrs: []DeviceAddress{
+				{Addr: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"), Deprecated: true},
+			},
+			want: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"),
+		},
+		{
+			name: "deprecated_before_non_deprecated",
+			addrs: []DeviceAddress{
+				{Addr: netip.MustParseAddr("fe80::1")},
+				{Addr: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"), Deprecated: true},
+				{Addr: netip.MustParseAddr("fdc1:e344:ba0a:8:10:2:8:81")},
+			},
+			want: netip.MustParseAddr("fdc1:e344:ba0a:8:10:2:8:81"),
+		},
+		{
+			name: "deprecated_only_with_link_local",
+			addrs: []DeviceAddress{
+				{Addr: netip.MustParseAddr("fe80::1")},
+				{Addr: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"), Deprecated: true},
+			},
+			want: netip.MustParseAddr("2602:47:193:4c08:be24:11ff:fe0a:da37"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fix: skip deprecated IPv6 addresses in PreferredIPv6Address

`preferredIPv6Address()` (baked into `IPV6_DIRECT_ROUTING`) takes the
**first** non-link-local IPv6 address on the direct-routing device,
ignoring `deprecated`/`preferred_lft` status and public-vs-private
preference. When a device carries two global-scope addresses (e.g. a
stable ULA plus a deprecated SLAAC/GUA with `preferred_lft 0sec`), the
deprecated address can be chosen depending on kernel enumeration order.
Traffic SNAT'd to that address never receives a reply.

This change:

- Adds a `Deprecated` field to `tables.DeviceAddress`, populated from
  the `IFA_F_DEPRECATED` flag (0x20) in `deviceAddressFromAddrUpdate`.
- Updates `tables.PreferredIPv6Address` to prefer the first
  **non-deprecated** global IPv6 address, falling back to the first
  deprecated global address, and finally to a link-local address —
  mirroring the kernel's own RFC 6724 address selection and the
  public/private preference already present in the `NodeAddress` table
  logic (added for #41866).

Fixes: #48133
