### PR TITLE
[v1.20] gh: verifier: run on 7.2 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -100,6 +100,10 @@ jobs:
           - kernel: '6.18'
             kernel-name: 'v6.18'
             ci-kernel: '61'
+          - kernel: '7.2'
+            kernel-name: 'v7.2'
+            ci-kernel: 'netnext'
+
     timeout-minutes: 60
     steps:
       - name: Set commit status to pending
@@ -150,6 +154,8 @@ jobs:
             "6.12") FULL_KERNEL="6.12-20260817.013106" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "6.18") FULL_KERNEL="6.18-20260817.013106" ;;
+            # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+            "7.2") FULL_KERNEL="7.2-20260824.055245" ;;
             *) FULL_KERNEL="$KERNEL" ;;
           esac
           echo "full=${FULL_KERNEL}" >> $GITHUB_OUTPUT

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -378,6 +378,7 @@ func loadAndRecordComplexity(
 					t.Fatalf("Failed to parse stack depth for program %s: %v", n, err)
 				}
 				r.StackDepth = stackDepth
+				r.HasStackDepth = true
 			}
 
 			// Extract the third to last line, which looks like:
@@ -446,8 +447,9 @@ type verifierComplexityRecord struct {
 	PeakStates       int `json:"peak_states"`
 	MarkRead         int `json:"mark_read"`
 
-	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
-	StackDepth                   int `json:"stack_depth"`
+	VerificationTimeMicroseconds int  `json:"verification_time_microseconds"`
+	StackDepth                   int  `json:"stack_depth"`
+	HasStackDepth                bool `json:"has_stack_depth"`
 
 	MapCount int `json:"map_count"`
 }

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -48,9 +48,10 @@ type verifierComplexityRecord struct {
 	PeakStates         int `json:"peak_states"`
 	MarkRead           int `json:"mark_read"`
 
-	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
-	StackDepth                   int `json:"stack_depth"`
-	OrigStackDepth               int `json:"orig_stack_depth"`
+	VerificationTimeMicroseconds int  `json:"verification_time_microseconds"`
+	StackDepth                   int  `json:"stack_depth"`
+	OrigStackDepth               int  `json:"orig_stack_depth"`
+	HasStackDepth                bool `json:"has_stack_depth"`
 
 	MapCount     int `json:"map_count"`
 	OrigMapCount int `json:"orig_map_count"`
@@ -112,7 +113,7 @@ func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord
 	printTopMinMax("largest differences by instructions processed", minMaxInsnsProcessed, percentInsnsProcessedDiff, colorRelativeChange)
 
 	minMaxStackDepth := calcMinMax(diffRecords, func(r verifierComplexityRecord) (int, int) {
-		if r.Kernel != "bpf-next" {
+		if !r.HasStackDepth {
 			return math.MinInt, math.MinInt
 		}
 		return r.StackDepth, r.OrigStackDepth
@@ -142,7 +143,7 @@ func printCurrentState(newRecords map[string]verifierComplexityRecord) []error {
 	}
 
 	minMaxStackDepth := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) (int, int) {
-		if r.Kernel != "bpf-next" {
+		if !r.HasStackDepth {
 			return math.MinInt, math.MinInt
 		}
 		return r.StackDepth, r.OrigStackDepth
@@ -405,6 +406,7 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 
 			VerificationTimeMicroseconds: newRecord.VerificationTimeMicroseconds - oldRecord.VerificationTimeMicroseconds,
 			StackDepth:                   newRecord.StackDepth - oldRecord.StackDepth,
+			HasStackDepth:                newRecord.HasStackDepth && oldRecord.HasStackDepth,
 			OrigStackDepth:               oldRecord.StackDepth,
 
 			MapCount:     newRecord.MapCount - oldRecord.MapCount,
@@ -431,6 +433,7 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 
 					VerificationTimeMicroseconds: -oldRecord.VerificationTimeMicroseconds,
 					StackDepth:                   -oldRecord.StackDepth,
+					HasStackDepth:                oldRecord.HasStackDepth,
 
 					MapCount: -oldRecord.MapCount,
 				})


### PR DESCRIPTION
Backport of
* [ ] #48236

along with a patch to wire up the 7.2 kernel in the verifier workflow:

```
Adding the 7.2 kernel in the verifier complexity tests
gives us stack depth analysis.

We can eventually replace this with the next LTS kernel.
```

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 48236
```