### PR TITLE
gha: survive a GKE zone running out of capacity

### DIFF
--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -74,6 +74,13 @@ runs:
         # long provisioning wait. Only capacity errors trigger a fallback: any
         # other failure (bad flag, quota, config) is not zone-specific, so we
         # fail fast and surface the real error rather than retrying blindly.
+        #
+        # The fallback zones are shuffled because several matrix legs share a
+        # zone and stock out together, so a fixed order would send all of them
+        # to the same next zone.
+        fallback_zones=$(tr ' ' '\n' <<< "${{ inputs.fallback-zones }}" | grep -v '^$' | shuf | tr '\n' ' ')
+        echo "Zone candidates: ${{ inputs.zone }} ${fallback_zones}"
+
         # An attempt that is still not done after this long is not worth waiting
         # for: the median creation takes under 5 minutes, while capacity
         # starvation can sit in the GCE instance group manager for 35 minutes
@@ -86,7 +93,7 @@ runs:
         budget_deadline=$(( SECONDS + 30 * 60 ))
 
         created_zone=""
-        for zone in "${{ inputs.zone }}" ${{ inputs.fallback-zones }}; do
+        for zone in "${{ inputs.zone }}" ${fallback_zones}; do
           if (( SECONDS >= budget_deadline )); then
             echo "::warning::Ran out of time to create cluster ${{ inputs.cluster-name }}"
             break
@@ -128,6 +135,13 @@ runs:
             continue
           fi
 
+          # GKE stages version rollouts per zone, and the matrix only checks
+          # the zone it asks for, so a fallback zone may not offer the version.
+          if echo "${create_out}" | grep -qiE 'No valid versions|version is unsupported'; then
+            echo "::warning::Zone ${zone} does not offer GKE version ${{ inputs.cluster-version }}; trying the next zone"
+            continue
+          fi
+
           if ! echo "${create_out}" | grep -qiE 'does not have enough resources|ZONE_RESOURCE_POOL_EXHAUSTED|STOCKOUT'; then
             echo "::error::Cluster creation in zone ${zone} failed for a non-capacity reason; not retrying in other zones"
             exit ${create_rc}
@@ -140,7 +154,7 @@ runs:
         done
 
         if [[ -z "${created_zone}" ]]; then
-          echo "::error::All requested zones (${{ inputs.zone }} ${{ inputs.fallback-zones }}) are out of capacity for cluster ${{ inputs.cluster-name }}"
+          echo "::error::Could not create cluster ${{ inputs.cluster-name }} in any of the zones ${{ inputs.zone }} ${fallback_zones}"
           exit 1
         fi
 

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -74,11 +74,27 @@ runs:
         # long provisioning wait. Only capacity errors trigger a fallback: any
         # other failure (bad flag, quota, config) is not zone-specific, so we
         # fail fast and surface the real error rather than retrying blindly.
+        # An attempt that is still not done after this long is not worth waiting
+        # for: the median creation takes under 5 minutes, while capacity
+        # starvation can sit in the GCE instance group manager for 35 minutes
+        # before it is reported as one. gcloud cannot cancel the operation it
+        # submitted, so an abandoned attempt keeps provisioning server side and
+        # is left to the teardown step of the caller.
+        attempt_minutes=12
+        # Bound all the attempts together as well, so that a job cannot spend
+        # its whole budget on getting a cluster.
+        budget_deadline=$(( SECONDS + 30 * 60 ))
+
         created_zone=""
         for zone in "${{ inputs.zone }}" ${{ inputs.fallback-zones }}; do
+          if (( SECONDS >= budget_deadline )); then
+            echo "::warning::Ran out of time to create cluster ${{ inputs.cluster-name }}"
+            break
+          fi
+
           echo "Attempting to create cluster in zone ${zone}"
           set +e
-          create_out=$(gcloud container clusters create "${{ inputs.cluster-name }}" \
+          create_out=$(timeout --kill-after=1m "${attempt_minutes}m" gcloud container clusters create "${{ inputs.cluster-name }}" \
             --zone "${zone}" \
             --enable-ip-alias \
             --create-subnetwork="range=/26" \
@@ -102,6 +118,14 @@ runs:
           if [[ ${create_rc} -eq 0 ]]; then
             created_zone="${zone}"
             break
+          fi
+
+          # 124 and 137 are timeout(1) giving up on gcloud. Do not delete the
+          # cluster here: GKE refuses a delete while the creation operation is
+          # still running, and that operation cannot be cancelled.
+          if [[ ${create_rc} -eq 124 || ${create_rc} -eq 137 ]]; then
+            echo "::warning::Cluster creation in zone ${zone} is still not done after ${attempt_minutes}m; abandoning that zone"
+            continue
           fi
 
           if ! echo "${create_out}" | grep -qiE 'does not have enough resources|ZONE_RESOURCE_POOL_EXHAUSTED|STOCKOUT'; then

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -414,11 +414,11 @@ jobs:
         uses: ./.github/actions/gke-create-esp-rule
         with:
           cluster_name: ${{ env.clusterName }}-${{ matrix.config.index }}
-          cluster_zone: ${{ matrix.k8s.zone }}
+          cluster_zone: ${{ steps.create-cluster.outputs.zone }}
 
       - name: Get cluster credentials
         run: |
-          gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
+          gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ steps.create-cluster.outputs.zone }}
 
       - name: Generate cilium-cli kubeconfig
         id: gen-kubeconfig
