### PR TITLE
bpf: tests: remove left-over IPV4_DIRECT_ROUTING

### DIFF
--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -14,8 +14,6 @@
 
 #define ENABLE_DSR_ICMP_ERRORS		1
 
-#define IPV4_DIRECT_ROUTING		v4_node_one
-
 #define fib_lookup mock_fib_lookup
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)


### PR DESCRIPTION
Fixup for
c13cbcfb2aaa ("bpf, datapath: move IPv4 direct routing address to runtime config").