### PR TITLE
bpf: terminate batch iteration on exhausted ENOSPC retries

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -170,10 +170,9 @@ func (m *Map) BatchCount() (count int, err error) {
 			// [BatchIterator.IterateAll]
 			case errors.Is(batchErr, unix.ENOSPC):
 				if retry == maxRetries-1 {
-					err = batchErr
-				} else {
-					chunkSize *= 2
+					return count, batchErr
 				}
+				chunkSize *= 2
 				keys = make(nopDecoder, chunkSize)
 				vals = make(nopDecoder, chunkSize)
 				continue
@@ -1145,11 +1144,11 @@ func (bi *BatchIterator[KT, VT, KP, VP]) IterateAll(ctx context.Context, opts ..
 				if errors.Is(batchErr, unix.ENOSPC) {
 					if retry == bi.maxBatchedRetries()-1 {
 						bi.err = batchErr
-					} else {
-						bi.chunkSize *= 2
-						bi.keys = make([]KT, bi.chunkSize)
-						bi.vals = make([]VT, bi.chunkSize)
+						return
 					}
+					bi.chunkSize *= 2
+					bi.keys = make([]KT, bi.chunkSize)
+					bi.vals = make([]VT, bi.chunkSize)
 					continue retry
 				} else if !done && batchErr != nil {
 					// If we're not done, and we didn't hit a ENOSPC then stop iteration and record

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -1081,3 +1081,41 @@ func TestPrivilegedBatchIterator(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchIterator_ENOSPCRetryExhaustion(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	mapSize := 1 << 13
+	size := 1 << 12
+
+	m := NewMap("cilium_test_enospc",
+		ebpf.Hash,
+		&TestLPMKey{PrefixLen: 32, Key: 0},
+		&TestValue{Value: 0},
+		mapSize,
+		0,
+	)
+	require.NoError(t, m.OpenOrCreate())
+	defer assert.NoError(t, m.UnpinIfExists())
+
+	for i := range size {
+		err := m.Update(&TestLPMKey{PrefixLen: 32, Key: uint32(i)}, &TestValue{Value: uint32(i)})
+		require.NoError(t, err)
+	}
+
+	// Setup iteration with starting chunk size 1 and maxRetries 1.
+	// When the batch lookup returns ENOSPC, retries are exhausted immediately.
+	// IterateAll must terminate promptly and set iter.Err() rather than looping indefinitely.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	iter := NewBatchIterator[TestLPMKey, TestValue](m)
+	for range iter.IterateAll(ctx,
+		WithStartingChunkSize[TestLPMKey, TestValue](1),
+		WithMaxRetries[TestLPMKey, TestValue](1),
+	) {
+	}
+
+	require.ErrorIs(t, iter.Err(), unix.ENOSPC)
+	assert.NoError(t, ctx.Err(), "IterateAll should terminate immediately without waiting for context timeout")
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

### Description

When performing batched lookups on eBPF hash or LRU maps, the kernel may return `unix.ENOSPC` if the batch buffer is insufficient to accommodate the largest bucket in the underlying hash table. `BatchCount()` and `BatchIterator.IterateAll()` attempt to double the buffer and retry up to `maxRetries` (default 3).

When `maxRetries` is reached (`retry == maxRetries - 1`), the code assigns the error to the error variable and executes `continue` (or `continue retry`). Because `retry` has reached the end of the range slice, the inner retry loop completes its execution. Control then falls through to the end of the enclosing infinite `for { ... }` (or `iterate: for { ... }`) loop. The outer loop repeats, resetting the retry sequence to `retry = 0` and entering an unbounded 100% CPU-spinning infinite loop.

This PR fixes this control-flow defect by returning immediately upon reaching the retry limit on `ENOSPC`:
- In `BatchCount()`: return `count, batchErr` immediately.
- In `BatchIterator.IterateAll()`: assign `bi.err = batchErr` and return from the iterator closure immediately, preserving the iterator's error contract via `Err()`.

This PR was prepared with AIL:3. I personally verified the control flow and loop termination logic in `pkg/bpf/map_linux.go`.

```release-note
Fix a CPU-spinning infinite loop in bpf.BatchCount and BatchIterator.IterateAll when batch lookup retries on ENOSPC are exhausted.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
