### PR TITLE
gha/e2e-upgrade: stop checking the L7 clients after an agent restart

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -677,7 +677,10 @@ jobs:
         with:
           job-name: cilium-restart-${{ matrix.name }}-${{ matrix.mode }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
-          include-conn-disrupt-test-l7-traffic: ${{ steps.vars-conn.outputs.include_conn_disrupt_test_l7_traffic }}
+          # Exclude the L7 clients from this check while the bugs that make
+          # them fail it are still open. The setup step above still creates
+          # them, so they keep running.
+          include-conn-disrupt-test-l7-traffic: 'false'
 
       - name: Features tested before downgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}


### PR DESCRIPTION
The L7 conn-disrupt clients are what fails this check, so set them to false
here rather than putting the continue-on-error back and tolerating the whole
step. The setup step above still creates them, so they keep running.

This PR was prepared with AIL:3.

