### PR TITLE
vendor: Bump StateDB to v0.8.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v1.0.4
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
-	github.com/cilium/statedb v0.8.3
+	github.com/cilium/statedb v0.8.4
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1 h1:F+SGcs1IpZTuy1bGWBVZQgyr65NiiTOjHli7WExSHnU=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1/go.mod h1:GEiA7dAvPLMMt5drHzjQDAwRtVFcHbVR4ExTN5ISRyg=
-github.com/cilium/statedb v0.8.3 h1:FeepHCxKPTyMQUrpai3i8QHDASZ75xR41B3nXSOty3o=
-github.com/cilium/statedb v0.8.3/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
+github.com/cilium/statedb v0.8.4 h1:JRexp9zUmGyDVVME3FkU2UcnE4HF54dEDkeUzyroWEI=
+github.com/cilium/statedb v0.8.4/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/vendor/github.com/cilium/statedb/http.go
+++ b/vendor/github.com/cilium/statedb/http.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/cilium/statedb/index"
@@ -87,6 +88,11 @@ func (h dbHandler) query(w http.ResponseWriter, r *http.Request) {
 	if table == nil {
 		w.WriteHeader(http.StatusNotFound)
 		enc.Encode(QueryResponse{Err: fmt.Sprintf("Table %q not found", req.Table)})
+		return
+	}
+	if req.Index != "" && req.Index != RevisionIndex && !slices.Contains(table.Indexes(), req.Index) {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(QueryResponse{Err: fmt.Sprintf("Index %q not found", req.Index)})
 		return
 	}
 

--- a/vendor/github.com/cilium/statedb/http_client.go
+++ b/vendor/github.com/cilium/statedb/http_client.go
@@ -49,6 +49,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	// Use a channel to return errors so we can use the same Iterator[Obj] interface as StateDB does.
 	errChanSend := make(chan error, 1)
 	errChan = errChanSend
+	seq = emptySeq2[Obj, Revision]()
 
 	key := base64.StdEncoding.EncodeToString(q.key)
 	queryReq := QueryRequest{
@@ -60,6 +61,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	bs, err := json.Marshal(&queryReq)
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
 
@@ -67,6 +69,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), bytes.NewBuffer(bs))
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -75,9 +78,15 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	resp, err := t.client.Do(req)
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
-	return remoteGetSeq[Obj](json.NewDecoder(resp.Body), errChanSend), errChan
+	if resp.StatusCode != http.StatusOK {
+		errChanSend <- decodeHTTPError(resp)
+		close(errChanSend)
+		return
+	}
+	return remoteGetSeq[Obj](resp.Body, json.NewDecoder(resp.Body), errChanSend), errChan
 }
 
 func (t *RemoteTable[Obj]) Get(ctx context.Context, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan error) {
@@ -92,30 +101,23 @@ func (t *RemoteTable[Obj]) LowerBound(ctx context.Context, q Query[Obj]) (iter.S
 type responseObject[Obj any] struct {
 	Rev uint64 `json:"rev"`
 	Obj Obj    `json:"obj"`
-	Err string `json:"err,omitempty"`
 }
 
-func remoteGetSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[Obj, Revision] {
+func remoteGetSeq[Obj any](body io.ReadCloser, dec *json.Decoder, errChan chan error) iter.Seq2[Obj, Revision] {
 	return func(yield func(Obj, Revision) bool) {
+		defer body.Close()
+		defer close(errChan)
 		for {
 			var resp responseObject[Obj]
-			err := dec.Decode(&resp)
-			errString := ""
-			if err != nil {
+			if err := dec.Decode(&resp); err != nil {
 				if errors.Is(err, io.EOF) {
-					close(errChan)
-					break
+					return
 				}
-				errString = "Decode error: " + err.Error()
-			} else {
-				errString = resp.Err
-			}
-			if errString != "" {
-				errChan <- errors.New(errString)
-				break
+				errChan <- fmt.Errorf("decode error: %w", err)
+				return
 			}
 			if !yield(resp.Obj, resp.Rev) {
-				break
+				return
 			}
 		}
 	}
@@ -125,6 +127,7 @@ func (t *RemoteTable[Obj]) Changes(ctx context.Context) (seq iter.Seq2[Change[Ob
 	// Use a channel to return errors so we can use the same Iterator[Obj] interface as StateDB does.
 	errChanSend := make(chan error, 1)
 	errChan = errChanSend
+	seq = emptySeq2[Change[Obj], Revision]()
 
 	url := t.base.JoinPath("/changes", t.tableName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
@@ -143,11 +146,17 @@ func (t *RemoteTable[Obj]) Changes(ctx context.Context) (seq iter.Seq2[Change[Ob
 		close(errChanSend)
 		return
 	}
-	return remoteChangeSeq[Obj](json.NewDecoder(resp.Body), errChanSend), errChan
+	if resp.StatusCode != http.StatusOK {
+		errChanSend <- decodeHTTPError(resp)
+		close(errChanSend)
+		return
+	}
+	return remoteChangeSeq[Obj](resp.Body, json.NewDecoder(resp.Body), errChanSend), errChan
 }
 
-func remoteChangeSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[Change[Obj], Revision] {
+func remoteChangeSeq[Obj any](body io.ReadCloser, dec *json.Decoder, errChan chan error) iter.Seq2[Change[Obj], Revision] {
 	return func(yield func(Change[Obj], Revision) bool) {
+		defer body.Close()
 		defer close(errChan)
 		for {
 			var change Change[Obj]
@@ -169,4 +178,19 @@ func remoteChangeSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[C
 			}
 		}
 	}
+}
+
+func emptySeq2[A, B any]() iter.Seq2[A, B] {
+	return func(func(A, B) bool) {}
+}
+
+func decodeHTTPError(resp *http.Response) error {
+	defer resp.Body.Close()
+
+	var queryErr QueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queryErr); err == nil && queryErr.Err != "" {
+		return fmt.Errorf("HTTP %s: %s", resp.Status, queryErr.Err)
+	}
+
+	return fmt.Errorf("HTTP %s", resp.Status)
 }

--- a/vendor/github.com/cilium/statedb/reconciler/incremental.go
+++ b/vendor/github.com/cilium/statedb/reconciler/incremental.go
@@ -265,7 +265,7 @@ func (incr *incremental[Obj]) commitStatus() (numErrors int) {
 			if currentStatus.Kind == StatusKindPending && currentStatus.ID == result.id {
 				current = incr.config.CloneObject(current)
 				current = incr.config.SetObjectStatus(current, status)
-				incr.table.Insert(wtxn, current)
+				_, _, err = incr.table.Insert(wtxn, current)
 			}
 		}
 

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -578,7 +578,7 @@ func insertOrDelete(insert bool, db *DB, s *script.State, args ...string) (scrip
 	}
 
 	wtxn := db.WriteTxn(tbl.Meta)
-	defer wtxn.Commit()
+	defer wtxn.Abort()
 
 	for _, arg := range args[1:] {
 		data, err := os.ReadFile(s.Path(arg))
@@ -605,6 +605,7 @@ func insertOrDelete(insert bool, db *DB, s *script.State, args ...string) (scrip
 			}
 		}
 	}
+	wtxn.Commit()
 	return nil, nil
 }
 

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -199,6 +199,11 @@ func (t *genTable[Obj]) released() {
 }
 
 func (t *genTable[Obj]) indexPos(name string) int {
+	// An empty index name refers to the primary index, matching getIndexer.
+	if name == "" {
+		return PrimaryIndexPos
+	}
+
 	// By default don't consider the internal indexes.
 	start := PrimaryIndexPos
 

--- a/vendor/github.com/cilium/statedb/watchset.go
+++ b/vendor/github.com/cilium/statedb/watchset.go
@@ -75,8 +75,9 @@ func (ws *WatchSet) Merge(other *WatchSet) {
 }
 
 // Wait for channels in the watch set to close or the context is cancelled.
-// After the first closed channel is seen Wait will wait [settleTime] for
-// more closed channels.
+// If [settleTime] is >0 the method waits for an additional [settleTime]
+// duration to collect further closed channels. The wait is performed
+// even when all channels in the set are closed.
 // If [settleTime] is 0 waits until [ctx] cancelled or any channel closes.
 // Returns the closed channels and removes them from the set.
 func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-chan struct{}, error) {
@@ -118,7 +119,7 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 		}
 	}()
 
-	// Wait for the first channel to close and shift it out from [cases]
+	// Wait for any channel to close and shift it out from [cases]
 	chosen, _, _ := reflect.Select(cases)
 	if chosen == 0 {
 		return nil, ctx.Err()
@@ -127,9 +128,8 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 	cases[chosen] = cases[len(cases)-1]
 	cases = cases[:len(cases)-1]
 
-	// If nothing else than context channel remains or we don't want to wait for further channels
-	// to close then we're done.
-	if len(cases) == 1 || settleTime == 0 {
+	// Stop here if no additional wait requested
+	if settleTime == 0 {
 		return closedChannels, nil
 	}
 
@@ -138,7 +138,7 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 	defer cancel()
 	cases[0].Chan = reflect.ValueOf(settleCtx.Done())
 
-	for len(cases) > 1 {
+	for len(cases) >= 1 {
 		chosen, _, _ := reflect.Select(cases)
 		if chosen == 0 /* settleCtx.Done() */ {
 			break

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -305,7 +305,7 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.8.3
+# github.com/cilium/statedb v0.8.4
 ## explicit; go 1.25.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Release notes at https://github.com/cilium/statedb/releases/tag/v0.8.4.

This brings in few fixes. The main one is the fix to the reconciler. If multiple reconcilers act on the same object (each with their own status) and they conflict on writing back an error status then one of them might not retry the reconciliation for that object.

Currently v1.20 does not have code with multiple reconcilers acting on a single object, but I'm bumping this in case that might change due to backports.