### PR TITLE
aws/ipam: Recalculate IP limits when falling back to single IPs

### DIFF
--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -612,6 +612,26 @@ func (n *Node) AllocateIPs(ctx context.Context, a *nodemanager.AllocationAction)
 				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 				logfields.Node, n.k8sObj.Name,
 			)
+			// If subnet is out of prefixes, re-calculate maximum allocatable IPs
+			limits, limitsAvailable := n.getLimits()
+			if !limitsAvailable {
+				return errors.New(errUnableToDetermineLimits)
+			}
+			n.mutex.RLock()
+			e, ok := n.enis[a.InterfaceID]
+			usePrimary := n.usePrimaryAddress()
+			n.mutex.RUnlock()
+			if !ok {
+				return fmt.Errorf("%s: %s", errENINotFound, a.InterfaceID)
+			}
+			maxAllocatableIPs := limits.IPv4
+			if !usePrimary {
+				// TODO: In v1.21 following #46987, e.Addresses always contains the primary IP and
+				// this accounting stops being necessary.
+				maxAllocatableIPs--
+			}
+			maxAllocatableIPs -= len(e.Addresses) - len(e.Prefixes)*(option.ENIPDBlockSizeIPv4-1)
+			a.IPv4.AvailableForAllocation = min(a.IPv4.AvailableForAllocation, maxAllocatableIPs)
 		}
 		assignedIPs, err := n.manager.ec2api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
 		if err != nil {
@@ -735,6 +755,7 @@ func (n *Node) findNextIndex(index int32) int32 {
 // usable for metrics accounting purposes.
 const (
 	errUnableToDetermineLimits   = "unable to determine limits"
+	errENINotFound               = "unable to find ENI"
 	unableToDetermineLimits      = "unableToDetermineLimits"
 	errUnableToGetSecurityGroups = "unable to get security groups"
 	unableToGetSecurityGroups    = "unableToGetSecurityGroups"
@@ -823,6 +844,8 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 				logfields.Node, n.k8sObj.Name,
 			)
+			// If subnet is out of prefixes, re-calculate maximum allocatable IPs
+			toAllocate = min(allocation.IPv4.MaxIPsToAllocate, limits.IPv4-1)
 			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, allocateIPv6)
 		}
 		if err != nil {
@@ -976,7 +999,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 		return nil, stats, fmt.Errorf("unable to retrieve ENIs")
 	}
 
-	stats.RemainingAvailableInterfaceCount += limits.Adapters - len(n.enis)
+	stats.RemainingAvailableInterfaceCount += limits.Adapters - enis
 	return available, stats, nil
 }
 


### PR DESCRIPTION
# What is this

This patches the AWS IPAM to avoid a deadlock when a subnet runs out of prefixes and prefix delegation is enabled. It does so by recalculating the max allocatable IPs per ENI without the x16 multiplier before performing the EC2 API call with single IPs instead of prefixes.

As an example, let's take an instance type whose ENIs allow for 20 IP/prefix attachments. Previously, if a subnet ran out of prefixes and a node suddenly has a lot of pods scheduled on it (30 for example) then it will see the attached ENI as having enough capacity for 30 IPs because it is in PD mode. The attachment call fails and falls back to single IPs but the number is not recalculated and 30 single IPs are requested on an ENI that only supports 20. Even worse, when the operator falls back to creating a new ENI, it will again try to use PD and fail and then try to create an ENI with 30 IPs and fail. This goes in a loop forever because no single IPs ever get attached to break the loop by automatically disabling PD on the node for future allocation.

# Next steps

I would like to make a more significant refactor by changing how the AWS IPAM reports the capacity of an ENI and ditching the current logic in `getEffectiveIPLimits` in favor of a calculation of "slot limit" instead of "IP limits" since the limit is related to an attachment which is either a /32 or a /28. This initial small patch is meant to be an easy additive fix which can be backported. The more significant factor can land later in 1.21 and not require a backport.

```release-note
aws/ipam: Fixed a bug where the operator would fail to allocate new IPs to nodes with prefix delegation enabled on subnets that ran out of prefixes.
```