### PR TITLE
[v1.20] policy: Fix data race on the map state identity index

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -48,9 +48,21 @@ var (
 	errPolicyComputationNotFound      = errors.New("policy computation result not found in statedb")
 )
 
-// PreviousMapState returns an empty policy.MapState with preallocated map sizes from the current one.
-func (e *Endpoint) PreviousMapState() *policy.MapState {
-	return e.desiredPolicy.GetMapState()
+// PreviousMapStateSizes returns the map sizes of the endpoint's current desired policy map state,
+// used as capacity hints when computing a new policy.
+//
+// The endpoint lock must not be held, as it is taken here to synchronize with the incremental
+// updates ApplyPolicyMapChanges applies to the current map state.
+func (e *Endpoint) PreviousMapStateSizes() policy.MapStateSizes {
+	if err := e.rlockAlive(); err != nil {
+		return policy.MapStateSizes{}
+	}
+	defer e.runlock()
+
+	if e.desiredPolicy == nil {
+		return policy.MapStateSizes{}
+	}
+	return e.desiredPolicy.GetMapState().Sizes()
 }
 
 // GetIngressNamedPort returns one port for the given name.

--- a/pkg/endpoint/policy_race_test.go
+++ b/pkg/endpoint/policy_race_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+// TestPreviousMapStateSizesRace checks that PreviousMapStateSizes, which policy computation
+// calls with the endpoint unlocked, does not race with the incremental map changes
+// ApplyPolicyMapChanges applies to the endpoint's current desired policy. The named port in
+// the rule below makes the desired policy's map state maintain the identity index that both
+// sides touch. Run with -race.
+func TestPreviousMapStateSizesRace(t *testing.T) {
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	logger := hivetest.Logger(t)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(nil)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_race_test", t.Name(), repo, idManager)
+
+	addIdentity := func(labelKeys ...string) *identity.Identity {
+		lbls := labels.Labels{}
+		for _, labelKey := range labelKeys {
+			lbls[labelKey] = labels.NewLabel("k8s:"+labelKey, "", "")
+		}
+		id, _, err := fakeAllocator.AllocateIdentity(context.Background(), lbls, false, 0)
+		assert.NoError(t, err)
+		wg := &sync.WaitGroup{}
+		repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{
+			id.ID: id.LabelArray,
+		}, nil, wg)
+		wg.Wait()
+		return id
+	}
+
+	podID := addIdentity("pod")
+	idManager.Add(podID)
+
+	ep := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+		status:           NewEndpointStatus(),
+	}
+	ep.UpdateLogger(nil)
+
+	// Deny egress from the pod to all 'peer' identities. The named port makes the computed
+	// policy maintain the map state identity index.
+	egressDenyRule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("pod")),
+		EgressDeny: []api.EgressDenyRule{{
+			EgressCommonRule: api.EgressCommonRule{
+				ToEndpoints: []api.EndpointSelector{
+					api.NewESFromLabels(labels.ParseSelectLabel("peer")),
+				},
+			},
+			ToPorts: []api.PortDenyRule{{
+				Ports: []api.PortProtocol{
+					{Port: "80", Protocol: "TCP"},
+					{Port: "http-alt", Protocol: "TCP"},
+				},
+			}},
+		}},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "egressDenyRule", labels.LabelSourceAny),
+		},
+	}
+	_, rev := repo.MustAddList(api.Rules{egressDenyRule})
+	computePolicyForEPAndWait(t, &ep, polComputer, rev)
+
+	stats := new(regenerationStatistics)
+	datapathRegenCtxt := new(datapathRegenerationContext)
+	datapathRegenCtxt.policyRevisionToWaitFor = rev
+	require.NoError(t, ep.regeneratePolicy(stats, datapathRegenCtxt))
+	require.NoError(t, ep.lockAlive())
+	err := ep.setDesiredPolicy(datapathRegenCtxt)
+	ep.unlock()
+	require.NoError(t, err)
+	require.True(t, ep.desiredPolicy.IsValid())
+
+	const numIdentities = 256
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	done := make(chan struct{})
+
+	// Writer: allocate identities selected by the rule and apply the resulting incremental
+	// map changes to the desired policy while holding the endpoint lock.
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		cmp := completion.NewWaitGroup(context.Background())
+		for i := range numIdentities {
+			addIdentity("peer", fmt.Sprintf("peer%d", i))
+			err, _, finalizeFunc := ep.ApplyPolicyMapChanges(cmp)
+			if !assert.NoError(t, err) {
+				return
+			}
+			if finalizeFunc != nil {
+				finalizeFunc()
+			}
+		}
+	}()
+
+	// Reader: policy recomputation sizes the new map state after the current one with the
+	// endpoint unlocked.
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				ep.PreviousMapStateSizes()
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// All the identity additions must have been applied to the desired policy.
+	require.GreaterOrEqual(t, ep.desiredPolicy.Len(), numIdentities)
+}
+
+// PreviousMapStateSizes must return zero sizes when the endpoint has no computed policy.
+func TestPreviousMapStateSizesNilPolicy(t *testing.T) {
+	require.Equal(t, policy.MapStateSizes{}, (&Endpoint{}).PreviousMapStateSizes())
+}

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -64,7 +64,9 @@ func (m *listenerProxyUpdaterMock) PolicyDebug(string, ...any) {}
 
 func (m *listenerProxyUpdaterMock) IsHost() bool { return false }
 