@@ -490,7 +490,7 @@ jobs:
       - name: Determine the CIDR of fake external targets
         id: external_cidr
         run: |
-          ZONE=${{ matrix.k8s.zone }}
+          ZONE=${{ steps.create-cluster.outputs.zone }}
           REGION=${ZONE%-?}
           SUBNET=$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.config.index }} --zone "$ZONE" --format 'value(subnetwork)')
           CIDR=$(gcloud compute networks subnets describe "$SUBNET" --region "$REGION" --format 'value(ipCidrRange)')
@@ -550,15 +550,18 @@ jobs:
         uses: ./../cilium-base-branch/.github/actions/gke-clean-esp-rule
         with:
           cluster_name: ${{ env.clusterName }}-${{ matrix.config.index }}
-          cluster_zone: ${{ matrix.k8s.zone }}
+          cluster_zone: ${{ steps.create-cluster.outputs.zone || matrix.k8s.zone }}
 
       - name: Clean up GKE
         if: ${{ always() }}
+        env:
+          CLUSTER: ${{ env.clusterName }}-${{ matrix.config.index }}
+          ZONE: ${{ steps.create-cluster.outputs.zone || matrix.k8s.zone }}
         run: |
-          while [ "$(gcloud container operations list --zone ${{ matrix.k8s.zone }} --filter="status=RUNNING AND targetLink~${{ env.clusterName }}-${{ matrix.config.index }}" --format="value(name)")" ];do
+          while [ "$(gcloud container operations list --zone ${ZONE} --filter="status=RUNNING AND targetLink~${CLUSTER}" --format="value(name)")" ];do
             echo "cluster has an ongoing operation, waiting for all operations to finish"; sleep 15
           done
