### PR TITLE
gateway-api: scope GAMMA ingestion to the reconciled service

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -119,11 +119,11 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	httpRoutes := r.filterHTTPRoutesByService(originalSvc, httpRouteList.Items)
 	grpcRoutes := r.filterGRPCRoutesByService(originalSvc, grpcRouteList.Items)
 
-	// TODO(youngnick): GammaHTTPRoutes needs to be updated now that we have a source Service.
 	httpListeners := ingestion.GammaHTTPRoutes(r.logger, ingestion.GammaInput{
-		HTTPRoutes: httpRoutes,
-		GRPCRoutes: grpcRoutes,
-		Services:   servicesList.Items,
+		HTTPRoutes:    httpRoutes,
+		GRPCRoutes:    grpcRoutes,
+		Services:      servicesList.Items,
+		SourceService: originalSvc,
 
 		ReferenceGrants: grants.Items,
 	})

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -77,6 +77,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 		{name: "mesh-frontend", serviceKey: []types.NamespacedName{serviceKeyEchoV2}},
 		{name: "mesh-matching", serviceKey: []types.NamespacedName{serviceKeyEcho}},
 		{name: "mesh-ports", serviceKey: []types.NamespacedName{serviceKeyEchoV1, serviceKeyEchoV2}},
+		{name: "mesh-multi-parent", serviceKey: []types.NamespacedName{serviceKeyEchoV1, serviceKeyEchoV2}},
 		{name: "mesh-query-param-matching", serviceKey: []types.NamespacedName{serviceKeyEcho}},
 		{name: "mesh-redirect-host-and-status", serviceKey: []types.NamespacedName{serviceKeyEcho}},
 		{name: "mesh-redirect-path", serviceKey: []types.NamespacedName{serviceKeyEcho}},

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/input/grpcroute-mesh-multi-parent-grpc.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/input/grpcroute-mesh-multi-parent-grpc.yaml
@@ -1,0 +1,21 @@
+# The GRPCRoute is parented by both echo-v2 and the shared echo Service.
+# Reconciling echo-v2 must only program the echo-v2 parent.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: mesh-multi-parent-grpc
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+    - group: ""
+      kind: Service
+      name: echo-v2
+      port: 7070
+    - group: ""
+      kind: Service
+      name: echo
+      port: 7070
+  rules:
+    - backendRefs:
+        - name: echo-v2
+          port: 7070

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/input/httproute-mesh-multi-parent.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/input/httproute-mesh-multi-parent.yaml
@@ -1,0 +1,27 @@
+# The HTTPRoute is parented by both echo-v1 and the shared echo Service.
+# Reconciling echo-v1 must only program the echo-v1 parent.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-multi-parent
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+    - group: ""
+      kind: Service
+      name: echo-v1
+      port: 80
+    - group: ""
+      kind: Service
+      name: echo
+      port: 80
+  rules:
+    - filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: X-Header-Set
+                value: v1
+      backendRefs:
+        - name: echo-v1
+          port: 80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/cec-echo-v1.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/cec-echo-v1.yaml
@@ -1,0 +1,112 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
+  labels:
+    gateway.networking.k8s.io/gateway-name: mesh-multi-parent
+  name: echo-v1
+  namespace: gateway-conformance-mesh
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: HTTPRoute
+      name: mesh-multi-parent
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: echo-v1
+      namespace: gateway-conformance-mesh
+      number:
+        - "80"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                prefix: /
+              responseHeadersToAdd:
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+                  header:
+                    key: X-Header-Set
+                    value: v1
+              route:
+                cluster: gateway-conformance-mesh:echo-v1:80
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-mesh/echo-v1:80
+      name: gateway-conformance-mesh:echo-v1:80
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: echo-v1
+      namespace: gateway-conformance-mesh
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/cec-echo-v2.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/cec-echo-v2.yaml
@@ -1,0 +1,107 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
+  labels:
+    gateway.networking.k8s.io/gateway-name: mesh-multi-parent-grpc
+  name: echo-v2
+  namespace: gateway-conformance-mesh
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: GRPCRoute
+      name: mesh-multi-parent-grpc
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: echo-v2
+      namespace: gateway-conformance-mesh
+      number:
+        - "7070"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                prefix: /
+              route:
+                cluster: gateway-conformance-mesh:echo-v2:7070
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-mesh/echo-v2:7070
+      name: gateway-conformance-mesh:echo-v2:7070
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: echo-v2
+      namespace: gateway-conformance-mesh
+      ports:
+        - 7070

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/grpcroute-mesh-multi-parent-grpc.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/grpcroute-mesh-multi-parent-grpc.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: mesh-multi-parent-grpc
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+    - group: ""
+      kind: Service
+      name: echo-v2
+      port: 7070
+    - group: ""
+      kind: Service
+      name: echo
+      port: 7070
+  rules:
+    - backendRefs:
+        - name: echo-v2
+          port: 7070
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-06-19T03:21:44Z"
+          message: Accepted GRPCRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-06-19T03:21:44Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        group: ""
+        kind: Service
+        name: echo-v2
+        port: 7070

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/httproute-mesh-multi-parent.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/httproute-mesh-multi-parent.yaml
@@ -1,0 +1,44 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-multi-parent
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+    - group: ""
+      kind: Service
+      name: echo-v1
+      port: 80
+    - group: ""
+      kind: Service
+      name: echo
+      port: 80
+  rules:
+    - backendRefs:
+        - name: echo-v1
+          port: 80
+      filters:
+        - responseHeaderModifier:
+            set:
+              - name: X-Header-Set
+                value: v1
+          type: ResponseHeaderModifier
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-06-19T03:21:44Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-06-19T03:21:44Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        group: ""
+        kind: Service
+        name: echo-v1
+        port: 80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/service-echo-v1.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/service-echo-v1.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: echo-v1
+  namespace: gateway-conformance-mesh
+  resourceVersion: "1000"
+spec:
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    targetPort: 80
+  - appProtocol: http
+    name: http-alt
+    port: 8080
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 443
+  - name: tcp
+    port: 9090
+    targetPort: 0
+  - appProtocol: grpc
+    name: grpc
+    port: 7070
+    targetPort: 0
+  selector:
+    app: echo
+    version: v1
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-19T03:21:44Z"
+    message: Gamma Service has routes attached
+    reason: Accepted
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesAttached
+  - lastTransitionTime: "2025-06-19T03:21:44Z"
+    message: Gamma Service has been programmed
+    reason: Programmed
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesProgrammed
+  loadBalancer: {}

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/service-echo-v2.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-multi-parent/output/service-echo-v2.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: echo-v2
+  namespace: gateway-conformance-mesh
+  resourceVersion: "1000"
+spec:
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    targetPort: 80
+  - appProtocol: http
+    name: http-alt
+    port: 8080
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 443
+  - name: tcp
+    port: 9090
+    targetPort: 0
+  - appProtocol: grpc
+    name: grpc
+    port: 7070
+    targetPort: 0
+  selector:
+    app: echo
+    version: v2
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-19T03:21:44Z"
+    message: Gamma Service has routes attached
+    reason: Accepted
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesAttached
+  - lastTransitionTime: "2025-06-19T03:21:44Z"
+    message: Gamma Service has been programmed
+    reason: Programmed
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesProgrammed
+  loadBalancer: {}

