### PR TITLE
bpf, datapath: move ENCAP4_IFINDEX, ENCAP6_IFINDEX to runtime config

### DIFF
--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -162,3 +162,8 @@ struct ipv6_snat_exclusion_prefix {
 
 NODE_CONFIG(struct ipv6_snat_exclusion_prefix, ipv6_snat_exclusion,
 	    "IPv6 destination prefix excluded from SNAT")
+
+NODE_CONFIG(__u32, encap4_ifindex,
+	    "Interface index of the IPv4 IPIP encapsulation device")
+NODE_CONFIG(__u32, encap6_ifindex,
+	    "Interface index of the IPv6 IPIP encapsulation device")

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -408,7 +408,7 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 #  else /* __ctx_is == __ctx_xdp */
 	if (dsr_set_ipip6_dev(ctx, backend_addr, 0) < 0)
 		return DROP_NO_TUNNEL_KEY;
-	*oif = ENCAP6_IFINDEX;
+	*oif = CONFIG(encap6_ifindex);
 	return CTX_ACT_REDIRECT;
 #  endif /* __ctx_is == __ctx_xdp */
 }
@@ -1732,7 +1732,7 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 #  else /* __ctx_is == __ctx_xdp */
 	if (dsr_set_ipip4_dev(ctx, backend_addr, 0) < 0)
 		return DROP_NO_TUNNEL_KEY;
-	*oif = ENCAP4_IFINDEX;
+	*oif = CONFIG(encap4_ifindex);
 	return CTX_ACT_REDIRECT;
 #  endif /* __ctx_is == __ctx_xdp */
 }

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -658,7 +658,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 			ctx->tc_index |= TC_INDEX_F_SKIP_HEALTH_CHECK;
 		}
 
-		return ctx_redirect(ctx, ENCAP4_IFINDEX, flags);
+		return ctx_redirect(ctx, CONFIG(encap4_ifindex), flags);
 	}
 #endif
 #if defined(ENABLE_IPV6) && DSR_ENCAP_MODE == DSR_ENCAP_IPIP
@@ -684,7 +684,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 			ctx->tc_index |= TC_INDEX_F_SKIP_HEALTH_CHECK;
 		}
 
-		return ctx_redirect(ctx, ENCAP6_IFINDEX, flags);
+		return ctx_redirect(ctx, CONFIG(encap6_ifindex), flags);
 	}
 #endif
 	default:

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -25,9 +25,6 @@
 #define BACKEND_IP		v4_pod_two
 #define BACKEND_PORT		__bpf_htons(8080)
 
-#define ENCAP4_IFINDEX		42
-#define ENCAP6_IFINDEX		42
-
 #define SOCKET_COOKIE		1
 
 static volatile const __u8 *client_mac = mac_one;
@@ -44,13 +41,7 @@ __u64 mock_get_socket_cookie(const struct __sk_buff *ctx __maybe_unused)
 
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
-		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
-{
-	if (ifindex == ENCAP4_IFINDEX)
-		return CTX_ACT_REDIRECT;
-
-	return CTX_ACT_DROP;
-}
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused);
 
 #define skb_set_tunnel_key mock_skb_set_tunnel_key
 
@@ -69,6 +60,19 @@ int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
 }
 
 #include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(__u32, encap4_ifindex, 42)
+ASSIGN_CONFIG(__u32, encap6_ifindex, 42)
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == (int)CONFIG(encap4_ifindex))
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
 
 /* Test that a health-check request to a remote backend is IPIP-encapsulated. */
 PKTGEN(PROG_TYPE, "l4lb_health_check_host")

--- a/bpf/tests/nodeport_hybrid_dsr_test.c
+++ b/bpf/tests/nodeport_hybrid_dsr_test.c
@@ -12,12 +12,12 @@
 #define DSR_ENCAP_MODE DSR_ENCAP_IPIP
 #define DSR_ENCAP_IPIP 1
 
-#define ENCAP4_IFINDEX		42
-#define ENCAP6_IFINDEX		42
-
 #include "lib/bpf_host.h"
 
 ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
+
+ASSIGN_CONFIG(__u32, encap4_ifindex, 42)
+ASSIGN_CONFIG(__u32, encap6_ifindex, 42)
 
 CHECK(PROG_TYPE, "test_nodeport_uses_dsr_ipv4_with_flag")
 int test_nodeport_uses_dsr_ipv4_with_flag(__maybe_unused struct __ctx_buff *ctx)

--- a/bpf/tests/tc_nodeport_lb4_dsr_ipip_local.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_ipip_local.c
@@ -33,12 +33,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 
-/* nodeport_lb4 references this for DSR_ENCAP_IPIP egress (TX side). The
- * remote-encap test exercises it; here we only ever pick local backends
- * so it shouldn't get used, but the symbol must resolve at compile time.
- */
-#define ENCAP4_IFINDEX		42
-
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
 
@@ -64,7 +58,7 @@ static volatile const __u8 *backend_mac = mac_four;
 enum {
 	RECORD_REDIRECT_PEER = 0,
 	RECORD_REDIRECT,
-	RECORD_ENCAP_REDIRECT,	/* redirect to ENCAP4_IFINDEX = IPIP encap egress */
+	RECORD_ENCAP_REDIRECT,	/* redirect to encap4_ifindex = IPIP encap egress */
 	RECORD_TAILCALL,
 	RECORD_MAX,
 };
