### PR TITLE
node: In writer restore the cilium internal IP conflict exemption

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -41,7 +41,7 @@ var LocalNodeStoreCell = cell.Module(
 	"Provides LocalNodeStore for observing and updating local node info",
 
 	cell.ProvidePrivate(NewNodeTable),
-	cell.Provide(NewWriter),
+	cell.Provide(provideWriter),
 	cell.Provide(NewNodeTableAndLocalNodeStore),
 	cell.Provide(NewClusterSizeDependantInterval),
 )

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -142,9 +142,10 @@ var (
 	}
 	NodeByName = NodeNameIndex.Query
 
-	// NodeAddressIndex indexes every address of the node. Writer enforces single
-	// ownership and resolves conflicts prior to insertion according to source
-	// priority.
+	// NodeAddressIndex indexes every address of the node. The index is non-unique
+	// because configured Cilium internal router addresses may legitimately be
+	// shared by every node. Writer resolves all other conflicts according to
+	// source priority.
 	NodeAddressIndex = statedb.Index[*Node, netip.Addr]{
 		Name: "address",
 		FromObject: func(obj *Node) index.KeySet {
@@ -167,7 +168,7 @@ var (
 		},
 		FromKey:    index.NetIPAddr,
 		FromString: index.NetIPAddrString,
-		Unique:     true,
+		Unique:     false,
 	}
 	NodeByAddress = NodeAddressIndex.Query
 

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -10,11 +10,14 @@ import (
 	"net/netip"
 	"slices"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -23,11 +26,30 @@ type Writer struct {
 	log   *slog.Logger
 	db    *statedb.DB
 	nodes statedb.RWTable[*Node]
+
+	isStaticLocalRouterIP func(string) bool
 }
 
 // NewWriter constructs a node table writer.
 func NewWriter(log *slog.Logger, db *statedb.DB, nodes statedb.RWTable[*Node]) *Writer {
 	return &Writer{log: log, db: db, nodes: nodes}
+}
+
+type writerParams struct {
+	cell.In
+
+	Log          *slog.Logger
+	DB           *statedb.DB
+	Nodes        statedb.RWTable[*Node]
+	DaemonConfig *option.DaemonConfig `optional:"true"`
+}
+
+func provideWriter(p writerParams) *Writer {
+	w := NewWriter(p.Log, p.DB, p.Nodes)
+	if p.DaemonConfig != nil {
+		w.isStaticLocalRouterIP = p.DaemonConfig.IsLocalRouterIP
+	}
+	return w
 }
 
 // Table returns read-only access to the node table.
@@ -113,19 +135,20 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 	// operation atomic when an incoming node overlaps multiple existing nodes:
 	// a single stronger owner rejects the update without deleting weaker ones.
 	conflicts := map[string]*Node{}
-	for _, addr := range conflictAddresses(n) {
-		candidate, _, found := w.nodes.Get(txn, NodeByAddress(addr))
-		if !found || candidate.Fullname() == obj.Fullname() {
-			continue
+	for _, addr := range w.conflictAddresses(n) {
+		for candidate := range w.nodes.List(txn, NodeByAddress(addr)) {
+			if candidate.Fullname() == obj.Fullname() {
+				continue
+			}
+			w.log.Warn("Node address conflicts with another node",
+				logfields.IPAddr, addr,
+				logfields.Node, obj.Fullname(),
+				logfields.Source, obj.Source,
+				logfields.ConflictingResource, candidate.Fullname(),
+				logfields.NodeOwner, candidate.Source,
+			)
+			conflicts[candidate.Fullname()] = candidate
 		}
-		w.log.Warn("Node address conflicts with another node",
-			logfields.IPAddr, addr,
-			logfields.Node, obj.Fullname(),
-			logfields.Source, obj.Source,
-			logfields.ConflictingResource, candidate.Fullname(),
-			logfields.NodeOwner, candidate.Source,
-		)
-		conflicts[candidate.Fullname()] = candidate
 	}
 	for _, candidate := range conflicts {
 		if candidate.Local != nil || !source.AllowOverwrite(candidate.Source, obj.Source) {
@@ -160,9 +183,11 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 }
 
 // conflictAddresses returns the normalized addresses whose ownership used to
-// gate NodeManager datapath updates. IPv4-mapped IPv6 addresses are normalized
-// to IPv4 so both representations conflict with one another.
-func conflictAddresses(n *nodeTypes.Node) []netip.Addr {
+// gate NodeManager datapath updates. Configured Cilium internal router IPs are
+// omitted because they may intentionally be shared by every node. IPv4-mapped
+// IPv6 addresses are normalized to IPv4 so both representations conflict with
+// one another.
+func (w *Writer) conflictAddresses(n *nodeTypes.Node) []netip.Addr {
 	addrs := make([]netip.Addr, 0, len(n.IPAddresses)+4)
 	appendAddr := func(addr netip.Addr) {
 		if addr.IsValid() {
@@ -171,6 +196,13 @@ func conflictAddresses(n *nodeTypes.Node) []netip.Addr {
 	}
 
 	for _, address := range n.IPAddresses {
+		// In delegated IPAM mode the local router IP is configured statically and is the same
+		// on all nodes. Exempt the conflict in those cases.
+		if address.Type == addressing.NodeCiliumInternalIP &&
+			w.isStaticLocalRouterIP != nil &&
+			w.isStaticLocalRouterIP(address.ToString()) {
+			continue
+		}
 		if addr, ok := netip.AddrFromSlice(address.IP); ok {
 			appendAddr(addr)
 		}

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"slices"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -199,6 +201,88 @@ func TestWriterAddressConflicts(t *testing.T) {
 	requireNode("mesh-2")
 	requireNode("kvstore")
 	requireNoNode("mixed")
+}
+
+func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+	w.isStaticLocalRouterIP = func(ip string) bool {
+		return ip == "169.254.23.0" || ip == "fe80::"
+	}
+
+	routerAddresses := []types.Address{
+		{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("169.254.23.0")},
+		{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("fe80::")},
+	}
+	localAddresses := append(slices.Clone(routerAddresses), types.Address{
+		Type: addressing.NodeInternalIP,
+		IP:   net.ParseIP("10.0.0.1"),
+	})
+	local := &Node{
+		Node: types.Node{
+			Name:        "local",
+			Source:      source.Local,
+			IPAddresses: localAddresses,
+		},
+		Local: &LocalNodeInfo{},
+	}
+	txn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, local)
+	require.NoError(t, err)
+	txn.Commit()
+
+	for _, name := range []string{"remote-1", "remote-2"} {
+		txn = db.WriteTxn(nodes)
+		require.True(t, w.Upsert(txn, &types.Node{
+			Name:        name,
+			Source:      source.CustomResource,
+			IPAddresses: slices.Clone(routerAddresses),
+		}))
+		txn.Commit()
+	}
+
+	for _, name := range []string{"local", "remote-1", "remote-2"} {
+		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.True(t, found, name)
+	}
+	for _, address := range []netip.Addr{
+		netip.MustParseAddr("169.254.23.0"),
+		netip.MustParseAddr("fe80::"),
+	} {
+		var owners []string
+		for n := range nodes.List(db.ReadTxn(), NodeByAddress(address)) {
+			owners = append(owners, n.Name)
+		}
+		require.ElementsMatch(t, []string{"local", "remote-1", "remote-2"}, owners)
+	}
+
+	// Matching a local node address alone is not enough: only the configured
+	// Cilium internal router addresses may be shared.
+	txn = db.WriteTxn(nodes)
+	require.False(t, w.Upsert(txn, &types.Node{
+		Name:   "conflict",
+		Source: source.CustomResource,
+		IPAddresses: []types.Address{{
+			Type: addressing.NodeCiliumInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		}},
+	}))
+	txn.Commit()
+
+	// The configured address remains conflicting when it is not advertised as
+	// a Cilium internal IP.
+	txn = db.WriteTxn(nodes)
+	require.False(t, w.Upsert(txn, &types.Node{
+		Name:   "wrong-type",
+		Source: source.CustomResource,
+		IPAddresses: []types.Address{{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("169.254.23.0"),
+		}},
+	}))
+	txn.Commit()
 }
 
 func TestWriterRefresh(t *testing.T) {


### PR DESCRIPTION
NodeManager allowed Cilium internal IPs to conflict across nodes when it matched the local IP which was a legitimate configuration for example in the delegated IPAM mode. Restore this behaviour in `node.Writer`.