--- a/operator/pkg/model/ingestion/gamma.go
+++ b/operator/pkg/model/ingestion/gamma.go
@@ -23,6 +23,13 @@ type GammaInput struct {
 	GRPCRoutes      []gatewayv1.GRPCRoute
 	ReferenceGrants []gatewayv1.ReferenceGrant
 	Services        []corev1.Service
+	// SourceService is the GAMMA Service being reconciled. Only route parents
+	// matching it contribute Listeners, so a Route parented by several Services
+	// cannot leak another Service's configuration into this reconciliation.
+	//
+	// The reconciler always sets this; nil is a test-only convenience that
+	// processes every Service parent.
+	SourceService *corev1.Service
 }
 
 // GammaHTTPRoutes takes a GammaInput and gives back the associated HTTP Listeners
@@ -48,8 +55,8 @@ func GammaHTTPRoutes(log *slog.Logger, input GammaInput) []model.HTTPListener {
 	// Set of services that will be parents for these HTTPRoutes
 	parentServices := make(map[types.NamespacedName]model.FullyQualifiedResource)
 
-	resHTTP = append(resHTTP, toGammaHTTPRoutes(log, parentServices, input.HTTPRoutes, input.Services, input.ReferenceGrants)...)
-	resHTTP = append(resHTTP, toGammaGRPCRoutes(log, parentServices, input.GRPCRoutes, input.Services, input.ReferenceGrants)...)
+	resHTTP = append(resHTTP, toGammaHTTPRoutes(log, parentServices, input.HTTPRoutes, input.Services, input.SourceService, input.ReferenceGrants)...)
+	resHTTP = append(resHTTP, toGammaGRPCRoutes(log, parentServices, input.GRPCRoutes, input.Services, input.SourceService, input.ReferenceGrants)...)
 	return resHTTP
 }
 