-          gcloud container clusters delete ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }} --quiet --async
+          gcloud container clusters delete ${CLUSTER} --zone ${ZONE} --quiet --async
         shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
   merge-upload-and-status:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -291,7 +291,8 @@ jobs:
     needs: [generate-matrix, wait-for-images]
     if: ${{ needs.generate-matrix.outputs.empty == 'false' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 75
+    # Enough headroom for the cluster creation to fall back to another zone.
+    timeout-minutes: 90
     env:
       job_name: "Installation and Connectivity Test"
     strategy:
@@ -398,12 +399,30 @@ jobs:
         run: |
           gcloud info
 
+      - name: Determine fallback zones
+        id: fallback-zones
+        env:
+          ZONE: ${{ matrix.k8s.zone }}
+        run: |
+          # The other zones of the same region, so that a zone which is out of
+          # capacity does not fail the whole job. Same region only, because
+          # cluster names encode just the config index, so legs of different
+          # k8s versions share a name and must not meet in one zone, and each
+          # version is pinned to its own region.
+          region="${ZONE%-?}"
+          zones=$(gcloud compute zones list --filter="status=UP" --format='value(name)' \
+            | grep "^${region}-" | grep -v "^${ZONE}$" | tr '\n' ' ')
+          echo "Fallback zones for ${ZONE}: ${zones}"
+          echo "zones=${zones}" >> $GITHUB_OUTPUT
+          echo "candidates=${ZONE} ${zones}" >> $GITHUB_OUTPUT
+
       - name: Create GKE cluster
         id: create-cluster
         uses: ./.github/actions/setup-gke-cluster
         with:
           cluster-name: ${{ env.clusterName }}-${{ matrix.config.index }}
           zone: ${{ matrix.k8s.zone }}
+          fallback-zones: ${{ steps.fallback-zones.outputs.zones }}
           cluster-version: ${{ matrix.k8s.version }}
           nodes: ${{ matrix.config.nodes || 2 }}
           machine-type: e2-custom-2-4096

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -575,12 +575,23 @@ jobs:
         if: ${{ always() }}
         env:
           CLUSTER: ${{ env.clusterName }}-${{ matrix.config.index }}
-          ZONE: ${{ steps.create-cluster.outputs.zone || matrix.k8s.zone }}
+          # Every zone the cluster could have been created in, not just the one
+          # it ended up in: a creation attempt that was abandoned because it was
+          # too slow keeps provisioning on the GKE side. The cluster name is
+          # unique to this leg, so deleting it by name in each candidate zone
+          # cannot touch another leg's cluster.
+          ZONES: ${{ steps.fallback-zones.outputs.candidates || matrix.k8s.zone }}
         run: |
-          while [ "$(gcloud container operations list --zone ${ZONE} --filter="status=RUNNING AND targetLink~${CLUSTER}" --format="value(name)")" ];do
-            echo "cluster has an ongoing operation, waiting for all operations to finish"; sleep 15
+          for zone in ${ZONES}; do
+            while [ "$(gcloud container operations list --zone "${zone}" --filter="status=RUNNING AND targetLink~${CLUSTER}" --format="value(name)")" ];do
+              echo "cluster has an ongoing operation in ${zone}, waiting for all operations to finish"; sleep 15
+            done
+            gcloud container clusters describe "${CLUSTER}" --zone "${zone}" --format 'value(name)' > /dev/null 2>&1 || continue
+            for i in 1 2 3; do
+              gcloud container clusters delete "${CLUSTER}" --zone "${zone}" --quiet --async && break
+              echo "delete of ${CLUSTER} in ${zone} failed (attempt ${i}/3), retrying in 15s"; sleep 15
+            done
           done
-          gcloud container clusters delete ${CLUSTER} --zone ${ZONE} --quiet --async
         shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
   merge-upload-and-status:

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -345,12 +345,22 @@ jobs:
       - name: Clean up GKE
         if: ${{ always() }}
         env:
-          cluster_zone: ${{ steps.create-cluster.outputs.zone || env.gcp_zone }}
+          CLUSTER: ${{ env.clusterName }}-${{ matrix.index }}
+          # Every zone the cluster could have been created in, not just the one
+          # it ended up in: a creation attempt that was abandoned because it was
+          # too slow keeps provisioning on the GKE side.
+          ZONES: ${{ env.gcp_zone }} ${{ env.gcp_fallback_zones }}
         run: |
-          while [ "$(gcloud container operations list --zone ${cluster_zone} --filter="status=RUNNING AND targetLink~${{ env.clusterName }}-${{ matrix.index }}" --format="value(name)")" ];do
-            echo "cluster has an ongoing operation, waiting for all operations to finish"; sleep 15
+          for zone in ${ZONES}; do
+            while [ "$(gcloud container operations list --zone "${zone}" --filter="status=RUNNING AND targetLink~${CLUSTER}" --format="value(name)")" ];do
+              echo "cluster has an ongoing operation in ${zone}, waiting for all operations to finish"; sleep 15
+            done
+            gcloud container clusters describe "${CLUSTER}" --zone "${zone}" --format 'value(name)' > /dev/null 2>&1 || continue
+            for i in 1 2 3; do
+              gcloud container clusters delete "${CLUSTER}" --zone "${zone}" --quiet --async && break
+              echo "delete of ${CLUSTER} in ${zone} failed (attempt ${i}/3), retrying in 15s"; sleep 15
+            done
           done
-          gcloud container clusters delete ${{ env.clusterName }}-${{ matrix.index }} --zone ${cluster_zone} --quiet --async
         shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
       # We needed to configure a unique suffix to ensure that the artifacts can


### PR DESCRIPTION
GKE cluster creation is the first failing step of about 9% of the red GKE legs. A census of the 18659 creations of the last 45 days shows 64 of them lost to a GCE stockout, all in the conformance workflows and none in net-perf, every log ending in "All requested zones (us-east4-b ) are out of capacity": conformance-gke never passed fallback-zones, so the loop added in #46969 had a single candidate to try. Capacity failures grew elevenfold over the last seven weeks, and one stockout reddens a whole run, so 4.45% of the GKE runs in the window had a leg fail during cluster setup.

Seen in https://github.com/cilium/cilium/actions/runs/32098516300

There is no way to avoid a bad zone up front. GCE exposes no API that reports whether a zone can serve N machines of a given type, quota being the only thing that is queryable, and the beta Capacity Advisor reported an obtainability of 0.9 for us-east4-b on the day it stocked out. So this reacts instead: conformance-gke hands the action the other zones of its own region, discovered rather than listed, and consumes the zone the cluster was actually created in everywhere it used to assume the zone it asked for.

Capacity exhaustion does not always fail fast, which is why the wall clock is bounded as well. 13 creations sat in the GCE instance group manager for its full 35 minute timeout, and net-perf legs, which do have fallback zones, cycled three of them for 95 to 119 minutes until the job timeout killed them, so arming a fallback without a bound makes that class slower rather than faster. An attempt now gets 12 minutes and all attempts together 30, against a median creation of 4.5 minutes and a 99th percentile of 7.3, so almost nothing that would have succeeded is aborted. gcloud cannot cancel the operation it submitted and GKE refuses a delete while that operation runs, so an abandoned attempt keeps provisioning and teardown deletes by name in every candidate zone.

This PR was prepared with AIL:3.