### PR TITLE
eni: make the ENA queue count of Cilium managed ENIs configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -206,6 +206,7 @@ cilium-agent [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
+      --eni-ena-queue-count string                                Number of ENA queues to request for each ENI attached to the node by Cilium: "default" to leave the number of queues to AWS, "auto" for as many as the interface can use, or a positive number of queues. ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on the node (default "default")
       --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -116,6 +116,7 @@ cilium-agent hive [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
+      --eni-ena-queue-count string                                Number of ENA queues to request for each ENI attached to the node by Cilium: "default" to leave the number of queues to AWS, "auto" for as many as the interface can use, or a positive number of queues. ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on the node (default "default")
       --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -122,6 +122,7 @@ cilium-agent hive dot-graph [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
+      --eni-ena-queue-count string                                Number of ENA queues to request for each ENI attached to the node by Cilium: "default" to leave the number of queues to AWS, "auto" for as many as the interface can use, or a positive number of queues. ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on the node (default "default")
       --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1563,7 +1563,7 @@
    * - :spelling:ignore:`eni.nodeSpec`
      - NodeSpec configuration for the ENI
      - object
-     - ``{"deleteOnTermination":null,"disablePrefixDelegation":false,"excludeInterfaceTags":[],"firstInterfaceIndex":null,"securityGroupTags":[],"securityGroups":[],"subnetIDs":[],"subnetTags":[],"usePrimaryAddress":false}``
+     - ``{"deleteOnTermination":null,"disablePrefixDelegation":false,"enaQueueCount":"","excludeInterfaceTags":[],"firstInterfaceIndex":null,"securityGroupTags":[],"securityGroups":[],"subnetIDs":[],"subnetTags":[],"usePrimaryAddress":false}``
    * - :spelling:ignore:`eni.nodeSpec.deleteOnTermination`
      - Delete ENI on termination @schema type: [null, boolean] @schema
      - string
@@ -1572,6 +1572,10 @@
      - Disable prefix delegation for IP allocation
      - bool
      - ``false``
+   * - :spelling:ignore:`eni.nodeSpec.enaQueueCount`
+     - Number of ENA queues to request for each ENI attached by Cilium: "auto" for as many as the interface can use, or a number of queues, which AWS requires to be a power of two. Empty leaves the number of queues to AWS, as does "default". ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on a node.
+     - string
+     - ``""``
    * - :spelling:ignore:`eni.nodeSpec.excludeInterfaceTags`
      - Exclude interface tags to use for IP allocation
      - list

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -315,6 +315,122 @@ allocation:
 
   If unspecified, this option is enabled.
 
+``spec.eni.ena-queue-count``
+  The number of ENA queues to request for each ENI that Cilium attaches to the
+  node: ``default``, ``auto`` or a positive number of queues. See
+  :ref:`ipam_eni_ena_queues`.
+
+  If unspecified, the agent writes ``default``, which leaves the number of
+  queues to AWS.
+
+.. _ipam_eni_ena_queues:
+
+****************
+ENA queue counts
+****************
+
+On instance types which support flexible ENA queues, the number of ENA queues
+of a network interface can be chosen when the interface is attached. Cilium can
+request a queue count for the ENIs it attaches, which is useful on nodes where
+the number of queues AWS assigns by default is lower than the number of vCPUs.
+
+Set the queue count with the ``eni.nodeSpec.enaQueueCount`` Helm value, which
+maps to the ``--eni-ena-queue-count`` agent flag and to
+``spec.eni.ena-queue-count`` of the ``CiliumNode`` resource:
+
+.. code-block:: shell-session
+
+    helm upgrade cilium |CHART_RELEASE| \
+      --namespace kube-system \
+      --reuse-values \
+      --set eni.nodeSpec.enaQueueCount=auto
+
+``auto`` requests one queue per vCPU, capped by the maximum number of queues per
+interface of the instance type. More queues than vCPUs do not help, as network
+drivers do not create more queues than there are CPUs.
+
+AWS only accepts a power of two as the number of queues of an attachment, while
+the vCPU count of an instance is not necessarily one, so ``auto`` rounds **up**:
+on an instance type with 12 vCPUs and a maximum of 16 queues per interface it
+requests 16, which yields one queue per CPU, where 8 would leave four CPUs
+without one. The surplus counts against the queue budget of the instance even
+though the driver does not create it.
+
+An explicit count is rounded **down** instead, as it is an upper bound the
+configuration asked for. So is a count reduced to what the budget has left.
+
+Should AWS reject the number of queues regardless, the ENI is attached with the
+default of the instance type: a queue count is a tuning knob, and IP allocation
+on a node never stops because of one.
+
+``default`` leaves the number of queues to AWS. It is the value the agent writes
+when nothing is configured, so the setting in effect can always be read off the
+node, and it is also the way to opt a single node or node pool out where a
+broader configuration applies:
+
+.. code-block:: shell-session
+
+    $ kubectl get ciliumnodes -o custom-columns='NODE:.metadata.name,ENA_QUEUE_COUNT:.spec.eni.ena-queue-count'
+    NODE                             ENA_QUEUE_COUNT
+    ip-10-0-1-10.ec2.internal        auto
+    ip-10-0-1-11.ec2.internal        default
+
+To tune node pools independently, for example because they run different
+instance types, set the flag per pool with a ``CiliumNodeConfig`` resource
+rather than cluster wide.
+
+Interfaces which Cilium does not attach
+=======================================
+
+The queue count only applies to ENIs which Cilium creates and attaches. The
+primary interface, and any interface attached before Cilium runs, keep the
+number of queues they were attached with, typically the one set by the launch
+template. Changing the setting does not change ENIs which are already attached
+either: it takes effect on the next ENI Cilium attaches.
+
+.. _ipam_eni_ena_queue_budget:
+
+ENA queues limit the number of ENIs
+===================================
+
+ENA queues are a budget shared by all interfaces of an instance, including the
+primary interface and interfaces Cilium does not manage. A high number of queues
+per ENI therefore reduces the number of ENIs, and with it the number of pods,
+which fit on the node.
+
+Cilium accounts for the budget as follows:
+
+#. The requested queue count is reduced to the maximum number of queues the
+   instance type allows per interface.
+#. It is then reduced to the number of queues left in the budget of the
+   instance. Cilium logs a warning when it does so, as the ENI is attached with
+   fewer queues than requested.
+#. Once the budget is exhausted, Cilium stops attaching ENIs to the node and
+   logs a warning. Pods which need an IP address from an additional ENI stay
+   pending until the queue count is lowered, or until IP addresses become
+   available on the ENIs already attached.
+
+With prefix delegation enabled (``eni.awsEnablePrefixDelegation``), a single ENI
+holds enough IP addresses for a typical node, so the budget is rarely reached.
+It becomes relevant on nodes which need many ENIs: when prefix delegation is
+disabled, and when Cilium falls back to individual IP addresses because the
+subnet has run out of contiguous ``/28`` prefixes. On such nodes, consider a
+lower queue count or an ``ipam-max-allocate`` bounding the ENIs a node needs.
+
+The number of queues each ENI runs with is reported per ENI in the
+``CiliumNode`` resource, which makes the consumption of the budget visible:
+
+.. code-block:: shell-session
+
+    $ kubectl get ciliumnode ip-10-0-1-10 -o json | jq -r '.status.eni.enis[] | "\(.id)\t\(.number)\t\(.["ena-queue-count"])"'
+    eni-0a1b2c3d4e5f60718     0       8
+    eni-0a1b2c3d4e5f60719     1       32
+
+The AWS API only reports a queue count for interfaces attached with a requested
+count, so interfaces Cilium did not attach, the primary one among them, are
+reported with the default of the instance type. That is the number they run
+with, and the number counted against the budget.
+
 .. _ipam_eni_ipv6:
 
 **********

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -902,6 +902,7 @@ userInfo
 userspace
 uuid
 vCPU
+vCPUs
 vSphere
 validator
 vendored

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -440,9 +440,10 @@ contributors across the globe, there is almost always someone available to help.
 | eni.gcTags | object | `{"io.cilium/cilium-managed":"true,"io.cilium/cluster-name":"<auto-detected>"}` | Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected |
 | eni.iamRole | string | `""` | If using IAM role for Service Accounts will not try to inject identity values from cilium-aws kubernetes secret. Adds annotation to service account if managed by Helm. See https://github.com/aws/amazon-eks-pod-identity-webhook |
 | eni.instanceTagsFilter | list | `[]` | Filter via AWS EC2 Instance tags (k=v) which will dictate which AWS EC2 Instances are going to be used to create new ENIs |
-| eni.nodeSpec | object | `{"deleteOnTermination":null,"disablePrefixDelegation":false,"excludeInterfaceTags":[],"firstInterfaceIndex":null,"securityGroupTags":[],"securityGroups":[],"subnetIDs":[],"subnetTags":[],"usePrimaryAddress":false}` | NodeSpec configuration for the ENI |
+| eni.nodeSpec | object | `{"deleteOnTermination":null,"disablePrefixDelegation":false,"enaQueueCount":"","excludeInterfaceTags":[],"firstInterfaceIndex":null,"securityGroupTags":[],"securityGroups":[],"subnetIDs":[],"subnetTags":[],"usePrimaryAddress":false}` | NodeSpec configuration for the ENI |
 | eni.nodeSpec.deleteOnTermination | string | `nil` | Delete ENI on termination @schema type: [null, boolean] @schema |
 | eni.nodeSpec.disablePrefixDelegation | bool | `false` | Disable prefix delegation for IP allocation |
+| eni.nodeSpec.enaQueueCount | string | `""` | Number of ENA queues to request for each ENI attached by Cilium: "auto" for as many as the interface can use, or a number of queues, which AWS requires to be a power of two. Empty leaves the number of queues to AWS, as does "default". ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on a node. |
 | eni.nodeSpec.excludeInterfaceTags | list | `[]` | Exclude interface tags to use for IP allocation |
 | eni.nodeSpec.firstInterfaceIndex | string | `nil` | First interface index to use for IP allocation @schema type: [null, integer] @schema |
 | eni.nodeSpec.securityGroupTags | list | `[]` | Security group tags to use for IP allocation |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -651,6 +651,9 @@ data:
   {{- if .Values.eni.nodeSpec.disablePrefixDelegation }}
   eni-disable-prefix-delegation: "true"
   {{- end }}
+  {{- if .Values.eni.nodeSpec.enaQueueCount }}
+  eni-ena-queue-count: {{ .Values.eni.nodeSpec.enaQueueCount | quote }}
+  {{- end }}
   {{- if ne .Values.eni.nodeSpec.deleteOnTermination nil }}
   eni-delete-on-termination: {{ .Values.eni.nodeSpec.deleteOnTermination | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2269,6 +2269,9 @@
             "disablePrefixDelegation": {
               "type": "boolean"
             },
+            "enaQueueCount": {
+              "type": "string"
+            },
             "excludeInterfaceTags": {
               "items": {},
               "type": "array"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1361,6 +1361,13 @@ eni:
     # type: [null, boolean]
     # @schema
     deleteOnTermination: ~
+    # -- Number of ENA queues to request for each ENI attached by Cilium:
+    # "auto" for as many as the interface can use, or a number of queues, which
+    # AWS requires to be a power of two. Empty leaves the number of queues to
+    # AWS, as does "default". ENA queues are a budget shared by all interfaces of an instance,
+    # so a high number of queues per ENI may reduce the number of ENIs, and
+    # therefore the number of pods, that fit on a node.
+    enaQueueCount: ""
 # fragmentTracking enables IPv4 fragment tracking support in the datapath.
 # fragmentTracking: true
 gke:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1373,6 +1373,13 @@ eni:
     # type: [null, boolean]
     # @schema
     deleteOnTermination: ~
+    # -- Number of ENA queues to request for each ENI attached by Cilium:
+    # "auto" for as many as the interface can use, or a number of queues, which
+    # AWS requires to be a power of two. Empty leaves the number of queues to
+    # AWS, as does "default". ENA queues are a budget shared by all interfaces of an instance,
+    # so a high number of queues per ENI may reduce the number of ENIs, and
+    # therefore the number of pods, that fit on a node.
+    enaQueueCount: ""
 
 # fragmentTracking enables IPv4 fragment tracking support in the datapath.
 # fragmentTracking: true

--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -505,6 +505,7 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 
 	if iface.Attachment != nil {
 		eni.Number = int(aws.ToInt32(iface.Attachment.DeviceIndex))
+		eni.ENAQueueCount = aws.ToInt32(iface.Attachment.EnaQueueCount)
 
 		if iface.Attachment.InstanceId != nil {
 			instanceID = aws.ToString(iface.Attachment.InstanceId)
@@ -900,8 +901,15 @@ func (c *Client) DeleteNetworkInterface(ctx context.Context, eniID string) error
 	return err
 }
 
-// AttachNetworkInterface attaches a previously created ENI to an instance
-func (c *Client) AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error) {
+// AttachNetworkInterface attaches a previously created ENI to an instance.
+//
+// enaQueueCount is the number of ENA queues to request for the attachment. A
+// value of zero leaves the number of queues to AWS. The caller is responsible
+// for keeping the requested count within the limits of the instance type: AWS
+// rejects the attachment if the count exceeds the maximum number of queues per
+// interface, or if it exceeds the queue budget left by the interfaces which are
+// already attached.
+func (c *Client) AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string, enaQueueCount int32) (string, error) {
 	input := &ec2.AttachNetworkInterfaceInput{
 		DeviceIndex:        aws.Int32(index),
 		InstanceId:         aws.String(instanceID),
@@ -918,6 +926,10 @@ func (c *Client) AttachNetworkInterface(ctx context.Context, index int32, instan
 		//
 		// See https://github.com/cilium/cilium/pull/42512
 		NetworkCardIndex: aws.Int32(0),
+	}
+
+	if enaQueueCount > 0 {
+		input.EnaQueueCount = aws.Int32(enaQueueCount)
 	}
 
 	c.limiter.Limit(ctx, AttachNetworkInterface)

--- a/pkg/aws/api/mock/mock.go
+++ b/pkg/aws/api/mock/mock.go
@@ -114,6 +114,30 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 			BareMetal:  aws.Bool(false),
 		},
 		{
+			// c8i.8xlarge supports flexible ENA queues. The queue limits are
+			// reported per network card, and are the values the EC2 API returns
+			// for this instance type.
+			InstanceType: "c8i.8xlarge",
+			NetworkInfo: &ec2_types.NetworkInfo{
+				MaximumNetworkInterfaces:  aws.Int32(10),
+				Ipv4AddressesPerInterface: aws.Int32(50),
+				Ipv6AddressesPerInterface: aws.Int32(50),
+				FlexibleEnaQueuesSupport:  ec2_types.FlexibleEnaQueuesSupportSupported,
+				NetworkCards: []ec2_types.NetworkCardInfo{
+					{
+						NetworkCardIndex:                 aws.Int32(0),
+						MaximumNetworkInterfaces:         aws.Int32(10),
+						MaximumEnaQueueCount:             aws.Int32(128),
+						MaximumEnaQueueCountPerInterface: aws.Int32(32),
+						DefaultEnaQueueCountPerInterface: aws.Int32(8),
+					},
+				},
+			},
+			VCpuInfo:   &ec2_types.VCpuInfo{DefaultVCpus: aws.Int32(32)},
+			Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+			BareMetal:  aws.Bool(false),
+		},
+		{
 			InstanceType: "m3.large",
 			NetworkInfo: &ec2_types.NetworkInfo{
 				MaximumNetworkInterfaces:  aws.Int32(3),

--- a/pkg/aws/api/mock/mock.go
+++ b/pkg/aws/api/mock/mock.go
@@ -66,6 +66,18 @@ type API struct {
 	limiter        *rate.Limiter
 	delaySim       *helpers.DelaySimulator
 	pdSubnet       netip.Prefix
+	// rejectENAQueueCount makes AttachNetworkInterface reject any attachment
+	// asking for a specific number of ENA queues, as AWS does when the count
+	// is not one it accepts.
+	rejectENAQueueCount bool
+}
+
+// RejectENAQueueCount makes the mock reject any attachment which asks for a
+// specific number of ENA queues.
+func (e *API) RejectENAQueueCount(reject bool) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.rejectENAQueueCount = reject
 }
 
 // NewAPI returns a new mocked EC2 API
@@ -411,7 +423,7 @@ func (e *API) DeleteNetworkInterface(ctx context.Context, eniID string) error {
 	return fmt.Errorf("ENI ID %s not found", eniID)
 }
 
-func (e *API) AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error) {
+func (e *API) AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string, enaQueueCount int32) (string, error) {
 	e.rateLimit()
 	e.delaySim.Delay(AttachNetworkInterface)
 
@@ -427,6 +439,15 @@ func (e *API) AttachNetworkInterface(ctx context.Context, index int32, instanceI
 		return "", fmt.Errorf("ENI ID %s does not exist", eniID)
 	}
 
+	// AWS only accepts a power of two as the number of ENA queues of an
+	// attachment, and rejects the attachment otherwise.
+	if enaQueueCount > 0 && (e.rejectENAQueueCount || enaQueueCount&(enaQueueCount-1) != 0) {
+		return "", &smithy.GenericAPIError{
+			Code:    api.InvalidParameterValueStr,
+			Message: "The ENA queue count specified must be a power of 2",
+		}
+	}
+
 	delete(e.unattached, eniID)
 
 	if _, ok := e.enis[instanceID]; !ok {
@@ -434,6 +455,7 @@ func (e *API) AttachNetworkInterface(ctx context.Context, index int32, instanceI
 	}
 
 	eni.Number = int(index)
+	eni.ENAQueueCount = enaQueueCount
 
 	e.enis[instanceID][eniID] = eni
 

--- a/pkg/aws/api/mock/mock_test.go
+++ b/pkg/aws/api/mock/mock_test.go
@@ -26,13 +26,13 @@ func TestMock(t *testing.T) {
 	eniID2, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 
-	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", eniID1)
+	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", eniID1, 0)
 	require.NoError(t, err)
 
 	_, ok := api.enis["i-1"][eniID1]
 	require.True(t, ok)
 
-	_, err = api.AttachNetworkInterface(t.Context(), 1, "i-1", eniID2)
+	_, err = api.AttachNetworkInterface(t.Context(), 1, "i-1", eniID2, 0)
 	require.NoError(t, err)
 
 	_, ok = api.enis["i-1"][eniID1]
@@ -93,7 +93,7 @@ func TestSetMockError(t *testing.T) {
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(AttachNetworkInterface, mockError)
-	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", "e-1")
+	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", "e-1", 0)
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(DeleteNetworkInterface, mockError)

--- a/pkg/aws/ipam/eni_gc_test.go
+++ b/pkg/aws/ipam/eni_gc_test.go
@@ -104,7 +104,7 @@ func TestStartENIGarbageCollector(t *testing.T) {
 	}
 
 	// Attach newENI, this means it can no longer be garbage collected
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, "i-1", newENI)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, "i-1", newENI, 0)
 	require.NoError(t, err)
 
 	controllerManager.TriggerController(gcENIControllerName)

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -38,7 +38,7 @@ type EC2API interface {
 
 	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error)
 	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes, allocateIPv6 bool) (string, *types.ENI, error)
-	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
+	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string, enaQueueCount int32) (string, error)
 	DeleteNetworkInterface(ctx context.Context, eniID string) error
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error
 	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error)

--- a/pkg/aws/ipam/limits/limits.go
+++ b/pkg/aws/ipam/limits/limits.go
@@ -99,6 +99,52 @@ func (l *LimitsGetter) Get(instanceType string) (ipamTypes.Limits, bool) {
 	}
 }
 
+// enaQueueLimit holds the ENA queue limits of an instance type, as reported by
+// the EC2 API for the network card Cilium attaches ENIs to.
+type enaQueueLimit struct {
+	supported           bool
+	maxTotal            int32
+	maxPerInterface     int32
+	defaultPerInterface int32
+}
+
+// enaQueueLimits extracts the ENA queue limits of an instance type. The limits
+// are reported per network card rather than per instance, so they are read from
+// network card 0, which is the card Cilium attaches ENIs to (see the hardcoded
+// NetworkCardIndex in pkg/aws/api.Client.AttachNetworkInterface).
+//
+// The zero value is returned for instance types which do not support choosing
+// the queue count of an interface, and for instance types for which the EC2 API
+// does not report the limits.
+func enaQueueLimits(networkInfo *ec2_types.NetworkInfo) (l enaQueueLimit) {
+	if networkInfo == nil {
+		return l
+	}
+
+	for _, card := range networkInfo.NetworkCards {
+		if aws.ToInt32(card.NetworkCardIndex) != 0 {
+			continue
+		}
+
+		l.maxTotal = aws.ToInt32(card.MaximumEnaQueueCount)
+		l.maxPerInterface = aws.ToInt32(card.MaximumEnaQueueCountPerInterface)
+		// The default is reported for every instance type, including the ones
+		// which do not allow the queue count of an interface to be chosen, so
+		// it is read regardless of support in order to report the number of
+		// queues an interface runs with.
+		l.defaultPerInterface = aws.ToInt32(card.DefaultEnaQueueCountPerInterface)
+		// Choosing the queue count additionally requires the instance type to
+		// support it, and requires both a total budget and a per interface
+		// maximum: without them there is nothing to distribute.
+		l.supported = networkInfo.FlexibleEnaQueuesSupport == ec2_types.FlexibleEnaQueuesSupportSupported &&
+			l.maxTotal > 0 && l.maxPerInterface > 0
+
+		return l
+	}
+
+	return l
+}
+
 // updateFromEC2API updates limits from the EC2 API via calling
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html.
 func (l *LimitsGetter) updateFromEC2API(ctx context.Context, api ec2API) error {
@@ -117,6 +163,11 @@ func (l *LimitsGetter) updateFromEC2API(ctx context.Context, api ec2API) error {
 		ipv6PerAdapter := aws.ToInt32(instanceTypeInfo.NetworkInfo.Ipv6AddressesPerInterface)
 		hypervisorType := instanceTypeInfo.Hypervisor
 		isBareMetal := aws.ToBool(instanceTypeInfo.BareMetal)
+		vCpus := int32(0)
+		if instanceTypeInfo.VCpuInfo != nil {
+			vCpus = aws.ToInt32(instanceTypeInfo.VCpuInfo.DefaultVCpus)
+		}
+		enaQueues := enaQueueLimits(instanceTypeInfo.NetworkInfo)
 
 		l.m[instanceType] = ipamTypes.Limits{
 			Adapters:       int(adapterLimit),
@@ -124,6 +175,12 @@ func (l *LimitsGetter) updateFromEC2API(ctx context.Context, api ec2API) error {
 			IPv6:           int(ipv6PerAdapter),
 			HypervisorType: string(hypervisorType),
 			IsBareMetal:    isBareMetal,
+			VCpus:          int(vCpus),
+
+			SupportsFlexibleENAQueues:        enaQueues.supported,
+			MaxENAQueueCount:                 int(enaQueues.maxTotal),
+			MaxENAQueueCountPerInterface:     int(enaQueues.maxPerInterface),
+			DefaultENAQueueCountPerInterface: int(enaQueues.defaultPerInterface),
 		}
 	}
 	l.lastUpdate = time.Now()

--- a/pkg/aws/ipam/limits/limits_test.go
+++ b/pkg/aws/ipam/limits/limits_test.go
@@ -120,3 +120,83 @@ func TestInitEC2APIUpdateTrigger(t *testing.T) {
 		IsBareMetal:    false,
 	}, limits)
 }
+
+func TestENAQueueLimits(t *testing.T) {
+	// The ENA queue limits of an instance type are reported per network card,
+	// and Cilium attaches ENIs to network card 0.
+	card := func(index, maxTotal, maxPerInterface, defaultPerInterface int32) ec2_types.NetworkCardInfo {
+		return ec2_types.NetworkCardInfo{
+			NetworkCardIndex:                 new(index),
+			MaximumEnaQueueCount:             new(maxTotal),
+			MaximumEnaQueueCountPerInterface: new(maxPerInterface),
+			DefaultEnaQueueCountPerInterface: new(defaultPerInterface),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		networkInfo *ec2_types.NetworkInfo
+		expected    enaQueueLimit
+	}{
+		{
+			name:        "no network info",
+			networkInfo: nil,
+			expected:    enaQueueLimit{},
+		},
+		{
+			// The default is reported for every instance type, so it is read
+			// even when the queue count cannot be chosen: it is the number of
+			// queues the interfaces of the instance run with.
+			name: "instance type without flexible queue support",
+			networkInfo: &ec2_types.NetworkInfo{
+				NetworkCards: []ec2_types.NetworkCardInfo{card(0, 128, 32, 8)},
+			},
+			expected: enaQueueLimit{
+				supported:           false,
+				maxTotal:            128,
+				maxPerInterface:     32,
+				defaultPerInterface: 8,
+			},
+		},
+		{
+			name: "limits are read from the network card Cilium attaches to",
+			networkInfo: &ec2_types.NetworkInfo{
+				FlexibleEnaQueuesSupport: ec2_types.FlexibleEnaQueuesSupportSupported,
+				NetworkCards: []ec2_types.NetworkCardInfo{
+					card(1, 256, 64, 16),
+					card(0, 128, 32, 8),
+				},
+			},
+			expected: enaQueueLimit{
+				supported:           true,
+				maxTotal:            128,
+				maxPerInterface:     32,
+				defaultPerInterface: 8,
+			},
+		},
+		{
+			name: "partial limits do not allow choosing a queue count",
+			networkInfo: &ec2_types.NetworkInfo{
+				FlexibleEnaQueuesSupport: ec2_types.FlexibleEnaQueuesSupportSupported,
+				NetworkCards: []ec2_types.NetworkCardInfo{
+					{NetworkCardIndex: new(int32(0)), DefaultEnaQueueCountPerInterface: new(int32(8))},
+				},
+			},
+			expected: enaQueueLimit{supported: false, defaultPerInterface: 8},
+		},
+		{
+			name: "no limits reported for network card 0",
+			networkInfo: &ec2_types.NetworkInfo{
+				FlexibleEnaQueuesSupport: ec2_types.FlexibleEnaQueuesSupportSupported,
+				NetworkCards:             []ec2_types.NetworkCardInfo{card(1, 256, 64, 16)},
+			},
+			expected: enaQueueLimit{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, enaQueueLimits(tt.networkInfo))
+		})
+	}
+}

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"net/netip"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -65,6 +66,18 @@ type Node struct {
 	// Protected by Node.mutex.
 	enis map[string]types.ENI
 
+	// defaultENAQueueCount is the number of ENA queues the instance type
+	// assigns to an interface whose attachment did not ask for a count. It is
+	// determined on resync, and is zero until the first one.
+	// Protected by Node.mutex.
+	defaultENAQueueCount int32
+
+	// enaQueueBudgetExhausted records whether the instance was last seen out of
+	// ENA queues, so that the condition is reported when it is reached rather
+	// than on every allocation cycle it lasts for. It is atomic as it is
+	// written by allocation, which only holds Node.mutex for reading.
+	enaQueueBudgetExhausted atomic.Bool
+
 	// k8sObj is the CiliumNode custom resource representing the node
 	k8sObj *v2.CiliumNode
 
@@ -113,10 +126,16 @@ func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 
 	n.mutex.RLock()
 	usePrimary := n.usePrimaryAddress()
+	defaultENAQueueCount := n.defaultENAQueueCount
 	n.mutex.RUnlock()
 
 	n.foreachENI(usePrimary, func(e *types.ENI) error {
-		k8sObj.Status.ENI.ENIs[e.ID] = *e.DeepCopy()
+		eni := *e.DeepCopy()
+		// Report the number of queues every ENI runs with, not only the ones
+		// Cilium requested a count for, so that the consumption of the instance
+		// queue budget can be read off the node.
+		eni.ENAQueueCount = effectiveENAQueueCount(e, defaultENAQueueCount)
+		k8sObj.Status.ENI.ENIs[e.ID] = eni
 		return nil
 	})
 }
@@ -572,6 +591,31 @@ func (n *Node) PrepareIPAllocation(scopedLog *slog.Logger) (a *nodemanager.Alloc
 	}
 	a.EmptyInterfaceSlots = limits.Adapters - len(n.enis)
 
+	// ENA queues are a budget shared by all interfaces of the instance, and AWS
+	// rejects the attachment of an interface the budget does not fit. Report
+	// the node as out of interface slots instead, so that the shortage surfaces
+	// as ordinary interface exhaustion rather than as retried attachments.
+	if _, managed := enaQueueCountRequested(n.k8sObj.Spec.ENI.ENAQueueCount, limits); managed && a.EmptyInterfaceSlots > 0 {
+		if used, remaining := n.enaQueueBudgetLocked(limits); remaining <= 0 {
+			// Allocation runs on every maintenance cycle while the budget stays
+			// exhausted, so warn on the transition only and stay quiet after.
+			if !n.enaQueueBudgetExhausted.Swap(true) {
+				scopedLog.Warn(
+					"ENA queue budget of the instance is exhausted, no further ENI can be attached to this node. "+
+						"Lower eni-ena-queue-count to fit more interfaces, and therefore more pods, on this node",
+					logfields.ENAQueueBudget, limits.MaxENAQueueCount,
+					logfields.ENAQueueBudgetUsed, used,
+					logfields.ENAQueueBudgetRemaining, remaining,
+					logfields.NumInterfaces, len(n.enis),
+					logfields.AdaptersLimit, limits.Adapters,
+				)
+			}
+			a.EmptyInterfaceSlots = 0
+		} else {
+			n.enaQueueBudgetExhausted.Store(false)
+		}
+	}
+
 	return
 }
 
@@ -698,6 +742,16 @@ func (n *Node) errorInstanceNotRunning(err error) (notRunning bool) {
 	return
 }
 
+// isENAQueueCountRejected parses an error from the AWS SDK to understand if an
+// attachment was rejected because of the number of ENA queues it asked for.
+func isENAQueueCountRejected(err error) bool {
+	if apiErr, ok := errors.AsType[smithy.APIError](err); ok {
+		return apiErr.ErrorCode() == api.InvalidParameterValueStr &&
+			strings.Contains(apiErr.ErrorMessage(), "ENA queue count")
+	}
+	return false
+}
+
 func isAttachmentIndexConflict(err error) bool {
 	if apiErr, ok := errors.AsType[smithy.APIError](err); ok {
 		return apiErr.ErrorCode() == api.InvalidParameterValueStr &&
@@ -745,6 +799,191 @@ const (
 	unableToMarkENIForDeletion   = "unableToMarkENIForDeletion"
 	unableToFindSubnet           = "unableToFindSubnet"
 )
+
+const (
+	// enaQueueCountAuto is the value of ENISpec.ENAQueueCount requesting as
+	// many ENA queues per ENI as the interface is able to use.
+	enaQueueCountAuto = "auto"
+
+	// enaQueueCountDefault is the value of ENISpec.ENAQueueCount leaving the
+	// number of ENA queues to AWS. It is the value the agent writes when
+	// nothing is configured, and is equivalent to an empty value.
+	enaQueueCountDefault = "default"
+)
+
+// enaQueueCountConfigured reports whether a queue count was asked for at all.
+func enaQueueCountConfigured(spec string) bool {
+	return spec != "" && spec != enaQueueCountDefault
+}
+
+// floorPowerOfTwo returns the largest power of two which is not greater than n,
+// and zero for a non positive n.
+//
+// AWS rejects an attachment whose ENA queue count is not a power of two. Every
+// count the EC2 API reports is one, but the vCPU count of an instance is not
+// necessarily: sizes of 12, 24, 48, 72, 96, 192 and 384 vCPUs exist.
+func floorPowerOfTwo(n int) int {
+	if n <= 0 {
+		return 0
+	}
+
+	p := 1
+	for p<<1 <= n {
+		p <<= 1
+	}
+
+	return p
+}
+
+// ceilPowerOfTwo returns the smallest power of two which is not smaller than n,
+// and zero for a non positive n. See floorPowerOfTwo for why the distinction
+// between the two matters.
+func ceilPowerOfTwo(n int) int {
+	if n <= 0 {
+		return 0
+	}
+
+	p := 1
+	for p < n {
+		p <<= 1
+	}
+
+	return p
+}
+
+// enaQueueCountRequested returns the number of ENA queues to request for a new
+// ENI, and whether Cilium manages the queue count on this node at all. It does
+// not log, as it is called on every allocation cycle.
+//
+// The count is capped by the maximum the instance type allows per interface,
+// above which AWS rejects the attachment. "auto" is additionally capped by the
+// vCPU count, as drivers do not create more queues than there are CPUs and the
+// surplus would consume the budget unused. An explicit count is not, so that a
+// node not driven by the kernel ENA driver can still ask for what it needs.
+func enaQueueCountRequested(spec string, limits ipamTypes.Limits) (int32, bool) {
+	if !enaQueueCountConfigured(spec) || !limits.SupportsFlexibleENAQueues {
+		return 0, false
+	}
+
+	if spec == enaQueueCountAuto {
+		desired := limits.MaxENAQueueCountPerInterface
+		if limits.VCpus > 0 {
+			// Rounded up rather than down: the driver caps itself at one queue
+			// per CPU anyway, while rounding down would leave CPUs without one.
+			desired = min(desired, ceilPowerOfTwo(limits.VCpus))
+		}
+		return int32(desired), true
+	}
+
+	requested, err := strconv.Atoi(spec)
+	if err != nil || requested <= 0 {
+		// The apiserver validates the field, so this is only reachable when the
+		// CRD schema and this code disagree. Leave the count to AWS rather than
+		// guessing what was meant.
+		return 0, false
+	}
+
+	// Both bounds are powers of two, so the result is one as well.
+	return int32(floorPowerOfTwo(min(requested, limits.MaxENAQueueCountPerInterface))), true
+}
+
+// effectiveENAQueueCount returns the number of ENA queues an ENI runs with.
+//
+// The EC2 API only reports a queue count for attachments which requested one,
+// so an attachment without a reported count runs with defaultCount, the number
+// of queues the instance type assigns by default.
+func effectiveENAQueueCount(eni *types.ENI, defaultCount int32) int32 {
+	if eni.ENAQueueCount > 0 {
+		return eni.ENAQueueCount
+	}
+
+	return defaultCount
+}
+
+// enaQueueBudgetLocked returns the number of ENA queues consumed by the
+// interfaces currently attached to the instance, and the number left. The
+// budget is shared by every interface, including the primary one and any
+// interface Cilium does not manage, so all of them are counted. n.enis holds
+// the effective count of every ENI, as recorded by ResyncInterfacesAndIPs.
+// n.mutex must be held.
+func (n *Node) enaQueueBudgetLocked(limits ipamTypes.Limits) (used, remaining int) {
+	for _, e := range n.enis {
+		used += int(e.ENAQueueCount)
+	}
+
+	return used, max(limits.MaxENAQueueCount-used, 0)
+}
+
+// grantENAQueueCount returns the number of ENA queues to request for an ENI
+// about to be attached, reduced to what is left of the instance queue budget.
+// It returns zero when Cilium does not manage the count, in which case AWS
+// assigns the default. Unlike enaQueueCountRequested it logs, and is therefore
+// only called when an ENI is actually created.
+func (n *Node) grantENAQueueCount(spec string, limits ipamTypes.Limits, scopedLog *slog.Logger) (int32, error) {
+	desired, managed := enaQueueCountRequested(spec, limits)
+	if !managed {
+		if enaQueueCountConfigured(spec) {
+			scopedLog.Debug(
+				"Instance type does not support choosing the number of ENA queues of an interface, ena-queue-count is ignored",
+				logfields.InstanceType, n.k8sObj.Spec.ENI.InstanceType,
+			)
+		}
+		return 0, nil
+	}
+
+	n.mutex.RLock()
+	used, remaining := n.enaQueueBudgetLocked(limits)
+	n.mutex.RUnlock()
+
+	// The remaining budget is not necessarily a power of two, so reducing the
+	// requested count to it has to round down: an attachment asking for a count
+	// which is not a power of two is rejected by AWS.
+	granted := floorPowerOfTwo(min(int(desired), remaining))
+	if granted <= 0 {
+		// PrepareIPAllocation stops offering interface slots once the budget is
+		// exhausted, so this is only reached if the budget was consumed since.
+		// Attaching would be rejected by AWS, so fail before calling the API.
+		return 0, fmt.Errorf("%s: ENA queue budget of the instance is exhausted (%d of %d queues used by %d interfaces)",
+			errUnableToAttachENI, used, limits.MaxENAQueueCount, len(n.enis))
+	}
+
+	usedAfter := used + granted
+	remainingAfter := max(limits.MaxENAQueueCount-usedAfter, 0)
+
+	if granted < int(desired) {
+		// Reducing the count is what keeps the node able to attach interfaces
+		// at all, so report what is left of the budget rather than the whole
+		// accounting: the trade-off between queues per ENI and number of ENIs
+		// is what the reader acts on.
+		scopedLog.Warn(
+			"Attaching the new ENI with fewer ENA queues than requested, as the queue budget of the instance does not fit the requested count. "+
+				"Attaching further ENIs may not be possible, which limits the number of pods that fit on this node",
+			logfields.ENAQueueCountConfigured, spec,
+			logfields.ENAQueueCountRequested, desired,
+			logfields.ENAQueueCountGranted, granted,
+			logfields.ENAQueueBudgetRemainingAfter, remainingAfter,
+			logfields.ENAQueueFundableInterfacesAfter, remainingAfter/granted,
+		)
+	} else {
+		// Both sides of the change this attachment makes to the queue budget.
+		scopedLog.Debug("Attaching the new ENI with the requested number of ENA queues",
+			logfields.ENAQueueCountConfigured, spec,
+			logfields.ENAQueueCountRequested, desired,
+			logfields.ENAQueueCountGranted, granted,
+			logfields.ENAQueueBudget, limits.MaxENAQueueCount,
+			logfields.ENAQueueBudgetUsedBefore, used,
+			logfields.ENAQueueBudgetUsedAfter, usedAfter,
+			logfields.ENAQueueBudgetRemainingBefore, remaining,
+			logfields.ENAQueueBudgetRemainingAfter, remainingAfter,
+			logfields.ENAQueueFundableInterfacesAfter, remainingAfter/granted,
+			logfields.NumInterfacesBefore, len(n.enis),
+			logfields.NumInterfacesAfter, len(n.enis)+1,
+			logfields.AdaptersLimit, limits.Adapters,
+		)
+	}
+
+	return int32(granted), nil
+}
 
 // CreateInterface creates an additional interface with the instance and
 // attaches it to the instance as specified by the CiliumNode. neededAddresses
@@ -804,6 +1043,13 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 		return 0, "", nil
 	}
 
+	// Resolved before creating the ENI: an exhausted queue budget means it
+	// cannot be attached, and there is no point in creating one to delete it.
+	enaQueueCount, err := n.grantENAQueueCount(resource.Spec.ENI.ENAQueueCount, limits, scopedLog)
+	if err != nil {
+		return 0, unableToAttachENI, err
+	}
+
 	index := n.findNextIndex(int32(*resource.Spec.ENI.FirstInterfaceIndex))
 
 	scopedLog = scopedLog.With(
@@ -840,16 +1086,29 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 
 	var attachmentID string
 	for range maxAttachRetries {
-		attachmentID, err = n.manager.ec2api.AttachNetworkInterface(ctx, index, n.node.InstanceID(), eniID)
+		attachmentID, err = n.manager.ec2api.AttachNetworkInterface(ctx, index, n.node.InstanceID(), eniID, enaQueueCount)
 
 		// The index is already in use, this can happen if the local
 		// list of ENIs is oudated.  Retry the attachment to avoid
 		// having to delete the ENI
-		if !isAttachmentIndexConflict(err) {
-			break
+		if isAttachmentIndexConflict(err) {
+			index = n.findNextIndex(index + 1)
+			continue
 		}
 
-		index = n.findNextIndex(index + 1)
+		// AWS rejected the count asked for. Attach with the default instead: a
+		// queue count is a tuning knob, and IP allocation must not stop for it.
+		if enaQueueCount > 0 && isENAQueueCountRejected(err) {
+			scopedLog.Warn(
+				"AWS rejected the number of ENA queues requested for the new ENI, attaching it with the number of queues AWS assigns by default",
+				logfields.ENAQueueCountRequested, enaQueueCount,
+				logfields.Error, err,
+			)
+			enaQueueCount = 0
+			continue
+		}
+
+		break
 	}
 
 	if err != nil {
@@ -920,6 +1179,10 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 	n.mutex.Lock()
 	n.enis = map[string]types.ENI{}
+	// PopulateStatusFields reports the queue count of every ENI, but iterates
+	// the shared instance inventory rather than n.enis, and must not block on
+	// the limits trigger. Record the default so it can normalize without either.
+	n.defaultENAQueueCount = int32(limits.DefaultENAQueueCountPerInterface)
 
 	// 1. This calculates the base interface effective limit on this Node, given:
 	// 		* IPAM Prefix Delegation
@@ -936,7 +1199,11 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 	n.foreachENI(n.usePrimaryAddress(),
 		func(e *types.ENI) error {
-			n.enis[e.ID] = *e
+			eni := *e
+			// The EC2 API only reports a count for attachments which requested
+			// one, so store the number of queues the ENI runs with.
+			eni.ENAQueueCount = effectiveENAQueueCount(e, n.defaultENAQueueCount)
+			n.enis[e.ID] = eni
 
 			// Check for public IP on primary ENI before exclusion logic
 			// The primary ENI may be excluded from IPAM but we still need to track its public IP

--- a/pkg/aws/ipam/node_ipv6_test.go
+++ b/pkg/aws/ipam/node_ipv6_test.go
@@ -29,7 +29,7 @@ func newWiredNode(t *testing.T, instanceID, instanceType string) (*Node, *apiMoc
 
 	eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "primary", []string{"sg-1"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)

--- a/pkg/aws/ipam/node_manager_test.go
+++ b/pkg/aws/ipam/node_manager_test.go
@@ -152,7 +152,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -461,7 +461,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -574,7 +574,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 		"cilium.io/no_manage": "true",
 	})
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -642,7 +642,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -704,7 +704,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -777,7 +777,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	for i := range state {
 		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false, false)
 		require.NoError(t, err)
-		_, err = ec2api.AttachNetworkInterface(t.Context(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
+		_, err = ec2api.AttachNetworkInterface(t.Context(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID, 0)
 		require.NoError(t, err)
 		_, err = instancesManager.Resync(t.Context())
 		require.NoError(t, err)
@@ -835,7 +835,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -883,11 +883,11 @@ func TestInstanceBeenDeleted(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	eniID2, _, err := ec2api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, eniID2)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, eniID2, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -946,7 +946,7 @@ func TestNodeManagerStaticIP(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	_, err = instances.Resync(t.Context())
 	require.NoError(t, err)
@@ -993,7 +993,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 
 	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
 	require.NoError(t, err)
 	staticIP, err := ec2api.AssociateEIP(t.Context(), eniID1, make(ipamTypes.Tags))
 	require.NoError(t, err)
@@ -1036,13 +1036,13 @@ func TestNodeManagerStaticIPPrimaryENI(t *testing.T) {
 	// Primary ENI (Number == 0).
 	primaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, primaryENI)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, primaryENI, 0)
 	require.NoError(t, err)
 
 	// Secondary ENI (Number == 1)
 	secondaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, secondaryENI)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, secondaryENI, 0)
 	require.NoError(t, err)
 
 	_, err = instances.Resync(t.Context())
@@ -1097,7 +1097,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	for i := range state {
 		eniID, _, err := ec2api.CreateNetworkInterface(b.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 		require.NoError(b, err)
-		_, err = ec2api.AttachNetworkInterface(b.Context(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
+		_, err = ec2api.AttachNetworkInterface(b.Context(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID, 0)
 		require.NoError(b, err)
 		_, err = instances.Resync(b.Context())
 		require.NoError(b, err)
@@ -1202,6 +1202,18 @@ func withInstanceType(instanceType string) func(*v2.CiliumNode) {
 	}
 }
 
+func withENIDisablePrefixDelegation() func(*v2.CiliumNode) {
+	return func(cn *v2.CiliumNode) {
+		cn.Spec.ENI.DisablePrefixDelegation = new(true)
+	}
+}
+
+func withENAQueueCount(count string) func(*v2.CiliumNode) {
+	return func(cn *v2.CiliumNode) {
+		cn.Spec.ENI.ENAQueueCount = count
+	}
+}
+
 func withFirstInterfaceIndex(firstInterface int) func(*v2.CiliumNode) {
 	return func(cn *v2.CiliumNode) {
 		cn.Spec.ENI.FirstInterfaceIndex = &firstInterface
@@ -1273,4 +1285,175 @@ func reachedAddressesNeeded(mngr *nodemanager.NodeManager, nodeName string, need
 		success = node.GetNeededAddresses() == needed
 	}
 	return
+}
+
+// TestNodeManagerENAQueueCount tests that the ENA queue count of the node
+// reaches the ENIs which Cilium attaches, and is reported back in the
+// CiliumNode status.
+//
+// - c8i.8xlarge (10x ENIs, 128 ENA queues, at most 32 per interface)
+// - ena-queue-count auto
+func TestNodeManagerENAQueueCount(t *testing.T) {
+	setup(t)
+
+	const instanceID = "i-testNodeManagerENAQueueCount-0"
+
+	ec2api := apiMock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	// The primary ENI is attached without a requested queue count, as it is not
+	// attached by Cilium.
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
+	require.NoError(t, err)
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
+
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
+	require.NoError(t, err)
+
+	// Prefix delegation is disabled so that an ENI holds 49 IPs rather than
+	// 784, which keeps the number of IPs needed to force a second ENI within
+	// the capacity of the test subnet.
+	cn := newCiliumNode("node1",
+		withTestDefaults(),
+		withInstanceID(instanceID),
+		withInstanceType("c8i.8xlarge"),
+		withENIDisablePrefixDelegation(),
+		withENAQueueCount("auto"),
+		withIPAMPreAllocate(8),
+	)
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+	mngr.Upsert(updateCiliumNode(cn, 60, 60))
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	node.Ops().PopulateStatusFields(cn)
+
+	// The ENI Cilium attached carries the queue count of the node, capped by
+	// the maximum the instance type allows per interface. The interface which
+	// was already attached keeps the queues it was attached with, reported as
+	// the default of the instance type because the EC2 API does not report a
+	// count for attachments which did not request one.
+	require.Len(t, cn.Status.ENI.ENIs, 2)
+	queueCounts := map[string]int32{}
+	for id, eni := range cn.Status.ENI.ENIs {
+		queueCounts[id] = eni.ENAQueueCount
+	}
+	require.Equal(t, int32(8), queueCounts[eniID1])
+	delete(queueCounts, eniID1)
+	require.Len(t, queueCounts, 1)
+	for _, count := range queueCounts {
+		require.Equal(t, int32(32), count)
+	}
+}
+
+// TestNodeManagerENAQueueCountRounded tests that a queue count which AWS would
+// reject is rounded to one it accepts before the attachment is made.
+//
+// - c8i.8xlarge (10x ENIs, 128 ENA queues, at most 32 per interface, 8 by default)
+// - ena-queue-count 24, which is not a power of two and becomes 16
+func TestNodeManagerENAQueueCountRounded(t *testing.T) {
+	setup(t)
+
+	const instanceID = "i-testNodeManagerENAQueueCountRounded-0"
+
+	ec2api := apiMock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
+	require.NoError(t, err)
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
+
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
+	require.NoError(t, err)
+
+	// A count which is not a power of two only reaches the operator through a
+	// path the CiliumNode schema does not validate, such as a CiliumNodeConfig.
+	cn := newCiliumNode("node1",
+		withTestDefaults(),
+		withInstanceID(instanceID),
+		withInstanceType("c8i.8xlarge"),
+		withENIDisablePrefixDelegation(),
+		withENAQueueCount("24"),
+		withIPAMPreAllocate(8),
+	)
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+	mngr.Upsert(updateCiliumNode(cn, 60, 60))
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	node.Ops().PopulateStatusFields(cn)
+
+	// 24 was rounded down to 16, which AWS accepts, rather than being sent as
+	// is and rejected. The pre-existing interface keeps its default of 8.
+	require.Len(t, cn.Status.ENI.ENIs, 2)
+	require.Equal(t, int32(8), cn.Status.ENI.ENIs[eniID1].ENAQueueCount)
+	for id, eni := range cn.Status.ENI.ENIs {
+		if id != eniID1 {
+			require.Equal(t, int32(16), eni.ENAQueueCount)
+		}
+	}
+}
+
+// TestNodeManagerENAQueueCountRejected tests that IP allocation continues when
+// AWS rejects the number of ENA queues requested for a new ENI. A queue count
+// is a tuning knob, and a node must not run out of IP addresses because of one.
+//
+// - c8i.8xlarge (10x ENIs, 128 ENA queues, at most 32 per interface, 8 by default)
+// - ena-queue-count auto, with an API rejecting any requested count
+func TestNodeManagerENAQueueCountRejected(t *testing.T) {
+	setup(t)
+
+	const instanceID = "i-testNodeManagerENAQueueCountRejected-0"
+
+	ec2api := apiMock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1, 0)
+	require.NoError(t, err)
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
+
+	// Every attachment asking for a specific number of queues is rejected.
+	ec2api.RejectENAQueueCount(true)
+
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
+	require.NoError(t, err)
+
+	cn := newCiliumNode("node1",
+		withTestDefaults(),
+		withInstanceID(instanceID),
+		withInstanceType("c8i.8xlarge"),
+		withENIDisablePrefixDelegation(),
+		withENAQueueCount("auto"),
+		withIPAMPreAllocate(8),
+	)
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+	mngr.Upsert(updateCiliumNode(cn, 60, 60))
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+
+	// The ENI was attached despite the rejection, with the number of queues
+	// AWS assigns by default, so the node did not run out of IP addresses.
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	node.Ops().PopulateStatusFields(cn)
+	require.Len(t, cn.Status.ENI.ENIs, 2)
+	for _, eni := range cn.Status.ENI.ENIs {
+		require.Equal(t, int32(8), eni.ENAQueueCount)
+	}
 }

--- a/pkg/aws/ipam/node_test.go
+++ b/pkg/aws/ipam/node_test.go
@@ -519,3 +519,500 @@ func TestPrepareCIDRRelease(t *testing.T) {
 		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.2/32")}, actions[0].CIDRsToRelease)
 	})
 }
+
+func TestENAQueueCountRequested(t *testing.T) {
+	// Limits of an instance type supporting flexible ENA queues, here
+	// c8i.8xlarge: 32 vCPUs, a budget of 128 queues and at most 32 queues per
+	// interface.
+	flexible := ipamTypes.Limits{
+		Adapters:                         10,
+		VCpus:                            32,
+		SupportsFlexibleENAQueues:        true,
+		MaxENAQueueCount:                 128,
+		MaxENAQueueCountPerInterface:     32,
+		DefaultENAQueueCountPerInterface: 8,
+	}
+	// Limits of an instance type which does not let the queue count be chosen.
+	fixed := ipamTypes.Limits{Adapters: 3, VCpus: 2}
+
+	tests := []struct {
+		name      string
+		spec      string
+		limits    ipamTypes.Limits
+		expected  int32
+		isManaged bool
+	}{
+		{
+			name:      "unset leaves the queue count to AWS",
+			spec:      "",
+			limits:    flexible,
+			expected:  0,
+			isManaged: false,
+		},
+		{
+			// The value the agent writes when nothing is configured, and the
+			// way to opt a node out where a broader configuration applies.
+			name:      "default leaves the queue count to AWS",
+			spec:      "default",
+			limits:    flexible,
+			expected:  0,
+			isManaged: false,
+		},
+		{
+			name:      "ignored on an instance type without flexible queues",
+			spec:      "auto",
+			limits:    fixed,
+			expected:  0,
+			isManaged: false,
+		},
+		{
+			name:      "auto uses the maximum per interface when below the vCPU count",
+			spec:      "auto",
+			limits:    flexible,
+			expected:  32,
+			isManaged: true,
+		},
+		{
+			// AWS rejects an attachment whose queue count is not a power of
+			// two, and vCPU counts of 12, 24, 48, 72, 96, 192 and 384 exist.
+			// Rounding up rather than down keeps one queue per CPU: a driver
+			// creates no more queues than there are CPUs, so asking for 16 on
+			// a 12 vCPU instance yields 12 queues, where asking for 8 would
+			// leave four CPUs without one.
+			name: "auto rounds the vCPU count up to a power of two",
+			spec: "auto",
+			limits: ipamTypes.Limits{
+				VCpus:                        12,
+				SupportsFlexibleENAQueues:    true,
+				MaxENAQueueCount:             48,
+				MaxENAQueueCountPerInterface: 16,
+			},
+			expected:  16,
+			isManaged: true,
+		},
+		{
+			// Rounding up never exceeds what the instance type allows per
+			// interface, which AWS would reject.
+			name: "auto rounding up is capped by the maximum per interface",
+			spec: "auto",
+			limits: ipamTypes.Limits{
+				VCpus:                        64,
+				SupportsFlexibleENAQueues:    true,
+				MaxENAQueueCount:             120,
+				MaxENAQueueCountPerInterface: 32,
+			},
+			expected:  32,
+			isManaged: true,
+		},
+		{
+			name:      "an explicit count is rounded down to a power of two",
+			spec:      "12",
+			limits:    flexible,
+			expected:  8,
+			isManaged: true,
+		},
+		{
+			name: "auto is capped by the number of vCPUs",
+			spec: "auto",
+			limits: ipamTypes.Limits{
+				VCpus:                        8,
+				SupportsFlexibleENAQueues:    true,
+				MaxENAQueueCount:             128,
+				MaxENAQueueCountPerInterface: 32,
+			},
+			expected:  8,
+			isManaged: true,
+		},
+		{
+			name: "auto ignores an unknown vCPU count",
+			spec: "auto",
+			limits: ipamTypes.Limits{
+				SupportsFlexibleENAQueues:    true,
+				MaxENAQueueCount:             128,
+				MaxENAQueueCountPerInterface: 32,
+			},
+			expected:  32,
+			isManaged: true,
+		},
+		{
+			name:      "an explicit count is used as is",
+			spec:      "16",
+			limits:    flexible,
+			expected:  16,
+			isManaged: true,
+		},
+		{
+			name:      "an explicit count is capped by the maximum per interface",
+			spec:      "64",
+			limits:    flexible,
+			expected:  32,
+			isManaged: true,
+		},
+		{
+			name: "an explicit count above the vCPU count is kept",
+			spec: "32",
+			limits: ipamTypes.Limits{
+				VCpus:                        8,
+				SupportsFlexibleENAQueues:    true,
+				MaxENAQueueCount:             128,
+				MaxENAQueueCountPerInterface: 32,
+			},
+			expected:  32,
+			isManaged: true,
+		},
+		{
+			name:      "an unparsable count leaves the queue count to AWS",
+			spec:      "many",
+			limits:    flexible,
+			expected:  0,
+			isManaged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, managed := enaQueueCountRequested(tt.spec, tt.limits)
+			require.Equal(t, tt.expected, count)
+			require.Equal(t, tt.isManaged, managed)
+		})
+	}
+}
+
+func TestENAQueueBudget(t *testing.T) {
+	limits := ipamTypes.Limits{
+		MaxENAQueueCount:                 128,
+		MaxENAQueueCountPerInterface:     32,
+		DefaultENAQueueCountPerInterface: 8,
+	}
+
+	tests := []struct {
+		name              string
+		enis              map[string]types.ENI
+		expectedUsed      int
+		expectedRemaining int
+	}{
+		{
+			name:              "no interface consumes no queue",
+			enis:              map[string]types.ENI{},
+			expectedUsed:      0,
+			expectedRemaining: 128,
+		},
+		{
+			name: "the queues of every attached interface are counted",
+			enis: map[string]types.ENI{
+				"eni-0": {ID: "eni-0", Number: 0, ENAQueueCount: 8},
+				"eni-1": {ID: "eni-1", Number: 1, ENAQueueCount: 32},
+			},
+			expectedUsed:      40,
+			expectedRemaining: 88,
+		},
+		{
+			name: "an exhausted budget leaves no queue",
+			enis: map[string]types.ENI{
+				"eni-0": {ID: "eni-0", Number: 0, ENAQueueCount: 32},
+				"eni-1": {ID: "eni-1", Number: 1, ENAQueueCount: 32},
+				"eni-2": {ID: "eni-2", Number: 2, ENAQueueCount: 32},
+				"eni-3": {ID: "eni-3", Number: 3, ENAQueueCount: 32},
+			},
+			expectedUsed:      128,
+			expectedRemaining: 0,
+		},
+		{
+			name: "a budget consumed beyond its size does not go negative",
+			enis: map[string]types.ENI{
+				"eni-0": {ID: "eni-0", Number: 0, ENAQueueCount: 128},
+				"eni-1": {ID: "eni-1", Number: 1, ENAQueueCount: 32},
+			},
+			expectedUsed:      160,
+			expectedRemaining: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &Node{enis: tt.enis}
+			used, remaining := n.enaQueueBudgetLocked(limits)
+			require.Equal(t, tt.expectedUsed, used)
+			require.Equal(t, tt.expectedRemaining, remaining)
+		})
+	}
+}
+
+// TestResyncNormalizesENAQueueCounts asserts that n.enis holds the number of
+// queues every ENI runs with, including the interfaces the EC2 API reports no
+// count for, so that the queue budget accounting reads the count rather than
+// deriving it.
+func TestResyncNormalizesENAQueueCounts(t *testing.T) {
+	api := apiMock.NewAPI(nil, nil, nil, nil)
+	metadataMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMock)
+	require.NoError(t, err)
+
+	const instanceID = "i-000"
+	// eni-requested was attached with a queue count and the EC2 API reports it.
+	// eni-default was not, so it runs with the 8 queues c8i.8xlarge assigns by
+	// default and the EC2 API reports no count for it.
+	instances.instances.Update(instanceID, &types.ENI{ID: "eni-requested", Number: 1, ENAQueueCount: 32})
+	instances.instances.Update(instanceID, &types.ENI{ID: "eni-default", Number: 0})
+
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		node:       &mockIPAMNode{instanceID: instanceID},
+		k8sObj: newCiliumNode("node",
+			withInstanceType("c8i.8xlarge"),
+			withFirstInterfaceIndex(0),
+		),
+	}
+	n.logger.Store(n.rootLogger)
+
+	_, _, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	require.NoError(t, err)
+
+	require.Equal(t, int32(32), n.enis["eni-requested"].ENAQueueCount)
+	require.Equal(t, int32(8), n.enis["eni-default"].ENAQueueCount)
+
+	limits, ok := n.getLimits()
+	require.True(t, ok)
+	used, remaining := n.enaQueueBudgetLocked(limits)
+	require.Equal(t, 40, used)
+	require.Equal(t, 88, remaining)
+}
+
+// enaQueueTestNode returns a node of an instance type supporting flexible ENA
+// queues, with the given ENIs already attached.
+func enaQueueTestNode(t *testing.T, spec string, enis map[string]types.ENI) *Node {
+	api := apiMock.NewAPI(nil, nil, nil, nil)
+	metadataMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMock)
+	require.NoError(t, err)
+
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		enis:       enis,
+		k8sObj: newCiliumNode("node",
+			withInstanceType("c8i.8xlarge"),
+			withFirstInterfaceIndex(0),
+			withENAQueueCount(spec),
+		),
+	}
+	n.logger.Store(n.rootLogger)
+
+	return n
+}
+
+// attachedENIs returns count ENIs consuming queues queues each.
+func attachedENIs(count int, queues int32) map[string]types.ENI {
+	enis := map[string]types.ENI{}
+	for i := range count {
+		id := fmt.Sprintf("eni-%d", i)
+		enis[id] = types.ENI{ID: id, Number: i, ENAQueueCount: queues}
+	}
+	return enis
+}
+
+func TestPrepareIPAllocationENAQueueBudget(t *testing.T) {
+	// c8i.8xlarge allows 10 interfaces and 128 ENA queues in total.
+	tests := []struct {
+		name               string
+		spec               string
+		enis               map[string]types.ENI
+		expectedEmptySlots int
+	}{
+		{
+			name:               "queue count unset leaves the interface slots alone",
+			spec:               "",
+			enis:               attachedENIs(4, 32),
+			expectedEmptySlots: 6,
+		},
+		{
+			name:               "queue count default leaves the interface slots alone",
+			spec:               "default",
+			enis:               attachedENIs(4, 32),
+			expectedEmptySlots: 6,
+		},
+		{
+			name:               "interface slots are offered while the budget lasts",
+			spec:               "auto",
+			enis:               attachedENIs(1, 8),
+			expectedEmptySlots: 9,
+		},
+		{
+			name:               "no interface slot is offered once the budget is exhausted",
+			spec:               "auto",
+			enis:               attachedENIs(4, 32),
+			expectedEmptySlots: 0,
+		},
+		{
+			name:               "an explicit queue count exhausts the budget just as well",
+			spec:               "16",
+			enis:               attachedENIs(8, 16),
+			expectedEmptySlots: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := enaQueueTestNode(t, tt.spec, tt.enis)
+
+			a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedEmptySlots, a.EmptyInterfaceSlots)
+		})
+	}
+}
+
+func TestGrantENAQueueCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        string
+		enis        map[string]types.ENI
+		expected    int32
+		expectedErr bool
+	}{
+		{
+			name:     "no queue count is requested when the setting is unset",
+			spec:     "",
+			enis:     attachedENIs(1, 8),
+			expected: 0,
+		},
+		{
+			name:     "the full count is granted when the budget allows it",
+			spec:     "auto",
+			enis:     attachedENIs(1, 8),
+			expected: 32,
+		},
+		{
+			name:     "the count is reduced to what is left of the budget",
+			spec:     "auto",
+			enis:     attachedENIs(3, 32),
+			expected: 32,
+		},
+		{
+			// 8 queues are left, which is already a power of two.
+			name:     "the count is reduced below what was requested",
+			spec:     "32",
+			enis:     attachedENIs(5, 24),
+			expected: 8, // 128 - 5*24 queues left
+		},
+		{
+			name:        "an exhausted budget fails before the interface is attached",
+			spec:        "auto",
+			enis:        attachedENIs(4, 32),
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := enaQueueTestNode(t, tt.spec, tt.enis)
+			limits, ok := n.getLimits()
+			require.True(t, ok)
+
+			count, err := n.grantENAQueueCount(tt.spec, limits, hivetest.Logger(t))
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, count)
+		})
+	}
+}
+
+func TestEffectiveENAQueueCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		eni          types.ENI
+		defaultCount int32
+		expected     int32
+	}{
+		{
+			name:         "a reported count is what the interface runs with",
+			eni:          types.ENI{ID: "eni-1", Number: 1, ENAQueueCount: 32},
+			defaultCount: 8,
+			expected:     32,
+		},
+		{
+			// The EC2 API reports no count for the primary interface, as it was
+			// not attached with a requested queue count.
+			name:         "an interface without a reported count runs with the default",
+			eni:          types.ENI{ID: "eni-0", Number: 0},
+			defaultCount: 8,
+			expected:     8,
+		},
+		{
+			// Before the first resync determined the default of the instance
+			// type, no count can be reported for such an interface.
+			name:     "an unknown default reports no count",
+			eni:      types.ENI{ID: "eni-0", Number: 0},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, effectiveENAQueueCount(&tt.eni, tt.defaultCount))
+		})
+	}
+}
+
+func TestFloorPowerOfTwo(t *testing.T) {
+	// The vCPU counts of AWS instance types which are not powers of two.
+	require.Equal(t, 8, floorPowerOfTwo(12))
+	require.Equal(t, 16, floorPowerOfTwo(24))
+	require.Equal(t, 32, floorPowerOfTwo(48))
+	require.Equal(t, 64, floorPowerOfTwo(72))
+	require.Equal(t, 64, floorPowerOfTwo(96))
+	require.Equal(t, 128, floorPowerOfTwo(192))
+	require.Equal(t, 256, floorPowerOfTwo(384))
+
+	// Powers of two are returned unchanged.
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		require.Equal(t, n, floorPowerOfTwo(n))
+	}
+
+	require.Equal(t, 0, floorPowerOfTwo(0))
+	require.Equal(t, 0, floorPowerOfTwo(-1))
+}
+
+func TestCeilPowerOfTwo(t *testing.T) {
+	// The vCPU counts of AWS instance types which are not powers of two.
+	require.Equal(t, 16, ceilPowerOfTwo(12))
+	require.Equal(t, 32, ceilPowerOfTwo(24))
+	require.Equal(t, 64, ceilPowerOfTwo(48))
+	require.Equal(t, 128, ceilPowerOfTwo(72))
+	require.Equal(t, 128, ceilPowerOfTwo(96))
+	require.Equal(t, 256, ceilPowerOfTwo(192))
+	require.Equal(t, 512, ceilPowerOfTwo(384))
+
+	// Powers of two are returned unchanged.
+	for _, n := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+		require.Equal(t, n, ceilPowerOfTwo(n))
+	}
+
+	require.Equal(t, 0, ceilPowerOfTwo(0))
+	require.Equal(t, 0, ceilPowerOfTwo(-1))
+}
+
+func TestGrantENAQueueCountRoundsBudgetDown(t *testing.T) {
+	// c8i.8xlarge: a budget of 128 queues, at most 32 per interface. Three
+	// interfaces at 32 and one at 8 leave 24 queues, which is not a power of
+	// two, so the grant has to round down to 16 rather than ask for 24 and be
+	// rejected by AWS.
+	enis := attachedENIs(3, 32)
+	enis["eni-primary"] = types.ENI{ID: "eni-primary", Number: 9, ENAQueueCount: 8}
+
+	n := enaQueueTestNode(t, "auto", enis)
+	limits, ok := n.getLimits()
+	require.True(t, ok)
+
+	used, remaining := n.enaQueueBudgetLocked(limits)
+	require.Equal(t, 104, used)
+	require.Equal(t, 24, remaining)
+
+	count, err := n.grantENAQueueCount("auto", limits, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, int32(16), count)
+}