@@ -58,6 +65,7 @@ func toGammaHTTPRoutes(
 	parentServices map[types.NamespacedName]model.FullyQualifiedResource,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
+	sourceService *corev1.Service,
 	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPListener {
 	var resHTTP []model.HTTPListener
@@ -67,7 +75,7 @@ func toGammaHTTPRoutes(
 		// route rules to Listeners for those Services.
 		var gammaParents []gatewayv1.ParentReference
 		for _, parent := range hr.Spec.ParentRefs {
-			if helpers.IsGammaService(parent) {
+			if helpers.IsGammaService(parent) && (sourceService == nil || helpers.IsGammaServiceEqual(parent, sourceService, hr.Namespace)) {
 				gammaParents = append(gammaParents, parent)
 			}
 		}
@@ -202,6 +210,7 @@ func toGammaGRPCRoutes(
 	parentServices map[types.NamespacedName]model.FullyQualifiedResource,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
+	sourceService *corev1.Service,
 	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPListener {
 	var resGRPC []model.HTTPListener
@@ -211,7 +220,7 @@ func toGammaGRPCRoutes(
 		// route rules to Listeners for those Services.
 		var gammaParents []gatewayv1.ParentReference
 		for _, parent := range grpcr.Spec.ParentRefs {
-			if helpers.IsGammaService(parent) {
+			if helpers.IsGammaService(parent) && (sourceService == nil || helpers.IsGammaServiceEqual(parent, sourceService, grpcr.Namespace)) {
 				gammaParents = append(gammaParents, parent)
 			}
 		}

--- a/operator/pkg/model/ingestion/gamma_test.go
+++ b/operator/pkg/model/ingestion/gamma_test.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 )
@@ -50,4 +54,121 @@ func readGammaInput(t *testing.T, testName string) GammaInput {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGammaTestdataDir, rewriteTestName(testName), "input-referencegrant.yaml"), &input.ReferenceGrants)
 
 	return input
+}
+
+// TestGammaSourceServiceScoping proves that a Route parented by more than one
+// Service only contributes Listeners for the Service currently being
+// reconciled. Without scoping, reconciling one Service would also program the
+// other Service's Listeners into that reconciliation's CEC.
+func TestGammaSourceServiceScoping(t *testing.T) {
+	const namespace = "gamma-scoping"
+
+	gammaService := func(name string) corev1.Service {
+		return corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:        "http",
+						Port:        80,
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: ptr.To("http"),
+					},
+					{
+						Name:        "grpc",
+						Port:        8080,
+						Protocol:    corev1.ProtocolTCP,
+						AppProtocol: ptr.To("grpc"),
+					},
+				},
+			},
+		}
+	}
+
+	serviceParent := func(name string) gatewayv1.ParentReference {
+		return gatewayv1.ParentReference{
+			Group: ptr.To(gatewayv1.Group(corev1.GroupName)),
+			Kind:  ptr.To(gatewayv1.Kind("Service")),
+			Name:  gatewayv1.ObjectName(name),
+		}
+	}
+
+	echoA := gammaService("echo-a")
+	echoB := gammaService("echo-b")
+
+	parentRefs := []gatewayv1.ParentReference{serviceParent("echo-a"), serviceParent("echo-b")}
+
+	input := GammaInput{
+		Services: []corev1.Service{echoA, echoB},
+		HTTPRoutes: []gatewayv1.HTTPRoute{{
+			ObjectMeta: metav1.ObjectMeta{Name: "http-route", Namespace: namespace},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: parentRefs},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					BackendRefs: []gatewayv1.HTTPBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "backend",
+								Port: ptr.To(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			},
+		}},
+		GRPCRoutes: []gatewayv1.GRPCRoute{{
+			ObjectMeta: metav1.ObjectMeta{Name: "grpc-route", Namespace: namespace},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: parentRefs},
+				Rules: []gatewayv1.GRPCRouteRule{{
+					BackendRefs: []gatewayv1.GRPCBackendRef{{
+						BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "backend",
+								Port: ptr.To(gatewayv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			},
+		}},
+	}
+
+	tests := map[string]struct {
+		sourceService *corev1.Service
+		expected      []string
+	}{
+		"unscoped input keeps every Service parent": {
+			sourceService: nil,
+			expected: []string{
+				"gamma-scoping-echo-a-80",
+				"gamma-scoping-echo-b-80",
+				"gamma-scoping-echo-a-8080",
+				"gamma-scoping-echo-b-8080",
+			},
+		},
+		"scoping to echo-a drops the echo-b parent": {
+			sourceService: &echoA,
+			expected:      []string{"gamma-scoping-echo-a-80", "gamma-scoping-echo-a-8080"},
+		},
+		"scoping to echo-b drops the echo-a parent": {
+			sourceService: &echoB,
+			expected:      []string{"gamma-scoping-echo-b-80", "gamma-scoping-echo-b-8080"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			scoped := input
+			scoped.SourceService = tc.sourceService
+
+			listeners := GammaHTTPRoutes(hivetest.Logger(t), scoped)
+
+			names := make([]string, 0, len(listeners))
+			for _, l := range listeners {
+				names = append(names, l.Name)
+			}
+			require.Equal(t, tc.expected, names)
+		})
+	}
 }


### PR DESCRIPTION
The GAMMA reconciler runs once per Service and selects the Routes naming that
Service as a parent. Ingestion then walked *every* Service ParentRef on those
Routes, so a Route parented by several Services contributed listeners for all of
them to whichever Service happened to be reconciling, putting another Service's
configuration into this Service's `CiliumEnvoyConfig`.

`GammaInput` gains a `SourceService` field. When set, only route rules parented
by that Service contribute Listeners. When nil, every Service ParentRef is
processed as before, so existing conformance fixtures are unaffected.

Adds `TestGammaSourceServiceScoping` with a single HTTPRoute parented by two
Services, asserting that scoping to either one drops the other's parent, and that
unscoped input still keeps both. Verified the test fails without the fix: both
scoping cases fail while the unscoped case passes.

Split out of #46479 so it can be reviewed and merged on its own.

This PR was prepared with AIL:3. I personally reviewed each line of the
submission.

```release-note
gateway-api: Fixed a bug where a GAMMA Route parented by multiple Services could contribute another Service's listeners to the reconciled Service's CiliumEnvoyConfig.
```