### PR TITLE
gateway-api: remove Gateway LBIPAM annotation warning

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -23,7 +23,6 @@ import (
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
-	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/shortener"
@@ -120,12 +119,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to load translation inputs", logfields.Error, err)
 		return controllerruntime.Fail(err)
-	}
-
-	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.Annotations[annotation.LBIPAMIPKeyAlias] != "" {
-		scopedLog.WarnContext(ctx, fmt.Sprintf("DEPRECATED: The Gateway <%s/%s> is setting an IP address using the infrastructure annotations <%s>."+
-			" These should be set using the spec.addresses field in Gateway objects instead."+
-			" At a future date this annotation will be removed if no spec.addresses are set.", gw.GetNamespace(), gw.GetName(), annotation.LBIPAMIPKeyAlias))
 	}
 
 	if err := r.routeStatusManager.SetRouteStatuses(ctx, scopedLog, RouteStatusInputs{


### PR DESCRIPTION
Remove the Gateway reconciliation warning for the LB IPAM IP annotation alias.

The warning only covered a single annotation alias and could not reliably detect other infrastructure annotations that may overlap with base Gateway API functionality exposed by the CRD. It also logged from the Cilium operator, which surfaces the message to the operator rather than the Gateway user who would need to act on it.

IMO there's also not much sense of removing the annotation from the list for similar reasons (as it was intended in the PR that introduced this warning log). We should simply treat this as user config issue.