### PR TITLE
l2announcer: use unambiguous separator in Lease name to avoid collision

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -850,7 +850,7 @@ func (l2a *L2Announcer) newLeaseLock(svc *loadbalancer.Service) *resourcelock.Le
 	return &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
 			Namespace: l2a.leaseNamespace(),
-			Name:      fmt.Sprintf("%s-%s-%s", leasePrefix, svc.Name.Namespace(), svc.Name.Name()),
+			Name:      fmt.Sprintf("%s-%s.%s", leasePrefix, svc.Name.Namespace(), svc.Name.Name()),
 		},
 		Client: l2a.params.Clientset.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{


### PR DESCRIPTION
The l2announcer constructs its per-Service leader-election Lease name
by joining the namespace and Service name with `-`:

    fmt.Sprintf("%s-%s-%s", leasePrefix, svc.Name.Namespace(), svc.Name.Name())

Both namespace (DNS-1123 label) and Service name (DNS-1035 label) use `-` as
a legal character. Two unrelated Services can therefore map onto the same
Lease name:

- Namespace `foo` + Service `bar-baz` → `cilium-l2announce-foo-bar-baz`
- Namespace `foo-bar` + Service `baz` → `cilium-l2announce-foo-bar-baz`

Fix: Use `.` as the separator between namespace and service name. Neither
DNS-1123 labels (namespace) nor DNS-1035 labels (service name) may contain
`.`, so this is unambiguous.

    fmt.Sprintf("%s-%s.%s", leasePrefix, ns, name)

The GC scan (`leasesGC`) uses `strings.HasPrefix(lease.Name, leasePrefix)`
which remains correct since the prefix is unchanged.

Fixes: #48084