### PR TITLE
test: fix the never-taken retry on a partially read JSON line

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -361,8 +361,9 @@ func (res *CmdRes) WaitUntilMatchFilterLineTimeout(filter, expected string, time
 	body := func() bool {
 		lines, err := res.FilterLinesJSONPath(parsedFilter)
 		if err != nil {
-			if errors.Is(err, &JSONParseError{}) {
-				// We might have read a partial line; continue
+			// The command is still writing, so the last line of its output
+			// may be a partial read; try again.
+			if _, ok := errors.AsType[*JSONParseError](err); ok {
 				return false
 			}
 			errChan <- err


### PR DESCRIPTION
K8sAgentHubbleTest Hubble Observe "Test L3/L4 Flow" fails every so often
with a JSON parse error instead of matching the flow it waits for. The
stdout of the backgrounded `hubble observe --follow` is filled by an
io.Copy from a pipe, so a poll can land while only part of the last flow
has arrived, and FilterLinesJSONPath rejects that half written line:

https://github.com/cilium/cilium/actions/runs/32710469363/job/97381100329
https://github.com/cilium/cilium/actions/runs/32586593942/job/97064041572

02406f2c70 added a retry for exactly that, but its guard has never been
taken: JSONParseError embeds the error interface, so its method set is
Error() alone, with no Is and no Unwrap, and errors.Is ends up comparing
two different pointers. Repair the guard with errors.As rather than
teach the filter to tolerate a line it cannot parse, so the nine
remaining polls of the 10s timeout get their chance while the filter
keeps reporting a precise error for output that is really malformed.

Related: #38463

This commit was prepared with AIL:3.