@@ -85,14 +79,7 @@ mock_ctx_redirect_peer(const struct __ctx_buff *ctx __maybe_unused,
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused,
-		  __u32 flags __maybe_unused)
-{
-	if (ifindex == ENCAP4_IFINDEX)
-		num_calls[RECORD_ENCAP_REDIRECT]++;
-	else
-		num_calls[RECORD_REDIRECT]++;
-	return CTX_ACT_REDIRECT;
-}
+		  __u32 flags __maybe_unused);
 
 /* The DNAT'ed packet is delivered to the local backend Pod via
  * ipv4_local_delivery() -> local_delivery(). With BPF host routing on a
@@ -170,10 +157,28 @@ int mock_tail_policy(struct __ctx_buff *ctx)
 #include "lib/ipcache.h"
 #include "lib/lb.h"
 
+/* nodeport_lb4 references this for DSR_ENCAP_IPIP egress (TX side). The
+ * remote-encap test exercises it; here we only ever pick local backends
+ * so it shouldn't get used, but the dummy runtime-config value is required.
+ */
+ASSIGN_CONFIG(__u32, encap4_ifindex, 42)
+
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
 ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)
 ASSIGN_CONFIG(bool, enable_netkit, true)
 ASSIGN_CONFIG(union v4addr, ipv4_direct_routing, { .be32 = LB_NODE_IP })
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused)
+{
+	if (ifindex == (int)CONFIG(encap4_ifindex))
+		num_calls[RECORD_ENCAP_REDIRECT]++;
+	else
+		num_calls[RECORD_REDIRECT]++;
+	return CTX_ACT_REDIRECT;
+}
 
 /* Build a plain client -> svc TCP SYN. No IPIP wrapping - this is the first
  * hop into the LB node from the external client.
@@ -271,7 +276,7 @@ int nodeport_dsr_ipip_lb_local_pod_check(struct __ctx_buff *ctx)
 		test_fatal("expected one ctx_redirect_peer, got %u",
 			   num_calls[RECORD_REDIRECT_PEER]);
 	if (num_calls[RECORD_ENCAP_REDIRECT] != 0)
-		test_fatal("packet was IPIP-encapped for a local backend (got %u redirects to ENCAP4_IFINDEX)",
+		test_fatal("local backend was IPIP-encapped: %u redirects to encap4_ifindex",
 			   num_calls[RECORD_ENCAP_REDIRECT]);
 	if (num_calls[RECORD_REDIRECT] != 0)
 		test_fatal("did not expect plain ctx_redirect, got %u",

--- a/bpf/tests/tc_nodeport_lb4_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb4_ipip_termination.c
@@ -33,11 +33,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 
-/* nodeport_lb4 references this for DSR_ENCAP_IPIP egress (TX side). We only
- * exercise the RX/decap side here, but the symbol needs to resolve.
- */
-#define ENCAP4_IFINDEX		42
-
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
 
@@ -199,6 +194,11 @@ int mock_tail_policy(struct __ctx_buff *ctx)
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+
+/* nodeport_lb4 references this for DSR_ENCAP_IPIP egress (TX side). We only
+ * exercise the RX/decap side here, but the dummy runtime-config value is required.
+ */
+ASSIGN_CONFIG(__u32, encap4_ifindex, 42)
 
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
 ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)

--- a/bpf/tests/tc_nodeport_lb6_dsr_ipip_local.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_ipip_local.c
@@ -24,8 +24,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 
-#define ENCAP6_IFINDEX		42
-
 #define CLIENT_PORT		__bpf_htons(111)
 #define FRONTEND_PORT		tcp_svc_one
 
