### PR TITLE
renovate: let gomod major upgrades ignore the vendor directory

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,6 +123,15 @@
     "^go mod tidy$",
     "^go mod vendor$"
   ],
+  // The gomod manager runs 'mod upgrade' (the gomodUpdateImportPaths step)
+  // before 'go mod vendor', so its 'go list' honours the default -mod=vendor
+  // and trips over the not-yet-synced vendor/modules.txt. '-mod=mod' makes it
+  // ignore the vendor directory. '-modcacherw' has to be repeated because this
+  // replaces the value the manager sets itself.
+  // See https://github.com/renovatebot/renovate/issues/21010
+  "customEnvVariables": {
+    "GOFLAGS": "-modcacherw -mod=mod"
+  },
   "assignAutomerge": true,
   "packageRules": [
     {
@@ -286,15 +295,12 @@
         "go.mod",
         "go.sum"
       ],
-      // Separate major upgrades from minor/patch. Renovate does not support
-      // major upgrades of vendored Go modules: the 'gomodUpdateImportPaths'
-      // 'mod upgrade' step runs before 'go mod vendor' re-syncs
-      // vendor/modules.txt and fails with "inconsistent vendoring", which
-      // aborts the whole grouped artifact update and blocks every minor/patch
-      // update sharing the branch. Separating majors keeps this group flowing.
-      // With this set, a dependency that has both a minor and a major available
-      // still gets its minor update here (and its major in the group below).
-      // See https://github.com/renovatebot/renovate/issues/21010
+      // Separate major upgrades from minor/patch. A major upgrade rewrites
+      // import paths across the tree and can still need manual work when the
+      // new major breaks API, so it must not be able to hold up the minor/patch
+      // updates sharing a branch. With this set, a dependency that has both a
+      // minor and a major available still gets its minor update here (and its
+      // major in the group below).
       "separateMajorMinor": true,
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -312,10 +318,8 @@
       ]
     },
     {
-      // Go module major upgrades, isolated into their own PR. These are expected
-      // to fail the automated artifact update for vendored modules (see the
-      // comment on the group above) and require manual intervention by
-      // maintainers, so they must not share a branch with the minor/patch group.
+      // Go module major upgrades, isolated into their own PR so that a major
+      // needing manual work does not sit on the minor/patch group's branch.
       "groupName": "all go dependencies main (major)",
       "groupSlug": "all-go-deps-major-main",
       "matchFileNames": [


### PR DESCRIPTION
Renovate already knows how to follow a Go major bump into the source. A major
changes the module path, so every import line has to change with it, and that
is what the gomodUpdateImportPaths option does. However, it never gets the
chance in this repository: major upgrade PRs arrive with a single go.mod line
changed and nothing else, no go.sum, no vendor/, no import rewrite, plus an
"Artifact update problem" comment.

The reason is the order of the steps. The import rewrite runs before go mod
vendor, so by then go.mod already asks for the new major while
vendor/modules.txt still lists the old one. In a vendored tree Go refuses to
resolve anything until those two agree, the rewrite dies on "inconsistent
vendoring", and Renovate discards the whole artifact update, import edits
included.

-mod=mod is what unblocks it. It tells Go to resolve from the module cache
instead of vendor/, so the mismatch is never looked at and the rewrite runs.
Skipping vendor/ there costs us nothing, because go mod vendor comes later in
the same sequence and re-syncs it against the rewritten imports.

It has to arrive through customEnvVariables because the step order is
hardcoded in Renovate and the manager exports GOFLAGS itself.
customEnvVariables is applied last, so it wins, and -modcacherw is carried
over because the override replaces the manager's value instead of merging with
it.

Only majors are affected. The rewrite step runs for nothing else, and it is
the one command in the sequence that resolves imports with vendor consistency
enforced: go get ignores vendor/, and go mod tidy and go mod vendor do not
check it.

This commit was prepared with AIL:3.