-func (m *listenerProxyUpdaterMock) PreviousMapState() *policy.MapState { return nil }
+func (m *listenerProxyUpdaterMock) PreviousMapStateSizes() policy.MapStateSizes {
+	return policy.MapStateSizes{}
+}
 
 func (m *listenerProxyUpdaterMock) RegenerateIfAlive(*regeneration.ExternalRegenerationMetadata) <-chan bool {
 	ch := make(chan bool)

--- a/pkg/policy/commands/mapstate_diff.go
+++ b/pkg/policy/commands/mapstate_diff.go
@@ -512,8 +512,8 @@ func (o *dummyPolicyOwner) IsHost() bool {
 	return o.ep.IsHost()
 }
 
-func (o *dummyPolicyOwner) PreviousMapState() *policy.MapState {
-	return o.ep.PreviousMapState()
+func (o *dummyPolicyOwner) PreviousMapStateSizes() policy.MapStateSizes {
+	return o.ep.PreviousMapStateSizes()
 }
 
 func (o *dummyPolicyOwner) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -57,7 +57,7 @@ func TestEgressNamedPortToMapStateUnion(t *testing.T) {
 	epPolicy := &EndpointPolicy{
 		SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 		PolicyOwner:    owner,
-		policyMapState: newMapState(logger, nil, namedPortRules),
+		policyMapState: newMapState(logger, MapStateSizes{}, namedPortRules),
 		selectors:      types.MockSelectorSnapshot(),
 	}
 	filter := &L4Filter{
@@ -113,7 +113,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules),
+			policyMapState: newMapState(logger, MapStateSizes{}, namedPortRules),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -139,7 +139,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules),
+			policyMapState: newMapState(logger, MapStateSizes{}, namedPortRules),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -163,7 +163,7 @@ func TestNamedPortRulesDeleteByID(t *testing.T) {
 	logger := hivetest.Logger(t)
 	epPolicy := &EndpointPolicy{
 		PolicyOwner:    DummyOwner{logger: logger},
-		policyMapState: newMapState(logger, nil, namedPortRules),
+		policyMapState: newMapState(logger, MapStateSizes{}, namedPortRules),
 	}
 	require.NotNil(t, epPolicy.policyMapState.byId)
 

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -143,9 +143,9 @@ func (ei *endpointInfo) IsHost() bool {
 	return false
 }
 
-// PreviousMapState returns an empty mapstate
-func (ei *endpointInfo) PreviousMapState() *MapState {
-	return nil
+// PreviousMapStateSizes returns zero map sizes, as there is no previous map state
+func (ei *endpointInfo) PreviousMapStateSizes() MapStateSizes {
+	return MapStateSizes{}
 }
 
 // RegenerateIfAlive returns immediately as there is nothing to regenerate

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -704,33 +704,53 @@ func NewMapStateEntry(e MapStateEntry) mapStateEntry {
 }
 
 func emptyMapState(logger *slog.Logger) mapState {
-	return newMapState(logger, nil, 0)
+	return newMapState(logger, MapStateSizes{}, 0)
 }
 
-// newMapState returns a new mapState with capacities from the given old mapState (if non-nil),
-// according to the given policy features.
-func newMapState(logger *slog.Logger, old *mapState, features policyFeatures) mapState {
-	var nEntries int
+// MapStateSizes are the map sizes of a mapState, taken as a value snapshot so that a new mapState
+// can be sized after an existing one without keeping a reference to it. Such a reference would be
+// read without synchronization against the incremental updates applied to the referenced mapState.
+type MapStateSizes struct {
+	// entries is the number of entries.
+	entries int
+	// byId is the number of keys of each identity in the id index. It is only populated when
+	// the id index is in use; consumers must not distinguish nil from empty.
+	byId map[identity.NumericIdentity]int
+}
 
-	if old != nil {
-		nEntries = len(old.entries)
+// Sizes returns the map sizes of 'ms'. The caller must synchronize against any concurrent
+// modification of 'ms'.
+func (ms *mapState) Sizes() MapStateSizes {
+	if ms == nil {
+		return MapStateSizes{}
 	}
 
+	sizes := MapStateSizes{
+		entries: ms.Len(),
+	}
+	if ms.byId != nil {
+		sizes.byId = make(map[identity.NumericIdentity]int, len(ms.byId))
+		for id, keys := range ms.byId {
+			sizes.byId[id] = len(keys)
+		}
+	}
+	return sizes
+}
+
+// newMapState returns a new mapState with capacities from the given map sizes, according to the
+// given policy features.
+func newMapState(logger *slog.Logger, sizes MapStateSizes, features policyFeatures) mapState {
 	ms := mapState{
 		logger:  logger,
-		entries: make(mapStateMap, nEntries),
+		entries: make(mapStateMap, sizes.entries),
 		trie:    bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
 	}
 
 	if features&(passRules|namedPortRules) != 0 {
-		if old == nil {
-			ms.byId = make(map[identity.NumericIdentity]LPMKeys)
-		} else {
-			ms.byId = make(map[identity.NumericIdentity]LPMKeys, len(old.byId))
-			// preallocate id index keysets to their current sizes, if any
-			for k, v := range old.byId {
-				ms.byId[k] = make(LPMKeys, len(v))
-			}
+		ms.byId = make(map[identity.NumericIdentity]LPMKeys, len(sizes.byId))
+		// preallocate id index keysets to their previous sizes, if any
+		for id, n := range sizes.byId {
+			ms.byId[id] = make(LPMKeys, n)
 		}
 	}
 	return ms

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3461,3 +3461,22 @@ func permutations(arr []int) [][]int {
 	helper(arr, len(arr))
 	return res
 }
+
+// TestNewMapStatePreallocation checks that a map state sized after another one preallocates a
+// distinct keyset per identity in the id index, as upsert reuses non-nil preallocated keysets.
+func TestNewMapStatePreallocation(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	key := EgressKey().WithTCPPort(80)
+	entry := newMapStateEntry(0, types.HighestPriority, types.LowestPriority, NilRuleOrigin, 0, 0, types.Allow, NoAuthRequirement)
+
+	old := newMapState(logger, MapStateSizes{}, namedPortRules)
+	old.upsert(key.WithIdentity(1000), entry)
+	old.upsert(key.WithIdentity(1001), entry)
+
+	ms := newMapState(logger, old.Sizes(), namedPortRules)
+	require.Len(t, ms.byId, 2)
+	ms.upsert(key.WithIdentity(1000), entry)
+	require.Len(t, ms.byId[identity.NumericIdentity(1000)], 1)
+	require.Empty(t, ms.byId[identity.NumericIdentity(1001)])
+}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -334,7 +334,11 @@ type PolicyOwner interface {
 	GetIngressNamedPort(name string, proto u8proto.U8proto) uint16
 	PolicyDebug(msg string, attrs ...any)
 	IsHost() bool
-	PreviousMapState() *MapState
+	// PreviousMapStateSizes returns the map sizes of the owner's current policy map state, to
+	// be used as capacity hints for the map state of a new policy. It is called with the
+	// PolicyOwner unlocked, so that it may take the owner's lock to synchronize against the
+	// incremental updates applied to the current map state.
+	PreviousMapStateSizes() MapStateSizes
 	RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool
 }
 
@@ -397,6 +401,13 @@ func (p *selectorPolicy) Detach() {
 func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOwner, redirects map[string]uint16) *EndpointPolicy {
 	var calculatedPolicy *EndpointPolicy
 
+	// Size the new map state after the owner's current one. This must be done before taking
+	// the selector cache read lock below: the accessor takes the PolicyOwner's (endpoint)
+	// lock, and the established lock order is endpoint lock first, selector cache lock second
+	// (e.g. Detach takes the selector cache write lock while the endpoint lock is held).
+	// Taking the endpoint lock inside 'WithRLock' would invert that order and deadlock.
+	sizes := policyOwner.PreviousMapStateSizes()
+
 	// EndpointPolicy is initialized while 'WithRLock' keeps the selector cache read
 	// locked. This syncronizes the selector snapshot creation and the registration of the new
 	// EndpointPolicy as a user of the selectorPolicy 'p' before any new incremental updated can
@@ -416,7 +427,7 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 		calculatedPolicy = &EndpointPolicy{
 			SelectorPolicy: p,
 			selectors:      selectors,
-			policyMapState: newMapState(logger, policyOwner.PreviousMapState(), features),
+			policyMapState: newMapState(logger, sizes, features),
 			policyMapChanges: MapChanges{
 				logger:   logger,
 				firstRev: selectors.Revision,

--- a/pkg/policy/resolve_race_test.go
+++ b/pkg/policy/resolve_race_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+// racingPolicyOwner mimics the endpoint's locking: the current EndpointPolicy is mutated by
+// incremental map changes while holding 'mutex', which is the only lock a policy recomputation
+// can use to synchronize with it. The selector cache read lock held by DistillPolicy provides no
+// mutual exclusion here, as incremental changes are applied without it.
+type racingPolicyOwner struct {
+	DummyOwner
+
+	mutex   lock.RWMutex
+	current *EndpointPolicy
+}
+
+func (o *racingPolicyOwner) PreviousMapStateSizes() MapStateSizes {
+	o.mutex.RLock()
+	defer o.mutex.RUnlock()
+	return o.current.GetMapState().Sizes()
+}
+
+// TestDistillPolicyMapStateRace checks that deriving the map state of a new EndpointPolicy from
+// the owner's current one does not race with incremental map changes applied to that current
+// policy. Run with -race.
+func TestDistillPolicyMapStateRace(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	sp := &selectorPolicy{
+		Revision:      1,
+		SelectorCache: testNewSelectorCache(t, logger, nil),
+		L4Policy:      NewL4Policy(1),
+	}
+	// named port rules make the map state maintain the identity index ('byId') that both the
+	// reader and the writer touch.
+	sp.L4Policy.Ingress.features.setFeature(namedPortRules)
+	features := sp.L4Policy.Ingress.features | sp.L4Policy.Egress.features
+
+	current := &EndpointPolicy{
+		SelectorPolicy:   sp,
+		policyMapState:   newMapState(logger, MapStateSizes{}, features),
+		policyMapChanges: MapChanges{logger: logger},
+	}
+	// the id index must be in use for the race on it to be covered
+	require.NotNil(t, current.policyMapState.byId)
+	owner := &racingPolicyOwner{
+		DummyOwner: DummyOwner{logger: logger},
+		current:    current,
+	}
+	current.PolicyOwner = owner
+
+	const numIdentities = 128
+	key := egressKey(0, u8proto.TCP, 80, 0)
+	entry := newMapStateEntry(0, types.HighestPriority, types.LowestPriority, NilRuleOrigin, 0, 0, types.Allow, NoAuthRequirement)
+	for i := range numIdentities {
+		current.policyMapState.upsert(key.WithIdentity(identity.NumericIdentity(i+1000)), entry)
+	}
+
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: incremental map changes, as applied by Endpoint.ApplyPolicyMapChanges while
+	// holding the endpoint lock.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			id := identity.NumericIdentity(i%numIdentities + 1000)
+			owner.mutex.Lock()
+			current.policyMapChanges.AccumulateMapChanges(0, 0,
+				identity.NumericIdentitySlice{id}, nil, key, entry)
+			current.policyMapChanges.SyncMapChanges(types.MockSelectorSnapshot())
+			current.policyMapChanges.consumeMapChanges(current, features)
+
+			current.policyMapChanges.AccumulateMapChanges(0, 0,
+				nil, identity.NumericIdentitySlice{id}, key, entry)
+			current.policyMapChanges.SyncMapChanges(types.MockSelectorSnapshot())
+			current.policyMapChanges.consumeMapChanges(current, features)
+			owner.mutex.Unlock()
+		}
+	}()
+
+	// Reader: policy recomputation, which runs with the endpoint unlocked.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ep := sp.DistillPolicy(logger, owner, nil)
+			ep.Ready()
+			ep.Detach(logger)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestDistillPolicyLockOrder guards the lock order documented in DistillPolicy: the map state
+// sizes accessor takes the PolicyOwner's lock, and the owner takes the selector cache write
+// lock while holding its own lock (as the endpoint's setDesiredPolicy does via Detach), so the
+// accessor must be called before the selector cache read lock is taken. Calling it inside
+// 'WithRLock' inverts the order and deadlocks this test.
+func TestDistillPolicyLockOrder(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	sp := &selectorPolicy{
+		Revision:      1,
+		SelectorCache: testNewSelectorCache(t, logger, nil),
+		L4Policy:      NewL4Policy(1),
+	}
+	sp.L4Policy.Ingress.features.setFeature(namedPortRules)
+
+	current := &EndpointPolicy{
+		SelectorPolicy:   sp,
+		policyMapState:   emptyMapState(logger),
+		policyMapChanges: MapChanges{logger: logger},
+	}
+	owner := &racingPolicyOwner{
+		DummyOwner: DummyOwner{logger: logger},
+		current:    current,
+	}
+	current.PolicyOwner = owner
+
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Owner: takes the selector cache write lock while holding its own lock, as the endpoint
+	// does when setDesiredPolicy detaches a superseded policy (Detach -> removeUser ->
+	// finishDetach -> RemoveSelectors).
+	go func() {
+		defer wg.Done()
+		sc := sp.SelectorCache
+		for range iterations {
+			owner.mutex.Lock()
+			sc.mutex.Lock()
+			sc.mutex.Unlock()
+			owner.mutex.Unlock()
+		}
+	}()
+
+	// Recomputation: DistillPolicy takes the owner's lock for the sizes snapshot before the
+	// selector cache read lock.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ep := sp.DistillPolicy(logger, owner, nil)
+			ep.Ready()
+			ep.Detach(logger)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Minute):
+		t.Fatal("deadlock: DistillPolicy did not complete against the selector cache write lock taken under the owner lock")
+	}
+}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -194,8 +194,8 @@ func (d DummyOwner) IsHost() bool {
 	return false
 }
 
-func (d DummyOwner) PreviousMapState() *MapState {
-	return d.previousMap
+func (d DummyOwner) PreviousMapStateSizes() MapStateSizes {
+	return d.previousMap.Sizes()
 }
 
 func (_ DummyOwner) RegenerateIfAlive(_ *regeneration.ExternalRegenerationMetadata) <-chan bool {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

---

Backport of [#48098](https://github.com/cilium/cilium/pull/48098) to v1.20. The full write up is there

Prepared with AIL:3. I checked the diff, the lock ordering and the test results myself.

```release-note
Fixed a cilium-agent crash (`fatal error: concurrent map iteration and map write`) when an endpoint's policy was recomputed while incremental policy map changes were being applied concurrently. This was most commonly triggered by policies using named ports under pod churn.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
