### PR TITLE
gateway-api: make gateway-api reconciler client and scheme fields private

### DIFF
--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -22,8 +22,8 @@ import (
 
 // gammaReconciler reconciles a Gateway object
 type gammaReconciler struct {
-	client.Client
-	Scheme     *runtime.Scheme
+	client     client.Client
+	scheme     *runtime.Scheme
 	translator translation.Translator
 
 	logger         *slog.Logger
@@ -32,8 +32,8 @@ type gammaReconciler struct {
 
 func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string) *gammaReconciler {
 	return &gammaReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
 		translator: translator,
 		logger: logger.With(
 			logfields.Controller, gamma,
@@ -62,11 +62,11 @@ func (r *gammaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch its own resource
 		For(&corev1.Service{}).
 		// Watch HTTPRoute linked to Service
-		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForGAMMAHTTPRoute(r.Client, r.logger)).
+		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForGAMMAHTTPRoute(r.client, r.logger)).
 		// Watch GRPCRoute linked to Service
-		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForGAMMAGRPCRoute(r.Client, r.logger)).
+		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForGAMMAGRPCRoute(r.client, r.logger)).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForGAMMAReferenceGrant(r.Client, r.logger)).
+		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForGAMMAReferenceGrant(r.client, r.logger)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{})
 

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -45,7 +45,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Step 1: Retrieve the Service
 	originalSvc := &corev1.Service{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, originalSvc, &client.GetOptions{}); err != nil {
+	if err := r.client.Get(ctx, req.NamespacedName, originalSvc, &client.GetOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return controllerruntime.Success()
 		}
@@ -66,7 +66,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Step 2: Gather all required information for the ingestion model
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}
-	if err := r.Client.List(ctx, httpRouteList, &client.ListOptions{
+	if err := r.client.List(ctx, httpRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.GammaHTTPRouteParentRefsIndex, client.ObjectKeyFromObject(svc).String()),
 	}); err != nil {
 		return controllerruntime.Fail(fmt.Errorf("failed to list HTTPRoutes: %w", err))
@@ -78,7 +78,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	grpcRouteList := &gatewayv1.GRPCRouteList{}
-	if err := r.Client.List(ctx, grpcRouteList, &client.ListOptions{
+	if err := r.client.List(ctx, grpcRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.GammaGRPCRouteParentRefsIndex, client.ObjectKeyFromObject(svc).String()),
 	}); err != nil {
 		return controllerruntime.Fail(fmt.Errorf("failed to list GRPCRoutes: %w", err))
@@ -97,12 +97,12 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
 	servicesList := &corev1.ServiceList{}
-	if err := r.Client.List(ctx, servicesList); err != nil {
+	if err := r.client.List(ctx, servicesList); err != nil {
 		return controllerruntime.Fail(fmt.Errorf("failed to list Services: %w", err))
 	}
 
 	grants := &gatewayv1.ReferenceGrantList{}
-	if err := r.Client.List(ctx, grants); err != nil {
+	if err := r.client.List(ctx, grants); err != nil {
 		return controllerruntime.Fail(fmt.Errorf("failed to list ReferenceGrants: %w", err))
 	}
 
@@ -171,7 +171,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 		i := &routechecks.HTTPRouteInput{
 			Ctx:            ctx,
 			Logger:         gammaLogger.With(httpRoute, hrName),
-			Client:         r.Client,
+			Client:         r.client,
 			Grants:         grants.Items,
 			HTTPRoute:      hr,
 			ControllerName: r.controllerName,
@@ -281,7 +281,7 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 		i := &routechecks.GRPCRouteInput{
 			Ctx:            ctx,
 			Logger:         gammaLogger.With(grpcRoute, grpcName),
-			Client:         r.Client,
+			Client:         r.client,
 			Grants:         grants.Items,
 			GRPCRoute:      grpc,
 			ControllerName: r.controllerName,
@@ -359,7 +359,7 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 
 func (r *gammaReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
 	ep := desired.DeepCopy()
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, ep, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.client, ep, func() error {
 		ep.Endpoints = desired.Endpoints
 		ep.Ports = desired.Ports
 		ep.OwnerReferences = desired.OwnerReferences
@@ -371,7 +371,7 @@ func (r *gammaReconciler) ensureEndpointSlice(ctx context.Context, desired *disc
 
 func (r *gammaReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {
 	cec := desired.DeepCopy()
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.client, cec, func() error {
 		cec.Spec = desired.Spec
 		cec.OwnerReferences = desired.OwnerReferences
 		setMergedLabelsAndAnnotations(cec, desired)
@@ -387,7 +387,7 @@ func (r *gammaReconciler) updateStatus(ctx context.Context, original *corev1.Ser
 	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
 		return nil
 	}
-	return r.Client.Status().Update(ctx, new)
+	return r.client.Status().Update(ctx, new)
 }
 
 func (r *gammaReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *corev1.Service, modified *corev1.Service) (ctrl.Result, error) {
@@ -406,7 +406,7 @@ func (r *gammaReconciler) updateHTTPRouteStatus(ctx context.Context, original *g
 		return nil
 	}
 	r.logger.DebugContext(ctx, "Updating HTTPRoute status", httpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
-	return r.Client.Status().Update(ctx, new)
+	return r.client.Status().Update(ctx, new)
 }
 
 func (r *gammaReconciler) handleHTTPRouteReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.HTTPRoute, modified *gatewayv1.HTTPRoute) error {
@@ -424,7 +424,7 @@ func (r *gammaReconciler) updateGRPCRouteStatus(ctx context.Context, original *g
 		return nil
 	}
 	r.logger.DebugContext(ctx, "Updating GRPCRoute status", grpcRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
-	return r.Client.Status().Update(ctx, new)
+	return r.client.Status().Update(ctx, new)
 }
 
 func (r *gammaReconciler) handleGRPCRouteReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.GRPCRoute, modified *gatewayv1.GRPCRoute) error {

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -108,7 +108,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 						Build()
 
 					r := &gammaReconciler{
-						Client:         c,
+						client:         c,
 						translator:     gatewayAPITranslator,
 						logger:         logger,
 						controllerName: defaultControllerName,
@@ -214,7 +214,7 @@ func Test_gammaReconciler_Reconcile_BackendRequestHeaderModifier(t *testing.T) {
 		Build()
 
 	r := &gammaReconciler{
-		Client:         c,
+		client:         c,
 		translator:     gatewayAPITranslator,
 		logger:         logger,
 		controllerName: defaultControllerName,
@@ -317,7 +317,7 @@ func Test_gammaReconciler_Reconcile_ReplacesOwnerReferencesForRecreatedRoute(t *
 		Build()
 
 	r := &gammaReconciler{
-		Client:         c,
+		client:         c,
 		translator:     gatewayAPITranslator,
 		logger:         logger,
 		controllerName: defaultControllerName,

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -37,8 +37,8 @@ const (
 
 // gatewayReconciler reconciles a Gateway object
 type gatewayReconciler struct {
-	client.Client
-	Scheme     *runtime.Scheme
+	client     client.Client
+	scheme     *runtime.Scheme
 	translator translation.Translator
 
 	inputLoader                   *loading.TranslationInputLoader
@@ -59,8 +59,8 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 	tcpUDPRouteSupport := !hostNetworkEnabled
 
 	return &gatewayReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
 		translator: translator,
 		inputLoader: loading.NewTranslationInputLoader(mgr.GetClient(), scopedLog, controllerName, loading.TranslationInputLoaderConfig{
 			IncludeTCPRoutes:      includeTCPRoutes,
@@ -101,7 +101,7 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Determine which optional CRDs are enabled. The scheme is registered from
 	// the autodetected CRDs, so Recognizes() reflects what is installed.
-	scheme := r.Client.Scheme()
+	scheme := r.client.Scheme()
 	tcpRouteEnabled := helpers.HasTCPRouteSupport(scheme)
 	udpRouteEnabled := helpers.HasUDPRouteSupport(scheme)
 	serviceImportEnabled := helpers.HasServiceImportSupport(scheme)
@@ -111,37 +111,37 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.client, r.controllerName, r.logger)
 	gatewayBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch its own resource
 		For(&gatewayv1.Gateway{},
 			builder.WithPredicates(predicates.GatewayOwnedByController(hasMatchingControllerFn))).
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
-			watchhandlers.EnqueueRequestForOwningGatewayClass(r.Client, *r.logger),
+			watchhandlers.EnqueueRequestForOwningGatewayClass(r.client, *r.logger),
 			builder.WithPredicates(predicates.GatewayClassOwnedByController(r.controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
-		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, r.Scheme, *r.logger, r.controllerName)).
+		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.client, r.scheme, *r.logger, r.controllerName)).
 		// Watch HTTPRoute linked to Gateway
-		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, r.controllerName)).
+		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.client, r.logger, r.controllerName)).
 		// Watch GRPCRoute linked to Gateway
-		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.Client, r.logger, r.controllerName)).
+		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.client, r.logger, r.controllerName)).
 		// Watch TLSRoute linked to Gateway
-		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, r.controllerName)).
+		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.client, r.logger, r.controllerName)).
 		// Watch related secrets used to configure TLS
 		Watches(&corev1.Secret{},
-			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.controllerName, r.logger)).
+			watchhandlers.EnqueueRequestForTLSSecret(r.client, r.controllerName, r.logger)).
 		// Watch related namespace in allowed namespaces
 		Watches(&corev1.Namespace{},
-			watchhandlers.EnqueueRequestForAllowedNamespace(r.Client, r.logger)).
+			watchhandlers.EnqueueRequestForAllowedNamespace(r.client, r.logger)).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForReferenceGrant(r.Client, r.logger)).
+		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForReferenceGrant(r.client, r.logger)).
 		// Watch for changes to BackendTLSPolicy
-		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger, r.controllerName)).
-		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger, r.controllerName)).
+		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.client, r.logger, r.controllerName)).
+		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.client, r.logger, r.controllerName)).
 		// Watch for changes to node in order to populate gateway ip addresses if svc of type NodePort
