### PR TITLE
Makefile.kind, contrib: add kind environment for topology aware routing

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -14,6 +14,34 @@ kind-egressgw: ## Create a kind cluster for egress gateway Cilium development.
 	$(QUIET)SED=$(SED) WORKERS=3 ./contrib/scripts/kind.sh
 	kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
+.PHONY: kind-topology
+kind-topology: ## Create a kind cluster for topology aware routing development. Needs a node image with Kubernetes 1.34 or newer.
+	$(QUIET)SED=$(SED) WORKERS=3 ./contrib/scripts/kind.sh
+	# Workers can still be registering with the API server when kind.sh returns,
+	# so wait for them before labeling. Waiting for Ready is not an option here:
+	# kind.sh disables the default CNI, so nodes stay NotReady until Cilium is
+	# installed.
+	$(QUIET)for node in kind-worker kind-worker2 kind-worker3; do \
+		for i in $$(seq 1 60); do \
+			kubectl get node $$node >/dev/null 2>&1 && break; \
+			if [ $$i -eq 60 ]; then \
+				echo "timed out waiting for $$node to register with the API server" >&2; \
+				exit 1; \
+			fi; \
+			sleep 2; \
+		done; \
+	done
+	# zone-a spans two nodes so that a backend can sit in the client's zone but
+	# on a different node. That is the case which tells zone based selection
+	# apart from node local selection.
+	kubectl label node kind-worker topology.kubernetes.io/zone=zone-a --overwrite
+	kubectl label node kind-worker3 topology.kubernetes.io/zone=zone-a --overwrite
+	kubectl label node kind-worker2 topology.kubernetes.io/zone=zone-b --overwrite
+	# kind.sh untaints the control plane, so it is schedulable too. An unlabeled
+	# node runs an agent without a zone, and a Pod landing there would carry no
+	# zone hint and switch topology filtering off for the whole Service.
+	kubectl label node kind-control-plane topology.kubernetes.io/zone=zone-c --overwrite
+
 .PHONY: kind-down
 kind-down: ## Destroy a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind-down.sh
@@ -497,6 +525,35 @@ kind-egressgw-install-cilium: check_deps kind-ready ## Install a local Cilium ve
 		--helm-values=$(ROOT_DIR)/contrib/testing/kind-egressgw-values.yaml \
 		--nodes-without-cilium \
 		--version=
+
+.PHONY: kind-topology-install-cilium
+kind-topology-install-cilium: check_deps kind-ready ## Install a local Cilium version into the cluster for topology aware routing development.
+	@echo "  INSTALL cilium"
+	# kind-ready only checks that some kind cluster exists. Installing onto a
+	# cluster that kind-topology did not create enables the feature on nodes
+	# that carry no zone, which leaves it silently inert.
+	$(QUIET)if [ -z "$$(kubectl get nodes -l topology.kubernetes.io/zone -o name)" ]; then \
+		echo "No node carries topology.kubernetes.io/zone, run 'make kind-topology' first"; \
+		exit 1; \
+	fi
+	# cilium-cli doesn't support idempotent installs, so we uninstall and
+	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
+	-@$(CILIUM_CLI) uninstall >/dev/null 2>&1 || true
+
+	$(CILIUM_CLI) install \
+		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
+		$(KIND_VALUES_FILES) \
+		--helm-values=$(ROOT_DIR)/contrib/testing/kind-topology-values.yaml \
+		--version=
+
+	# The workloads below need CNI on the nodes they land on, so wait for the
+	# agent DaemonSet. Not `cilium status --wait`, which also waits for Envoy and
+	# Hubble: topology aware routing uses neither, and a cold install needs more
+	# than the 30s WAIT_DURATION default anyway.
+	kubectl -n kube-system rollout status ds/cilium --timeout=5m
+
+	@echo "Deploying topology test workloads..."
+	kubectl apply -f $(ROOT_DIR)/contrib/testing/topology/
 
 KVSTORE_POD_NAME ?= "kvstore"
 KVSTORE_POD_PORT ?= "2378"

--- a/contrib/testing/kind-topology-values.yaml
+++ b/contrib/testing/kind-topology-values.yaml
@@ -1,0 +1,8 @@
+kubeProxyReplacement: "true"
+# Talk to the API server directly instead of via the kubernetes ClusterIP,
+# which is not reachable until the agent itself is up when kube-proxy
+# replacement is enabled (see kubeproxy-free docs for kind).
+k8sServiceHost: kind-control-plane
+k8sServicePort: 6443
+loadBalancer:
+  serviceTopology: true

--- a/contrib/testing/topology/client.yaml
+++ b/contrib/testing/topology/client.yaml
@@ -1,0 +1,15 @@
+# Client pod pinned to zone-a. Traffic to the echo Service should only
+# reach zone-a backends while topology aware routing is engaged.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client
+  labels:
+    app: echo-client
+spec:
+  nodeSelector:
+    topology.kubernetes.io/zone: zone-a
+  containers:
+  - name: client
+    image: curlimages/curl:8.16.0
+    command: ["sleep", "infinity"]

--- a/contrib/testing/topology/echo.yaml
+++ b/contrib/testing/topology/echo.yaml
@@ -1,0 +1,87 @@
+# Echo servers for topology aware routing testing.
+#
+# Two Deployments back the same Service (app=echo), pinned per zone:
+#   - echo-zone-a: 2 replicas, forced onto different zone-a nodes. Without that
+#     spread the zone-a backends and the client would share a node, and zone
+#     based selection would be indistinguishable from node local selection.
+#   - echo-zone-b: 1 replica in zone-b.
+#
+# netexec keeps serving for --delay-shutdown seconds after SIGTERM, so a
+# terminating endpoint stays observable while it drains.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-zone-a
+  labels:
+    app: echo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: echo
+      zone: zone-a
+  template:
+    metadata:
+      labels:
+        app: echo
+        zone: zone-a
+    spec:
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-a
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: echo
+                zone: zone-a
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 120
+      containers:
+      - name: echo
+        image: registry.k8s.io/e2e-test-images/agnhost:2.45
+        args:
+        - netexec
+        - --http-port=8080
+        - --delay-shutdown=90
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /hostname
+            port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-zone-b
+  labels:
+    app: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+      zone: zone-b
+  template:
+    metadata:
+      labels:
+        app: echo
+        zone: zone-b
+    spec:
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-b
+      terminationGracePeriodSeconds: 120
+      containers:
+      - name: echo
+        image: registry.k8s.io/e2e-test-images/agnhost:2.45
+        args:
+        - netexec
+        - --http-port=8080
+        - --delay-shutdown=90
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /hostname
+            port: 8080

--- a/contrib/testing/topology/service.yaml
+++ b/contrib/testing/topology/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  type: ClusterIP
+  selector:
+    app: echo
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  trafficDistribution: PreferSameZone


### PR DESCRIPTION
_This PR was prepared with AIL:3. I designed the fix and reviewed every line myself. An AI agent drafted the code and tests under my review._

Topology-aware routing is covered by unit tests and the topology-aware{,-terminating}.txtar script tests, but no existing kind target brings up a cluster configured to exercise this functionality.
This PR adds a make kind-topology target to test topology-aware routing in a kind cluster.
