### PR TITLE
Address Go 1.27 `modernize` linter warnings

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -219,8 +219,7 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 		instrLog.Write(localBuf.Bytes())
 	}
 
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		t.Fatalf("verifier error: %+v", ve)
 	}
 	if err != nil {

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -434,7 +434,7 @@ func writeCmdToFile(cmdDir, prompt string, enableMarkdown bool, postProcess func
 	}
 	defer f.Close()
 
-	cmd := strings.Split(prompt, " ")[0]
+	cmd, _, _ := strings.Cut(prompt, " ")
 
 	// The command does not exist, abort.
 	if _, err := exec.LookPath(cmd); err != nil {

--- a/cilium-cli/features/summary.go
+++ b/cilium-cli/features/summary.go
@@ -483,8 +483,7 @@ func loadWorkflowData(directory string) (perWorkflowMetrics, error) {
 				// Because the runtime tests are running on a single node,
 				// they will only have a list of metrics stored on each .json
 				// file
-				var errUTE *json.UnmarshalTypeError
-				if !errors.As(err, &errUTE) {
+				if _, ok := errors.AsType[*json.UnmarshalTypeError](err); !ok {
 					return fmt.Errorf("error unmarshalling file %q: %w", path, err)
 				}
 				var metrics []*models.Metric

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -233,8 +233,7 @@ func (r *infraIPAllocator) allocateNextFromPool(ctx context.Context, family ipam
 		return result, nil
 	}
 
-	var poolErr *ipam.ErrPoolNotReadyYet
-	if !errors.As(err, &poolErr) {
+	if _, ok := errors.AsType[*ipam.ErrPoolNotReadyYet](err); !ok {
 		return nil, err
 	}
 
@@ -256,8 +255,7 @@ func (r *infraIPAllocator) allocateNextFromPool(ctx context.Context, family ipam
 			return true, nil
 		}
 
-		var poolErr *ipam.ErrPoolNotReadyYet
-		if errors.As(allocErr, &poolErr) {
+		if _, ok := errors.AsType[*ipam.ErrPoolNotReadyYet](allocErr); ok {
 			lastErr = allocErr
 			return false, nil
 		}

--- a/hubble/cmd/config/set.go
+++ b/hubble/cmd/config/set.go
@@ -126,8 +126,7 @@ func newFileOnlyViper(configPath string) (*viper.Viper, error) {
 	if err := vp.ReadInConfig(); err != nil {
 		// it's OK so long as the failure is ConfigFileNotFound
 		// for all other cases, failing to read the config should be an error
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return nil, err
 		}
 	}

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -376,8 +376,7 @@ func isTransientError(err error) bool {
 	}
 
 	// Check for network-level errors (connection refused, reset, host unreachable)
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
+	if errno, ok := errors.AsType[syscall.Errno](err); ok {
 		switch errno {
 		case syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.EHOSTUNREACH, syscall.ENETUNREACH:
 			return true

--- a/operator/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/operator/pkg/ipam/allocator/podcidr/podcidr.go
@@ -688,8 +688,7 @@ func (n *NodesPodCIDRManager) reuseIPNets(
 			// If already allocated, skip this family rather than
 			// reverting the other. The caller strips the conflicting
 			// CIDR from the node's spec.
-			var errAllocated *ErrCIDRAllocated
-			if !errors.As(v4Err, &errAllocated) {
+			if _, ok := errors.AsType[*ErrCIDRAllocated](v4Err); !ok {
 				return nil, false, v4Err
 			}
 			n.logger.Warn("Duplicate v4 CIDR, will be released from this node",
@@ -722,8 +721,7 @@ func (n *NodesPodCIDRManager) reuseIPNets(
 			v6CIDR = append(v6CIDR, newv6CIDR)
 		}
 		if v6Err != nil {
-			var errAllocated *ErrCIDRAllocated
-			if !errors.As(v6Err, &errAllocated) {
+			if _, ok := errors.AsType[*ErrCIDRAllocated](v6Err); !ok {
 				if v4RevertFunc != nil {
 					v4RevertFunc()
 				}

--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -648,8 +648,7 @@ func (c *Client) EcsListTagResources(ctx context.Context, tags map[string]string
 // the AlibabaCloud API server. If no specific status is provided, either "OK" or
 // "Failed" is returned based on the error variable.
 func deriveStatus(err error) string {
-	var respErr httperr.Error
-	if errors.As(err, &respErr) {
+	if respErr, ok := errors.AsType[httperr.Error](err); ok {
 		return respErr.ErrorCode()
 	}
 

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -123,8 +123,7 @@ func LoadAndAssign(logger *slog.Logger, to any, spec *ebpf.CollectionSpec, opts 
 	opts.Keep = keep
 
 	coll, commit, err := LoadCollection(logger, spec, opts)
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
 			return nil, fmt.Errorf("writing verifier log to stderr: %w", err)
 		}

--- a/pkg/bpf/unused_maps_test.go
+++ b/pkg/bpf/unused_maps_test.go
@@ -20,8 +20,7 @@ import (
 func mustNewCollection(t *testing.T, spec *ebpf.CollectionSpec) *ebpf.Collection {
 	t.Helper()
 	coll, err := ebpf.NewCollection(spec)
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		require.NoError(t, ve)
 	}
 	require.NoError(t, err)

--- a/pkg/ciliumenvoyconfig/reconciler.go
+++ b/pkg/ciliumenvoyconfig/reconciler.go
@@ -94,8 +94,7 @@ func isPortBindingError(err error) bool {
 		return false
 	}
 
-	var proxyErr *xds.ProxyError
-	if errors.As(err, &proxyErr) {
+	if proxyErr, ok := errors.AsType[*xds.ProxyError](err); ok {
 		// Check ProxyError.Detail field which contains the actual Envoy error message
 		detail := strings.ToLower(proxyErr.Detail)
 		if strings.Contains(detail, "cannot bind") ||

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -56,8 +56,7 @@ func output(ctx context.Context, cmd *exec.Cmd, scopedLog *slog.Logger, verbose 
 		return nil, fmt.Errorf("Command execution failed for %s: %w", cmd.Args, ctx.Err())
 	}
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			err = fmt.Errorf("%w stderr=%q", exitErr, exitErr.Stderr)
 		}
 		if verbose {

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -45,8 +45,7 @@ func ToStringMapStringE(data any) (map[string]string, error) {
 
 	v, err := cast.ToStringMapStringE(data)
 	if err != nil {
-		var syntaxErr *json.SyntaxError
-		if !errors.As(err, &syntaxErr) {
+		if _, ok := errors.AsType[*json.SyntaxError](err); !ok {
 			return v, err
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -350,8 +350,7 @@ func (c *controller) runController() {
 				err = NewExitReason("controller context canceled")
 			}
 
-			var exitReason ExitReason
-			if errors.As(err, &exitReason) {
+			if exitReason, ok := errors.AsType[ExitReason](err); ok {
 				// This is actually not an error case, but it causes an exit
 				c.recordSuccess(params.Health)
 				c.lastError = exitReason // This will be shown in the controller status

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -562,8 +562,7 @@ func loadProbesObjects() (*bpfgen.ProbesObjects, error) {
 	objs := &bpfgen.ProbesObjects{}
 
 	err := bpfgen.LoadProbesObjects(objs, &ebpf.CollectionOptions{})
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
 			return nil, fmt.Errorf("writing verifier log to stderr: %w", err)
 		}

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -259,8 +259,7 @@ func (ops *ops) UpdateBatch(ctx context.Context, txn statedb.ReadTxn, batch []re
 	// Write all events to the WAL first, then process the updates.
 	if err := ops.wal.Write(events...); err != nil {
 		// If we failed to write individual entries, mark them as failed.
-		var ba wal.BatchErrors
-		if errors.As(err, &ba) {
+		if ba, ok := errors.AsType[wal.BatchErrors](err); ok {
 			for _, e := range ba {
 				selected[e.Index].Result = e.Err
 			}
@@ -325,8 +324,7 @@ func (ops *ops) DeleteBatch(ctx context.Context, txn statedb.ReadTxn, batch []re
 	// Write all events to the WAL first, then process the updates.
 	if err := ops.wal.Write(events...); err != nil {
 		// If we failed to write individual entries, mark them as failed.
-		var ba wal.BatchErrors
-		if errors.As(err, &ba) {
+		if ba, ok := errors.AsType[wal.BatchErrors](err); ok {
 			for _, e := range ba {
 				toDelete[e.Index].Result = e.Err
 			}

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -194,8 +194,7 @@ func (l *bpfCollectionLoader) LoadAndAssign(ctx context.Context, logger *slog.Lo
 	opts.Keep = keep
 
 	coll, commit, cleanupLinks, err := l.Load(ctx, logger, spec, opts, lnc, attachmentContext, pinsDir)
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
 			return nil, nil, fmt.Errorf("writing verifier log to stderr: %w", err)
 		}

--- a/pkg/datapath/loader/plugins_test.go
+++ b/pkg/datapath/loader/plugins_test.go
@@ -284,8 +284,7 @@ func runTestProgs(t *testing.T, inputValues inputValues, baseObjs *ebpf.Collecti
 }
 
 func maybeReportVerifierError(err error) error {
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve)
 	}
 

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -268,8 +268,7 @@ func loadAndRecordComplexity(
 			break
 		}
 
-		var ve *ebpf.VerifierError
-		if errors.As(err, &ve) {
+		if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 			// Write full verifier log to a path on disk for offline analysis.
 			var buf bytes.Buffer
 			fmt.Fprintf(&buf, "%+v", ve)

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -499,8 +499,7 @@ func (m *endpointAPIManager) EndpointUpdate(id string, cfg *models.EndpointConfi
 	}
 
 	if err := ep.Update(cfg); err != nil {
-		var updateValidationError endpoint.UpdateValidationError
-		if errors.As(err, &updateValidationError) {
+		if _, ok := errors.AsType[endpoint.UpdateValidationError](err); ok {
 			return api.Error(PatchEndpointIDConfigInvalidCode, err)
 		}
 		return api.Error(PatchEndpointIDConfigFailedCode, err)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1632,8 +1632,7 @@ func CheckHealth(ep *Endpoint) error {
 		return nil
 	}
 	_, err := safenetlink.LinkByName(iface)
-	var linkNotFoundError netlink.LinkNotFoundError
-	if errors.As(err, &linkNotFoundError) {
+	if _, ok := errors.AsType[netlink.LinkNotFoundError](err); ok {
 		return fmt.Errorf("Endpoint is invalid: %w", err)
 	}
 	if err != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -564,8 +564,7 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 	revision, err = e.regenerateBPF(ctx)
 
 	// Write full verifier log to the endpoint directory.
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		p := path.Join(tmpDir, "verifier.log")
 		f, err := os.Create(p)
 		if err != nil {
@@ -699,8 +698,7 @@ func (e *Endpoint) updateRegenerationStatistics(ctx *regenerationContext, err er
 			scopedLog.Warn("Regeneration of endpoint failed", logAttrs...)
 		}
 
-		var regenErr *regenerationError
-		if errors.As(err, &regenErr) {
+		if regenErr, ok := errors.AsType[*regenerationError](err); ok {
 			stats.regenFailureReason = regenErr.GetReason()
 		} else {
 			stats.regenFailureReason = regenerationFailureReasonUnknown

--- a/pkg/fqdn/dnsproxy/types.go
+++ b/pkg/fqdn/dnsproxy/types.go
@@ -88,8 +88,7 @@ type ProxyRequestContext struct {
 
 // IsTimeout return true if the ProxyRequest timeout
 func (proxyStat *ProxyRequestContext) IsTimeout() bool {
-	var neterr net.Error
-	if errors.As(proxyStat.Err, &neterr) {
+	if neterr, ok := errors.AsType[net.Error](proxyStat.Err); ok {
 		return neterr.Timeout()
 	}
 	return false

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -712,8 +712,7 @@ func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.
 }
 
 func responseCodeFromError(err error) pb.ResponseCode {
-	var noEp dnsproxy.ErrDNSRequestNoEndpoint
-	if errors.As(err, &noEp) {
+	if _, ok := errors.AsType[dnsproxy.ErrDNSRequestNoEndpoint](err); ok {
 		return pb.ResponseCode_RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND
 	}
 	return pb.ResponseCode_RESPONSE_CODE_SERVER_FAILURE

--- a/pkg/hubble/metrics/api/registry.go
+++ b/pkg/hubble/metrics/api/registry.go
@@ -55,8 +55,7 @@ func (r *Registry) ConfigureHandlers(logger *slog.Logger, registry *prometheus.R
 	for _, metricsConfig := range enabled.Metrics {
 		h, err := r.validateAndCreateHandlerLocked(metricsConfig, &metricNames)
 		if err != nil {
-			var errM *errMetricNotExist
-			if errors.As(err, &errM) {
+			if errM, ok := errors.AsType[*errMetricNotExist](err); ok {
 				logger.Warn("Skipping unknown hubble metric", logfields.Name, errM.name)
 				continue
 			}

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -145,7 +145,7 @@ func provideMetrics[S any](metricSet S) hiveMetricOut {
 	}
 
 	for i := range typ.NumField() {
-		if withMeta, ok := value.Field(i).Interface().(pkgmetric.WithMetadata); ok {
+		if withMeta, ok := reflect.TypeAssert[pkgmetric.WithMetadata](value.Field(i)); ok {
 			metrics = append(metrics, withMeta)
 		}
 	}

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -1133,7 +1133,7 @@ func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
 		if !f.CanInterface() {
 			continue
 		}
-		c, ok := f.Interface().(prometheus.Collector)
+		c, ok := reflect.TypeAssert[prometheus.Collector](f)
 		if !ok {
 			continue
 		}

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -118,7 +118,7 @@ func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
 		if !f.CanInterface() {
 			continue
 		}
-		c, ok := f.Interface().(prometheus.Collector)
+		c, ok := reflect.TypeAssert[prometheus.Collector](f)
 		if !ok {
 			continue
 		}

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -110,8 +110,7 @@ func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 		},
 		ConfigDumpPath: configDumpPath,
 	}, lnc, attachmentContextSocket(), cgroupPluginsLinkPath())
-	var ve *ebpf.VerifierError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
 			return fmt.Errorf("writing verifier log to stderr: %w", err)
 		}


### PR DESCRIPTION
Address linter warnings as reported by running golangci-lint 2.13.1 build using Go 1.27.

See commit messages for details.

AIL: 0