### PR TITLE
Operator: migrate CRD storage versions

### DIFF
--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -213,7 +213,7 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfi
 	log.Info("Setting up kubernetes client")
 
 	// Update CRDs to ensure ciliumIdentity is present
-	ciliumClient.RegisterCRDs(log, clientset, bgpCfg)
+	ciliumClient.RegisterCRDs(ctx, log, clientset, bgpCfg)
 
 	// Create a CRD Backend
 	crdBackend, err := identitybackend.NewCRDBackend(log, identitybackend.CRDBackendConfiguration{

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -213,7 +213,7 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfi
 	log.Info("Setting up kubernetes client")
 
 	// Update CRDs to ensure ciliumIdentity is present
-	ciliumClient.RegisterCRDs(ctx, log, clientset, bgpCfg)
+	ciliumClient.CreateCustomResourceDefinitions(ctx, log, clientset, bgpCfg)
 
 	// Create a CRD Backend
 	crdBackend, err := identitybackend.NewCRDBackend(log, identitybackend.CRDBackendConfiguration{

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -252,6 +252,7 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
   - update
   resourceNames:
@@ -286,6 +287,17 @@ rules:
   - ciliumnetworkdriverclusterconfigs.cilium.io
   - ciliumresourceippools.cilium.io
 {{- end }}
+# The operator will migrate any custom resources that have "upgraded" storage versions.
+# To do this, it must be allowed to list and patch the resource. (This triggers a storage migration
+# on the apiserver.)
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodeconfigs
+  - ciliumcidrgroups
+  verbs:
+  - list
+  - patch
 - apiGroups:
   - cilium.io
   resources:

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -65,7 +65,7 @@ func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 	cesController := &DefaultController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
@@ -161,7 +161,7 @@ func TestDifferentSpeedQueuesDefault(t *testing.T) {
 	cesController := &DefaultController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
@@ -266,7 +266,7 @@ func TestCESManagementDefault(t *testing.T) {
 	cesController := &DefaultController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
@@ -360,7 +360,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	cesController := &SlimController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			ciliumNodes:         ciliumNode,
 			namespace:           namespace,
@@ -489,7 +489,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	cesController := &SlimController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			ciliumNodes:         ciliumNode,
 			namespace:           namespace,
@@ -614,7 +614,7 @@ func TestCESManagement(t *testing.T) {
 	cesController := &SlimController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			ciliumNodes:         ciliumNode,
 			namespace:           namespace,
@@ -738,7 +738,7 @@ func TestSyncCESsInLocalCacheOperatorDowntime(t *testing.T) {
 	cesController := &SlimController{
 		Controller: &Controller{
 			logger:              log,
-			clientset:           fakeClient.Clientset,
+			clientset:           fakeClient,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			ciliumNodes:         ciliumNode,
 			namespace:           namespace,

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -86,7 +86,7 @@ func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reco
 		ctx,
 		tlog,
 		cmtypes.DefaultClusterInfo,
-		fakeClient.Clientset,
+		fakeClient,
 		namespace,
 		pod,
 		ciliumIdentity,

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -144,13 +144,10 @@ func registerMCSAPIController(params mcsAPIParams) error {
 }
 
 func newMCSAPICRDs(cfg mcsapitypes.MCSAPIConfig) apis.RegisterCRDsFuncOut {
+	if !cfg.ShouldInstallMCSAPICrds() {
+		return apis.RegisterCRDsFuncOut{}
+	}
 	return apis.RegisterCRDsFuncOut{
-		Func: func(ctx context.Context, logger *slog.Logger, client k8sClient.Clientset) error {
-			if !cfg.ShouldInstallMCSAPICrds() {
-				return nil
-			}
-
-			return createCustomResourceDefinitions(ctx, logger, client)
-		},
+		Func: createCustomResourceDefinitions,
 	}
 }

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -145,12 +145,12 @@ func registerMCSAPIController(params mcsAPIParams) error {
 
 func newMCSAPICRDs(cfg mcsapitypes.MCSAPIConfig) apis.RegisterCRDsFuncOut {
 	return apis.RegisterCRDsFuncOut{
-		Func: func(logger *slog.Logger, client k8sClient.Clientset) error {
+		Func: func(ctx context.Context, logger *slog.Logger, client k8sClient.Clientset) error {
 			if !cfg.ShouldInstallMCSAPICrds() {
 				return nil
 			}
 
-			return createCustomResourceDefinitions(logger, client)
+			return createCustomResourceDefinitions(ctx, logger, client)
 		},
 	}
 }

--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -4,6 +4,7 @@
 package mcsapi
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -22,9 +23,9 @@ import (
 
 // createCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
-func createCustomResourceDefinitions(logger *slog.Logger, clientset apiextensionsclient.Interface) error {
+func createCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface) error {
 	for _, crdName := range []string{mcsapiv1beta1.ServiceImportVersionedName, mcsapiv1beta1.ServiceExportVersionedName} {
-		if err := createCRD(logger, clientset, crdName); err != nil {
+		if err := createCRD(ctx, logger, clientset, crdName); err != nil {
 			return fmt.Errorf("Unable to create custom resource definition: %w", err)
 		}
 	}
@@ -64,10 +65,11 @@ func getPregeneratedCRD(logger *slog.Logger, crdName string) apiextensionsv1.Cus
 
 // createCRD creates and updates a CRD.
 // It should be called on operator startup but is idempotent and safe to call again.
-func createCRD(logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string) error {
+func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string) error {
 	crd := getPregeneratedCRD(logger, crdVersionedName)
 
 	return crdhelpers.CreateUpdateCRD(
+		ctx,
 		logger,
 		clientset,
 		&crd,

--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/crdhelpers"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -23,14 +24,20 @@ import (
 
 // createCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
-func createCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface) error {
+func createCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset k8sClient.Clientset) (
+	needsMigration []*apiextensionsv1.CustomResourceDefinition,
+	err error) {
+
 	for _, crdName := range []string{mcsapiv1beta1.ServiceImportVersionedName, mcsapiv1beta1.ServiceExportVersionedName} {
-		if err := createCRD(ctx, logger, clientset, crdName); err != nil {
-			return fmt.Errorf("Unable to create custom resource definition: %w", err)
+		crd, err := createCRD(ctx, logger, clientset, crdName)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to create custom resource definition: %w", err)
+		}
+		if crdhelpers.CRDNeedsMigration(crd) {
+			needsMigration = append(needsMigration, crd)
 		}
 	}
-
-	return nil
+	return
 }
 
 // getPregeneratedCRD returns the pregenerated CRD based on the requested CRD
@@ -65,7 +72,7 @@ func getPregeneratedCRD(logger *slog.Logger, crdName string) apiextensionsv1.Cus
 
 // createCRD creates and updates a CRD.
 // It should be called on operator startup but is idempotent and safe to call again.
-func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string) error {
+func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crd := getPregeneratedCRD(logger, crdVersionedName)
 
 	return crdhelpers.CreateUpdateCRD(

--- a/pkg/k8s/apis/cell.go
+++ b/pkg/k8s/apis/cell.go
@@ -4,6 +4,7 @@
 package apis
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -46,7 +47,7 @@ func (c RegisterCRDsConfig) Flags(flags *pflag.FlagSet) {
 }
 
 // RegisterCRDsFunc is a function that register all the CRDs for a k8s group
-type RegisterCRDsFunc func(*slog.Logger, k8sClient.Clientset) error
+type RegisterCRDsFunc func(context.Context, *slog.Logger, k8sClient.Clientset) error
 
 type params struct {
 	cell.In
@@ -71,7 +72,7 @@ func createCRDs(p params) {
 			}
 
 			for _, f := range p.RegisterCRDsFuncs {
-				if err := f(p.Logger, p.Clientset); err != nil {
+				if err := f(ctx, p.Logger, p.Clientset); err != nil {
 					return fmt.Errorf("unable to create CRDs: %w", err)
 				}
 			}
@@ -89,8 +90,8 @@ type RegisterCRDsFuncOut struct {
 
 func newCiliumGroupCRDs(bc bgpConfig.BGPConfig) RegisterCRDsFuncOut {
 	return RegisterCRDsFuncOut{
-		Func: func(l *slog.Logger, c k8sClient.Clientset) error {
-			return client.RegisterCRDs(l, c, bc)
+		Func: func(ctx context.Context, l *slog.Logger, c k8sClient.Clientset) error {
+			return client.RegisterCRDs(ctx, l, c, bc)
 		},
 	}
 }

--- a/pkg/k8s/apis/cell.go
+++ b/pkg/k8s/apis/cell.go
@@ -9,10 +9,13 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+	"github.com/cilium/cilium/pkg/k8s/apis/crdhelpers"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
 
@@ -47,13 +50,14 @@ func (c RegisterCRDsConfig) Flags(flags *pflag.FlagSet) {
 }
 
 // RegisterCRDsFunc is a function that register all the CRDs for a k8s group
-type RegisterCRDsFunc func(context.Context, *slog.Logger, k8sClient.Clientset) error
+type RegisterCRDsFunc func(ctx context.Context, log *slog.Logger, clientset k8sClient.Clientset) (needsMigration []*apiextensionsv1.CustomResourceDefinition, err error)
 
 type params struct {
 	cell.In
 
 	Logger    *slog.Logger
 	Lifecycle cell.Lifecycle
+	JG        job.Group
 
 	Clientset k8sClient.Clientset
 
@@ -71,12 +75,35 @@ func createCRDs(p params) {
 				return nil
 			}
 
+			// gather CRDs that need storage version migration
+			migrateCRDs := []*apiextensionsv1.CustomResourceDefinition{}
+
 			for _, f := range p.RegisterCRDsFuncs {
-				if err := f(ctx, p.Logger, p.Clientset); err != nil {
+				if f == nil {
+					continue
+				}
+				m, err := f(ctx, p.Logger, p.Clientset)
+				if err != nil {
 					return fmt.Errorf("unable to create CRDs: %w", err)
 				}
+				migrateCRDs = append(migrateCRDs, m...)
 			}
 
+			// If migration was requested, then schedule a separate job
+			// for each requested CRD.
+			for _, crd := range migrateCRDs {
+				if crd == nil {
+					continue
+				}
+				jobname := "crd-migrate-" + crd.Spec.Names.Plural
+				log := p.Logger.WithGroup(jobname)
+				p.JG.Add(job.OneShot(
+					jobname,
+					func(ctx context.Context, _ cell.Health) error {
+						return crdhelpers.MigrateStorageVersion(ctx, log, p.Clientset, crd.Name)
+					},
+				))
+			}
 			return nil
 		},
 	})
@@ -90,8 +117,8 @@ type RegisterCRDsFuncOut struct {
 
 func newCiliumGroupCRDs(bc bgpConfig.BGPConfig) RegisterCRDsFuncOut {
 	return RegisterCRDsFuncOut{
-		Func: func(ctx context.Context, l *slog.Logger, c k8sClient.Clientset) error {
-			return client.RegisterCRDs(ctx, l, c, bc)
+		Func: func(ctx context.Context, l *slog.Logger, c k8sClient.Clientset) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+			return client.CreateCustomResourceDefinitions(ctx, l, c, bc)
 		},
 	}
 }

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -14,13 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/cilium/cilium/pkg/bgp/config"
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconstv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/apis/crdhelpers"
-	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -216,20 +214,24 @@ func CustomResourceDefinitionList() map[string]*CRDList {
 
 // CreateCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
-func CreateCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, bgpCfg bgpConfig.BGPConfig) error {
+func CreateCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, bgpCfg bgpConfig.BGPConfig) (
+	needsMigration []*apiextensionsv1.CustomResourceDefinition, err error) {
 	crds := CustomResourceDefinitionList()
 
 	for _, r := range synced.AllCiliumCRDResourceNames(bgpCfg) {
 		if crd, ok := crds[r]; ok {
-			if err := createCRD(ctx, logger, clientset, crd.Name, crd.FullName); err != nil {
-				return err
+			obj, err := createCRD(ctx, logger, clientset, crd.Name, crd.FullName)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to create custom resource definition %s: %w", crd.FullName, err)
+			}
+			if crdhelpers.CRDNeedsMigration(obj) {
+				needsMigration = append(needsMigration, obj)
 			}
 		} else {
 			logging.Fatal(logger, fmt.Sprintf("Unknown resource %s. Please update pkg/k8s/apis/cilium.io/client to understand this type.", r))
 		}
 	}
-
-	return nil
+	return
 }
 
 var (
@@ -391,7 +393,7 @@ func GetPregeneratedCRD(logger *slog.Logger, crdName string) apiextensionsv1.Cus
 
 // createCRD creates and updates a CRD.
 // It should be called on agent startup but is idempotent and safe to call again.
-func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string, crdMetaName string) error {
+func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string, crdMetaName string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	ciliumCRD := GetPregeneratedCRD(logger, crdVersionedName)
 
 	return crdhelpers.CreateUpdateCRD(
@@ -432,13 +434,4 @@ func constructV1CRD(
 			Conversion: template.Spec.Conversion, // conversion strategy is needed to support several versions of a same CRD
 		},
 	}
-}
-
-// RegisterCRDs registers all CRDs with the K8s apiserver.
-func RegisterCRDs(ctx context.Context, logger *slog.Logger, clientset client.Clientset, bgpCfg config.BGPConfig) error {
-	if err := CreateCustomResourceDefinitions(ctx, logger, clientset, bgpCfg); err != nil {
-		return fmt.Errorf("Unable to create custom resource definition: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log/slog"
@@ -215,12 +216,12 @@ func CustomResourceDefinitionList() map[string]*CRDList {
 
 // CreateCustomResourceDefinitions creates our CRD objects in the Kubernetes
 // cluster.
-func CreateCustomResourceDefinitions(logger *slog.Logger, clientset apiextensionsclient.Interface, bgpCfg bgpConfig.BGPConfig) error {
+func CreateCustomResourceDefinitions(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, bgpCfg bgpConfig.BGPConfig) error {
 	crds := CustomResourceDefinitionList()
 
 	for _, r := range synced.AllCiliumCRDResourceNames(bgpCfg) {
 		if crd, ok := crds[r]; ok {
-			if err := createCRD(logger, clientset, crd.Name, crd.FullName); err != nil {
+			if err := createCRD(ctx, logger, clientset, crd.Name, crd.FullName); err != nil {
 				return err
 			}
 		} else {
@@ -390,10 +391,11 @@ func GetPregeneratedCRD(logger *slog.Logger, crdName string) apiextensionsv1.Cus
 
 // createCRD creates and updates a CRD.
 // It should be called on agent startup but is idempotent and safe to call again.
-func createCRD(logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string, crdMetaName string) error {
+func createCRD(ctx context.Context, logger *slog.Logger, clientset apiextensionsclient.Interface, crdVersionedName string, crdMetaName string) error {
 	ciliumCRD := GetPregeneratedCRD(logger, crdVersionedName)
 
 	return crdhelpers.CreateUpdateCRD(
+		ctx,
 		logger,
 		clientset,
 		constructV1CRD(crdMetaName, ciliumCRD),
@@ -433,8 +435,8 @@ func constructV1CRD(
 }
 
 // RegisterCRDs registers all CRDs with the K8s apiserver.
-func RegisterCRDs(logger *slog.Logger, clientset client.Clientset, bgpCfg config.BGPConfig) error {
-	if err := CreateCustomResourceDefinitions(logger, clientset, bgpCfg); err != nil {
+func RegisterCRDs(ctx context.Context, logger *slog.Logger, clientset client.Clientset, bgpCfg config.BGPConfig) error {
+	if err := CreateCustomResourceDefinitions(ctx, logger, clientset, bgpCfg); err != nil {
 		return fmt.Errorf("Unable to create custom resource definition: %w", err)
 	}
 

--- a/pkg/k8s/apis/crdhelpers/migrate.go
+++ b/pkg/k8s/apis/crdhelpers/migrate.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package crdhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"syscall"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// needsStorageMigration returns true if the CRD in question may need its
+// versions migrated.
+//
+// CRD's have a Status field that list all (potentially) stored versionss.
+// This is the list of any versions that have *ever* been set as stored, and is
+// maintained by the apiserver.
+// A migration is required if the current CRD spec has fewer stored
+// versions than the CRD's Status.
+func CRDNeedsMigration(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	// Get the set of stored versions as understood by the APIServer -- these are the set
+	// that may exist in storage.
+	specStoredVersions := sets.New(crd.Status.StoredVersions...)
+
+	// Delete all versions currently marked as stored - we don't need to migrate them
+	for _, ver := range crd.Spec.Versions {
+		if ver.Storage {
+			specStoredVersions.Delete(ver.Name)
+		}
+	}
+
+	// We will need a migration if there is a stored version not listed as stored in the CRD spec
+	return specStoredVersions.Len() > 0
+}
+
+// List chunk size
+const chunkSize = 500
+
+// MigrateStorageVersion performs a storage version migration of the given CRD.
+//
+// To do this, we issue a no-op PATCH request against all existing objects. This
+// will trigger the apiserver to migrate the stored version. Once all objects have
+// been patched, we can remove any obsolete stored versions from the CRD Status field.
+//
+// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/
+func MigrateStorageVersion(ctx context.Context, log *slog.Logger, clientset k8sClient.Clientset, crdName string) error {
+	log = log.With(logfields.Resource, crdName)
+
+	var crd *apiextensionsv1.CustomResourceDefinition
+	err := transientRetry(log, ctx, func() error {
+		var err error
+		crd, err = clientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if !CRDNeedsMigration(crd) {
+		return nil
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    crd.Spec.Group,
+		Resource: crd.Spec.Names.Plural,
+	}
+	// pick the first served + stored version to use for the patch resource
+	for _, ver := range crd.Spec.Versions {
+		if !ver.Storage || !ver.Served {
+			continue
+		}
+		gvr.Version = ver.Name
+		break
+	}
+	// not possible; version must be stored + served
+	if gvr.Version == "" {
+		return nil
+	}
+
+	log = log.With(logfields.Version, gvr.Version)
+	log.Info("CRD version migration: listing existing objects")
+
+	// List all objects, using a paged lister.
+	objs := []types.NamespacedName{}
+	listContinue := ""
+	for {
+		log.Debug("listing objects",
+			logfields.Remaining, listContinue)
+
+		var l *unstructured.UnstructuredList
+		listErr := transientRetry(log, ctx, func() error {
+			var err error
+			l, err = clientset.Resource(gvr).List(ctx,
+				metav1.ListOptions{
+					Limit:    chunkSize,
+					Continue: listContinue,
+				})
+			return err
+		})
+		if listErr != nil {
+			// pagination stumbled, need to restart
+			if apierrors.IsResourceExpired(listErr) {
+				listContinue = ""
+				log.Info("List continue expired, retrying", logfields.Error, err)
+				continue
+			}
+
+			log.Warn("Failed to list existing objects", logfields.Error, err)
+			return fmt.Errorf("failed to list %s for storage migration: %w", crd.Name, listErr)
+		}
+
+		for _, obj := range l.Items {
+			objs = append(objs, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()})
+		}
+
+		listContinue = l.GetContinue()
+		if listContinue == "" {
+			// paging complete
+			break
+		}
+	}
+
+	log.Info("Migrating existing objects", logfields.Count, len(objs))
+
+	for _, nsn := range objs {
+		log := log.With(
+			logfields.K8sNamespace, nsn.Namespace,
+			logfields.Name, nsn.Name)
+		log.Debug("Issuing no-op patch")
+
+		patchErr := transientRetry(log, ctx, func() error {
+			_, err := clientset.Resource(gvr).Namespace(nsn.Namespace).Patch(
+				ctx,
+				nsn.Name,
+				types.MergePatchType,
+				[]byte(`{}`),
+				metav1.PatchOptions{},
+			)
+			return err
+		})
+		if patchErr != nil {
+			// Object was deleted - nothing to do
+			if apierrors.IsNotFound(patchErr) {
+				continue
+			}
+
+			log.Warn("No-op patch request failed",
+				logfields.Error, patchErr)
+			return fmt.Errorf("failed to patch %s %s/%s: %w", crd.Name, nsn.Namespace, nsn.Name, patchErr)
+		}
+	}
+
+	log.Info("All objects migrated, removing obsolete CRD storage version references from status")
+
+	origStatusVersions := crd.Status.StoredVersions
+
+	// Remove all non-spec stored versions from the Status
+	err = transientRetry(log, ctx, func() error {
+		crd, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// paranoia: something changed during migration
+		if !slices.Equal(origStatusVersions, crd.Status.StoredVersions) {
+			log.Warn("CRD was updated during storage migration, not touching stored version")
+			return fmt.Errorf("CRD was updated during storage migration")
+		}
+
+		storedVersions := []string{}
+		for _, version := range crd.Spec.Versions {
+			if version.Storage {
+				storedVersions = append(storedVersions, version.Name)
+			}
+		}
+
+		crd = crd.DeepCopy()
+		crd.Status.StoredVersions = storedVersions
+		_, err = clientset.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(ctx, crd, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.Warn("Failed to update CRD .Status.StoredVersions", logfields.Error, err)
+		return fmt.Errorf("failed to update CRD %s .Status.StoredVersions : %w", crdName, err)
+	}
+
+	log.Info("CRD version migration complete.")
+	return nil
+}
+
+// isTransientError returns true if the error is temporary and retryable
+// (network issues, API server overload), vs permanent errors (CRD not installed).
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for Kubernetes API server errors that are transient
+	if apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsConflict(err) {
+		return true
+	}
+
+	// Check for network-level errors (connection refused, reset, host unreachable)
+	if errno, ok := errors.AsType[syscall.Errno](err); ok {
+		switch errno {
+		case syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.EHOSTUNREACH, syscall.ENETUNREACH:
+			return true
+		}
+	}
+
+	return false
+}
+
+const retries = 10
+
+// transientRetry retries the given function until no error
+// or a non-transient error is returned
+func transientRetry(log *slog.Logger, ctx context.Context, f func() error) error {
+	var err error
+	delaySecs := 1
+	for range retries {
+		err = f()
+		if err == nil {
+			return nil
+		}
+		if !isTransientError(err) {
+			return err
+		}
+
+		log.Debug("API request failed with transient error, will retry", logfields.Error, err)
+
+		// delay more if the apiserver suggests it
+		s, _ := apierrors.SuggestsClientDelay(err)
+		delaySecs = max(delaySecs, s)
+
+		ch := time.After(time.Second * time.Duration(delaySecs))
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		delaySecs *= 2
+	}
+	return err
+}

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -28,6 +28,7 @@ type NeedUpdateCRDFunc func(targetCRD, currentCRD *apiextensionsv1.CustomResourc
 // will create or update the CRD and its validation schema as necessary. This
 // function only accepts v1 CRD objects.
 func CreateUpdateCRD(
+	ctx context.Context,
 	logger *slog.Logger,
 	clientset apiextensionsclient.Interface,
 	targetCRD *apiextensionsv1.CustomResourceDefinition,
@@ -38,7 +39,7 @@ func CreateUpdateCRD(
 
 	v1CRDClient := clientset.ApiextensionsV1()
 	currentCRD, err := v1CRDClient.CustomResourceDefinitions().Get(
-		context.TODO(),
+		ctx,
 		targetCRD.ObjectMeta.Name,
 		metav1.GetOptions{})
 	if errors.IsNotFound(err) {
@@ -58,10 +59,10 @@ func CreateUpdateCRD(
 		return err
 	}
 
-	if err := updateV1CRD(scopedLog, targetCRD, currentCRD, v1CRDClient, poller, needsUpdateCRDFunc); err != nil {
+	if err := updateV1CRD(ctx, scopedLog, targetCRD, currentCRD, v1CRDClient, poller, needsUpdateCRDFunc); err != nil {
 		return err
 	}
-	if err := waitForV1CRD(scopedLog, currentCRD, v1CRDClient, poller); err != nil {
+	if err := waitForV1CRD(ctx, scopedLog, currentCRD, v1CRDClient, poller); err != nil {
 		return err
 	}
 
@@ -96,6 +97,7 @@ func NeedsUpdateV1Factory(
 }
 
 func updateV1CRD(
+	ctx context.Context,
 	scopedLog *slog.Logger,
 	targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinition,
 	client v1client.CustomResourceDefinitionsGetter,
@@ -112,10 +114,10 @@ func updateV1CRD(
 		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
 
 		// Update the CRD with the validation schema.
-		err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		err := poller.Poll(ctx, 500*time.Millisecond, 60*time.Second, func(ctx context.Context) (bool, error) {
 			var err error
 			currentCRD, err = client.CustomResourceDefinitions().Get(
-				context.TODO(),
+				ctx,
 				targetCRD.ObjectMeta.Name,
 				metav1.GetOptions{})
 			if err != nil {
@@ -142,7 +144,7 @@ func updateV1CRD(
 				currentCRD.Spec.PreserveUnknownFields = false
 
 				_, err := client.CustomResourceDefinitions().Update(
-					context.TODO(),
+					ctx,
 					currentCRD,
 					metav1.UpdateOptions{})
 				switch {
@@ -177,6 +179,7 @@ func updateV1CRD(
 }
 
 func waitForV1CRD(
+	ctx context.Context,
 	scopedLog *slog.Logger,
 	crd *apiextensionsv1.CustomResourceDefinition,
 	client v1client.CustomResourceDefinitionsGetter,
@@ -184,7 +187,7 @@ func waitForV1CRD(
 ) error {
 	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
 
-	err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+	err := poller.Poll(ctx, 500*time.Millisecond, 60*time.Second, func(ctx context.Context) (bool, error) {
 		for _, cond := range crd.Status.Conditions {
 			switch cond.Type {
 			case apiextensionsv1.Established:
@@ -204,7 +207,7 @@ func waitForV1CRD(
 
 		var err error
 		if crd, err = client.CustomResourceDefinitions().Get(
-			context.TODO(),
+			ctx,
 			crd.ObjectMeta.Name,
 			metav1.GetOptions{}); err != nil {
 			return false, err
@@ -222,18 +225,19 @@ func waitForV1CRD(
 // CRD changes / updates to the apiserver. The reason this exists is mainly for
 // unit-testing.
 type poller interface {
-	Poll(interval, duration time.Duration, conditionFn func() (bool, error)) error
+	Poll(ctx context.Context, interval, duration time.Duration, conditionFn func(context.Context) (bool, error)) error
 }
 
-func NewDefaultPoller() defaultPoll {
+func NewDefaultPoller() poller {
 	return defaultPoll{}
 }
 
 type defaultPoll struct{}
 
 func (p defaultPoll) Poll(
+	ctx context.Context,
 	interval, duration time.Duration,
-	conditionFn func() (bool, error),
+	conditionFn func(context.Context) (bool, error),
 ) error {
-	return wait.Poll(interval, duration, conditionFn)
+	return wait.PollUntilContextTimeout(ctx, interval, duration, false, conditionFn)
 }

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -5,7 +5,7 @@ package crdhelpers
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -13,7 +13,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -27,6 +27,8 @@ type NeedUpdateCRDFunc func(targetCRD, currentCRD *apiextensionsv1.CustomResourc
 // CreateUpdateCRD ensures the CRD object is installed into the K8s cluster. It
 // will create or update the CRD and its validation schema as necessary. This
 // function only accepts v1 CRD objects.
+//
+// Returns the created object
 func CreateUpdateCRD(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -34,7 +36,7 @@ func CreateUpdateCRD(
 	targetCRD *apiextensionsv1.CustomResourceDefinition,
 	poller poller,
 	needsUpdateCRDFunc NeedUpdateCRDFunc,
-) error {
+) (*apiextensionsv1.CustomResourceDefinition, error) {
 	scopedLog := logger.With(logfields.Name, targetCRD.Name)
 
 	v1CRDClient := clientset.ApiextensionsV1()
@@ -42,8 +44,9 @@ func CreateUpdateCRD(
 		ctx,
 		targetCRD.ObjectMeta.Name,
 		metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		scopedLog.Info("Creating CRD (CustomResourceDefinition)...")
+		prev := currentCRD
 
 		currentCRD, err = v1CRDClient.CustomResourceDefinitions().Create(
 			context.TODO(),
@@ -51,24 +54,26 @@ func CreateUpdateCRD(
 			metav1.CreateOptions{})
 		// This occurs when multiple agents race to create the CRD. Since another has
 		// created it, it will also update it, hence the non-error return.
-		if errors.IsAlreadyExists(err) {
-			return nil
+		if apierrors.IsAlreadyExists(err) {
+			return prev, nil
 		}
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if err := updateV1CRD(ctx, scopedLog, targetCRD, currentCRD, v1CRDClient, poller, needsUpdateCRDFunc); err != nil {
-		return err
+	currentCRD, err = updateV1CRD(ctx, scopedLog, targetCRD, currentCRD, v1CRDClient, poller, needsUpdateCRDFunc)
+	if err != nil {
+		return nil, err
 	}
-	if err := waitForV1CRD(ctx, scopedLog, currentCRD, v1CRDClient, poller); err != nil {
-		return err
+	currentCRD, err = waitForV1CRD(ctx, scopedLog, currentCRD, v1CRDClient, poller)
+	if err != nil {
+		return nil, err
 	}
 
 	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")
 
-	return nil
+	return currentCRD, nil
 }
 
 func NeedsUpdateV1Factory(
@@ -103,11 +108,11 @@ func updateV1CRD(
 	client v1client.CustomResourceDefinitionsGetter,
 	poller poller,
 	needsUpdateCRDFunc NeedUpdateCRDFunc,
-) error {
+) (*apiextensionsv1.CustomResourceDefinition, error) {
 	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
 	needsUpdate, err := needsUpdateCRDFunc(targetCRD, currentCRD)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if targetCRD.Spec.Versions[0].Schema != nil && needsUpdate {
@@ -148,7 +153,7 @@ func updateV1CRD(
 					currentCRD,
 					metav1.UpdateOptions{})
 				switch {
-				case errors.IsConflict(err): // Occurs as Operators race to update CRDs.
+				case apierrors.IsConflict(err): // Occurs as Operators race to update CRDs.
 					scopedLog.Debug(
 						"The CRD update was based on an older version, retrying...",
 						logfields.Error, err,
@@ -171,11 +176,11 @@ func updateV1CRD(
 			scopedLog.Error("Unable to update CRD",
 				logfields.Error, err,
 			)
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return currentCRD, nil
 }
 
 func waitForV1CRD(
@@ -184,7 +189,7 @@ func waitForV1CRD(
 	crd *apiextensionsv1.CustomResourceDefinition,
 	client v1client.CustomResourceDefinitionsGetter,
 	poller poller,
-) error {
+) (*apiextensionsv1.CustomResourceDefinition, error) {
 	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
 
 	err := poller.Poll(ctx, 500*time.Millisecond, 60*time.Second, func(ctx context.Context) (bool, error) {
@@ -196,7 +201,7 @@ func waitForV1CRD(
 				}
 			case apiextensionsv1.NamesAccepted:
 				if cond.Status == apiextensionsv1.ConditionFalse {
-					err := goerrors.New(cond.Reason)
+					err := errors.New(cond.Reason)
 					scopedLog.Error("Name conflict for CRD",
 						logfields.Error, err,
 					)
@@ -215,10 +220,10 @@ func waitForV1CRD(
 		return false, err
 	})
 	if err != nil {
-		return fmt.Errorf("error occurred waiting for CRD: %w", err)
+		return nil, fmt.Errorf("error occurred waiting for CRD: %w", err)
 	}
 
-	return nil
+	return crd, nil
 }
 
 // poller is an interface that abstracts the polling logic when dealing with

--- a/pkg/k8s/apis/crdhelpers/register_test.go
+++ b/pkg/k8s/apis/crdhelpers/register_test.go
@@ -88,7 +88,8 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				require.NoError(t, k8sversion.Force(v1Support.Major+"."+v1Support.Minor))
-				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				_, err := CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return err
 			},
 			wantErr: false,
 		},
@@ -99,7 +100,8 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				require.NoError(t, k8sversion.Force(v1beta1Support.Major+"."+v1beta1Support.Minor))
-				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				_, err := CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return err
 			},
 			wantErr: false,
 		},
@@ -126,7 +128,8 @@ func TestCreateUpdateCRD(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				_, err = CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return err
 			},
 			wantErr: false,
 		},
@@ -166,7 +169,8 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				crd.ObjectMeta.Name = crdToInstall.ObjectMeta.Name
 
-				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				_, err = CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return err
 			},
 			wantErr: false,
 		},

--- a/pkg/k8s/apis/crdhelpers/register_test.go
+++ b/pkg/k8s/apis/crdhelpers/register_test.go
@@ -88,7 +88,7 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				require.NoError(t, k8sversion.Force(v1Support.Major+"."+v1Support.Minor))
-				return CreateUpdateCRD(hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
 			},
 			wantErr: false,
 		},
@@ -99,7 +99,7 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				require.NoError(t, k8sversion.Force(v1beta1Support.Major+"."+v1beta1Support.Minor))
-				return CreateUpdateCRD(hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
 			},
 			wantErr: false,
 		},
@@ -126,7 +126,7 @@ func TestCreateUpdateCRD(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				return CreateUpdateCRD(hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
 			},
 			wantErr: false,
 		},
@@ -166,7 +166,7 @@ func TestCreateUpdateCRD(t *testing.T) {
 				crd := getV1TestCRD()
 				crd.ObjectMeta.Name = crdToInstall.ObjectMeta.Name
 
-				return CreateUpdateCRD(hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
+				return CreateUpdateCRD(t.Context(), hivetest.Logger(t), client, crd, newFakePoller(), NeedsUpdateV1Factory(labelKey, minVersion))
 			},
 			wantErr: false,
 		},
@@ -278,8 +278,9 @@ func newFakePoller() fakePoller { return fakePoller{} }
 type fakePoller struct{}
 
 func (m fakePoller) Poll(
+	_ context.Context,
 	interval, duration time.Duration,
-	conditionFn func() (bool, error),
+	conditionFn func(context.Context) (bool, error),
 ) error {
 	return nil
 }

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -20,6 +20,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/connrotation"
@@ -82,6 +83,7 @@ type Clientset interface {
 	apiext_clientset.Interface
 	cilium_clientset.Interface
 	policy_clientset.Interface
+	dynamic.Interface
 	Getters
 
 	// Slim returns the slim client, which contains some of the same APIs as the
@@ -107,6 +109,7 @@ type compositeClientset struct {
 	*APIExtClientset
 	*CiliumClientset
 	*PolicyClientset
+	*dynamic.DynamicClient
 	ClientsetGetters
 
 	controller        *controller.Manager
@@ -116,6 +119,8 @@ type compositeClientset struct {
 	closeAllConns     func()
 	restConfigManager *restConfigManager
 }
+
+var _ Clientset = (*compositeClientset)(nil)
 
 // ConfigureK8sClientsetDialer provides an optional extension point
 // to configure the dialer used by the clientset.
@@ -172,12 +177,19 @@ func newClientsetForUserAgent(params compositeClientsetParams, name string) (Cli
 		}
 	}
 
+	client.ClientsetGetters = ClientsetGetters{Client: &client}
+
 	// Slim and K8s clients use protobuf marshalling.
 	rc.ContentConfig.ContentType = `application/vnd.kubernetes.protobuf`
 
 	client.slim, err = slim_clientset.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create slim k8s client: %w", err)
+	}
+
+	client.DynamicClient, err = dynamic.NewForConfigAndClient(rc, httpClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create k8s dynamic client: %w", err)
 	}
 
 	client.APIExtClientset, err = apiext_clientset.NewForConfigAndClient(rc, httpClient)
@@ -199,8 +211,6 @@ func newClientsetForUserAgent(params compositeClientsetParams, name string) (Cli
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create policy k8s client: %w", err)
 	}
-
-	client.ClientsetGetters = ClientsetGetters{&client}
 
 	// The cilium client uses JSON marshalling.
 	rc.ContentConfig.ContentType = `application/json`

--- a/pkg/k8s/client/getters.go
+++ b/pkg/k8s/client/getters.go
@@ -16,17 +16,18 @@ type Getters interface {
 }
 
 // ClientsetGetters implements the Getters interface in terms of the clientset.
+// This is used to provide a consistent interface on top of multiple client implementations
 type ClientsetGetters struct {
-	Clientset
+	Client Clientset
 }
 
 // GetSecrets returns the secrets found in the given namespace and name.
 func (cs *ClientsetGetters) GetSecrets(ctx context.Context, ns, name string) (map[string][]byte, error) {
-	if !cs.IsEnabled() {
+	if !cs.Client.IsEnabled() {
 		return nil, fmt.Errorf("GetSecrets: No k8s, cannot access k8s secrets")
 	}
 
-	result, err := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+	result, err := cs.Client.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamic_fake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	k8sTesting "k8s.io/client-go/testing"
@@ -79,6 +80,7 @@ type FakeClientset struct {
 	*CiliumFakeClientset
 	*APIExtFakeClientset
 	*PolicyFakeClientset
+	*dynamic_fake.FakeDynamicClient
 	k8sclient.ClientsetGetters
 
 	ot *statedbObjectTracker
@@ -161,6 +163,7 @@ func NewFakeClientsetWithVersion(log *slog.Logger, ot *statedbObjectTracker, ver
 		MCSAPIFakeClientset:     mcsapi_fake.NewSimpleClientset(),
 		PolicyFakeClientset:     policy_fake.NewSimpleClientset(),
 		KubernetesFakeClientset: fake.NewSimpleClientset(),
+		FakeDynamicClient:       dynamic_fake.NewSimpleDynamicClient(testutils.Scheme),
 	}
 	client.KubernetesFakeClientset.Resources = resources
 	client.SlimFakeClientset.Resources = resources
@@ -194,7 +197,7 @@ func NewFakeClientsetWithVersion(log *slog.Logger, ot *statedbObjectTracker, ver
 	fd := client.KubernetesFakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
 	fd.FakedServerVersion = toVersionInfo(version)
 
-	client.ClientsetGetters = k8sclient.ClientsetGetters{Clientset: &client}
+	client.ClientsetGetters = k8sclient.ClientsetGetters{Client: &client}
 	return &client, &client
 }
 

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	unstructuredScheme := runtime.NewScheme()
+	for gvk := range scheme.AllKnownTypes() {
+		if unstructuredScheme.Recognizes(gvk) {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+
+	objects, err := convertObjectsToUnstructured(scheme, objects)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, obj := range objects {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+		gvk.Kind += "List"
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		}
+	}
+
+	return NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, nil, objects...)
+}
+
+// NewSimpleDynamicClientWithCustomListKinds try not to use this.  In general you want to have the scheme have the List types registered
+// and allow the default guessing for resources match.  Sometimes that doesn't work, so you can specify a custom mapping here.
+func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have your lists registered so that the object tracker will find them
+	// in the scheme to support the t.scheme.New(listGVK) call when it's building the return value.
+	// Since the base fake client needs the listGVK passed through the action (in cases where there are no instances, it
+	// cannot look up the actual hits), we need to know a mapping of GVR to listGVK here.  For GETs and other types of calls,
+	// there is no return value that contains a GVK, so it doesn't have to know the mapping in advance.
+
+	// first we attempt to invert known List types from the scheme to auto guess the resource with unsafe guesses
+	// this covers common usage of registering types in scheme and passing them
+	completeGVRToListKind := map[schema.GroupVersionResource]string{}
+	for listGVK := range scheme.AllKnownTypes() {
+		if !strings.HasSuffix(listGVK.Kind, "List") {
+			continue
+		}
+		nonListGVK := listGVK.GroupVersion().WithKind(listGVK.Kind[:len(listGVK.Kind)-4])
+		plural, _ := meta.UnsafeGuessKindToResource(nonListGVK)
+		completeGVRToListKind[plural] = listGVK.Kind
+	}
+
+	for gvr, listKind := range gvrToListKind {
+		if !strings.HasSuffix(listKind, "List") {
+			panic("coding error, listGVK must end in List or this fake client doesn't work right")
+		}
+		listGVK := gvr.GroupVersion().WithKind(listKind)
+
+		// if we already have this type registered, just skip it
+		if _, err := scheme.New(listGVK); err == nil {
+			completeGVRToListKind[gvr] = listKind
+			continue
+		}
+
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		completeGVRToListKind[gvr] = listKind
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme, gvrToListKind: completeGVRToListKind, tracker: o}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		var opts metav1.ListOptions
+		if watchAction, ok := action.(testing.WatchActionImpl); ok {
+			opts = watchAction.ListOptions
+		}
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns, opts)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme        *runtime.Scheme
+	gvrToListKind map[schema.GroupVersionResource]string
+	tracker       testing.ObjectTracker
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+	listKind  string
+}
+
+var (
+	_ dynamic.Interface  = &FakeDynamicClient{}
+	_ testing.FakeClient = &FakeDynamicClient{}
+)
+
+func (c *FakeDynamicClient) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, listKind: c.gvrToListKind[resource]}
+}
+
+func (c *FakeDynamicClient) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, "status", obj, opts), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, "status", c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionActionWithOptions(c.resource, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionActionWithOptions(c.resource, c.namespace, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceActionWithOptions(c.resource, c.namespace, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.listKind) == 0 {
+		panic(fmt.Sprintf("coding error: you must register resource to list kind for every resource you're going to LIST when creating the client.  See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme: %v out of %v", c.resource, c.client.gvrToListKind))
+	}
+	listGVK := c.resource.GroupVersion().WithKind(c.listKind)
+	listForFakeClientGVK := c.resource.GroupVersion().WithKind(c.listKind[:len(c.listKind)-4]) /*base library appends List*/
+
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListActionWithOptions(c.resource, listForFakeClientGVK, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListActionWithOptions(c.resource, listForFakeClientGVK, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.SetContinue(entireList.GetContinue())
+	list.GetObjectKind().SetGroupVersionKind(listGVK)
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchActionWithOptions(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchActionWithOptions(c.resource, c.namespace, opts))
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	patchOptions := metav1.PatchOptions{
+		Force:        &options.Force,
+		DryRun:       options.DryRun,
+		FieldManager: options.FieldManager,
+	}
+	var uncastRet runtime.Object
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (c *dynamicResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return c.Apply(ctx, name, obj, options, "status")
+}
+
+func convertObjectsToUnstructured(s *runtime.Scheme, objs []runtime.Object) ([]runtime.Object, error) {
+	ul := make([]runtime.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		u, err := convertToUnstructured(s, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		ul = append(ul, u)
+	}
+	return ul, nil
+}
+
+func convertToUnstructured(s *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var (
+		err error
+		u   unstructured.Unstructured
+	)
+
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured - unable to get GVK %w", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiv)
+		u.SetKind(k)
+	}
+	return &u, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2349,6 +2349,7 @@ k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/features
 k8s.io/client-go/gentype
 k8s.io/client-go/informers


### PR DESCRIPTION
The operator manages Cilium CRDs, but it does not perform [storage version migration](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version). This has caused bugs in the past, where we failed to remove older versions from the CRD's .Status.Versions fields, leading to a failure to upgrade.

This change adds an additional step to CRD creation that kicks off a background storage version migration. To do so, the operator needs to issue a no-op PATCH request for every instance of a CRD. That will cause the apiserver to automatically migrate the stored version. Once that is done, the crd's .Status.Versions field can be adjusted accordingly.

Fixes: #47774

```release-note
The Cilium Operator will automatically perform a storage version migration for obsolete Cilium-manged objects.
```