--- a/pkg/aws/types/types.go
+++ b/pkg/aws/types/types.go
@@ -112,6 +112,25 @@ type ENISpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	DisablePrefixDelegation *bool `json:"disable-prefix-delegation,omitempty"`
+
+	// ENAQueueCount is the number of ENA queues to request for each ENI that
+	// Cilium attaches to this node. It accepts "default", "auto", or a number
+	// of queues, which AWS requires to be a power of two.
+	//
+	// "default" leaves the number of queues to AWS, and is what the agent
+	// writes when nothing is configured. "auto" requests one queue per vCPU,
+	// rounded up to a power of two since drivers do not create more queues than
+	// there are CPUs. Any count is reduced to what the instance type allows.
+	//
+	// ENA queues are a budget shared by all interfaces of an instance, so a
+	// high count per ENI may reduce the number of ENIs, and therefore the
+	// number of pods, that fit on the node. See the ENI documentation for
+	// details. The setting only applies to ENIs Cilium attaches, and is ignored
+	// on instance types which do not support choosing the number of queues.
+	//
+	// +kubebuilder:validation:Enum={default,auto,"1","2","4","8","16","32","64","128","256","512","1024"}
+	// +kubebuilder:validation:Optional
+	ENAQueueCount string `json:"ena-queue-count,omitempty"`
 }
 
 // ENI represents an AWS Elastic Network Interface
