### PR TITLE
hubble/container: fix closed-channel panic and goroutine leak in RingReader.NextFollow

### DIFF
--- a/pkg/hubble/container/ring_reader.go
+++ b/pkg/hubble/container/ring_reader.go
@@ -19,6 +19,7 @@ type RingReader struct {
 	ring          *Ring
 	idx           uint64
 	ctx           context.Context
+	cancel        context.CancelFunc
 	mutex         lock.Mutex // protects writes to followChan
 	followChan    chan *v1.Event
 	followChanLen int
@@ -84,28 +85,34 @@ func (r *RingReader) NextFollow(ctx context.Context) *v1.Event {
 	// if the context changed between invocations, we also have to restart
 	// readFrom, as the old readFrom instance will be using the old context.
 	if r.ctx != ctx {
-		r.mutex.Lock()
-		if r.followChan == nil {
-			r.followChan = make(chan *v1.Event, r.followChanLen)
+		if r.cancel != nil {
+			r.cancel()
 		}
+		readerCtx, cancel := context.WithCancel(ctx)
+		r.cancel = cancel
+
+		followChan := make(chan *v1.Event, r.followChanLen)
+		r.mutex.Lock()
+		r.followChan = followChan
 		r.mutex.Unlock()
 
 		r.wg.Add(1)
-		go func(ctx context.Context) {
-			r.ring.readFrom(ctx, r.idx, r.followChan)
+		go func(c context.Context, ch chan *v1.Event) {
+			defer r.wg.Done()
+			defer close(ch)
+			r.ring.readFrom(c, r.idx, ch)
 			r.mutex.Lock()
-			if ctx.Err() != nil && r.followChan != nil { // context is done
-				close(r.followChan)
+			if r.followChan == ch {
 				r.followChan = nil
 			}
 			r.mutex.Unlock()
-			r.wg.Done()
-		}(ctx)
+		}(readerCtx, followChan)
 		r.ctx = ctx
 	}
 	defer func() {
 		if ctx.Err() != nil { // context is done
 			r.ctx = nil
+			r.cancel = nil
 		}
 	}()
 
@@ -137,6 +144,11 @@ func (r *RingReader) NextFollow(ctx context.Context) *v1.Event {
 // situations such as testing. Must not be called concurrently with NextFollow,
 // as otherwise NextFollow spawns new goroutines that are not waited on.
 func (r *RingReader) Close() error {
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	r.ctx = nil
 	r.wg.Wait()
 	return nil
 }

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -303,3 +303,59 @@ func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 	<-done
 	assert.NoError(t, reader.Close())
 }
+
+func TestRingReader_NextFollow_ContextRotation(t *testing.T) {
+	defer testutils.GoleakVerifyNone(
+		t,
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
+
+	ring := NewRing(Capacity15)
+	// Write initial events (0 and 1)
+	ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 0}})
+	ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 1}})
+
+	reader := NewRingReader(ring, 0)
+
+	// Step 1: Read event 0 with ctx1.
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	ev0 := reader.NextFollow(ctx1)
+	if assert.NotNil(t, ev0) {
+		assert.Equal(t, int64(0), ev0.Timestamp.Seconds)
+	}
+
+	// Step 2: Switch to ctx2 and read event 1.
+	ctx2, cancel2 := context.WithCancel(t.Context())
+	ev1 := reader.NextFollow(ctx2)
+	if assert.NotNil(t, ev1) {
+		assert.Equal(t, int64(1), ev1.Timestamp.Seconds)
+	}
+
+	// Step 3: Cancel ctx1.
+	cancel1()
+
+	// Step 4: Write subsequent events (2, 3, 4) to ring.
+	ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 2}})
+	ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 3}})
+	ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: 4}})
+
+	// Step 5: Verify ctx2 reader sequentially receives events 2, 3, 4.
+	ev2 := reader.NextFollow(ctx2)
+	if assert.NotNil(t, ev2) {
+		assert.Equal(t, int64(2), ev2.Timestamp.Seconds)
+	}
+
+	ev3 := reader.NextFollow(ctx2)
+	if assert.NotNil(t, ev3) {
+		assert.Equal(t, int64(3), ev3.Timestamp.Seconds)
+	}
+
+	ev4 := reader.NextFollow(ctx2)
+	if assert.NotNil(t, ev4) {
+		assert.Equal(t, int64(4), ev4.Timestamp.Seconds)
+	}
+
+	cancel2()
+	assert.NoError(t, reader.Close())
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

### Description

When `RingReader.NextFollow(ctx)` is invoked with a different context (`r.ctx != ctx`), such as when callers rotate per-message timeouts, it spawns a new background `readFrom()` goroutine. However, the previous goroutine is not cancelled, and the existing `r.followChan` channel is reused.

When the older context terminates, the older goroutine executes `close(r.followChan)`. Meanwhile, the newer goroutine running concurrently on the same channel attempts to send the next event, triggering a fatal panic: `panic: send on closed channel`.

This fixes a regression introduced by commit 40fcfa3c1d ("hubble: Protect ring reader channel with mutex").

Fix this by:
1. Allocating a dedicated channel per background goroutine, ensuring that each goroutine exclusively owns and closes its private channel.
2. Managing an internal context cancellation func (`r.cancel`) to cancel the previous background goroutine upon context change or `Close()`.
3. Clearing `r.followChan` in goroutine cleanup only if it still points to that goroutine's channel.
4. Adding a regression test forcing context rotation while events are being produced, asserting exact event sequence delivery and absence of panics.

This PR was prepared with AIL:3. I personally verified the channel concurrency semantics and lifecycle management in `pkg/hubble/container/ring_reader.go`.

```release-note
Fix a panic on send to closed channel in Hubble RingReader.NextFollow when rotating context.Context across sequential calls.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
