### PR TITLE
gateway-api: remove duplicate gateway reconcile error logs

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -49,8 +49,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if k8serrors.IsNotFound(err) {
 			return controllerruntime.Success()
 		}
-		scopedLog.ErrorContext(ctx, "Unable to get Service for GAMMA checks", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to get Service for GAMMA checks: %w", err))
 	}
 
 	// Ignore deleting Service, this can happen when foregroundDeletion is enabled
@@ -70,8 +69,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err := r.Client.List(ctx, httpRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.GammaHTTPRouteParentRefsIndex, client.ObjectKeyFromObject(svc).String()),
 	}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list HTTPRoutes", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to list HTTPRoutes: %w", err))
 	}
 
 	if len(httpRouteList.Items) != 0 {
@@ -83,8 +81,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err := r.Client.List(ctx, grpcRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.GammaGRPCRouteParentRefsIndex, client.ObjectKeyFromObject(svc).String()),
 	}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list GRPCRoutes", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to list GRPCRoutes: %w", err))
 	}
 
 	if len(grpcRouteList.Items) != 0 {
@@ -101,26 +98,22 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
 	servicesList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, servicesList); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list Services", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to list Services: %w", err))
 	}
 
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list ReferenceGrants", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to list ReferenceGrants: %w", err))
 	}
 
 	// Run the HTTPRoute route checks here and update the status accordingly.
 	if err := r.setHTTPRouteStatuses(scopedLog, ctx, originalSvc, httpRouteList, grants); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to update HTTPRoute Status", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to update HTTPRoute status: %w", err))
 	}
 
 	// Run the GRPCRoute route checks here and update the status accordingly.
 	if err := r.setGRPCRouteStatuses(scopedLog, ctx, originalSvc, grpcRouteList, grants); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to update GRPCRoute Status", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to update GRPCRoute status: %w", err))
 	}
 
 	httpRoutes := r.filterHTTPRoutesByService(originalSvc, httpRouteList.Items)
@@ -139,21 +132,18 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	cec, _, ceps, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to translate resources: %w", err), originalSvc, svc)
 	}
 
 	if err = r.ensureEnvoyConfig(ctx, cec); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure CiliumEnvoyConfig", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to ensure CiliumEnvoyConfig: %w", err), originalSvc, svc)
 	}
 
 	// GAMMA only ever produces a single dummy EndpointSlice; unwrap from the
 	// shared Translator interface that returns a list to support gateway-api L4.
 	if len(ceps) > 0 {
 		if err = r.ensureEndpointSlice(ctx, ceps[0]); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
-			return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+			return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to ensure Endpoints: %w", err), originalSvc, svc)
 		}
 	}
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -46,8 +46,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if k8serrors.IsNotFound(err) {
 			return controllerruntime.Success()
 		}
-		scopedLog.ErrorContext(ctx, "Unable to get Gateway", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to get Gateway: %w", err))
 	}
 
 	// Ignore deleting Gateway, this can happen when foregroundDeletion is enabled
@@ -67,8 +66,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				gatewayClass, gw.Spec.GatewayClassName)
 
 			if err := r.cleanupOwnedResources(ctx, gw); err != nil {
-				scopedLog.ErrorContext(ctx, "Unable to cleanup managed Gateway resources", logfields.Error, err)
-				return controllerruntime.Fail(err)
+				return controllerruntime.Fail(fmt.Errorf("failed to cleanup managed Gateway resources: %w", err))
 			}
 
 			return controllerruntime.Success()
@@ -85,8 +83,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			gatewayClass, gw.Spec.GatewayClassName,
 			logfields.Controller, gwc.Spec.ControllerName)
 		if err := r.cleanupOwnedResources(ctx, gw); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to cleanup managed Gateway resources", logfields.Error, err)
-			return controllerruntime.Fail(err)
+			return controllerruntime.Fail(fmt.Errorf("failed to cleanup managed Gateway resources: %w", err))
 		}
 		return controllerruntime.Success()
 	}
@@ -118,8 +115,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	inputs, err := r.inputLoader.Load(ctx, scopedLog, gw, gwc)
 	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to load translation inputs", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to load translation inputs: %w", err))
 	}
 
 	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.Annotations[annotation.LBIPAMIPKeyAlias] != "" {
@@ -136,8 +132,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		UDPRoutes:       inputs.UDPRoutes,
 		ReferenceGrants: inputs.ReferenceGrants,
 	}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to update route status", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to update route status: %w", err))
 	}
 
 	// Attached*Routes() relies on route status parents populated by the status
@@ -152,8 +147,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		inputs.AttachedHTTPRoutes(gw),
 	)
 	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
-		return controllerruntime.Fail(err)
+		return controllerruntime.Fail(fmt.Errorf("failed to update BackendTLSPolicy status: %w", err))
 	}
 
 	listenerStatusResult, err := r.listenerStatusManager.SetListenerStatuses(ctx, gw, ListenerStatusInputs{
@@ -169,19 +163,16 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ReferenceGrants:        inputs.ReferenceGrants,
 	})
 	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to set listener status", gatewayv1.GatewayReasonListenersNotValid)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to set listener status: %w", err), original, gw)
 	}
 
 	switch listenerStatusResult.GatewayStatus {
 	case ListenersStatusNoneValid:
-		err := fmt.Errorf("No Accepted Listeners for Gateway")
-		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
 		setGatewayAccepted(gw, false, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("no Accepted Listeners for Gateway"), original, gw)
 	case ListenersStatusValidWithUnsupportedProtocol:
 		setGatewayAccepted(gw, true, "Gateway has unsupported listeners", gatewayv1.GatewayReasonListenersNotValid)
 	case ListenersStatusSomeInvalid, ListenersStatusAllValid:
@@ -208,40 +199,36 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Step 4: Translate the listeners into Cilium model
 	cec, svc, eps, err := r.translator.Translate(m)
 	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to translate resources", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to translate resources", gatewayv1.GatewayReasonListenersNotValid)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to translate resources: %w", err), original, gw)
 	}
 
 	if err = r.ensureService(ctx, svc); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to create Service", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to create Service resource: %w", err), original, gw)
 	}
 
 	if err = r.reconcileEndpointSlices(ctx, gw, svc, eps); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to reconcile EndpointSlices", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to reconcile EndpointSlices: %w", err), original, gw)
 	}
 
 	if err = r.ensureEnvoyConfig(ctx, gw, cec); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure CiliumEnvoyConfig", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to ensure CEC resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create CEC resource", gatewayv1.GatewayReasonNoResources)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to ensure CEC resource: %w", err), original, gw)
 	}
 
 	// Step 5: Update the status of the Gateway
 	if err = r.gatewayAddressStatusManager.SetAddressStatus(ctx, gw); err != nil {
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to set address status: %w", err), original, gw)
 	}
 
 	if err = r.gatewayAddressStatusManager.SetStaticAddressStatus(ctx, gw); err != nil {
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to set static address status: %w", err), original, gw)
 	}
 
 	if err := r.updateStatus(ctx, original, gw); err != nil {


### PR DESCRIPTION
Stop logging reconcile errors directly in the Gateway reconciler when
the error is returned to controller-runtime, which already logs failed
reconciliations. Wrap returned errors with step-specific context so the
single emitted log still identifies the failing operation.