@@ -188,6 +207,16 @@ type ENI struct {
 	//
 	// +optional
 	PublicIP iputil.Addr `json:"public-ip,omitzero"`
+
+	// ENAQueueCount is the number of ENA queues the ENI runs with.
+	//
+	// The EC2 API only reports a count for attachments which requested one, so
+	// for any other attachment, including the primary interface and interfaces
+	// Cilium does not manage, this is the default of the instance type. It is
+	// zero only while that default is unknown.
+	//
+	// +optional
+	ENAQueueCount int32 `json:"ena-queue-count,omitempty"`
 }
 
 func (e *ENI) DeepCopyInterface() ipamTypes.Interface {

--- a/pkg/aws/types/zz_generated.deepequal.go
+++ b/pkg/aws/types/zz_generated.deepequal.go
@@ -186,6 +186,10 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 		return false
 	}
 
+	if in.ENAQueueCount != other.ENAQueueCount {
+		return false
+	}
+
 	return true
 }
 
@@ -335,6 +339,10 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		if *in.DisablePrefixDelegation != *other.DisablePrefixDelegation {
 			return false
 		}
+	}
+
+	if in.ENAQueueCount != other.ENAQueueCount {
+		return false
 	}
 
 	return true

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -352,6 +352,12 @@ const (
 	// CiliumNode.Spec.ENI.DeleteOnTermination if no value is set.
 	ENIDeleteOnTermination = true
 
+	// ENIENAQueueCount is the default value for
+	// CiliumNode.Spec.ENI.ENAQueueCount if no value is set. It leaves the
+	// number of ENA queues of an ENI to AWS, and is written explicitly so that
+	// the value in effect can be read off the CiliumNode.
+	ENIENAQueueCount = "default"
+
 	// ENIGarbageCollectionTagManagedName is part of the ENIGarbageCollectionTags default tag set
 	ENIGarbageCollectionTagManagedName = "io.cilium/cilium-managed"
 

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -30,6 +30,31 @@ type Limits struct {
 
 	// IsBareMetal tracks whether an instance is a bare metal instance or not
 	IsBareMetal bool
+
+	// VCpus is the default number of vCPUs of the instance type. It is used
+	// as an upper bound when deriving a queue count for network interfaces,
+	// as drivers do not create more queues than there are CPUs.
+	VCpus int
+
+	// SupportsFlexibleENAQueues tracks whether the instance type allows the
+	// number of ENA queues of a network interface to be chosen at attachment
+	// time. On instance types which do not support it, any requested queue
+	// count is ignored.
+	SupportsFlexibleENAQueues bool
+
+	// MaxENAQueueCount is the maximum total number of ENA queues that can be
+	// distributed across all network interfaces attached to the instance. It
+	// is a budget shared by every interface, including interfaces which are
+	// not managed by Cilium.
+	MaxENAQueueCount int
+
+	// MaxENAQueueCountPerInterface is the maximum number of ENA queues that
+	// can be assigned to a single network interface.
+	MaxENAQueueCountPerInterface int
+
+	// DefaultENAQueueCountPerInterface is the number of ENA queues assigned
+	// to a network interface when no queue count is requested explicitly.
+	DefaultENAQueueCountPerInterface int
 }
 
 // AllocationIP is an IP which is available for allocation, or already

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -344,6 +344,21 @@ func (in *Limits) DeepEqual(other *Limits) bool {
 	if in.IsBareMetal != other.IsBareMetal {
 		return false
 	}
+	if in.VCpus != other.VCpus {
+		return false
+	}
+	if in.SupportsFlexibleENAQueues != other.SupportsFlexibleENAQueues {
+		return false
+	}
+	if in.MaxENAQueueCount != other.MaxENAQueueCount {
+		return false
+	}
+	if in.MaxENAQueueCountPerInterface != other.MaxENAQueueCountPerInterface {
+		return false
+	}
+	if in.DefaultENAQueueCountPerInterface != other.DefaultENAQueueCountPerInterface {
+		return false
+	}
 
 	return true
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -159,6 +159,37 @@ spec:
                       DisablePrefixDelegation determines whether ENI prefix delegation should be
                       disabled on this node.
                     type: boolean
+                  ena-queue-count:
+                    description: |-
+                      ENAQueueCount is the number of ENA queues to request for each ENI that
+                      Cilium attaches to this node. It accepts "default", "auto", or a number
+                      of queues, which AWS requires to be a power of two.
+
+                      "default" leaves the number of queues to AWS, and is what the agent
+                      writes when nothing is configured. "auto" requests one queue per vCPU,
+                      rounded up to a power of two since drivers do not create more queues than
+                      there are CPUs. Any count is reduced to what the instance type allows.
+
+                      ENA queues are a budget shared by all interfaces of an instance, so a
+                      high count per ENI may reduce the number of ENIs, and therefore the
+                      number of pods, that fit on the node. See the ENI documentation for
+                      details. The setting only applies to ENIs Cilium attaches, and is ignored
+                      on instance types which do not support choosing the number of queues.
+                    enum:
+                    - default
+                    - auto
+                    - "1"
+                    - "2"
+                    - "4"
+                    - "8"
+                    - "16"
+                    - "32"
+                    - "64"
+                    - "128"
+                    - "256"
+                    - "512"
+                    - "1024"
+                    type: string
                   exclude-interface-tags:
                     additionalProperties:
                       type: string
@@ -622,6 +653,16 @@ spec:
                           description: Description is the description field of the
                             ENI
                           type: string
+                        ena-queue-count:
+                          description: |-
+                            ENAQueueCount is the number of ENA queues the ENI runs with.
+
+                            The EC2 API only reports a count for attachments which requested one, so
+                            for any other attachment, including the primary interface and interfaces
+                            Cilium does not manage, this is the default of the instance type. It is
+                            zero only while that default is unknown.
+                          format: int32
+                          type: integer
                         id:
                           description: ID is the ENI ID
                           type: string

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.34.3"
+	CustomResourceDefinitionSchemaVersion = "1.34.4"
 )

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1377,6 +1377,36 @@ const (
 
 	IsPrefixDelegated = "isPrefixDelegated"
 
+	// ENA queue fields describing the state of an instance. Fields describing
+	// a change carry a Before and an After variant, so that a log line about
+	// attaching an interface states both sides of the change it makes.
+
+	ENAQueueCountConfigured = "enaQueueCountConfigured"
+
+	ENAQueueCountRequested = "enaQueueCountRequested"
+
+	ENAQueueCountGranted = "enaQueueCountGranted"
+
+	ENAQueueBudget = "enaQueueBudget"
+
+	ENAQueueBudgetUsed = "enaQueueBudgetUsed"
+
+	ENAQueueBudgetUsedBefore = "enaQueueBudgetUsedBefore"
+
+	ENAQueueBudgetUsedAfter = "enaQueueBudgetUsedAfter"
+
+	ENAQueueBudgetRemaining = "enaQueueBudgetRemaining"
+
+	ENAQueueBudgetRemainingBefore = "enaQueueBudgetRemainingBefore"
+
+	ENAQueueBudgetRemainingAfter = "enaQueueBudgetRemainingAfter"
+
+	ENAQueueFundableInterfacesAfter = "enaQueueFundableInterfacesAfter"
+
+	NumInterfacesBefore = "numInterfacesBefore"
+
+	NumInterfacesAfter = "numInterfacesAfter"
+
 	AttachmentID = "attachmentID"
 
 	FirstInterfaceIndex = "firstInterfaceIndex"

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -48,6 +48,7 @@ var defaultConfig = config{
 	ENIUsePrimaryAddress:       defaults.UseENIPrimaryAddress,
 	ENIDisablePrefixDelegation: defaults.ENIDisableNodeLevelPD,
 	ENIDeleteOnTermination:     defaults.ENIDeleteOnTermination,
+	ENIENAQueueCount:           defaults.ENIENAQueueCount,
 
 	AzureInterfaceName: "",
 
@@ -72,6 +73,7 @@ type config struct {
 	ENIUsePrimaryAddress       bool
 	ENIDisablePrefixDelegation bool
 	ENIDeleteOnTermination     bool
+	ENIENAQueueCount           string
 
 	AzureInterfaceName string
 
@@ -96,6 +98,7 @@ func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("eni-use-primary-address", c.ENIUsePrimaryAddress, "Whether an ENI's primary address should be available for allocations on the node at the node level")
 	flags.Bool("eni-disable-prefix-delegation", c.ENIDisablePrefixDelegation, "Whether ENI prefix delegation should be disabled on this node at the node level")
 	flags.Bool("eni-delete-on-termination", c.ENIDeleteOnTermination, "Whether the ENI should be deleted when the associated instance is terminated at the node level")
+	flags.String("eni-ena-queue-count", c.ENIENAQueueCount, "Number of ENA queues to request for each ENI attached to the node by Cilium: \"default\" to leave the number of queues to AWS, \"auto\" for as many as the interface can use, or a positive number of queues. ENA queues are a budget shared by all interfaces of an instance, so a high number of queues per ENI may reduce the number of ENIs, and therefore the number of pods, that fit on the node")
 
 	flags.String("azure-interface-name", c.AzureInterfaceName, "InterfaceName the cilium-operator will use to allocate all the IPs on at the node level")
 

--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -117,6 +117,7 @@ func applyAgentConfiguration(in nodediscovery.ENIMutateInputs, spec *ciliumv2.No
 		UsePrimaryAddress:       aws.Bool(in.UsePrimaryAddress),
 		DisablePrefixDelegation: aws.Bool(in.DisablePrefixDelegation),
 		DeleteOnTermination:     aws.Bool(in.DeleteOnTermination),
+		ENAQueueCount:           in.ENAQueueCount,
 
 		SubnetIDs:            in.SubnetIDs,
 		SubnetTags:           in.SubnetTags,
@@ -167,6 +168,9 @@ func overrideFromNetConf(logger *slog.Logger, spec *ciliumv2.NodeSpec, c *cnityp
 	}
 	if c.ENI.DeleteOnTermination != nil {
 		spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
+	}
+	if c.ENI.ENAQueueCount != "" {
+		spec.ENI.ENAQueueCount = c.ENI.ENAQueueCount
 	}
 
 	warnIgnoredInstanceFact(logger, "vpc-id", c.ENI.VpcID, info.VPCID)

--- a/pkg/nodediscovery/eni/eni_test.go
+++ b/pkg/nodediscovery/eni/eni_test.go
@@ -147,3 +147,56 @@ func TestInstanceFactsRetriesFailures(t *testing.T) {
 		})
 	}
 }
+
+// TestENAQueueCountFromConfiguration asserts that the ENA queue count reaches
+// the CiliumNode from the agent configuration, and that the CNI configuration
+// file overrides it when it sets one.
+func TestENAQueueCountFromConfiguration(t *testing.T) {
+	info := awsMetadata.MetaDataInfo{InstanceID: "i-instance", InstanceType: "c8i.8xlarge"}
+
+	tests := []struct {
+		name     string
+		agent    string
+		netConf  string
+		expected string
+	}{
+		{
+			name:     "unset by default",
+			expected: "",
+		},
+		{
+			name:     "set from the agent configuration",
+			agent:    "auto",
+			expected: "auto",
+		},
+		{
+			name:     "overridden by the CNI configuration file",
+			agent:    "auto",
+			netConf:  "16",
+			expected: "16",
+		},
+		{
+			name:     "kept when the CNI configuration file sets nothing",
+			agent:    "16",
+			netConf:  "",
+			expected: "16",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := nodediscovery.ENIMutateInputs{
+				Logger:        slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+				ENAQueueCount: tt.agent,
+				CNIConfigManager: &netConfManager{conf: &cnitypes.NetConf{
+					ENI: awsTypes.ENISpec{ENAQueueCount: tt.netConf},
+				}},
+			}
+
+			node := &ciliumv2.CiliumNode{}
+			apply(in, info, node)
+
+			require.Equal(t, tt.expected, node.Spec.ENI.ENAQueueCount)
+		})
+	}
+}

--- a/pkg/nodediscovery/nodediscovery_eni.go
+++ b/pkg/nodediscovery/nodediscovery_eni.go
@@ -24,6 +24,7 @@ type ENIMutateInputs struct {
 	UsePrimaryAddress       bool
 	DisablePrefixDelegation bool
 	DeleteOnTermination     bool
+	ENAQueueCount           string
 	SubnetIDs               []string
 	SubnetTags              map[string]string
 	SecurityGroups          []string
@@ -65,6 +66,7 @@ func (n *NodeDiscovery) mutateENINodeResource(ctx context.Context, nodeResource 
 		UsePrimaryAddress:       n.config.ENIUsePrimaryAddress,
 		DisablePrefixDelegation: n.config.ENIDisablePrefixDelegation,
 		DeleteOnTermination:     n.config.ENIDeleteOnTermination,
+		ENAQueueCount:           n.config.ENIENAQueueCount,
 		SubnetIDs:               n.config.ENISubnetIDs,
 		SubnetTags:              n.config.ENISubnetTags,
 		SecurityGroups:          n.config.ENISecurityGroups,


### PR DESCRIPTION
Adds support for configuring the number of ENA queues of the ENIs Cilium attaches in AWS ENI IPAM mode.

## Why

On instance types which report `FlexibleEnaQueuesSupport: supported`, the number of ENA queues of an interface can be chosen at attachment time. The number AWS assigns by default is the queue budget of the instance divided by the *maximum* number of interfaces the instance type supports: across the 530 instance types supporting the feature, `DefaultEnaQueueCountPerInterface == floor(MaximumEnaQueueCount / MaximumNetworkInterfaces)` holds for 442 of them, and never exceeds it.

A node which runs fewer ENIs than the hardware maximum therefore leaves most of its queue budget unused, and spreads pod traffic over fewer queues than the node has CPUs. On 377 of those 530 types the default is below the vCPU count. With prefix delegation, where a single ENI holds hundreds of addresses, running far fewer ENIs than the maximum is the common case.

## What

A new `spec.eni.ena-queue-count` field, settable cluster wide with the `eni.nodeSpec.enaQueueCount` Helm value, per node pool with a `CiliumNodeConfig`, and per node through the CNI configuration file. It accepts:

- `default` — leave the number of queues to AWS. This is what the agent writes when nothing is configured, so the value in effect can always be read off the `CiliumNode`, and it is how a node pool opts out where a broader configuration applies.
- `auto` — the number of vCPUs of the instance, capped by the maximum the instance type allows per interface.
- an explicit number of queues.

Behaviour is unchanged unless the field is set.

## Powers of two

AWS only accepts a power of two as the queue count of an attachment, and rejects the attachment otherwise. Every queue count the EC2 API reports is a power of two, but the number of vCPUs of an instance is not necessarily one: sizes of 12, 24, 48, 72, 96, 192 and 384 vCPUs exist, and those are exactly the instance types where `MaximumEnaQueueCountPerInterface` exceeds the vCPU count, that is where the vCPU cap binds at all. The three places a count is derived therefore round explicitly:

- **`auto` rounds up.** A driver does not create more queues than there are CPUs, so on an instance with 12 vCPUs and a maximum of 16 per interface, asking for 16 yields one queue for each of the 12 CPUs, where asking for 8 would leave four CPUs without one. The surplus is charged against the queue budget without being used, which is the price of the granularity. The result is still capped by the maximum per interface, so it never exceeds what AWS accepts.
- **An explicit count rounds down**, as it is an upper bound the configuration asked for. `CiliumNodeConfig` values are not validated against the `CiliumNode` schema, so this is enforced in the operator rather than by validation alone; the CRD additionally only accepts powers of two, so a bad value is rejected at apply time where it can be.
- **The reduction to the remaining queue budget rounds down**, as what is left of a budget is not a power of two in general.

Should AWS reject the count regardless, the ENI is attached with the number of queues AWS assigns by default and a warning is logged. A queue count is a tuning knob, and IP allocation on a node must not stop because of one.

## Queue budget

ENA queues are a budget shared by every interface of the instance, including the primary interface and interfaces Cilium does not manage. The requested count is therefore reduced to what the budget has left, and once the budget is exhausted no further interface can be attached, as AWS rejects an attachment which does not fit.

Rather than letting that attachment fail and be retried against the EC2 API, `PrepareIPAllocation` stops offering interface slots, so the shortage surfaces as ordinary interface exhaustion. **A high queue count can therefore reduce the number of ENIs, and with it the number of pods, that fit on a node.** This is documented, and the operator logs the budget before and after each attachment along with how many further interfaces what is left funds.

With prefix delegation the budget is rarely reached: measured across all 530 supported types, a node needing up to 250 pods uses at most 2 ENIs, and `min(vCPUs, maxPerInterface)` on every needed ENI plus the primary fits the budget on 530/530 types. Without prefix delegation at 250 pods, only 51% of types fit, which is what the guard is for.

## Notes for reviewers

- The queue limits are reported on `NetworkInfo.NetworkCards[]`, not on `NetworkInfo`. They are read from network card 0, which is the card `AttachNetworkInterface` hardcodes.
- The EC2 API only reports `Attachment.EnaQueueCount` for attachments which requested a count. Interfaces attached without one, the primary interface among them, report nothing, so they are counted at the instance type default, both in the budget arithmetic and in what the `CiliumNode` status reports. `DefaultEnaQueueCountPerInterface` is reported for all 1356 instance types, including those which do not support choosing a count, so the status shows the effective queue count on every node.
- `AttachNetworkInterface` gained a parameter rather than a second entry point, so no call site can bypass the budget by accident.
- The EC2 mock rejects a queue count which is not a power of two, so the test suite encodes the constraint rather than only the intent.
- The setting applies only to ENIs Cilium attaches. The primary interface keeps the queue count of the launch template, and changing the setting does not re-attach existing ENIs: queue counts are fixed at attachment time, so it takes effect on the next ENI attached.
- `ModifyNetworkInterfaceAttribute` can carry `Attachment.EnaQueueCount`, which would allow reconciling already attached ENIs. Left out deliberately: whether AWS permits it on an in-use attachment, and whether it is traffic disruptive, needs confirming first.

## Testing

Unit tests cover the limits parsing (network card selection, partial limits, unsupported instance types), queue count resolution including the rounding in all three places, budget accounting, the interface slot guard, and the configuration plumbing including the CNI configuration file override. Three tests cover the operator against the mocked EC2 API end to end: a count granted as requested, a count rounded before it reaches the API, and an API rejecting any requested count, asserting the ENI is attached with the default rather than IP allocation stopping.

Validated on a live AWS cluster, with prefix delegation enabled, on two instance types:

**`m6i.8xlarge`** (32 vCPUs, 64 queue budget, 32 per interface, 8 by default), `auto`:

```
$ kubectl get ciliumnode $NODE -o json | jq -r '.status.eni.enis[] | "\(.id)\t\(.number)\t\(.["ena-queue-count"])"'
eni-…4cca5   0   8      # primary, attached by EC2, counted at the instance type default
eni-…4d59e   1   32     # attached by Cilium

# in the node's network namespace
$ ethtool -l ens5 | tail -1
Combined:       8
$ ethtool -l ens6 | tail -1
Combined:       32
```

`ethtool` confirms the requested count materialises as driver channels rather than only being accepted by the API.

**`m8azn.3xlarge`** (12 vCPUs, 48 queue budget, 16 per interface, 4 by default) was used because it is one of the 84 types where the vCPU cap binds, and where the queue count `auto` derives is therefore not a power of two. This is what surfaced the power of two rule: `auto` first resolved to 12, the attachment was rejected with `InvalidParameterValue: The ENA queue count specified must be a power of 2`, and IP allocation on the node stopped, which is what the rounding and the fallback described above now prevent.

With the rounding in place, `auto` requests 16 on that instance type:

```
"msg":"Attaching the new ENI with the requested number of ENA queues"
"enaQueueCountRequested":16, "enaQueueCountGranted":16,
"enaQueueBudget":48, "enaQueueBudgetUsedBefore":4, "enaQueueBudgetUsedAfter":20,
"enaQueueBudgetRemainingBefore":44, "enaQueueBudgetRemainingAfter":28,
"enaQueueFundableInterfacesAfter":1, "numInterfacesBefore":1, "numInterfacesAfter":2,
"adaptersLimit":8
```

```
$ kubectl get ciliumnode $NODE -o json | jq -r '.status.eni.enis[] | "\(.id)\t\(.number)\t\(.["ena-queue-count"])"'
eni-…76cb8e   0   4      # primary, counted at the instance type default
eni-…c06e278   1   16     # attached by Cilium

# in the node's network namespace
$ ethtool -l enp39s0 | tail -1
Combined:       4
$ ethtool -l enp40s0 | tail -1
Combined:       12
```

The driver creating 12 channels from an attachment of 16 is the measurement rounding up rests on: a driver does not create more queues than there are CPUs, so the interface ends up with one queue per vCPU, and only the budget carries the surplus. Rounding down would have given the interface 8 queues for 12 CPUs. It also confirms the instance type default the primary interface is counted at: `ethtool` reports the 4 queues the status derives for it.

Instance type data throughout was collected from `DescribeInstanceTypes` in `us-east-1` (1356 types, 530 supporting flexible ENA queues).

This PR was prepared with AI assistance, AIL:3. The behaviour was verified by hand on a live cluster with the commands shown above.

```release-note
Add eni.nodeSpec.enaQueueCount to configure the number of ENA queues of the ENIs Cilium attaches in AWS ENI IPAM mode.
```
