### PR TITLE
hubble-relay & cilium-dbg: fix reading config from the environment

### DIFF
--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,7 +79,8 @@ func initConfig() {
 	vp.SetEnvPrefix("cilium")
 	vp.SetConfigName(".cilium") // name of config file (without extension)
 	vp.AddConfigPath("$HOME")   // adding home directory as first search path
-	vp.AutomaticEnv()           // read in environment variables that match
+	vp.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	vp.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := vp.ReadInConfig(); err == nil {

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -77,6 +79,7 @@ func newViper() *viper.Viper {
 	vp := viper.New()
 	vp.SetEnvPrefix("relay")
 	vp.SetConfigFile(configFilePath)
+	vp.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	vp.AutomaticEnv()
 	return vp
 }


### PR DESCRIPTION
hubble-relay & cilium-dbg use Viper to read config including from environment variables. Viper derives the environment variable name by uppercasing the config key and preserving dashes (-). Environment variables cannot contain dashes, so config keys containing a dash could not be set this way.

Replace - with _ when deriving the environment variable, like hubble CLI and clustermesh-apiserver.

```release-note
Fix reading config from environment variables in hubble-relay & cilium-dbg.
```
