### PR TITLE
Add IPv6 to local-redirect-policy-with-node-dns connectivity test

### DIFF
--- a/.github/actions/e2e/lb.yaml
+++ b/.github/actions/e2e/lb.yaml
@@ -39,6 +39,9 @@
   ingress-controller: 'true'
   local-redirect-policy: 'true'
   node-local-dns: 'true'
+  # Make IPv6 the primary service address family by listing its CIDR first.
+  # This should give the kube-dns service an IPv6 ClusterIP.
+  service-subnet: 'fd00:10:96::/112,10.96.0.0/16'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.secretsBackend=k8s,tls.secretSync.enabled=true'
   # L7 testing: SNAT load balancer + Ingress controller + node local DNS requires DNS proxy
   test-l7: 'true'

--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -14,6 +14,10 @@ inputs:
   kind-config:
     required: false
     description: 'Optional Kind configuration'
+  service-subnet:
+    required: false
+    description: 'Optional service subnet passed to kind.sh'
+    default: ''
   port-forward:
     required: false
     description: 'Optional list of ports to forward'
@@ -78,6 +82,8 @@ runs:
         lvh: 'true'
 
     - name: Create K8s cluster
+      env:
+        KIND_SERVICE_SUBNET: ${{ inputs.service-subnet }}
       uses: cilium/little-vm-helper@5ae749011735fd77f30f38add52f1a53a5568671 # v0.0.30
       with:
         provision: 'false'
@@ -90,6 +96,7 @@ runs:
           # in order to include them into the enviroment of kind.sh called
           # below, they also need to be set inside the ssh session.
           export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+          export SERVICESUBNET=${KIND_SERVICE_SUBNET@Q}
 
           if [ "${{ inputs.kind-config }}" != "" ]; then
             kind create cluster --config ${{ inputs.kind-config }} --image ${{ inputs.kind-image }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -415,6 +415,7 @@ jobs:
           kernel: ${{ steps.kernel-version.outputs.full }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
+          service-subnet: ${{ matrix.service-subnet }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' && steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -297,11 +297,13 @@ func (s lrpWithNodeDNS) Run(ctx context.Context, t *check.Test) {
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
-			actionName := fmt.Sprintf("lrp-node-dns-http-to-%s-%d", externalEcho.NameWithoutNamespace(), i)
-			t.NewAction(s, actionName, &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+			t.ForEachIPFamily(func(ipFamily features.IPFamily) {
+				actionName := fmt.Sprintf("lrp-node-dns-http-to-%s-%s-%d", externalEcho.NameWithoutNamespace(), ipFamily, i)
+				t.NewAction(s, actionName, &client, externalEcho, ipFamily).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+				})
+				i++
 			})
-			i++
 		}
 	}
 }


### PR DESCRIPTION
Commit 1 expands the `local-redirect-policy-with-node-dns` connectivity test to cover both IPv4 and IPv6 address families.

Commit 2 expands e2e `lb-3` test to reverse service subnet ranges, so IPv6 is used for kube-dns ClusterIP.

Fixes: #38444

```release-note
CI: extend Cilium LocalRedirectPolicy NodeLocalDNS e2e test coverage to include IPv6.
```

AIL: 2