### PR TITLE
gha: stop JUnit reports being destroyed by same-name legs

### DIFF
--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -49,6 +49,7 @@ jobs:
           name: cilium-junits
           pattern: cilium-junits-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
       - name: Merge Features tested
         if: ${{ inputs.merge-features }}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -466,7 +466,7 @@ jobs:
         run: |
           cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --test-concurrency=${{ env.test_concurrency }} \
-          --junit-file "cilium-junits/${{ env.job_name }}-concurrent-clear (${{ join(matrix.*, ', ') }}).xml" \
+          --junit-file "cilium-junits/${{ env.job_name }}-concurrent-clear (${{ join(matrix.*, ', ') }})-${{ inputs.UID || 1 }}.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Run common post steps

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -721,7 +721,7 @@ jobs:
           if [[ "$total_drops" != ${{ steps.no_nodeid_drops_prev.outputs.total_drops }} ]]; then
             # run no-unexpected-packet-drops connectivity to collect sysdumps
             cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - no-node-id-drops.xml" \
             --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})" \
             --test 'no-unexpected-packet-drops'
           fi

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -631,7 +631,7 @@ jobs:
         run: |
           cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --test-concurrency=${{ env.test_concurrency }} \
-          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}, ${{ inputs.UID || 1 }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       # Re-run the tests quarantined above (see the quarantine list in the job
@@ -652,7 +652,7 @@ jobs:
           # shellcheck disable=SC2086
           cilium connectivity test ${{ steps.e2e_config.outputs.test_flags }} ${TEST_FLAGS} \
           --test-concurrency=${{ env.test_concurrency }} \
-          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - quarantined.xml" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}, ${{ inputs.UID || 1 }}) - quarantined.xml" \
           --junit-property github_job_step="Run quarantined tests (${{ join(matrix.*, ', ') }})"
 
       - name: Warn on quarantined test failure (${{ join(matrix.*, ', ') }})
@@ -683,7 +683,7 @@ jobs:
         if: ${{ matrix.ipsec == true }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: ${{ env.job_name }}-${{ matrix.version }}-post-rotate
+          job-name: ${{ env.job_name }}-${{ matrix.version }}-${{ inputs.UID || 1 }}-post-rotate
           full-test: 'true'
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -534,7 +534,7 @@ jobs:
         id: run-tests
         run: |
           cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
-          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}, ${{ inputs.UID || 1 }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 
       - name: Run common post steps

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -359,6 +359,7 @@ jobs:
           name: cilium-junits
           pattern: cilium-junits-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -244,6 +244,7 @@ jobs:
           name: cilium-junits
           pattern: cilium-junits-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -605,7 +605,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-upgrade-${{ matrix.name }}-precheck
+          job-name: cilium-upgrade-${{ matrix.name }}-${{ matrix.mode }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after upgrade
@@ -622,7 +622,7 @@ jobs:
         timeout-minutes: 50
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-upgrade-${{ matrix.name }}-concurrent
+          job-name: cilium-upgrade-${{ matrix.name }}-${{ matrix.mode }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           conn-disrupt: 'false'
           test-concurrency: ${{ env.test_concurrency }}
@@ -632,7 +632,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-upgrade-${{ matrix.name }}-postcheck
+          job-name: cilium-upgrade-${{ matrix.name }}-${{ matrix.mode }}-postcheck
           tests: 'no-unexpected-packet-drops'
           conn-disrupt: 'false'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
@@ -671,7 +671,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-restart-${{ matrix.name }}-precheck
+          job-name: cilium-restart-${{ matrix.name }}-${{ matrix.mode }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
           include-conn-disrupt-test-l7-traffic: ${{ steps.vars-conn.outputs.include_conn_disrupt_test_l7_traffic }}
 
@@ -716,7 +716,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-downgrade-${{ matrix.name }}-precheck
+          job-name: cilium-downgrade-${{ matrix.name }}-${{ matrix.mode }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
@@ -731,7 +731,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-downgrade-${{ matrix.name }}-concurrent
+          job-name: cilium-downgrade-${{ matrix.name }}-${{ matrix.mode }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           conn-disrupt: 'false'
           test-concurrency: ${{ env.test_concurrency }}
@@ -741,7 +741,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          job-name: cilium-upgrade-${{ matrix.name }}-postcheck
+          job-name: cilium-downgrade-${{ matrix.name }}-${{ matrix.mode }}-postcheck
           tests: 'no-unexpected-packet-drops'
           conn-disrupt: 'false'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}


### PR DESCRIPTION
JUnit reports are being destroyed before anyone can read them, because two
legs of one run can render the same file name.

The Merge JUnits step never passed separate-directories, so every
cilium-junits-* artifact was unzipped into one flat directory where only the
file name inside mattered, and delete-merged then removed the originals. The
file names do not identify the leg either: the cloud workflows leave
inputs.UID out, e2e-upgrade leaves matrix.mode out, and the clustermesh drop
re-run reuses the name of the full suite that ran before it.

Two runs lost a real failure record this way. In
https://github.com/cilium/cilium/actions/runs/32708700699 the three KPR AKS
legs uploaded 3636, 1185 and 3623 bytes and the merged artifact came out at
3636, so the 1185-byte report of the only leg that failed is gone and what
survives reads failures="0". In
https://github.com/cilium/cilium/actions/runs/32707953882 on v1.20 the misc-1
minor leg failed while running the concurrent tests, and its report was
replaced by the passing patch leg's, which again reads failures="0". The scale
is larger than those two: on stable branches every e2e-upgrade config runs in
both minor and patch mode, so
https://github.com/cilium/cilium/actions/runs/32703121702 kept 352 of the 704
XMLs it produced. https://github.com/cilium/cilium/actions/runs/32689542222
kept 15 of 24 and https://github.com/cilium/cilium/actions/runs/32689221010
kept 3 of 9, and https://github.com/cilium/cilium/actions/runs/32677457672
discards the scale-test-egw baseline leg's ClusterLoader2 report on every run.

The names have to carry the discriminator regardless of the merge layout,
because the OpenSearch scraper builds its document id from the base file name
and so collapses the legs again. The UID carries a fallback because the inputs
context does not exist on the directly scheduled runs of those workflows, where
it would otherwise render empty. Two of these commits change JUnit file names,
so historical series break once at that boundary. The clustermesh one is latent
rather than observed: the drop counter has to increase for the re-run to fire,
and because that step is implicitly gated on success it can only replace a
passing report.

All of these collisions are present on v1.18 through v1.20, so this wants
backporting to each of them. The e2e-upgrade half matters most there, since
main runs a -dev version and therefore only ever builds one mode.

This PR was prepared with AIL:3.
