### PR TITLE
gateway-api: retry CRD discovery on any error but NotFound

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"syscall"
 
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
@@ -148,7 +147,7 @@ func discoverCRDsWithRetry(ctx context.Context, client k8sClient.Clientset, logg
 			}, nil
 		}
 
-		// Context expiry errors from checkCRDs bypass isTransientError, silently
+		// Context expiry errors from checkCRDs bypass isPermanentError, silently
 		// disabling Gateway API. Catch them here to trigger an operator restart.
 		if ctx.Err() != nil {
 			logger.Error(
@@ -159,7 +158,7 @@ func discoverCRDsWithRetry(ctx context.Context, client k8sClient.Clientset, logg
 			return nil, fmt.Errorf("gateway API CRD discovery timed out: %w", err)
 		}
 
-		if !isTransientError(err) {
+		if isPermanentError(err) {
 			logger.Error(
 				"Required GatewayAPI resources are not found, please refer to docs for installation instructions",
 				logfields.Error, err,
@@ -359,32 +358,31 @@ func validateExternalTrafficPolicy(cfg gatewayApiConfig, logger *slog.Logger) er
 	return fmt.Errorf("invalid externalTrafficPolicy: %s", cfg.GatewayAPIServiceExternalTrafficPolicy)
 }
 
-// isTransientError returns true if the error is temporary and retryable
-// (network issues, API server overload), vs permanent errors (CRD not installed).
-// This is used to determine whether to retry Gateway API CRD discovery.
-func isTransientError(err error) bool {
+// isPermanentError returns true only if err (and, if it wraps multiple
+// errors via errors.Join, every one of them) unambiguously means "the CRD
+// does not exist" per the Kubernetes API. Anything else - a transient
+// network error, a 5xx, an unrecognized error shape - is treated as
+// retryable rather than permanent, since misclassifying a transient
+// failure as permanent silently and permanently disables Gateway API.
+//
+// checkCRDs joins one error per missing required GVK, so a single
+// genuinely-transient failure among several results must not be masked by
+// also finding a NotFound error elsewhere in the tree.
+func isPermanentError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	// Check for Kubernetes API server errors that are transient
-	if k8serrors.IsServerTimeout(err) ||
-		k8serrors.IsServiceUnavailable(err) ||
-		k8serrors.IsTooManyRequests(err) ||
-		k8serrors.IsTimeout(err) {
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, sub := range joined.Unwrap() {
+			if !isPermanentError(sub) {
+				return false
+			}
+		}
 		return true
 	}
 
-	// Check for network-level errors (connection refused, reset, host unreachable)
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		switch errno {
-		case syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.EHOSTUNREACH, syscall.ENETUNREACH:
-			return true
-		}
-	}
-
-	return false
+	return k8serrors.IsNotFound(err)
 }
 
 // checkCRDs checks if required and optional CRDs are present in the cluster,

--- a/operator/pkg/gateway-api/cell_test.go
+++ b/operator/pkg/gateway-api/cell_test.go
@@ -26,7 +26,11 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func TestIsTransientError(t *testing.T) {
+func TestIsPermanentError(t *testing.T) {
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "cilium")
+	otherNotFound := k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "grpcroutes"}, "cilium")
+	internalErr := k8serrors.NewInternalError(errors.New("etcdserver: leader changed"))
+
 	tests := []struct {
 		name     string
 		err      error
@@ -38,66 +42,87 @@ func TestIsTransientError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "connection refused",
+			name:     "not found is the only permanent error",
+			err:      notFound,
+			expected: true,
+		},
+		{
+			name:     "connection refused is retried, not permanent",
 			err:      syscall.ECONNREFUSED,
-			expected: true,
-		},
-		{
-			name:     "connection reset",
-			err:      syscall.ECONNRESET,
-			expected: true,
-		},
-		{
-			name:     "no route to host",
-			err:      syscall.EHOSTUNREACH,
-			expected: true,
-		},
-		{
-			name:     "network unreachable",
-			err:      syscall.ENETUNREACH,
-			expected: true,
-		},
-		{
-			name:     "server timeout",
-			err:      k8serrors.NewServerTimeout(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "get", 5),
-			expected: true,
-		},
-		{
-			name:     "service unavailable",
-			err:      k8serrors.NewServiceUnavailable("API server is shutting down"),
-			expected: true,
-		},
-		{
-			name:     "too many requests",
-			err:      k8serrors.NewTooManyRequests("rate limited", 5),
-			expected: true,
-		},
-		{
-			name:     "timeout",
-			err:      k8serrors.NewTimeoutError("request timed out", 30),
-			expected: true,
-		},
-		{
-			name:     "not found - permanent error",
-			err:      k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "cilium"),
 			expected: false,
 		},
 		{
-			name:     "generic error - not transient",
+			name:     "connection reset is retried, not permanent",
+			err:      syscall.ECONNRESET,
+			expected: false,
+		},
+		{
+			name:     "no route to host is retried, not permanent",
+			err:      syscall.EHOSTUNREACH,
+			expected: false,
+		},
+		{
+			name:     "network unreachable is retried, not permanent",
+			err:      syscall.ENETUNREACH,
+			expected: false,
+		},
+		{
+			name:     "server timeout is retried, not permanent",
+			err:      k8serrors.NewServerTimeout(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "get", 5),
+			expected: false,
+		},
+		{
+			name:     "service unavailable is retried, not permanent",
+			err:      k8serrors.NewServiceUnavailable("API server is shutting down"),
+			expected: false,
+		},
+		{
+			name:     "too many requests is retried, not permanent",
+			err:      k8serrors.NewTooManyRequests("rate limited", 5),
+			expected: false,
+		},
+		{
+			name:     "timeout is retried, not permanent",
+			err:      k8serrors.NewTimeoutError("request timed out", 30),
+			expected: false,
+		},
+		{
+			// The regression this guards against: cilium/cilium#48083. A 500 from
+			// the apiserver (e.g. etcd losing its leader) must not be treated the
+			// same as a genuine "the CRD is absent" NotFound answer.
+			name:     "internal server error is retried, not permanent",
+			err:      internalErr,
+			expected: false,
+		},
+		{
+			name:     "unrecognized error is retried, not permanent",
 			err:      errors.New("some random error"),
 			expected: false,
 		},
 		{
-			name:     "wrapped connection refused",
+			name:     "wrapped connection refused is retried, not permanent",
 			err:      errors.New("dial tcp: connect: " + syscall.ECONNREFUSED.Error()),
-			expected: false, // string matching won't work, only errors.As
+			expected: false,
+		},
+		{
+			name:     "all joined errors not found is permanent",
+			err:      errors.Join(notFound, otherNotFound),
+			expected: true,
+		},
+		{
+			name: "one transient error among joined not-found errors is retried, not permanent",
+			// checkCRDs joins one error per missing required GVK. A single 500
+			// among several otherwise-genuine NotFound answers must not be
+			// masked into a permanent "CRDs not installed" verdict.
+			err:      errors.Join(notFound, internalErr),
+			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isTransientError(tt.err)
-			assert.Equal(t, tt.expected, result, "isTransientError(%v) should return %v", tt.err, tt.expected)
+			result := isPermanentError(tt.err)
+			assert.Equal(t, tt.expected, result, "isPermanentError(%v) should return %v", tt.err, tt.expected)
 		})
 	}
 }
