### PR TITLE
gateway-api: export IsReferenceAllowed helper

### DIFF
--- a/operator/pkg/gateway-api/helpers/referencegrants.go
+++ b/operator/pkg/gateway-api/helpers/referencegrants.go
@@ -13,10 +13,10 @@ import (
 // IsBackendReferenceAllowed returns true if the backend reference is allowed by the reference grant.
 func IsBackendReferenceAllowed(originatingNamespace string, be gatewayv1.BackendRef, gvk schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
 	if IsService(be.BackendObjectReference) {
-		return isReferenceAllowed(originatingNamespace, string(be.Name), be.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Service"), grants)
+		return IsReferenceAllowed(originatingNamespace, string(be.Name), be.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Service"), grants)
 	}
 	if IsServiceImport(be.BackendObjectReference) {
-		return isReferenceAllowed(originatingNamespace, string(be.Name), be.Namespace, gvk, mcsapiv1beta1.SchemeGroupVersion.WithKind("ServiceImport"), grants)
+		return IsReferenceAllowed(originatingNamespace, string(be.Name), be.Namespace, gvk, mcsapiv1beta1.SchemeGroupVersion.WithKind("ServiceImport"), grants)
 	}
 
 	return false
@@ -24,10 +24,13 @@ func IsBackendReferenceAllowed(originatingNamespace string, be gatewayv1.Backend
 
 // IsSecretReferenceAllowed returns true if the secret reference is allowed by the reference grant.
 func IsSecretReferenceAllowed(originatingNamespace string, sr gatewayv1.SecretObjectReference, gvk schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
-	return isReferenceAllowed(originatingNamespace, string(sr.Name), sr.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Secret"), grants)
+	return IsReferenceAllowed(originatingNamespace, string(sr.Name), sr.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Secret"), grants)
 }
 
-func isReferenceAllowed(originatingNamespace, name string, namespace *gatewayv1.Namespace, fromGVK, toGVK schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
+// IsReferenceAllowed returns true if a reference from originatingNamespace to
+// name/namespace is allowed by ReferenceGrant. Same-namespace references are
+// always allowed.
+func IsReferenceAllowed(originatingNamespace, name string, namespace *gatewayv1.Namespace, fromGVK, toGVK schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
 	ns := NamespaceDerefOr(namespace, originatingNamespace)
 	if originatingNamespace == ns {
 		return true // same namespace is always allowed

--- a/operator/pkg/gateway-api/helpers/referencegrants_test.go
+++ b/operator/pkg/gateway-api/helpers/referencegrants_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsReferenceAllowed(t *testing.T) {
+	secretGVK := corev1.SchemeGroupVersion.WithKind("Secret")
+
+	grantIn := func(namespace string, to gatewayv1.ReferenceGrantTo) gatewayv1.ReferenceGrant {
+		return gatewayv1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: namespace},
+			Spec: gatewayv1.ReferenceGrantSpec{
+				From: []gatewayv1.ReferenceGrantFrom{{
+					Group:     gatewayv1.GroupName,
+					Kind:      "Gateway",
+					Namespace: "gateway-ns",
+				}},
+				To: []gatewayv1.ReferenceGrantTo{to},
+			},
+		}
+	}
+
+	secretTo := gatewayv1.ReferenceGrantTo{Group: corev1.GroupName, Kind: "Secret"}
+
+	tests := []struct {
+		name                 string
+		originatingNamespace string
+		refName              string
+		refNamespace         *gatewayv1.Namespace
+		grants               []gatewayv1.ReferenceGrant
+		want                 bool
+	}{
+		{
+			name:                 "same namespace is allowed without a grant",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         nil,
+			want:                 true,
+		},
+		{
+			name:                 "explicit same namespace is allowed without a grant",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("gateway-ns"),
+			want:                 true,
+		},
+		{
+			name:                 "cross namespace is denied without a grant",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			want:                 false,
+		},
+		{
+			name:                 "cross namespace is allowed by a matching grant",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants: []gatewayv1.ReferenceGrant{
+				grantIn("secret-ns", gatewayv1.ReferenceGrantTo{
+					Group: corev1.GroupName,
+					Kind:  "Secret",
+					Name:  ptr.To[gatewayv1.ObjectName]("tls-secret"),
+				}),
+			},
+			want: true,
+		},
+		{
+			name:                 "a grant without a name allows any name of that kind",
+			originatingNamespace: "gateway-ns",
+			refName:              "any-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants:               []gatewayv1.ReferenceGrant{grantIn("secret-ns", secretTo)},
+			want:                 true,
+		},
+		{
+			name:                 "a grant naming another object does not allow this one",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants: []gatewayv1.ReferenceGrant{
+				grantIn("secret-ns", gatewayv1.ReferenceGrantTo{
+					Group: corev1.GroupName,
+					Kind:  "Secret",
+					Name:  ptr.To[gatewayv1.ObjectName]("other-secret"),
+				}),
+			},
+			want: false,
+		},
+		{
+			name:                 "a grant in the wrong namespace does not apply",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants:               []gatewayv1.ReferenceGrant{grantIn("other-ns", secretTo)},
+			want:                 false,
+		},
+		{
+			name:                 "a grant for another target kind does not apply",
+			originatingNamespace: "gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants: []gatewayv1.ReferenceGrant{
+				grantIn("secret-ns", gatewayv1.ReferenceGrantTo{Group: corev1.GroupName, Kind: "ConfigMap"}),
+			},
+			want: false,
+		},
+		{
+			name:                 "a grant from another source namespace does not apply",
+			originatingNamespace: "other-gateway-ns",
+			refName:              "tls-secret",
+			refNamespace:         ptr.To[gatewayv1.Namespace]("secret-ns"),
+			grants:               []gatewayv1.ReferenceGrant{grantIn("secret-ns", secretTo)},
+			want:                 false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsReferenceAllowed(
+				tt.originatingNamespace,
+				tt.refName,
+				tt.refNamespace,
+				GatewayV1GVK("Gateway"),
+				secretGVK,
+				tt.grants,
+			)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Export the ReferenceGrant helper that already backs `IsBackendReferenceAllowed`
and `IsSecretReferenceAllowed`, so callers checking a reference kind without a
dedicated wrapper can reuse it instead of duplicating the grant walk.

No behavior change. The exported function is identical to the unexported one;
only the name and a doc comment differ.

Also adds direct unit coverage. The grant-walking logic had no unit test of its
own — it was only exercised indirectly through ingestion tests — so this adds
`TestIsReferenceAllowed` covering same-namespace allow, cross-namespace deny,
matching grant, `to.Name` wildcard, name mismatch, wrong grant namespace, wrong
target kind, and wrong source namespace.

Split out of #46479 so it can be reviewed and merged on its own.

This PR was prepared with AIL:3. I personally reviewed each line of the
submission.

```release-note
gateway-api: export ReferenceGrant helper to allow reuse 
```