@@ -61,14 +59,7 @@ mock_ctx_redirect_peer(const struct __ctx_buff *ctx __maybe_unused,
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused,
-		  __u32 flags __maybe_unused)
-{
-	if (ifindex == ENCAP6_IFINDEX)
-		num_calls[RECORD_ENCAP_REDIRECT]++;
-	else
-		num_calls[RECORD_REDIRECT]++;
-	return CTX_ACT_REDIRECT;
-}
+		  __u32 flags __maybe_unused);
 
 /* The DNAT'ed packet is delivered to the local backend Pod via
  * ipv6_local_delivery() -> local_delivery(). With BPF host routing on a
@@ -124,6 +115,20 @@ mock_ctx_get_ingress_ifindex(const struct __sk_buff *ctx __maybe_unused)
 }
 
 #include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(__u32, encap6_ifindex, 42)
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused)
+{
+	if (ifindex == (int)CONFIG(encap6_ifindex))
+		num_calls[RECORD_ENCAP_REDIRECT]++;
+	else
+		num_calls[RECORD_REDIRECT]++;
+	return CTX_ACT_REDIRECT;
+}
 
 /* Stands in for bpf_lxc's tail_ipv6_policy program: reads the calling-convention
  * meta that local_delivery_fill_meta() set and performs the redirect_ep() with
@@ -243,7 +248,7 @@ int nodeport_dsr_ipip_lb_local_pod_v6_check(struct __ctx_buff *ctx)
 		test_fatal("expected one ctx_redirect_peer, got %u",
 			   num_calls[RECORD_REDIRECT_PEER]);
 	if (num_calls[RECORD_ENCAP_REDIRECT] != 0)
-		test_fatal("packet was IPIP-encapped for a local backend (got %u redirects to ENCAP6_IFINDEX)",
+		test_fatal("local backend was IPIP-encapped: %u redirects to encap6_ifindex",
 			   num_calls[RECORD_ENCAP_REDIRECT]);
 	if (num_calls[RECORD_REDIRECT] != 0)
 		test_fatal("did not expect plain ctx_redirect, got %u",

--- a/bpf/tests/tc_nodeport_lb6_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb6_ipip_termination.c
@@ -25,8 +25,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 
-#define ENCAP6_IFINDEX		42
-
 #define CLIENT_PORT		__bpf_htons(111)
 
 #define FRONTEND_PORT		tcp_svc_one
@@ -162,6 +160,7 @@ int mock_tail_policy(struct __ctx_buff *ctx)
 #include "lib/lb.h"
 
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
+ASSIGN_CONFIG(__u32, encap6_ifindex, 42)
 ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)
 ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 ASSIGN_CONFIG(bool, enable_netkit, false)

--- a/bpf/tests/tc_nodeport_lb_dsr_ipip.c
+++ b/bpf/tests/tc_nodeport_lb_dsr_ipip.c
@@ -14,10 +14,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 
-#define ENCAP_IFINDEX		42
-#define ENCAP4_IFINDEX		ENCAP_IFINDEX
-#define ENCAP6_IFINDEX		ENCAP_IFINDEX
-
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_IPV6		{ .addr = { 0x1 } }
 #define CLIENT_PORT		__bpf_htons(111)
@@ -42,13 +38,7 @@ static volatile const __u8 *remote_backend_mac = mac_five;
 #define ctx_redirect mock_ctx_redirect
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
-		  __u32 flags __maybe_unused)
-{
-	if (ifindex != ENCAP_IFINDEX)
-		return CTX_ACT_DROP;
-
-	return CTX_ACT_REDIRECT;
-}
+		  __u32 flags __maybe_unused);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -82,6 +72,20 @@ mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 ASSIGN_CONFIG(union v4addr, ipv4_direct_routing, { .be32 = LB_IP })
 ASSIGN_CONFIG(union v6addr, ipv6_direct_routing, LB_IPV6)
+
+ASSIGN_CONFIG(__u32, encap4_ifindex, 42)
+ASSIGN_CONFIG(__u32, encap6_ifindex, 42)
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused)
+{
+	if (ifindex != (int)CONFIG(encap4_ifindex) &&
+	    ifindex != (int)CONFIG(encap6_ifindex))
+		return CTX_ACT_DROP;
+
+	return CTX_ACT_REDIRECT;
+}
 
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -169,6 +169,12 @@ type Config struct {
 	// subsequent calls to NodeConfigurationChanged().
 	EnableEncapsulation bool
 
+	// Interface index of the IPv4 IPIP encapsulation device.
+	Encap4IfIndex uint32
+
+	// Interface index of the IPv6 IPIP encapsulation device.
+	Encap6IfIndex uint32
+
 	// RequiresNativeRouting returns true if the node requires native routing to setup.
 	RequiresNativeRouting bool
 

--- a/pkg/datapath/config/node.go
+++ b/pkg/datapath/config/node.go
@@ -141,6 +141,9 @@ func NodeConfig(lnc *Config) Node {
 		}
 	}
 
+	node.Encap4IfIndex = lnc.Encap4IfIndex
+	node.Encap6IfIndex = lnc.Encap6IfIndex
+
 	node.EnableJiffies = option.Config.ClockSource == option.ClockSourceJiffies
 	node.KernelHz = uint32(option.Config.KernelHz)
 

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -47,6 +47,10 @@ type Node struct {
 	EnableNodeportSourceLookup bool `config:"enable_nodeport_source_lookup"`
 	// Enable BPF-based proxy redirection.
 	EnableTproxy bool `config:"enable_tproxy"`
+	// Interface index of the IPv4 IPIP encapsulation device.
+	Encap4IfIndex uint32 `config:"encap4_ifindex"`
+	// Interface index of the IPv6 IPIP encapsulation device.
+	Encap6IfIndex uint32 `config:"encap6_ifindex"`
 	// Enable strict encryption for ingress traffic.
 	EncryptionStrictIngress bool `config:"encryption_strict_ingress"`
 	// Maximum number of messages that can be written to BPF events map in 1
@@ -115,7 +119,7 @@ func NewNode() *Node {
 		0x0,
 		cast[types.MACAddr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		0x0, 0x8, false, 0x0, false, false, false, false, false, false,
-		false, false, false, 0x0, 0x0, 0x0, 0x0, cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
+		false, false, 0x0, 0x0, false, 0x0, 0x0, 0x0, 0x0, cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		cast[types.IPv4SNATExclusionPrefix]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -131,6 +131,12 @@ func (in *Config) deepEqual(other *Config) bool {
 	if in.EnableEncapsulation != other.EnableEncapsulation {
 		return false
 	}
+	if in.Encap4IfIndex != other.Encap4IfIndex {
+		return false
+	}
+	if in.Encap6IfIndex != other.Encap6IfIndex {
+		return false
+	}
 	if in.RequiresNativeRouting != other.RequiresNativeRouting {
 		return false
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -388,26 +388,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		}
 	}
 
-	if option.Config.UnsafeDaemonConfigOption.EnableIPIPDevices {
-		if option.Config.IPv4Enabled() {
-			ipip4, err := safenetlink.LinkByName(defaults.IPIPv4Device)
-			if err != nil {
-				return fmt.Errorf("looking up link %s: %w", defaults.IPIPv4Device, err)
-			}
-			cDefinesMap["ENCAP4_IFINDEX"] = fmt.Sprintf("%d", ipip4.Attrs().Index)
-		}
-		if option.Config.IPv6Enabled() {
-			ipip6, err := safenetlink.LinkByName(defaults.IPIPv6Device)
-			if err != nil {
-				return fmt.Errorf("looking up link %s: %w", defaults.IPIPv6Device, err)
-			}
-			cDefinesMap["ENCAP6_IFINDEX"] = fmt.Sprintf("%d", ipip6.Attrs().Index)
-		}
-	} else {
-		cDefinesMap["ENCAP4_IFINDEX"] = "0"
-		cDefinesMap["ENCAP6_IFINDEX"] = "0"
-	}
-
 	fmt.Fprint(fw, declareConfig("interface_ifindex", uint32(0), "ifindex of the interface the bpf program is attached to"))
 
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---

--- a/pkg/datapath/linux/device/netlink.go
+++ b/pkg/datapath/linux/device/netlink.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	mtuconst "github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// EnableForwarding puts the given link into the up state and enables IP forwarding.
+func EnableForwarding(logger *slog.Logger, sysctl sysctl.Sysctl, link netlink.Link) error {
+	ifName := link.Attrs().Name
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		logger.Warn("Could not set up the link",
+			logfields.Error, err,
+			logfields.Device, ifName,
+		)
+		return fmt.Errorf("failed to set link up: %w", err)
+	}
+
+	sysSettings := make([]tables.Sysctl, 0, 5)
+	if option.Config.EnableIPv6 {
+		sysSettings = append(sysSettings, tables.Sysctl{
+			Name: []string{"net", "ipv6", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false})
+	}
+	if option.Config.EnableIPv4 {
+		sysSettings = append(sysSettings, []tables.Sysctl{
+			{Name: []string{"net", "ipv4", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "rp_filter"}, Val: "0", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "accept_local"}, Val: "1", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "send_redirects"}, Val: "0", IgnoreErr: false},
+		}...)
+	}
+	if err := sysctl.ApplySettings(sysSettings); err != nil {
+		return fmt.Errorf("failed to apply sysctl settings for %s: %w", ifName, err)
+	}
+
+	return nil
+}
+
+// RemoveDevice removes the device with the given name. Returns error if the
+// device exists but was unable to be removed.
+func RemoveDevice(name string) error {
+	link, err := safenetlink.LinkByName(name)
+	if err != nil {
+		return nil
+	}
+
+	if err := netlink.LinkDel(link); err != nil {
+		return fmt.Errorf("removing device %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// EnsureDevice ensures a device with the given attrs is present on the system.
+// If a device with the given name already exists, device creation is skipped and
+// the existing device will be used as-is for the subsequent configuration steps.
+// The device is never recreated.
+//
+// The device's state is set to 'up', L3 forwarding sysctls are applied, and MTU
+// is set.
+func EnsureDevice(logger *slog.Logger, sysctl sysctl.Sysctl, attrs netlink.Link) (netlink.Link, error) {
+	name := attrs.Attrs().Name
+
+	// Reuse existing tunnel interface created by previous runs.
+	l, err := safenetlink.LinkByName(name)
+	if err != nil {
+		if err := netlink.LinkAdd(attrs); err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				err = fmt.Errorf("%w, maybe kernel module for %s is not available?", err, attrs.Type())
+			}
+			return nil, fmt.Errorf("creating device %s: %w", name, err)
+		}
+
+		// Fetch the link we've just created.
+		l, err = safenetlink.LinkByName(name)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving created device %s: %w", name, err)
+		}
+	}
+
+	if err := EnableForwarding(logger, sysctl, l); err != nil {
+		return nil, fmt.Errorf("setting up device %s: %w", name, err)
+	}
+
+	// Update MTU on the link if necessary.
+	wantMTU, gotMTU := attrs.Attrs().MTU, l.Attrs().MTU
+	if wantMTU != 0 && wantMTU != gotMTU {
+		if err := netlink.LinkSetMTU(l, wantMTU); err != nil {
+			return nil, fmt.Errorf("setting MTU on %s: %w", name, err)
+		}
+	}
+
+	return l, nil
+}
+
+// SetupIPIPDevices ensures the specified v4 and/or v6 devices are created and
+// configured with their respective sysctls.
+//
+// Calling this function may result in tunl0 (v4) or ip6tnl0 (v6) fallback
+// interfaces being created as a result of loading the ipip and ip6_tunnel
+// kernel modules by creating cilium_ tunnel interfaces. These are catch-all
+// interfaces for the ipip decapsulation stack. By default, these interfaces
+// will be created in new network namespaces, but Cilium disables this behaviour
+// by setting net.core.fb_tunnels_only_for_init_net = 2.
+//
+// In versions of Cilium prior to 1.15, the behaviour was as follows:
+//   - Repurpose the default tunl0 by setting it into collect_md mode and renaming
+//     it to cilium_ipip4. Use the interface for production traffic.
+//   - The same cannot be done for ip6tunl0, as collect_md cannot be enabled on
+//     this interface. Leave it unused.
+//   - Rename sit0 to cilium_sit, if present. This was potentially a mistake,
+//     as the sit module is not involved with ip6tnl interfaces.
+//
+// As of Cilium 1.15, if present, tunl0 is renamed to cilium_tunl and ip6tnl0 is
+// renamed to cilium_ip6tnl. This is to communicate to the user that Cilium has
+// taken control of the encapsulation stack on the node, as it currently doesn't
+// explicitly support sharing it with other tools/CNIs. Fallback devices are left
+// unused for production traffic. Only devices that were explicitly created are
+// used. As of Cilium 1.18, cilium_tunl and cilium_ip6tnl are not created anymore.
+func SetupIPIPDevices(logger *slog.Logger, sysctl sysctl.Sysctl, ipv4, ipv6 bool, mtu int) error {
+	// This setting needs to be applied before creating the IPIP devices.
+	sysIPIP := []tables.Sysctl{
+		{Name: []string{"net", "core", "fb_tunnels_only_for_init_net"}, Val: "2", IgnoreErr: true},
+	}
+	if err := sysctl.ApplySettings(sysIPIP); err != nil {
+		return err
+	}
+	// FlowBased sets IFLA_IPTUN_COLLECT_METADATA, the equivalent of 'ip link add
+	// ... type ipip/ip6tnl external'. This is needed so bpf programs can use
+	// bpf_skb_[gs]et_tunnel_key() on packets flowing through tunnels.
+	if ipv4 {
+		dev := &netlink.Iptun{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: defaults.IPIPv4Device,
+				MTU:  mtu - mtuconst.IPIPv4Overhead,
+			},
+			FlowBased: true,
+		}
+
+		if _, err := EnsureDevice(logger, sysctl, dev); err != nil {
+			return fmt.Errorf("creating %s: %w", defaults.IPIPv4Device, err)
+		}
+
+		// Rename fallback device created by potential kernel module load after
+		// creating tunnel interface.
+		if err := renameDevice("tunl0", "cilium_tunl"); err != nil {
+			return fmt.Errorf("renaming fallback device %s: %w", "tunl0", err)
+		}
+	} else {
+		if err := RemoveDevice(defaults.IPIPv4Device); err != nil {
+			return fmt.Errorf("removing %s: %w", defaults.IPIPv4Device, err)
+		}
+	}
+
+	if ipv6 {
+		dev := &netlink.Ip6tnl{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: defaults.IPIPv6Device,
+				MTU:  mtu - mtuconst.IPIPv6Overhead,
+			},
+			FlowBased: true,
+		}
+
+		if _, err := EnsureDevice(logger, sysctl, dev); err != nil {
+			return fmt.Errorf("creating %s: %w", defaults.IPIPv6Device, err)
+		}
+
+		// Rename fallback device created by potential kernel module load after
+		// creating tunnel interface.
+		if err := renameDevice("ip6tnl0", "cilium_ip6tnl"); err != nil {
+			return fmt.Errorf("renaming fallback device %s: %w", "ip6tnl0", err)
+		}
+	} else {
+		if err := RemoveDevice(defaults.IPIPv6Device); err != nil {
+			return fmt.Errorf("removing %s: %w", defaults.IPIPv6Device, err)
+		}
+	}
+
+	return nil
+}
+
+// renameDevice renames a network device from and to a given value. Returns nil
+// if the device does not exist.
+func renameDevice(from, to string) error {
+	link, err := safenetlink.LinkByName(from)
+	if err != nil {
+		return nil
+	}
+
+	if err := netlink.LinkSetName(link, to); err != nil {
+		return fmt.Errorf("renaming device %s to %s: %w", from, to, err)
+	}
+
+	return nil
+}

--- a/pkg/datapath/linux/device/netlink_test.go
+++ b/pkg/datapath/linux/device/netlink_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package device
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	sysctlfake "github.com/cilium/cilium/pkg/datapath/linux/sysctl/fake"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
+)
+
+func TestPrivilegedEnableForwarding(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+
+	prevConfigEnableIPv4 := option.Config.EnableIPv4
+	prevConfigEnableIPv6 := option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4 = prevConfigEnableIPv4
+		option.Config.EnableIPv6 = prevConfigEnableIPv6
+	})
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+
+	ns := netns.NewNetNS(t)
+
+	ns.Do(func() error {
+		ifName := "dummy"
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: ifName,
+			},
+		}
+		err := netlink.LinkAdd(dummy)
+		require.NoError(t, err)
+
+		err = EnableForwarding(logger, sysctl, dummy)
+		require.NoError(t, err)
+
+		enabledSettings := [][]string{
+			{"net", "ipv6", "conf", ifName, "forwarding"},
+			{"net", "ipv4", "conf", ifName, "forwarding"},
+			{"net", "ipv4", "conf", ifName, "accept_local"},
+		}
+		disabledSettings := [][]string{
+			{"net", "ipv4", "conf", ifName, "rp_filter"},
+			{"net", "ipv4", "conf", ifName, "send_redirects"},
+		}
+		for _, setting := range enabledSettings {
+			s, err := sysctl.Read(setting)
+			require.NoError(t, err)
+			require.Equal(t, "1", s)
+		}
+		for _, setting := range disabledSettings {
+			s, err := sysctl.Read(setting)
+			require.NoError(t, err)
+			require.Equal(t, "0", s)
+		}
+
+		err = netlink.LinkDel(dummy)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+func TestPrivilegedSetupIPIPDevices(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	logger := hivetest.Logger(t)
+
+	sysctl := &sysctlfake.Sysctl{}
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		err := SetupIPIPDevices(logger, sysctl, true, true, 1500)
+		require.NoError(t, err)
+
+		dev4, err := safenetlink.LinkByName(defaults.IPIPv4Device)
+		require.NoError(t, err)
+		require.Equal(t, 1480, dev4.Attrs().MTU)
+
+		dev6, err := safenetlink.LinkByName(defaults.IPIPv6Device)
+		require.NoError(t, err)
+		require.Equal(t, 1452, dev6.Attrs().MTU)
+
+		err = SetupIPIPDevices(logger, sysctl, false, false, 1500)
+		require.NoError(t, err)
+
+		_, err = safenetlink.LinkByName(defaults.IPIPv4Device)
+		require.Error(t, err)
+
+		_, err = safenetlink.LinkByName(defaults.IPIPv6Device)
+		require.Error(t, err)
+
+		err = SetupIPIPDevices(logger, sysctl, true, true, 1480)
+		require.NoError(t, err)
+
+		dev4, err = safenetlink.LinkByName(defaults.IPIPv4Device)
+		require.NoError(t, err)
+		require.Equal(t, 1460, dev4.Attrs().MTU)
+
+		dev6, err = safenetlink.LinkByName(defaults.IPIPv6Device)
+		require.NoError(t, err)
+		require.Equal(t, 1432, dev6.Attrs().MTU)
+
+		err = SetupIPIPDevices(logger, sysctl, false, false, 1480)
+		require.NoError(t, err)
+
+		_, err = safenetlink.LinkByName(defaults.IPIPv4Device)
+		require.Error(t, err)
+
+		_, err = safenetlink.LinkByName(defaults.IPIPv6Device)
+		require.Error(t, err)
+
+		return nil
+	})
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -336,19 +336,6 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		return fmt.Errorf("failed to setup base devices: %w", err)
 	}
 
-	if option.Config.UnsafeDaemonConfigOption.EnableIPIPDevices {
-		// This setting needs to be applied before creating the IPIP devices.
-		sysIPIP := []tables.Sysctl{
-			{Name: []string{"net", "core", "fb_tunnels_only_for_init_net"}, Val: "2", IgnoreErr: true},
-		}
-		if err := l.sysctl.ApplySettings(sysIPIP); err != nil {
-			return err
-		}
-		if err := setupIPIPDevices(l.logger, l.sysctl, option.Config.IPv4Enabled(), option.Config.IPv6Enabled(), lnc.DeviceMTU); err != nil {
-			return fmt.Errorf("unable to create ipip devices: %w", err)
-		}
-	}
-
 	if err := setupTunnelDevice(l.logger, l.sysctl, tunnelConfig.EncapProtocol(), tunnelConfig.Port(),
 		tunnelConfig.SrcPortLow(), tunnelConfig.SrcPortHigh(), lnc.DeviceMTU, bigtcp); err != nil {
 		return fmt.Errorf("failed to setup %s tunnel device: %w", tunnelConfig.EncapProtocol(), err)

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -4,7 +4,6 @@
 package loader
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -12,18 +11,15 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
+	"github.com/cilium/cilium/pkg/datapath/linux/device"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
-	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
-	mtuconst "github.com/cilium/cilium/pkg/mtu"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 const qdiscClsact = "clsact"
@@ -36,38 +32,6 @@ func directionToParent(dir string) uint32 {
 		return netlink.HANDLE_MIN_EGRESS
 	}
 	return 0
-}
-
-// enableForwarding puts the given link into the up state and enables IP forwarding.
-func enableForwarding(logger *slog.Logger, sysctl sysctl.Sysctl, link netlink.Link) error {
-	ifName := link.Attrs().Name
-
-	if err := netlink.LinkSetUp(link); err != nil {
-		logger.Warn("Could not set up the link",
-			logfields.Error, err,
-			logfields.Device, ifName,
-		)
-		return fmt.Errorf("failed to set link up: %w", err)
-	}
-
-	sysSettings := make([]tables.Sysctl, 0, 5)
-	if option.Config.EnableIPv6 {
-		sysSettings = append(sysSettings, tables.Sysctl{
-			Name: []string{"net", "ipv6", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false})
-	}
-	if option.Config.EnableIPv4 {
-		sysSettings = append(sysSettings, []tables.Sysctl{
-			{Name: []string{"net", "ipv4", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false},
-			{Name: []string{"net", "ipv4", "conf", ifName, "rp_filter"}, Val: "0", IgnoreErr: false},
-			{Name: []string{"net", "ipv4", "conf", ifName, "accept_local"}, Val: "1", IgnoreErr: false},
-			{Name: []string{"net", "ipv4", "conf", ifName, "send_redirects"}, Val: "0", IgnoreErr: false},
-		}...)
-	}
-	if err := sysctl.ApplySettings(sysSettings); err != nil {
-		return fmt.Errorf("failed to apply sysctl settings for %s: %w", ifName, err)
-	}
-
-	return nil
 }
 
 func setupVethPair(logger *slog.Logger, sysctl sysctl.Sysctl, name, peerName string) error {
@@ -116,10 +80,10 @@ func setupVethPair(logger *slog.Logger, sysctl sysctl.Sysctl, name, peerName str
 		return fmt.Errorf("failed to set ARP off for %s: %w", peerName, err)
 	}
 
-	if err := enableForwarding(logger, sysctl, veth); err != nil {
+	if err := device.EnableForwarding(logger, sysctl, veth); err != nil {
 		return fmt.Errorf("failed to enable forwarding on veth: %w", err)
 	}
-	if err := enableForwarding(logger, sysctl, peer); err != nil {
+	if err := device.EnableForwarding(logger, sysctl, peer); err != nil {
 		return fmt.Errorf("failed to enable forwarding on peer: %w", err)
 	}
 
@@ -194,7 +158,7 @@ func setupTunnelDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mode tunnel.En
 		if err := setupTunnelGSOGRO(logger, defaults.GeneveDevice, bigtcp); err != nil {
 			return fmt.Errorf("setting up GSO/GRO on GENEVE netdev: %w", err)
 		}
-		if err := removeDevice(defaults.VxlanDevice); err != nil {
+		if err := device.RemoveDevice(defaults.VxlanDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.VxlanDevice, err)
 		}
 
@@ -205,15 +169,15 @@ func setupTunnelDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mode tunnel.En
 		if err := setupTunnelGSOGRO(logger, defaults.VxlanDevice, bigtcp); err != nil {
 			return fmt.Errorf("setting up GSO/GRO on VXLAN netdev: %w", err)
 		}
-		if err := removeDevice(defaults.GeneveDevice); err != nil {
+		if err := device.RemoveDevice(defaults.GeneveDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.GeneveDevice, err)
 		}
 
 	default:
-		if err := removeDevice(defaults.VxlanDevice); err != nil {
+		if err := device.RemoveDevice(defaults.VxlanDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.VxlanDevice, err)
 		}
-		if err := removeDevice(defaults.GeneveDevice); err != nil {
+		if err := device.RemoveDevice(defaults.GeneveDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.GeneveDevice, err)
 		}
 	}
@@ -249,7 +213,7 @@ func setupGeneveDevice(logger *slog.Logger, sysctl sysctl.Sysctl, dport, srcPort
 		PortHigh:  int(srcPortHigh),
 	}
 
-	l, err := ensureDevice(logger, sysctl, dev)
+	l, err := device.EnsureDevice(logger, sysctl, dev)
 	if err != nil {
 		return fmt.Errorf("creating geneve device: %w", err)
 	}
@@ -261,7 +225,7 @@ func setupGeneveDevice(logger *slog.Logger, sysctl sysctl.Sysctl, dport, srcPort
 		if err := netlink.LinkDel(l); err != nil {
 			return fmt.Errorf("deleting outdated geneve device: %w", err)
 		}
-		if _, err := ensureDevice(logger, sysctl, dev); err != nil {
+		if _, err := device.EnsureDevice(logger, sysctl, dev); err != nil {
 			return fmt.Errorf("recreating geneve device %s: %w", defaults.GeneveDevice, err)
 		}
 	}
@@ -317,7 +281,7 @@ func setupVxlanDevice(logger *slog.Logger, sysctl sysctl.Sysctl, port, srcPortLo
 		}
 	}
 
-	l, err := ensureDevice(logger, sysctl, dev)
+	l, err := device.EnsureDevice(logger, sysctl, dev)
 	if err != nil {
 		return fmt.Errorf("creating vxlan device %s: %w", dev.Attrs().Name, err)
 	}
@@ -367,157 +331,6 @@ func setupTunnelGSOGRO(logger *slog.Logger, device string, bc bigtcp.Config) err
 			return err
 		}
 	}
-	return nil
-}
-
-// setupIPIPDevices ensures the specified v4 and/or v6 devices are created and
-// configured with their respective sysctls.
-//
-// Calling this function may result in tunl0 (v4) or ip6tnl0 (v6) fallback
-// interfaces being created as a result of loading the ipip and ip6_tunnel
-// kernel modules by creating cilium_ tunnel interfaces. These are catch-all
-// interfaces for the ipip decapsulation stack. By default, these interfaces
-// will be created in new network namespaces, but Cilium disables this behaviour
-// by setting net.core.fb_tunnels_only_for_init_net = 2.
-//
-// In versions of Cilium prior to 1.15, the behaviour was as follows:
-//   - Repurpose the default tunl0 by setting it into collect_md mode and renaming
-//     it to cilium_ipip4. Use the interface for production traffic.
-//   - The same cannot be done for ip6tunl0, as collect_md cannot be enabled on
-//     this interface. Leave it unused.
-//   - Rename sit0 to cilium_sit, if present. This was potentially a mistake,
-//     as the sit module is not involved with ip6tnl interfaces.
-//
-// As of Cilium 1.15, if present, tunl0 is renamed to cilium_tunl and ip6tnl0 is
-// renamed to cilium_ip6tnl. This is to communicate to the user that Cilium has
-// taken control of the encapsulation stack on the node, as it currently doesn't
-// explicitly support sharing it with other tools/CNIs. Fallback devices are left
-// unused for production traffic. Only devices that were explicitly created are
-// used. As of Cilium 1.18, cilium_tunl and cilium_ip6tnl are not created anymore.
-func setupIPIPDevices(logger *slog.Logger, sysctl sysctl.Sysctl, ipv4, ipv6 bool, mtu int) error {
-	// FlowBased sets IFLA_IPTUN_COLLECT_METADATA, the equivalent of 'ip link add
-	// ... type ipip/ip6tnl external'. This is needed so bpf programs can use
-	// bpf_skb_[gs]et_tunnel_key() on packets flowing through tunnels.
-	if ipv4 {
-		dev := &netlink.Iptun{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: defaults.IPIPv4Device,
-				MTU:  mtu - mtuconst.IPIPv4Overhead,
-			},
-			FlowBased: true,
-		}
-
-		if _, err := ensureDevice(logger, sysctl, dev); err != nil {
-			return fmt.Errorf("creating %s: %w", defaults.IPIPv4Device, err)
-		}
-
-		// Rename fallback device created by potential kernel module load after
-		// creating tunnel interface.
-		if err := renameDevice("tunl0", "cilium_tunl"); err != nil {
-			return fmt.Errorf("renaming fallback device %s: %w", "tunl0", err)
-		}
-	} else {
-		if err := removeDevice(defaults.IPIPv4Device); err != nil {
-			return fmt.Errorf("removing %s: %w", defaults.IPIPv4Device, err)
-		}
-	}
-
-	if ipv6 {
-		dev := &netlink.Ip6tnl{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: defaults.IPIPv6Device,
-				MTU:  mtu - mtuconst.IPIPv6Overhead,
-			},
-			FlowBased: true,
-		}
-
-		if _, err := ensureDevice(logger, sysctl, dev); err != nil {
-			return fmt.Errorf("creating %s: %w", defaults.IPIPv6Device, err)
-		}
-
-		// Rename fallback device created by potential kernel module load after
-		// creating tunnel interface.
-		if err := renameDevice("ip6tnl0", "cilium_ip6tnl"); err != nil {
-			return fmt.Errorf("renaming fallback device %s: %w", "tunl0", err)
-		}
-	} else {
-		if err := removeDevice(defaults.IPIPv6Device); err != nil {
-			return fmt.Errorf("removing %s: %w", defaults.IPIPv6Device, err)
-		}
-	}
-
-	return nil
-}
-
-// ensureDevice ensures a device with the given attrs is present on the system.
-// If a device with the given name already exists, device creation is skipped and
-// the existing device will be used as-is for the subsequent configuration steps.
-// The device is never recreated.
-//
-// The device's state is set to 'up', L3 forwarding sysctls are applied, and MTU
-// is set.
-func ensureDevice(logger *slog.Logger, sysctl sysctl.Sysctl, attrs netlink.Link) (netlink.Link, error) {
-	name := attrs.Attrs().Name
-
-	// Reuse existing tunnel interface created by previous runs.
-	l, err := safenetlink.LinkByName(name)
-	if err != nil {
-		if err := netlink.LinkAdd(attrs); err != nil {
-			if errors.Is(err, unix.ENOTSUP) {
-				err = fmt.Errorf("%w, maybe kernel module for %s is not available?", err, attrs.Type())
-			}
-			return nil, fmt.Errorf("creating device %s: %w", name, err)
-		}
-
-		// Fetch the link we've just created.
-		l, err = safenetlink.LinkByName(name)
-		if err != nil {
-			return nil, fmt.Errorf("retrieving created device %s: %w", name, err)
-		}
-	}
-
-	if err := enableForwarding(logger, sysctl, l); err != nil {
-		return nil, fmt.Errorf("setting up device %s: %w", name, err)
-	}
-
-	// Update MTU on the link if necessary.
-	wantMTU, gotMTU := attrs.Attrs().MTU, l.Attrs().MTU
-	if wantMTU != 0 && wantMTU != gotMTU {
-		if err := netlink.LinkSetMTU(l, wantMTU); err != nil {
-			return nil, fmt.Errorf("setting MTU on %s: %w", name, err)
-		}
-	}
-
-	return l, nil
-}
-
-// removeDevice removes the device with the given name. Returns error if the
-// device exists but was unable to be removed.
-func removeDevice(name string) error {
-	link, err := safenetlink.LinkByName(name)
-	if err != nil {
-		return nil
-	}
-
-	if err := netlink.LinkDel(link); err != nil {
-		return fmt.Errorf("removing device %s: %w", name, err)
-	}
-
-	return nil
-}
-
-// renameDevice renames a network device from and to a given value. Returns nil
-// if the device does not exist.
-func renameDevice(from, to string) error {
-	link, err := safenetlink.LinkByName(from)
-	if err != nil {
-		return nil
-	}
-
-	if err := netlink.LinkSetName(link, to); err != nil {
-		return fmt.Errorf("renaming device %s to %s: %w", from, to, err)
-	}
-
 	return nil
 }
 

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -53,63 +53,6 @@ func mustXDPProgram(t *testing.T, name string) *ebpf.Program {
 	return p
 }
 
-func TestPrivilegedSetupDev(t *testing.T) {
-	testutils.PrivilegedTest(t)
-	logger := hivetest.Logger(t)
-
-	sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
-
-	prevConfigEnableIPv4 := option.Config.EnableIPv4
-	prevConfigEnableIPv6 := option.Config.EnableIPv6
-	t.Cleanup(func() {
-		option.Config.EnableIPv4 = prevConfigEnableIPv4
-		option.Config.EnableIPv6 = prevConfigEnableIPv6
-	})
-	option.Config.EnableIPv4 = true
-	option.Config.EnableIPv6 = true
-
-	ns := netns.NewNetNS(t)
-
-	ns.Do(func() error {
-		ifName := "dummy"
-		dummy := &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: ifName,
-			},
-		}
-		err := netlink.LinkAdd(dummy)
-		require.NoError(t, err)
-
-		err = enableForwarding(logger, sysctl, dummy)
-		require.NoError(t, err)
-
-		enabledSettings := [][]string{
-			{"net", "ipv6", "conf", ifName, "forwarding"},
-			{"net", "ipv4", "conf", ifName, "forwarding"},
-			{"net", "ipv4", "conf", ifName, "accept_local"},
-		}
-		disabledSettings := [][]string{
-			{"net", "ipv4", "conf", ifName, "rp_filter"},
-			{"net", "ipv4", "conf", ifName, "send_redirects"},
-		}
-		for _, setting := range enabledSettings {
-			s, err := sysctl.Read(setting)
-			require.NoError(t, err)
-			require.Equal(t, "1", s)
-		}
-		for _, setting := range disabledSettings {
-			s, err := sysctl.Read(setting)
-			require.NoError(t, err)
-			require.Equal(t, "0", s)
-		}
-
-		err = netlink.LinkDel(dummy)
-		require.NoError(t, err)
-
-		return nil
-	})
-}
-
 // TestPrivilegedSetupBaseDeviceIPv6NotTentative checks that the IPv6 link-local
 // addresses of the base devices are usable as soon as setupBaseDevice returns.
 // Bringing a link up before turning ARP off leaves the kernel-generated
@@ -513,59 +456,6 @@ func TestPrivilegedAddHostDeviceAddr(t *testing.T) {
 
 		err = netlink.LinkDel(dummy)
 		require.NoError(t, err)
-
-		return nil
-	})
-}
-
-func TestPrivilegedSetupIPIPDevices(t *testing.T) {
-	testutils.PrivilegedTest(t)
-
-	logger := hivetest.Logger(t)
-
-	sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
-
-	ns := netns.NewNetNS(t)
-	ns.Do(func() error {
-		err := setupIPIPDevices(logger, sysctl, true, true, 1500)
-		require.NoError(t, err)
-
-		dev4, err := safenetlink.LinkByName(defaults.IPIPv4Device)
-		require.NoError(t, err)
-		require.Equal(t, 1480, dev4.Attrs().MTU)
-
-		dev6, err := safenetlink.LinkByName(defaults.IPIPv6Device)
-		require.NoError(t, err)
-		require.Equal(t, 1452, dev6.Attrs().MTU)
-
-		err = setupIPIPDevices(logger, sysctl, false, false, 1500)
-		require.NoError(t, err)
-
-		_, err = safenetlink.LinkByName(defaults.IPIPv4Device)
-		require.Error(t, err)
-
-		_, err = safenetlink.LinkByName(defaults.IPIPv6Device)
-		require.Error(t, err)
-
-		err = setupIPIPDevices(logger, sysctl, true, true, 1480)
-		require.NoError(t, err)
-
-		dev4, err = safenetlink.LinkByName(defaults.IPIPv4Device)
-		require.NoError(t, err)
-		require.Equal(t, 1460, dev4.Attrs().MTU)
-
-		dev6, err = safenetlink.LinkByName(defaults.IPIPv6Device)
-		require.NoError(t, err)
-		require.Equal(t, 1432, dev6.Attrs().MTU)
-
-		err = setupIPIPDevices(logger, sysctl, false, false, 1480)
-		require.NoError(t, err)
-
-		_, err = safenetlink.LinkByName(defaults.IPIPv4Device)
-		require.Error(t, err)
-
-		_, err = safenetlink.LinkByName(defaults.IPIPv6Device)
-		require.Error(t, err)
 
 		return nil
 	})

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -153,6 +153,26 @@ func newLocalNodeConfig(
 		return config.Config{}, nil, fmt.Errorf("failed to parse hardware address of '%s': %w", defaults.SecondHostDevice, err)
 	}
 
+	var encap4IfIndex, encap6IfIndex uint32
+	if daemon.UnsafeDaemonConfigOption.EnableIPIPDevices {
+		if daemon.EnableIPv4 {
+			dev, _, watch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.IPIPv4Device))
+			if !ok {
+				return config.Config{}, watch, fmt.Errorf("failed to look up IPv4 IPIP device '%s'", defaults.IPIPv4Device)
+			}
+			watchChans = append(watchChans, watch)
+			encap4IfIndex = uint32(dev.Index)
+		}
+		if daemon.EnableIPv6 {
+			dev, _, watch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.IPIPv6Device))
+			if !ok {
+				return config.Config{}, watch, fmt.Errorf("failed to look up IPv6 IPIP device '%s'", defaults.IPIPv6Device)
+			}
+			watchChans = append(watchChans, watch)
+			encap6IfIndex = uint32(dev.Index)
+		}
+	}
+
 	return config.Config{
 		ClusterID:                    localNode.ClusterID,
 		NodeIPv4:                     ip.AddrFromIP(localNode.GetNodeIP(false)),
@@ -181,6 +201,8 @@ func newLocalNodeConfig(
 		EnableIPv4:                   daemon.EnableIPv4,
 		EnableIPv6:                   daemon.EnableIPv6,
 		EnableEncapsulation:          daemon.TunnelingEnabled(),
+		Encap4IfIndex:                encap4IfIndex,
+		Encap6IfIndex:                encap6IfIndex,
 		RequiresNativeRouting:        daemon.RequiresNativeRouting(),
 		TunnelProtocol:               tunnelCfg.EncapProtocol().ToDpID(),
 		TunnelPort:                   tunnelCfg.Port(),

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
+	"github.com/cilium/cilium/pkg/datapath/linux/device"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
@@ -218,44 +219,62 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 		retryChan <-chan time.Time
 	)
 	for {
-		localNodeConfig, localNodeConfigWatch, err := newLocalNodeConfig(
-			ctx,
-			option.Config,
-			localNode,
-			o.params.Sysctl,
-			o.params.TunnelConfig,
-			o.params.DB.ReadTxn(),
-			o.params.DirectRoutingDevice,
-			o.params.Devices,
-			o.params.NodeAddresses,
-			o.params.Config.DeriveMasqIPAddrFromDevice,
-			o.params.XDPConfig,
-			o.params.LBConfig,
-			o.params.KPRConfig,
-			o.params.SvcRouteConfig,
-			o.params.MaglevConfig,
-			o.params.MTU,
-			o.params.WgAgent,
-			o.params.IPsecConfig,
-			o.params.ConnectorConfig,
-			o.params.PluginRegistry.Plugins(),
+		var (
+			localNodeConfig      config.Config
+			localNodeConfigWatch <-chan struct{}
 		)
+
+		// Re-run this on every reconciliation to update the tunnel MTU or
+		// recreate IPIP devices if they disappear.
+		ipipWatch, err := o.ensureIPIPDevices(agentConfig)
 		if err != nil {
-			health.Degraded("failed to get local node configuration", err)
-			o.params.Log.Warn("Failed to construct local node configuration", logfields.Error, err)
+			o.params.Log.Warn("Failed to ensure IPIP devices, retrying later",
+				logfields.Error, err,
+				logfields.RetryDelay, reinitRetryDuration,
+			)
+			health.Degraded("Failed to ensure IPIP devices", err)
+			retryChan = time.After(reinitRetryDuration)
 		} else {
-			// Reinitializing is expensive, only do so if the configuration has changed.
-			prevConfig := o.latestLocalNodeConfig.Load()
-			if prevConfig == nil || !prevConfig.DeepEqual(&localNodeConfig) {
-				err = o.reinitialize(request.ctx, &localNodeConfig)
-				if err != nil {
-					o.params.Log.Warn("Failed to initialize datapath, retrying later",
-						logfields.Error, err,
-						logfields.RetryDelay, reinitRetryDuration,
-					)
-					health.Degraded("Failed to reinitialize datapath", err)
-					retryChan = time.After(reinitRetryDuration)
-				} else {
+			localNodeConfig, localNodeConfigWatch, err = newLocalNodeConfig(
+				ctx,
+				option.Config,
+				localNode,
+				o.params.Sysctl,
+				o.params.TunnelConfig,
+				o.params.DB.ReadTxn(),
+				o.params.DirectRoutingDevice,
+				o.params.Devices,
+				o.params.NodeAddresses,
+				o.params.Config.DeriveMasqIPAddrFromDevice,
+				o.params.XDPConfig,
+				o.params.LBConfig,
+				o.params.KPRConfig,
+				o.params.SvcRouteConfig,
+				o.params.MaglevConfig,
+				o.params.MTU,
+				o.params.WgAgent,
+				o.params.IPsecConfig,
+				o.params.ConnectorConfig,
+				o.params.PluginRegistry.Plugins(),
+			)
+			if err != nil {
+				health.Degraded("failed to get local node configuration", err)
+				o.params.Log.Warn("Failed to construct local node configuration", logfields.Error, err)
+			} else {
+				// Reinitializing is expensive, only do so if the configuration has changed.
+				prevConfig := o.latestLocalNodeConfig.Load()
+				if prevConfig == nil || !prevConfig.DeepEqual(&localNodeConfig) {
+					err = o.reinitialize(request.ctx, &localNodeConfig)
+					if err != nil {
+						o.params.Log.Warn("Failed to initialize datapath, retrying later",
+							logfields.Error, err,
+							logfields.RetryDelay, reinitRetryDuration,
+						)
+						health.Degraded("Failed to reinitialize datapath", err)
+						retryChan = time.After(reinitRetryDuration)
+					}
+				}
+				if err == nil {
 					retryChan = nil
 					health.OK("OK")
 				}
@@ -271,6 +290,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-ipipWatch:
 		case <-localNodeConfigWatch:
 		case <-retryChan:
 		case localNode = <-localNodes:
@@ -309,6 +329,32 @@ func (o *orchestrator) waitForHostDevices(ctx context.Context, health cell.Healt
 		case <-netWatch:
 		}
 	}
+}
+
+func (o *orchestrator) ensureIPIPDevices(agentConfig *option.DaemonConfig) (<-chan struct{}, error) {
+	if !agentConfig.UnsafeDaemonConfigOption.EnableIPIPDevices {
+		return nil, nil
+	}
+
+	mtuRoute, _, mtuWatch, found := o.params.MTU.GetWatch(
+		o.params.DB.ReadTxn(),
+		mtu.MTURouteByPrefix(mtu.DefaultPrefixV4),
+	)
+	if !found {
+		return mtuWatch, fmt.Errorf("default route MTU is not available")
+	}
+
+	err := device.SetupIPIPDevices(
+		o.params.Log,
+		o.params.Sysctl,
+		agentConfig.IPv4Enabled(),
+		agentConfig.IPv6Enabled(),
+		mtuRoute.DeviceMTU,
+	)
+	if err != nil {
+		return mtuWatch, fmt.Errorf("reconciling IPIP devices: %w", err)
+	}
+	return mtuWatch, nil
 }
 
 func (o *orchestrator) DatapathInitialized() <-chan struct{} {


### PR DESCRIPTION
This PR moves ENCAP4_IFINDEX, ENCAP6_IFINDEX macros to runtime config.

Please review per-commit.

Related issue: https://github.com/cilium/cilium/issues/38370