### PR TITLE
xds: make mock metrics concurrency-safe

### DIFF
--- a/pkg/envoy/xds/metrics_mock_test.go
+++ b/pkg/envoy/xds/metrics_mock_test.go
@@ -3,21 +3,30 @@
 
 package xds
 
+import "github.com/cilium/cilium/pkg/lock"
+
 type mockMetrics struct {
+	mutex  lock.Mutex
 	ack    map[string]int
 	nack   map[string]int
 	cancel map[string]int
 }
 
 func (m *mockMetrics) IncreaseACK(typeURL string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.ack[typeURL]++
 }
 
 func (m *mockMetrics) IncreaseNACK(typeURL string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.nack[typeURL]++
 }
 
 func (m *mockMetrics) IncreaseCancel(typeURL string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.cancel[typeURL]++
 }
 


### PR DESCRIPTION
Protect the test-only mockMetrics helper with a mutex so concurrent ACK, NACK, and cancel updates do not write to shared maps unsafely.

This fixes a panic in xDS tests where multiple request streams can share the same mockMetrics instance and trigger "fatal error: concurrent map writes" while updating counters.