### PR TITLE
Make ENI node registration resilient to a slow IMDS

### DIFF
--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -19,6 +19,7 @@ import (
 	awsMetadata "github.com/cilium/cilium/pkg/aws/metadata"
 	awsTypes "github.com/cilium/cilium/pkg/aws/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
@@ -28,19 +29,59 @@ func init() {
 	nodediscovery.RegisterENIMutator(mutate)
 }
 
+type metadataClient interface {
+	GetInstanceMetadata(ctx context.Context) (awsMetadata.MetaDataInfo, error)
+}
+
+// instanceFacts fetches the EC2 instance metadata once and remembers it.
+type instanceFacts struct {
+	mu     lock.Mutex
+	newFn  func(ctx context.Context) (metadataClient, error)
+	client metadataClient
+	info   *awsMetadata.MetaDataInfo
+}
+
+var facts = &instanceFacts{
+	newFn: func(ctx context.Context) (metadataClient, error) {
+		return awsMetadata.NewClient(ctx)
+	},
+}
+
+// get returns the metadata of the EC2 instance the agent runs on.
+func (f *instanceFacts) get(ctx context.Context) (awsMetadata.MetaDataInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.info != nil {
+		return *f.info, nil
+	}
+
+	if f.client == nil {
+		client, err := f.newFn(ctx)
+		if err != nil {
+			return awsMetadata.MetaDataInfo{}, fmt.Errorf("unable to create EC2 metadata client: %w", err)
+		}
+		f.client = client
+	}
+
+	info, err := f.client.GetInstanceMetadata(ctx)
+	if err != nil {
+		return awsMetadata.MetaDataInfo{}, fmt.Errorf("unable to retrieve InstanceID of own EC2 instance: %w", err)
+	}
+	if info.InstanceID == "" {
+		return awsMetadata.MetaDataInfo{}, errors.New("InstanceID of own EC2 instance is empty")
+	}
+
+	f.info = &info
+	return info, nil
+}
+
 // mutate populates the ENI-specific fields of nodeResource using EC2 IMDS
 // metadata and the agent configuration carried in in.
 func mutate(ctx context.Context, in nodediscovery.ENIMutateInputs, nodeResource *ciliumv2.CiliumNode) error {
-	imds, err := awsMetadata.NewClient(ctx)
+	info, err := facts.get(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to create EC2 metadata client: %w", err)
-	}
-	info, err := imds.GetInstanceMetadata(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to retrieve InstanceID of own EC2 instance: %w", err)
-	}
-	if info.InstanceID == "" {
-		return errors.New("InstanceID of own EC2 instance is empty")
+		return err
 	}
 
 	apply(in, info, nodeResource)

--- a/pkg/nodediscovery/eni/eni_test.go
+++ b/pkg/nodediscovery/eni/eni_test.go
@@ -5,9 +5,14 @@ package eni
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	cnifake "github.com/cilium/cilium/daemon/cmd/cni/fake"
@@ -70,5 +75,75 @@ func TestApplyInstanceFactsNotOverridable(t *testing.T) {
 
 	for _, key := range []string{"vpc-id", "instance-type", "availability-zone", "node-subnet-id"} {
 		require.Contains(t, logs.String(), "configKey="+key)
+	}
+}
+
+// stubMetadata counts the fetches of a metadataClient and can be told to fail
+// them.
+type stubMetadata struct {
+	info     awsMetadata.MetaDataInfo
+	err      error
+	fetches  atomic.Int32
+	newCalls atomic.Int32
+}
+
+func (s *stubMetadata) GetInstanceMetadata(context.Context) (awsMetadata.MetaDataInfo, error) {
+	s.fetches.Add(1)
+	return s.info, s.err
+}
+
+func (s *stubMetadata) facts() *instanceFacts {
+	return &instanceFacts{newFn: func(context.Context) (metadataClient, error) {
+		s.newCalls.Add(1)
+		return s, nil
+	}}
+}
+
+func TestInstanceFactsFetchesOnce(t *testing.T) {
+	stub := &stubMetadata{info: awsMetadata.MetaDataInfo{InstanceID: "i-instance"}}
+	facts := stub.facts()
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			info, err := facts.get(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "i-instance", info.InstanceID)
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), stub.fetches.Load())
+	require.Equal(t, int32(1), stub.newCalls.Load())
+}
+
+// TestInstanceFactsRetriesFailures asserts that a failed fetch is not cached,
+// so that the CiliumNode update retried by pkg/nodediscovery can succeed, and
+// that the retry reuses the IMDS client.
+func TestInstanceFactsRetriesFailures(t *testing.T) {
+	tests := map[string]struct {
+		info awsMetadata.MetaDataInfo
+		err  error
+	}{
+		"fetch error":       {err: errors.New("i/o timeout")},
+		"empty instance ID": {info: awsMetadata.MetaDataInfo{}},
+	}
+
+	for name, failure := range tests {
+		t.Run(name, func(t *testing.T) {
+			stub := &stubMetadata{info: failure.info, err: failure.err}
+			facts := stub.facts()
+
+			_, err := facts.get(context.Background())
+			require.Error(t, err)
+
+			stub.info, stub.err = awsMetadata.MetaDataInfo{InstanceID: "i-instance"}, nil
+			info, err := facts.get(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, "i-instance", info.InstanceID)
+
+			require.Equal(t, int32(2), stub.fetches.Load())
+			require.Equal(t, int32(1), stub.newCalls.Load())
+		})
 	}
 }


### PR DESCRIPTION
### Problem

On ENI IPAM nodes, mutate built a fresh EC2 IMDS client and re-fetched the instance metadata on every invocation. However, the data itself never changed during the lifecycle of the node. The fetch was made on :

- mutateNodeResource runs on each local-node update, and
- once per iteration of the updateCiliumNodeResource retry loop.

On top of that, each Metadata fetch call produced 6 IMDS calls. This created a whole lot more requests to IMDS than necessary. We believe that this was causing some sort of rate-limiting from IMDS. And importantly, if the agent fails to fetch the instance ID from IMDS it panics and eventually goes into CLBO.

### Visible impact

The impact of this is visible on some of our larger clusters on each deployment and restart of the agents. Every time this happens, we see a spike in Crashloop BOs that resolve after a while.

<img width="792" height="394" alt="Agents in CrashLoopBackoff" src="https://github.com/user-attachments/assets/bcb3f044-4cbf-4609-af0a-527a3ebfca34" />

And all fatal logs in that timeframe point to the same IMDS context deadline exceeded error.
<img width="1392" height="261" alt="Screenshot 2026-08-25 at 16 28 59" src="https://github.com/user-attachments/assets/6cbaef96-9abf-467b-ad38-5cdcd0f75548" />

After running the changes in this PR on top of our fork of the v1.20 branch, I was able to rollout the cilium agent without a single agent restart which made for a much smoother operation.

### Changes

Client construction and the metadata fetch move behind an `instanceFacts` value that caches the result under a mutex and hands the same `MetaDataInfo` to every later call. Failures, including an empty `InstanceID`, are not cached, so the existing retry loop still gets a real attempt each time.

### AI Influence Level

This PR was prepared with AIL:3. I let the agent write the code and then reviewed and updated it to match my expectations.

```release-note
nodediscovery: Reduced EC2 IMDS load and made ENI node registration more resilient by fetching the instance metadata once instead of on every CiliumNode update.
```