### PR TITLE
logging: downgrade canceled response-body reads to info

### DIFF
--- a/pkg/logging/klog_bridge.go
+++ b/pkg/logging/klog_bridge.go
@@ -5,6 +5,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"regexp"
 
@@ -22,6 +23,16 @@ var klogOverrides = []logLevelOverride{
 		// failures still surface at error. See GH-45426.
 		matcher:      regexp.MustCompile("Failed to update lease"),
 		errPredicate: apierrors.IsConflict,
+		targetLevel:  slog.LevelInfo,
+	},
+	{
+		// client-go logs every response-body read failure at error, including a
+		// plain cancellation, which happens whenever the caller's context goes
+		// away mid-read. Our own callers already treat that as a non-event, so
+		// downgrade only the cancellation and leave genuine read failures at
+		// error.
+		matcher:      regexp.MustCompile("Unexpected error when reading response body"),
+		errPredicate: func(err error) bool { return errors.Is(err, context.Canceled) },
 		targetLevel:  slog.LevelInfo,
 	},
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -5,8 +5,10 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -166,6 +168,51 @@ func TestKlogBridgeErrPredicate(t *testing.T) {
 			assert.Equal(t, "info", level, "conflict should be downgraded, got line: %s", line)
 		default:
 			assert.Equal(t, "error", level, "non-conflict should stay error, got line: %s", line)
+		}
+	}
+}
+
+func TestKlogBridgeBodyReadCanceled(t *testing.T) {
+	var out bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&out,
+			&slog.HandlerOptions{
+				ReplaceAttr: ReplaceAttrFnWithoutTimestamp,
+			},
+		),
+	)
+	log := logger.With(logfields.LogSubsys, "klog")
+
+	// Exercise the overrides we ship, not a test-local copy.
+	handler := &klogOverrideHandler{
+		inner:     log.Handler(),
+		overrides: klogOverrides,
+	}
+	klog.SetSlogLogger(slog.New(handler))
+
+	const bodyRead = "Unexpected error when reading response body"
+
+	klog.ErrorS(context.Canceled, bodyRead)
+	klog.ErrorS(fmt.Errorf("read body: %w", context.Canceled), bodyRead)
+	klog.ErrorS(context.DeadlineExceeded, bodyRead)
+	klog.ErrorS(io.ErrUnexpectedEOF, bodyRead)
+	klog.ErrorS(context.Canceled, "Unable to decode response body")
+	klog.Flush()
+
+	logout := strings.Trim(out.String(), "\n")
+	lines := strings.Split(logout, "\n")
+	require.Len(t, lines, 5)
+
+	for i, line := range lines {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+
+		level, _ := entry["level"].(string)
+		switch i {
+		case 0, 1:
+			assert.Equal(t, "info", level, "cancellation should be downgraded, got line: %s", line)
+		default:
+			assert.Equal(t, "error", level, "should stay error, got line: %s", line)
 		}
 	}
 }


### PR DESCRIPTION
client-go logs every response-body read failure at error level, special
casing only http2.StreamError, so a plain cancellation surfaces as
level=error with error="context canceled" and fails check-log-errors.

The cancellation is expected: deleting an endpoint cancels its aliveCtx,
aborting a CiliumEndpoint read the endpoint synchronizer had in flight.
Cilium already scores that as a non-event, the controller framework
records success and the synchronizer returns nil on context.Canceled.
Downgrade the message to info when the error unwraps to context.Canceled,
the way the lease conflict override is scoped to apierrors.IsConflict, so
that a genuine read failure still surfaces at error.

This PR was prepared with AIL:3.
