### PR TITLE
bpf: conntrack: don't report SYN-ACK as 'observed SYN' (v2)

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -47,7 +47,7 @@ struct ct_state {
 	__u16 loopback:1,
 	      node_port:1,
 	      dsr_internal:1,   /* DSR is k8s service related, cluster internal */
-	      syn:1,
+	      syn:1,		/* Is a TCP SYN */
 	      proxy_redirect:1,	/* Connection is redirected to a proxy */
 	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
@@ -682,7 +682,7 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_bu
 
 		action = ct_tcp_select_action(tcp_flags);
 
-		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+		if (ct_state && dir == CT_SERVICE && tcp_is_syn(tcp_flags))
 			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
@@ -943,7 +943,7 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_bu
 
 		action = ct_tcp_select_action(tcp_flags);
 
-		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+		if (ct_state && dir == CT_SERVICE && tcp_is_syn(tcp_flags))
 			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -458,8 +458,8 @@ int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (tunnel_key->tunnel_id != WORLD_ID)
 		test_fatal("tunnel id is not correct");
 
-	if (!tunnel_opt_set)
-		test_fatal("expected DSR opt");
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
 # endif
 #else
 # ifdef ATTACHMENT_XDP
@@ -916,8 +916,8 @@ int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (tunnel_key->tunnel_id != WORLD_ID)
 		test_fatal("tunnel id is not correct");
 
-	if (!tunnel_opt_set)
-		test_fatal("expected DSR opt");
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
 # endif
 #else
 # ifdef ATTACHMENT_XDP

--- a/bpf/tests/kpr_dsr_remote_node.h
+++ b/bpf/tests/kpr_dsr_remote_node.h
@@ -60,6 +60,10 @@ const __u8 kpr_v4_dsr_remote_node_reply2_post[] = {
 	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply2_post)
 };
 
+const __u8 kpr_v4_dsr_remote_node_syn_non_dsr[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_syn_non_dsr)
+};
+
 const __u8 kpr_v6_dsr_remote_node_syn[] = {
 	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option_xdp)
 };
@@ -82,6 +86,10 @@ const __u8 kpr_v6_dsr_remote_node_reply_post[] = {
 
 const __u8 kpr_v6_dsr_remote_node_reply2_post[] = {
 	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply2_post)
+};
+
+const __u8 kpr_v6_dsr_remote_node_syn_non_dsr[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_syn_non_dsr)
 };
 
 #ifdef ENABLE_IPV4
@@ -459,6 +467,77 @@ int kpr_v4_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *
 	test_finish();
 }
 #endif
+
+/* Now receive a SYN without DSR-info. CT entry should be updated accordingly.
+ */
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_7syn_non_dsr")
+int kpr_v4_dsr_remote_node_7syn_non_dsr_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_syn_non_dsr,
+			sizeof(kpr_v4_dsr_remote_node_syn_non_dsr));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_7syn_non_dsr")
+int kpr_v4_dsr_remote_node_7syn_non_dsr_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_7syn_non_dsr")
+int kpr_v4_dsr_remote_node_7syn_non_dsr_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_syn_non_dsr",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_syn_non_dsr,
+			   sizeof(kpr_v4_dsr_remote_node_syn_non_dsr));
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (ct_entry->dsr_internal)
+		test_fatal("CT entry still has the .dsr_internal flag set");
+
+	test_finish();
+}
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
@@ -840,4 +919,75 @@ int kpr_v6_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *
 	test_finish();
 }
 #endif
+
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_7syn_non_dsr")
+int kpr_v6_dsr_remote_node_7syn_non_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_syn_non_dsr,
+			sizeof(kpr_v6_dsr_remote_node_syn_non_dsr));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_7syn_non_dsr")
+int kpr_v6_dsr_remote_node_7syn_non_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_7syn_non_dsr")
+int kpr_v6_dsr_remote_node_7syn_non_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_syn_non_dsr",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_syn_non_dsr,
+			   sizeof(kpr_v6_dsr_remote_node_syn_non_dsr));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (ct_entry->dsr_internal)
+		test_fatal("CT entry still has the .dsr_internal flag set");
+
+	test_finish();
+}
 #endif /* ENABLE_IPV6 */

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -110,15 +110,13 @@ kpr_v4_dsr_lb1_synack = (
 
 kpr_v4_dsr_lb1_synack_post_option = (
     Ether(src=host_mac_addr, dst=mac_one) /
-    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
-       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
 kpr_v4_dsr_lb1_synack_post_option_xdp = (
     Ether(src=mac_one, dst=mac_two) /
-    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
-       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
@@ -132,8 +130,7 @@ kpr_v4_dsr_lb1_synack_post_geneve_xdp = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
     UDP(sport=56602, dport=6081, chksum=0) /
-    GENEVE(vni=2,proto=0x6558,
-           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_one)]) /
+    GENEVE(vni=2,proto=0x6558) /
     Ether(src=host_mac_addr, dst=mac_one) /
     IP(src=v4_ext_one, dst=v4_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
@@ -298,16 +295,14 @@ kpr_v6_dsr_lb1_synack = (
 
 kpr_v6_dsr_lb1_synack_post_option = (
     Ether(src=host_mac_addr, dst=mac_one) /
-    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
-    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
 kpr_v6_dsr_lb1_synack_post_option_xdp = (
     Ether(src=mac_one, dst=mac_two) /
-    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
-    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
 kpr_v6_dsr_lb1_synack_post_geneve = (
@@ -320,8 +315,7 @@ kpr_v6_dsr_lb1_synack_post_geneve_xdp = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_node_one, dst=v4_node_two, id=0) /
     UDP(sport=52625, dport=6081, chksum=0) /
-    GENEVE(vni=2,proto=0x6558,
-           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_one)]) /
+    GENEVE(vni=2,proto=0x6558) /
     Ether(src=host_mac_addr, dst=mac_one) /
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -244,6 +244,12 @@ kpr_v4_dsr_remote_node_data_option = (
     b"foobar"
 )
 
+kpr_v4_dsr_remote_node_syn_non_dsr = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
 kpr_v4_dsr_remote_node_reply2_post = (
     Ether(src=mac_two, dst=mac_one) /
     IP(src=v4_svc_one, dst=v4_ext_one) /
@@ -433,4 +439,10 @@ kpr_v6_dsr_remote_node_reply2_post = (
     Ether(src=mac_two, dst=mac_one) /
     IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
     TCP(sport=tcp_svc_two, dport=tcp_src_one, flags="R")
+)
+
+kpr_v6_dsr_remote_node_syn_non_dsr = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
 )


### PR DESCRIPTION
Bring back https://github.com/cilium/cilium/pull/47448, now that the remote node's ingress path no longer [expects](https://github.com/cilium/cilium/pull/47592) the SYN-ACK to carry DSR info.
