### PR TITLE
bpf: wireguard: fix ctx_is_wireguard() for fragmented UDP packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1055,6 +1055,7 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
+	fraginfo_t __maybe_unused fraginfo = 0;
 	__u32 __maybe_unused ipcache_srcid = 0;
 	enum metric_dir dir = METRIC_INGRESS;
 	void __maybe_unused *data, *data_end;
@@ -1140,9 +1141,10 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 # ifdef ENABLE_WIREGUARD
 		if (!from_host) {
 			next_proto = ip6->nexthdr;
-			hdrlen = ipv6_hdrlen(ctx, &next_proto);
+			hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &next_proto, &fraginfo);
 			if (likely(hdrlen > 0) &&
-			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, identity)) {
+			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, fraginfo,
+					     identity)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
 			}
 		}
@@ -1234,7 +1236,9 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 		if (!from_host) {
 			next_proto = ip4->protocol;
 			hdrlen = ipv4_hdrlen(ip4);
-			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, identity)) {
+			fraginfo = ipfrag_encode_ipv4(ip4);
+			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, fraginfo,
+					     identity)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
 			}
 		}

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -29,7 +29,8 @@ DECLARE_CONFIG(__u16, wg_port, "Port for the WireGuard interface.")
  * - valid remote node identity.
  */
 static __always_inline bool
-ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identity)
+ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, fraginfo_t fraginfo,
+		 __u32 identity)
 {
 	struct {
 		__be16 sport;
@@ -41,7 +42,8 @@ ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identi
 		return false;
 
 	/* Unable to retrieve L4 ports. */
-	if (l4_load_ports(ctx, l4_off + UDP_SPORT_OFF, &l4.sport) < 0)
+	if (!ipfrag_has_l4_header(fraginfo) ||
+	    l4_load_ports(ctx, l4_off + UDP_SPORT_OFF, &l4.sport) < 0)
 		return false;
 
 	/* Packet is not for cilium@WireGuard.*/

--- a/bpf/tests/encryption_helpers_wireguard.c
+++ b/bpf/tests/encryption_helpers_wireguard.c
@@ -54,6 +54,7 @@ int check1(struct __ctx_buff *ctx)
 	void *data, *data_end = NULL;
 	struct iphdr *ipv4 = NULL;
 	struct udphdr *udp = NULL;
+	fraginfo_t fraginfo;
 	int l4_off = 0;
 	__u8 protocol = 0;
 
@@ -65,23 +66,24 @@ int check1(struct __ctx_buff *ctx)
 
 	l4_off = sizeof(struct ethhdr) + ipv4_hdrlen(ipv4);
 	protocol = ipv4->protocol;
+	fraginfo = ipfrag_encode_ipv4(ipv4);
 
 	/* Valid Wireguard packet. */
-	assert(ctx_is_wireguard(ctx, l4_off, protocol, REMOTE_NODE_ID));
+	assert(ctx_is_wireguard(ctx, l4_off, protocol, fraginfo, REMOTE_NODE_ID));
 
 	/* Invalid identity within CIDR. */
-	assert(!ctx_is_wireguard(ctx, l4_off, protocol, CIDR_IDENTITY_RANGE_START));
+	assert(!ctx_is_wireguard(ctx, l4_off, protocol, fraginfo, CIDR_IDENTITY_RANGE_START));
 
 	/* Invalid protocol TCP. */
-	assert(!ctx_is_wireguard(ctx, l4_off, IPPROTO_TCP, REMOTE_NODE_ID));
+	assert(!ctx_is_wireguard(ctx, l4_off, IPPROTO_TCP, fraginfo, REMOTE_NODE_ID));
 
 	/* Invalid L4 offset. */
-	assert(!ctx_is_wireguard(ctx, l4_off + 2, protocol, REMOTE_NODE_ID));
+	assert(!ctx_is_wireguard(ctx, l4_off + 2, protocol, fraginfo, REMOTE_NODE_ID));
 
 	udp->source += 1;
 
 	/* Invalid L4 ports mismatching. */
-	assert(!ctx_is_wireguard(ctx, l4_off, protocol, REMOTE_NODE_ID));
+	assert(!ctx_is_wireguard(ctx, l4_off, protocol, fraginfo, REMOTE_NODE_ID));
 
 	test_finish();
 }


### PR DESCRIPTION
Calling l4_load_ports() for packet without L4 header only returns garbage.

We might actually want to support fragmented packets in this path, but that's a separate change.

```release-note
Fragmented UDP packets were potentially mis-classified as Cilium Wireguard traffic.
```