-		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.Client, r.logger, owningGatewayLabel, r.controllerName)).
+		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.client, r.logger, owningGatewayLabel, r.controllerName)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
@@ -149,22 +149,22 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if tcpRouteEnabled {
 		// Watch TCPRoute linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TCPRoute{}, watchhandlers.EnqueueRequestForOwningTCPRoute(r.Client, r.logger, r.controllerName))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TCPRoute{}, watchhandlers.EnqueueRequestForOwningTCPRoute(r.client, r.logger, r.controllerName))
 	}
 
 	if udpRouteEnabled {
 		// Watch UDPRoute linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.UDPRoute{}, watchhandlers.EnqueueRequestForOwningUDPRoute(r.Client, r.logger, r.controllerName))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.UDPRoute{}, watchhandlers.EnqueueRequestForOwningUDPRoute(r.client, r.logger, r.controllerName))
 	}
 
 	if listenerSetEnabled {
 		// Watch ListenerSet linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForListenerSetOwner(r.Client, r.logger, r.controllerName))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForListenerSetOwner(r.client, r.logger, r.controllerName))
 	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports
-		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.Client, *r.logger, r.controllerName))
+		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.client, *r.logger, r.controllerName))
 	}
 
 	return gatewayBuilder.Complete(r)

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -41,7 +41,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Step 1: Retrieve the Gateway
 	original := &gatewayv1.Gateway{}
