### PR TITLE
gateway-api: skip external auth on no-backend responses

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -315,6 +315,17 @@ func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFil
 	return config
 }
 
+// getTypedPerFilterConfigForSyntheticRoute returns the TypedPerFilterConfig map
+// for a route Cilium generates itself rather than one backed by a Service, such
+// as an HTTPS redirect or the 500 served when a rule has no resolvable backend.
+// External authorization is disabled on these routes: the request never reaches
+// a backend, so calling the authorization service is wasted work and exposes it
+// to traffic for a route that cannot be served. Non-external per-route
+// configuration such as CORS and session persistence is retained.
+func getTypedPerFilterConfigForSyntheticRoute(route model.HTTPRoute, allAuthFilters []*model.HTTPExternalAuthFilter, statefulSessionFilterEnabled bool) map[string]*anypb.Any {
+	return getTypedPerFilterConfig(nil, allAuthFilters, route, statefulSessionFilterEnabled)
+}
+
 func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter, statefulSessionFilterEnabled bool) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
@@ -348,7 +359,7 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 				hRoutes[0].HeadersMatch,
 				hRoutes[0].Method),
 			Action:               rRedirect,
-			TypedPerFilterConfig: getTypedPerFilterConfig(nil, allAuthFilters, r, statefulSessionFilterEnabled),
+			TypedPerFilterConfig: getTypedPerFilterConfigForSyntheticRoute(r, allAuthFilters, statefulSessionFilterEnabled),
 		}
 		routes = append(routes, &route)
 		delete(matchBackendMap, key)
@@ -719,7 +730,7 @@ func envoyHTTPRouteDirectResponse(route model.HTTPRoute, hostnames []string, hos
 				},
 			},
 		},
-		TypedPerFilterConfig: getTypedPerFilterConfig(route.ExternalAuth, allAuthFilters, route, statefulSessionFilterEnabled),
+		TypedPerFilterConfig: getTypedPerFilterConfigForSyntheticRoute(route, allAuthFilters, statefulSessionFilterEnabled),
 	}
 }
 

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -1198,6 +1198,67 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 	})
 }
 
+// Test_envoyHTTPRoutes_disablesExtAuthzOnNoBackendResponse verifies that the
+// synthetic 500 generated for a rule with no resolvable backend does not invoke
+// the external authorization service, even though the rule declares one.
+func Test_envoyHTTPRoutes_disablesExtAuthzOnNoBackendResponse(t *testing.T) {
+	auth := &model.HTTPExternalAuthFilter{
+		Backend:  model.Backend{Name: "authz", Namespace: "ns", Port: &model.BackendPort{Port: 9000}},
+		Protocol: model.ExternalAuthProtocolGRPC,
+	}
+	filterName := ExtAuthzFilterName(extAuthzFilterKey(auth))
+
+	t.Run("auth filter is disabled on the synthetic response", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch:      model.StringMatch{Prefix: "/"},
+				ExternalAuth:   auth,
+				DirectResponse: &model.DirectResponse{StatusCode: 500},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, []*model.HTTPExternalAuthFilter{auth}, false)
+		require.Len(t, res, 1)
+		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
+
+		entry, ok := res[0].TypedPerFilterConfig[filterName]
+		require.True(t, ok, "auth filter must be explicitly disabled on the synthetic response")
+		perRoute := &extauthzv3.ExtAuthzPerRoute{}
+		require.NoError(t, proto.Unmarshal(entry.Value, perRoute))
+		require.True(t, perRoute.GetDisabled())
+	})
+
+	t.Run("non-external per-route config is retained", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch:      model.StringMatch{Prefix: "/"},
+				ExternalAuth:   auth,
+				CORS:           &model.HTTPCORSFilter{AllowOrigins: []string{"https://example.com"}},
+				DirectResponse: &model.DirectResponse{StatusCode: 500},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, []*model.HTTPExternalAuthFilter{auth}, false)
+		require.Len(t, res, 1)
+		require.Contains(t, res[0].TypedPerFilterConfig, "envoy.filters.http.cors")
+	})
+
+	t.Run("routes that do serve a backend keep their auth filter", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch:    model.StringMatch{Prefix: "/"},
+				ExternalAuth: auth,
+				Backends:     []model.Backend{{Name: "backend-v1", Namespace: "default", Port: &model.BackendPort{Port: 8080}}},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, false, 80, []*model.HTTPExternalAuthFilter{auth}, false)
+		require.Len(t, res, 1)
+		require.NotContains(t, res[0].TypedPerFilterConfig, filterName,
+			"auth filter must stay enabled on a route that reaches a backend")
+	})
+}
+
 // Test_envoyHTTPSRoutes_disablesExtAuthzFilters verifies that HTTPS redirect routes
 // explicitly disable any ext_authz filters present on the listener. Without this,
 // redirect routes on a mixed listener inherit auth enforcement, which is incorrect.


### PR DESCRIPTION
When an HTTPRoute rule declares an `ExternalAuth` filter but none of its
backends resolve, ingestion replaces the rule's action with a synthetic
direct response returning 500. Translation still attached the rule's
ext_authz per-route configuration to that route, so Envoy calls the
external authorization service on every request before returning an error
it has already committed to.

The call cannot change the outcome, and it exposes the authorization
service to traffic for a route that cannot be served.

This moves the synthetic direct response onto a named
`getTypedPerFilterConfigForSyntheticRoute` helper that disables external
authorization while retaining ordinary per-route configuration such as
CORS. HTTPS redirect routes were already passing no auth filter and now
share the helper, so the intent is stated once instead of implied by a
bare `nil` argument.

No golden fixture changed, because no existing fixture combines an
`ExternalAuth` filter with an unresolvable backend. The new test covers it.

Simplifies #46479, where ext_proc `ExtensionRef` widens the path: an
unresolved ext_proc reference or an ext_proc ordering conflict also fails
closed to a synthetic 500 and deliberately preserves `ExternalAuth` on it.
That branch extends the same helper to disable ext_proc on those routes.

This PR was prepared with AIL:3. I personally reviewed each line of the
submission.

```release-note
gateway-api: an HTTPRoute rule with an ExternalAuth filter and no resolvable backend no longer calls the external authorization service before returning its 500 response.
```