@@ -192,6 +217,38 @@ func TestDiscoverCRDsWithRetry_TransientErrorThenSuccess(t *testing.T) {
 	assert.Greater(t, int(callCount.Load()), len(helpers.RequiredGVKs))
 }
 
+// TestDiscoverCRDsWithRetry_InternalServerErrorThenSuccess reproduces the
+// exact scenario in cilium/cilium#48083: the apiserver answers with a 500
+// (e.g. etcd losing its leader) during CRD discovery, which must be retried
+// rather than immediately and permanently disabling Gateway API.
+func TestDiscoverCRDsWithRetry_InternalServerErrorThenSuccess(t *testing.T) {
+	logger := hivetest.Logger(t)
+	fcs, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	installRequiredCRDs(t, fcs)
+
+	var callCount atomic.Int32
+	fcs.APIExtFakeClientset.PrependReactor("get", "customresourcedefinitions",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			if callCount.Add(1) <= int32(len(helpers.RequiredGVKs)) {
+				return true, nil, k8serrors.NewInternalError(errors.New("etcdserver: leader changed"))
+			}
+			return false, nil, nil
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	assert.Equal(t, cell.StatusOK, simpleHealth.Level)
+	assert.Greater(t, int(callCount.Load()), len(helpers.RequiredGVKs))
+}
+
 func TestDiscoverCRDsWithRetry_TransientErrorUntilTimeout(t *testing.T) {
 	logger := hivetest.Logger(t)
 	fcs, cs := k8sClient.NewFakeClientset(logger)
@@ -218,7 +275,7 @@ func TestDiscoverCRDsWithRetry_TransientErrorUntilTimeout(t *testing.T) {
 }
 
 // TestDiscoverCRDsWithRetry_ContextAlreadyCancelled tests the race condition fix:
-// when the retry context expires and checkCRDs returns an error that isTransientError
+// when the retry context expires and checkCRDs returns an error that isPermanentError
 // doesn't recognize, the function must return a fatal error instead of silently
 // disabling Gateway API by treating it as "CRDs not installed".
 func TestDiscoverCRDsWithRetry_ContextAlreadyCancelled(t *testing.T) {


### PR DESCRIPTION
## Summary
- `isTransientError()` was an allowlist of 4 `k8serrors` predicates + 4 `syscall.Errno` values. Anything not on that list — including a 500 `InternalError` from the apiserver (e.g. etcd losing its leader during operator startup) — fell through to the "CRDs not installed" branch, which is **permanent**: Gateway API is disabled for the lifetime of the operator process, with no retry, no restart, and no further gateway-related log lines, even though the CRDs were installed the whole time.
- Per the issue's own analysis and suggested fix: invert the default. `isPermanentError()` now returns `true` only when the error unambiguously means the CRD does not exist (`k8serrors.IsNotFound`), and retries everything else — removing the need to keep extending an allowlist for every new transient error shape.
- `checkCRDs` joins one error per missing required GVK via `errors.Join`. Since `errors.As`/predicate checks on a joined error only need to find a match *somewhere* in the tree, a naive inversion could misclassify a batch as "permanent" if it contains a NotFound error alongside a genuinely transient one. `isPermanentError` walks joined errors explicitly and requires *every* sub-error to be NotFound before treating the whole batch as permanent.

Fixes #48083


## AI

Used Claude Code (Anthropic) to research the issue, implement the fix, and write the
accompanying test, under my direction and review.

## Test plan
- [x] `TestIsPermanentError` — rewrote/extended the existing `TestIsTransientError` table for the new (inverted) semantics, plus new cases: the exact `InternalError` regression from the issue, and joined-error cases (all-NotFound = permanent, one transient among NotFounds = not permanent).
- [x] `TestDiscoverCRDsWithRetry_InternalServerErrorThenSuccess` (new) — reproduces the issue's exact repro steps against `discoverCRDsWithRetry` directly: a 500 on the first pass, success on retry, confirms `Enabled: true` and no premature "CRDs not installed" degradation.
- [x] Full existing `TestDiscoverCRDsWithRetry_*` suite still passes unmodified (success, CRDs-not-installed, transient-then-success, transient-until-timeout, context-cancelled, context-deadline-exceeded).
- [x] `go test ./operator/pkg/gateway-api/...` — all packages pass (via `golang:1.26` container, since this repo requires Linux).