-	if err := r.Client.Get(ctx, req.NamespacedName, original); err != nil {
+	if err := r.client.Get(ctx, req.NamespacedName, original); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return controllerruntime.Success()
 		}
@@ -59,7 +59,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Step 2: Gather all required information for the ingestion model
 	gwc := &gatewayv1.GatewayClass{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: string(gw.Spec.GatewayClassName)}, gwc); err != nil {
+	if err := r.client.Get(ctx, client.ObjectKey{Name: string(gw.Spec.GatewayClassName)}, gwc); err != nil {
 		if k8serrors.IsNotFound(err) {
 			scopedLog.InfoContext(ctx, "GatewayClass no longer exists, cleaning up previously managed resources",
 				gatewayClass, gw.Spec.GatewayClassName)
@@ -234,7 +234,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.Service) error {
 	svc := desired.DeepCopy()
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, svc, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.client, svc, func() error {
 		// Save and restore loadBalancerClass
 		// e.g. if a mutating webhook writes this field
 		lbClass := svc.Spec.LoadBalancerClass
@@ -259,7 +259,7 @@ func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *di
 			Namespace: desired.Namespace,
 		},
 	}
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, eps, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.client, eps, func() error {
 		if eps.ResourceVersion == "" {
 			eps.AddressType = desired.AddressType
 			eps.Endpoints = desired.Endpoints
@@ -300,7 +300,7 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, gw *gatewayv1
 		return r.ensureOwnedEnvoyConfigDeleted(ctx, gw)
 	}
 	cec := desired.DeepCopy()
-	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.client, cec, func() error {
 		cec.Spec = desired.Spec
 		setMergedLabelsAndAnnotations(cec, desired)
 		return nil
@@ -327,7 +327,7 @@ func (r *gatewayReconciler) reconcileEndpointSlices(ctx context.Context, gw *gat
 	}
 
 	existing := &discoveryv1.EndpointSliceList{}
-	if err := r.Client.List(
+	if err := r.client.List(
 		ctx, existing,
 		client.InNamespace(gw.Namespace),
 		client.MatchingLabels{
@@ -346,7 +346,7 @@ func (r *gatewayReconciler) reconcileEndpointSlices(ctx context.Context, gw *gat
 		if _, ok := desiredByName[eps.Name]; ok {
 			continue
 		}
-		if err := client.IgnoreNotFound(r.Client.Delete(ctx, &eps)); err != nil {
+		if err := client.IgnoreNotFound(r.client.Delete(ctx, &eps)); err != nil {
 			return fmt.Errorf("failed to delete stale EndpointSlice %s/%s: %w", eps.Namespace, eps.Name, err)
 		}
 	}
@@ -375,7 +375,7 @@ func (r *gatewayReconciler) filterEndpointSlicesByBackendFamilies(ctx context.Co
 		fams, cached := cache[key]
 		if !cached {
 			be := &corev1.Service{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, be); err != nil {
+			if err := r.client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, be); err != nil {
 				cache[key] = nil
 				out = append(out, s)
 				continue
@@ -427,14 +427,14 @@ func (r *gatewayReconciler) ensureOwnedServiceDeleted(ctx context.Context, gw *g
 		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
 	}
 
-	if err := r.Client.Get(ctx, key, svc); err != nil {
+	if err := r.client.Get(ctx, key, svc); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(svc, gw) {
 		return nil
 	}
 
-	return client.IgnoreNotFound(r.Client.Delete(ctx, svc))
+	return client.IgnoreNotFound(r.client.Delete(ctx, svc))
 }
 
 func (r *gatewayReconciler) ensureOwnedEndpointSlicesDeleted(ctx context.Context, gw *gatewayv1.Gateway) error {
@@ -445,7 +445,7 @@ func (r *gatewayReconciler) ensureOwnedEndpointSlicesDeleted(ctx context.Context
 		),
 	}
 
-	if err := r.Client.List(ctx, eps, client.InNamespace(gw.Namespace), matchingLabels); err != nil {
+	if err := r.client.List(ctx, eps, client.InNamespace(gw.Namespace), matchingLabels); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
@@ -453,7 +453,7 @@ func (r *gatewayReconciler) ensureOwnedEndpointSlicesDeleted(ctx context.Context
 		if !metav1.IsControlledBy(&ep, gw) {
 			continue
 		}
-		if err := client.IgnoreNotFound(r.Client.Delete(ctx, &ep)); err != nil {
+		if err := client.IgnoreNotFound(r.client.Delete(ctx, &ep)); err != nil {
 			return err
 		}
 	}
@@ -468,14 +468,14 @@ func (r *gatewayReconciler) ensureOwnedEnvoyConfigDeleted(ctx context.Context, g
 		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
 	}
 
-	if err := r.Client.Get(ctx, key, cec); err != nil {
+	if err := r.client.Get(ctx, key, cec); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(cec, gw) {
 		return nil
 	}
 
-	return client.IgnoreNotFound(r.Client.Delete(ctx, cec))
+	return client.IgnoreNotFound(r.client.Delete(ctx, cec))
 }
 
 func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv1.Gateway, new *gatewayv1.Gateway) error {
@@ -485,7 +485,7 @@ func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv
 	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
 		return nil
 	}
-	return r.Client.Status().Update(ctx, new)
+	return r.client.Status().Update(ctx, new)
 }
 func (r *gatewayReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.Gateway, modified *gatewayv1.Gateway) (ctrl.Result, error) {
 	if err := r.updateStatus(ctx, original, modified); err != nil {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -452,8 +452,8 @@ func Test_Conformance(t *testing.T) {
 			})
 
 			r := &gatewayReconciler{
-				Client:     c,
-				Scheme:     c.Scheme(),
+				client:     c,
+				scheme:     c.Scheme(),
 				translator: gatewayAPITranslator,
 				inputLoader: loading.NewTranslationInputLoader(c, logger, defaultControllerName, loading.TranslationInputLoaderConfig{
 					IncludeTCPRoutes:      !tt.disableTCPRoute,
@@ -827,8 +827,8 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 				Build()
 
 			r := &gatewayReconciler{
-				Client: c,
-				Scheme: c.Scheme(),
+				client: c,
+				scheme: c.Scheme(),
 				inputLoader: loading.NewTranslationInputLoader(c, hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)), defaultControllerName, loading.TranslationInputLoaderConfig{
 					IncludeTCPRoutes:      helpers.HasTCPRouteSupport(c.Scheme()),
 					IncludeUDPRoutes:      helpers.HasUDPRouteSupport(c.Scheme()),
@@ -904,7 +904,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 			WithObjects(gw, ownedCEC()).
 			Build()
 		r := &gatewayReconciler{
-			Client: c,
+			client: c,
 			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
 		}
 
@@ -923,7 +923,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 			WithObjects(gw, foreign).
 			Build()
 		r := &gatewayReconciler{
-			Client: c,
+			client: c,
 			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
 		}
 
@@ -938,7 +938,7 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 			WithObjects(gw).
 			Build()
 		r := &gatewayReconciler{
-			Client: c,
+			client: c,
 			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
 		}
 
@@ -1078,13 +1078,13 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 			}
 
 			r := &gatewayReconciler{
-				Client: func() client.WithWatch {
+				client: func() client.WithWatch {
 					return fake.NewClientBuilder().
 						WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 						Build()
 				}(),
 			}
-			r.listenerStatusManager = NewListenerStatusManager(r.Client, hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)), ListenerStatusManagerConfig{
+			r.listenerStatusManager = NewListenerStatusManager(r.client, hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)), ListenerStatusManagerConfig{
 				TCPUDPRouteSupport:      true,
 				TCPUDPUnsupportedReason: hostNetworkTCPUDPRouteUnsupportedReason,
 			})
@@ -1282,7 +1282,7 @@ func testReconciler(t *testing.T, obj ...client.Object) (*gatewayReconciler, cli
 		Build()
 
 	reconciler := &gatewayReconciler{
-		Client:                      fakeClient,
+		client:                      fakeClient,
 		logger:                      logger,
 		controllerName:              defaultControllerName,
 		tcpUDPRouteSupport:          true,


### PR DESCRIPTION
Stop embedding controller-runtime's client.Client in the gateway and GAMMA reconcilers. Store it as an explicit private field instead, and unexport the scheme field as well.

This keeps the reconciler surface narrower, makes dependencies more explicit, avoids promoting the full client interface through embedding, and removes embedding-related warnings. Update the gateway-api reconciler setup, reconcile paths, and in-package tests to use the new field names.