### PR TITLE
endpoint: preserve concurrent policy updates for new endpoints

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -400,10 +400,9 @@ type Endpoint struct {
 	// skipped regeneration levels.
 	skippedRegenerationLevel regeneration.DatapathRegenerationLevel
 
-	// skippedPolicyRevision is the highest PolicyRevisionToWaitFor from a regeneration
-	// event that was skipped because the endpoint was already in StateWaitingToRegenerate.
-	// The queued regeneration is bumped to wait for this revision so it doesn't complete
-	// at an older one.
+	// skippedPolicyRevision is the highest PolicyRevisionToWaitFor deferred to an already
+	// queued or upcoming regeneration. The regeneration is bumped to wait for this revision
+	// so it doesn't complete at an older one.
 	skippedPolicyRevision uint64
 
 	// DatapathConfiguration is the endpoint's datapath configuration as

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -837,7 +837,20 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// Otherwise, bump the policy revision directly.
 	if !idsToRegen.Has(secID) {
 		if e.policyRevision == 0 {
-			// We are deferring to the upcoming regen since the endpoint is new.
+			// Unaffected identities are not normally recomputed at toRev. Schedule
+			// this one before making the upcoming regeneration wait for it.
+			if toRev > e.skippedPolicyRevision {
+				if _, err := e.policyFetcher.RecomputeIdentityPolicy(e.SecurityIdentity, toRev); err != nil {
+					e.getLogger().Warn(
+						"Failed to recompute policy for initializing endpoint",
+						logfields.Error, err,
+						logfields.PolicyRevision, toRev,
+					)
+					unlock()
+					return
+				}
+				e.skippedPolicyRevision = toRev
+			}
 			unlock()
 			return
 		}

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -283,6 +284,20 @@ func (f *supersedeFetcher) GetIdentityPolicyByIdentity(*identity.Identity) (comp
 	return res, 0, watch, true
 }
 
+type recomputeRecordingFetcher struct {
+	compute.PolicyRecomputer
+	identity *identity.Identity
+	revision uint64
+}
+
+func (f *recomputeRecordingFetcher) RecomputeIdentityPolicy(identity *identity.Identity, revision uint64) (<-chan struct{}, error) {
+	f.identity = identity
+	f.revision = revision
+	done := make(chan struct{})
+	close(done)
+	return done, nil
+}
+
 // waitForPolicyComputationResult must skip a superseded policy and wait for the
 // replacement instead of failing.
 func TestWaitSkipsSupersededPolicy(t *testing.T) {
@@ -415,5 +430,31 @@ func TestSkippedPolicyRevision(t *testing.T) {
 		ep.unconditionalLock()
 		defer ep.unlock()
 		require.Nil(t, ep.consumeDeferredRegenerationLocked())
+	})
+
+	t.Run("new unaffected endpoint buffers policy revision", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+		ep.SecurityIdentity = &identity.Identity{ID: 1234}
+		fetcher := &recomputeRecordingFetcher{}
+		ep.policyFetcher = fetcher
+		affected := set.NewSet[identity.NumericIdentity]()
+
+		ep.UpdatePolicy(&affected, rev1, rev2)
+
+		// An initializing endpoint must explicitly request recomputation because
+		// unaffected identities are not normally recomputed at the new revision.
+		require.Same(t, ep.SecurityIdentity, fetcher.identity)
+		require.Equal(t, uint64(rev2), fetcher.revision)
+
+		// The endpoint must not report the revision as realized before regeneration.
+		require.Zero(t, ep.policyRevision)
+		require.Equal(t, uint64(rev2), ep.skippedPolicyRevision)
+
+		// The queued regeneration must consume and clear the deferred target.
+		ctx := &datapathRegenerationContext{}
+		consume(ep, ctx)
+		require.Equal(t, uint64(rev2), ctx.policyRevisionToWaitFor)
+		require.Zero(t, ep.skippedPolicyRevision)
 	})
 }


### PR DESCRIPTION
A newly created endpoint is exposed to the endpoint manager before its first regeneration completes. This allows endpoint initialization to overlap with a policy import.

For identities unaffected by an import, UpdatePolicy normally advances the endpoint's realized revision without regenerating it. An initializing endpoint is handled differently because its policyRevision is still zero: UpdatePolicy returns without advancing it, assuming that the already queued initial regeneration will realize the latest revision.

That assumption is not always true. Policy computation for the endpoint may already have selected the previous repository revision before the import occurs. Since the import does not affect this endpoint's identity, the policy computer does not schedule another computation for it. The initial regeneration therefore completes with the previous revision, and the endpoint remains behind until another policy update or periodic regeneration occurs.

This was observed happening with a new endpoint in the CI IPsec connectivity job. Its identity policy was selected at revision N immediately before an unrelated policy advanced the repository to revision N+1. The initial and periodic regenerations both completed at revision N, causing the connectivity test's policy wait to time out.

When UpdatePolicy encounters an unaffected endpoint whose realized revision is still zero, explicitly schedule policy computation for its identity at the new revision. Preserve that revision in skippedPolicyRevision so that the queued initial regeneration waits for the computation before proceeding.

UpdatePolicy and endpoint regeneration are serialized by buildMutex. If regeneration has already started, UpdatePolicy waits for it and follows the normal nonzero-revision path. Otherwise, the queued regeneration consumes the deferred revision after UpdatePolicy releases the lock.

Add a unit test covering the initializing, unaffected endpoint case. The test verifies that policy computation is scheduled at the target revision, the revision is not reported as realized prematurely, and the queued regeneration consumes and clears the deferred target.

This PR was prepared with AIL:3; all changes were manually reviewed and the comments in the new test were revised for clarity.

Fixes: #44900