### PR TITLE
datapath/iptables: Bring back IPSetFilterFn

### DIFF
--- a/pkg/datapath/iptables/ipset/node_sync.go
+++ b/pkg/datapath/iptables/ipset/node_sync.go
@@ -14,9 +14,15 @@ import (
 
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
+
+// IPSetFilterFn is a function allowing to optionally filter out the insertion
+// of IPSet entries based on node characteristics. The insertion is performed
+// if the function returns false, and skipped otherwise.
+type IPSetFilterFn func(*nodeTypes.Node) bool
 
 const nodeIPSetSyncInterval = time.Second
 
@@ -33,28 +39,35 @@ type nodeIPSetSync struct {
 	initializer Initializer
 	v4          AddrSet
 	v6          AddrSet
+	filterFn    IPSetFilterFn
 }
 
-func registerNodeIPSetSync(
-	jobs job.Group,
-	db *statedb.DB,
-	nodes statedb.Table[*node.Node],
-	manager *manager,
-	config config,
-) {
-	if !config.NodeIPSetNeeded {
+type nodeIPSetSyncParams struct {
+	cell.In
+
+	Jobs     job.Group
+	DB       *statedb.DB
+	Nodes    statedb.Table[*node.Node]
+	Manager  *manager
+	Config   config
+	FilterFn IPSetFilterFn `optional:"true"`
+}
+
+func registerNodeIPSetSync(p nodeIPSetSyncParams) {
+	if !p.Config.NodeIPSetNeeded {
 		return
 	}
 
 	sync := &nodeIPSetSync{
-		db:          db,
-		nodes:       nodes,
-		manager:     manager,
-		initializer: manager.NewInitializer(),
+		db:          p.DB,
+		nodes:       p.Nodes,
+		manager:     p.Manager,
+		initializer: p.Manager.NewInitializer(),
 		v4:          AddrSet{},
 		v6:          AddrSet{},
+		filterFn:    p.FilterFn,
 	}
-	jobs.Add(job.OneShot("node-ipset-sync", sync.run))
+	p.Jobs.Add(job.OneShot("node-ipset-sync", sync.run))
 }
 
 func (s *nodeIPSetSync) run(ctx context.Context, health cell.Health) error {
@@ -92,7 +105,7 @@ func (s *nodeIPSetSync) run(ctx context.Context, health cell.Health) error {
 }
 
 func (s *nodeIPSetSync) update(nodes iter.Seq2[*node.Node, statedb.Revision]) {
-	v4, v6 := nodeIPSets(nodes)
+	v4, v6 := nodeIPSets(nodes, s.filterFn)
 
 	s.manager.AddToIPSet(
 		CiliumNodeIPSetV4,
@@ -119,10 +132,14 @@ func (s *nodeIPSetSync) update(nodes iter.Seq2[*node.Node, statedb.Revision]) {
 
 func nodeIPSets(
 	nodes iter.Seq2[*node.Node, statedb.Revision],
+	filterFn IPSetFilterFn,
 ) (v4, v6 AddrSet) {
 	v4 = AddrSet{}
 	v6 = AddrSet{}
 	for n := range nodes {
+		if filterFn != nil && filterFn(&n.Node) {
+			continue
+		}
 		for _, address := range n.IPAddresses {
 			if address.Type != addressing.NodeInternalIP {
 				continue

--- a/pkg/datapath/iptables/ipset/node_sync_test.go
+++ b/pkg/datapath/iptables/ipset/node_sync_test.go
@@ -163,6 +163,37 @@ func TestNodeIPSetSync(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
+func TestNodeIPSetSyncFilter(t *testing.T) {
+	db := statedb.New()
+	nodes, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+
+	insertNode(t, db, nodes, testNode("included",
+		testAddress(addressing.NodeInternalIP, "10.0.0.1"),
+		testAddress(addressing.NodeInternalIP, "2001:db8::1"),
+	))
+	insertNode(t, db, nodes, testNode("excluded",
+		testAddress(addressing.NodeInternalIP, "10.0.0.2"),
+		testAddress(addressing.NodeInternalIP, "2001:db8::2"),
+	))
+
+	manager := newFakeNodeIPSetManager()
+	syncer := &nodeIPSetSync{
+		manager: manager,
+		v4:      AddrSet{},
+		v6:      AddrSet{},
+		filterFn: func(n *nodeTypes.Node) bool {
+			return n.Name == "excluded"
+		},
+	}
+	syncer.update(nodes.All(db.ReadTxn()))
+
+	require.True(t, manager.has(
+		[]netip.Addr{netip.MustParseAddr("10.0.0.1")},
+		[]netip.Addr{netip.MustParseAddr("2001:db8::1")},
+	))
+}
+
 func testNode(name string, addresses ...nodeTypes.Address) *node.Node {
 	return &node.Node{Node: nodeTypes.Node{
 		Name:        name,


### PR DESCRIPTION
Commit 38c5dce3f3acddda0fc39a88a6ec346744e11b59 removed the hook for filter which nodes are considered for IPSets. This was useful functionality that we want to preserve.

Fixes: 38c5dce3f3ac ("datapath/iptables: Synchronize node IP sets from table")