### PR TITLE
bpf: nat: extract shared helper for L4 rewrite

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -135,6 +135,53 @@ __snat_delete(const void *map, const void *tuple)
 	return map_delete_elem(map, tuple);
 }
 
+static __always_inline int
+snat_rewrite_l4_header(struct __ctx_buff *ctx, struct csum_offset *csum,
+		       __wsum l3_sum, __u8 nexthdr, int l4_off,
+		       __be16 old_port, __be16 new_port, __u16 port_off)
+{
+	if (old_port != new_port) {
+		int ret;
+
+		switch (nexthdr) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+		case IPPROTO_ICMPV6:
+			break;
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+			return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
+		case IPPROTO_ICMP:
+			/* Not initialized by csum_l4_offset_and_flags(), because ICMPv4
+			 * doesn't use a pseudo-header, and the change in IP addresses is
+			 * not supposed to change the L4 checksum.
+			 * Set it temporarily to amend the checksum after changing ports.
+			 */
+			csum->offset = offsetof(struct icmphdr, checksum);
+			break;
+		default:
+			return DROP_UNKNOWN_L4;
+		}
+
+		/* Amend the L4 checksum due to changing the ports. */
+		ret = l4_modify_port(ctx, l4_off, port_off, csum, new_port, old_port);
+		if (ret < 0)
+			return ret;
+
+		/* Restore the original offset. */
+		if (nexthdr == IPPROTO_ICMP)
+			csum->offset = 0;
+	}
+
+	/* Amend the L4 checksum due to changing the addresses. */
+	if (csum->offset &&
+	    csum_l4_replace(ctx, l4_off, csum, 0, l3_sum, BPF_F_PSEUDO_HDR) < 0)
+		return DROP_CSUM_L4;
+
+	return 0;
+}
+
 struct ipv4_nat_entry {
 	struct nat_entry common;
 	union {
@@ -542,41 +589,10 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 
 		csum_l4_offset_and_flags(nexthdr, &csum);
 
-		if (old_port != new_port) {
-			switch (nexthdr) {
-			case IPPROTO_TCP:
-			case IPPROTO_UDP:
-				break;
-#ifdef ENABLE_SCTP
-			case IPPROTO_SCTP:
-				return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-			case IPPROTO_ICMP:
-				/* Not initialized by csum_l4_offset_and_flags(), because ICMPv4
-				 * doesn't use a pseudo-header, and the change in IP addresses is
-				 * not supposed to change the L4 checksum.
-				 * Set it temporarily to amend the checksum after changing ports.
-				 */
-				csum.offset = offsetof(struct icmphdr, checksum);
-				break;
-			default:
-				return DROP_UNKNOWN_L4;
-			}
-
-			/* Amend the L4 checksum due to changing the ports. */
-			err = l4_modify_port(ctx, l4_off, port_off, &csum, new_port, old_port);
-			if (err < 0)
-				return err;
-
-			/* Restore the original offset. */
-			if (nexthdr == IPPROTO_ICMP)
-				csum.offset = 0;
-		}
-
-		/* Amend the L4 checksum due to changing the addresses. */
-		if (csum.offset &&
-		    csum_l4_replace(ctx, l4_off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
-			return DROP_CSUM_L4;
+		err = snat_rewrite_l4_header(ctx, &csum, sum, nexthdr, l4_off,
+					     old_port, new_port, port_off);
+		if (err < 0)
+			return err;
 
 		/* Apply additional L4 checksum diff if provided (for ICMP error messages). */
 		if (l4_csum_diff_from_inner && !csum.offset) {
@@ -1695,33 +1711,8 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 
 	csum_l4_offset_and_flags(nexthdr, &csum);
 
-	if (old_port != new_port) {
-		int err;
-
-		switch (nexthdr) {
-		case IPPROTO_TCP:
-		case IPPROTO_UDP:
-		case IPPROTO_ICMPV6:
-			break;
-#ifdef ENABLE_SCTP
-		case IPPROTO_SCTP:
-			return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-		default:
-			return DROP_UNKNOWN_L4;
-		}
-
-		/* Amend the L4 checksum due to changing the ports. */
-		err = l4_modify_port(ctx, l4_off, port_off, &csum, new_port, old_port);
-		if (err < 0)
-			return err;
-	}
-
-	if (csum.offset &&
-	    csum_l4_replace(ctx, l4_off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
-		return DROP_CSUM_L4;
-
-	return 0;
+	return snat_rewrite_l4_header(ctx, &csum, sum, nexthdr, l4_off,
+				      old_port, new_port, port_off);
 }
 
 static __always_inline bool


### PR DESCRIPTION
Most of this logic is shared between IPv4 and IPv6.