### PR TITLE
vendor: Bump StateDB to v0.5.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.5.9
+	github.com/cilium/statedb v0.5.10
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.5.9 h1:HbZhIfos5jld0Gh1hhRIg6h2v84ZrGLq4Bt5Y82ZUUU=
-github.com/cilium/statedb v0.5.9/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
+github.com/cilium/statedb v0.5.10 h1:0NC5eGJySTkU+niaYUfCTh9ocCxM5txF99L1Y6DBZ8s=
+github.com/cilium/statedb v0.5.10/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/reconciler/incremental.go
+++ b/vendor/github.com/cilium/statedb/reconciler/incremental.go
@@ -249,7 +249,7 @@ func (incr *incremental[Obj]) commitStatus() (numErrors int) {
 			if currentStatus.Kind == StatusKindPending && currentStatus.ID == result.id {
 				current = incr.config.CloneObject(current)
 				current = incr.config.SetObjectStatus(current, status)
-				incr.table.Insert(wtxn, current)
+				_, _, err = incr.table.Insert(wtxn, current)
 			}
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.5.9
+# github.com/cilium/statedb v0.5.10
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Release notes at https://github.com/cilium/statedb/releases/tag/v0.5.10.

This fixes an issue in the StateDB reconciler. When multiple reconcilers act on the same object (with their own statuses) we may in conflict cases end up not retrying reconcilation. At the moment there are no code in v1.19 exercising this bug, but out of caution I'm bumping this anyway in case any such code might be backported.