### PR TITLE
fqdn: document serial assumption for DNS over TCP

### DIFF
--- a/pkg/fqdn/dnsproxy/shared_client_test.go
+++ b/pkg/fqdn/dnsproxy/shared_client_test.go
@@ -11,7 +11,10 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cilium/dns"
@@ -655,4 +658,105 @@ func (c *connWrapper) Write(p []byte) (int, error) {
 
 func (c *connWrapper) RemoteAddr() net.Addr {
 	return c.PacketConn.(net.Conn).RemoteAddr()
+}
+
+// TestDNSOverTCPIsSerial exists solely to "document" the assumption that the
+// shared client code makes, namely that there are _not_ multiple goroutines
+// handling multiple DNS over TCP queries.
+//
+// The background is that there otherwise exists a race condition which can
+// cause an agent panic caused by a delayed write to a closed requests channel.
+// The problem comes up during shutdown of a TCP connection, causing the shared
+// client's requests channel to be closed while there's the potential that a
+// query is about to be written into it/blocked on writing into it.
+func TestDNSOverTCPIsSerial(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Anything which is not a PacketConn gets treated like TCP by miekg/dns.
+		clientConn, serverConn := net.Pipe()
+		if _, ok := clientConn.(net.PacketConn); ok {
+			t.Fatalf("net.Pipe unexpectedly implements net.PacketConn")
+		}
+
+		listener := &singleConnListener{conn: serverConn, closed: make(chan struct{})}
+
+		var handlerCalls atomic.Int32
+		firstStarted := make(chan struct{})
+		releaseFirst := make(chan struct{})
+		server := &dns.Server{
+			Listener: listener,
+			Handler: dns.HandlerFunc(func(dns.ResponseWriter, *dns.Msg) {
+				if handlerCalls.Add(1) == 1 {
+					close(firstStarted)
+					<-releaseFirst
+				}
+			}),
+		}
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- server.ActivateAndServe()
+		}()
+
+		conn := &dns.Conn{Conn: clientConn}
+		request := new(dns.Msg)
+		request.SetQuestion("miek.nl.", dns.TypeSOA)
+		if err := conn.WriteMsg(request); err != nil {
+			t.Fatalf("writing first request: %v", err)
+		}
+		<-firstStarted
+
+		request.Id++
+		secondWriteDone := make(chan error, 1)
+		go func() {
+			secondWriteDone <- conn.WriteMsg(request)
+		}()
+		synctest.Wait()
+
+		if got := handlerCalls.Load(); got != 1 {
+			t.Fatalf("got %d concurrent handler calls, want 1", got)
+		}
+
+		close(releaseFirst)
+		if err := <-secondWriteDone; err != nil {
+			t.Fatalf("writing second request: %v", err)
+		}
+		synctest.Wait()
+		if got := handlerCalls.Load(); got != 2 {
+			t.Fatalf("got %d handler calls after releasing the first, want 2", got)
+		}
+
+		if err := server.Shutdown(); err != nil {
+			t.Fatalf("shutting down server: %v", err)
+		}
+		if err := <-serverDone; err != nil {
+			t.Fatalf("serving DNS: %v", err)
+		}
+		if err := clientConn.Close(); err != nil {
+			t.Fatalf("closing client connection: %v", err)
+		}
+	})
+}
+
+type singleConnListener struct {
+	conn     net.Conn
+	accepted bool
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if !l.accepted {
+		l.accepted = true
+		return l.conn, nil
+	}
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *singleConnListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *singleConnListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
 }


### PR DESCRIPTION
The shared client machinery is concurrent, complex and a bit brittle. One particularly tricky aspect is that there's a channel which is being written to by some goroutines and closed by another, seemingly without proper synchronisation.

However, the synchronisation lies in the fact that the upstream DNS server of miekg/dns does _not_ spawn goroutines for each query when they come in via TCP, it keeps one per connection.

Fixing the channel ownership or synchronizing the goroutines each also have downsides, they make the concurrency even more pronounced and difficult to think about, hence I'm opting for a slightly unorthodox solution: "document" the assumption in form of a test which fails if the TCP queries are ever executed in parallel (i.e. due to an update of the upstream library).

The test uses synctest, hence both fast and deterministic, as far as I understand. I've tested that it fails when I simply let each TCP handler run in its own goroutine (which would break other things, too), so it's sensitive enough.

AIL:3 - test is generated, edited by me. Commit message by me.