### PR TITLE
iptables: parameterize endpoint NOTRACK rule description and report every rule failure

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -64,6 +64,14 @@ const (
 	encryptionDescription = "cilium-encryption-notrack:"
 )
 
+// formatComment returns the iptables match labelling a rule as cilium's, taking
+// action ("NOTRACK", "ACCEPT") on the traffic described by descr. The comment is
+// part of the rule spec, so a rule can only be deleted with the same comment it
+// was inserted with.
+func formatComment(action, descr string) []string {
+	return []string{"-m", "comment", "--comment", fmt.Sprintf("cilium: %s for %s", action, descr)}
+}
+
 // Minimum iptables versions supporting the -w and -w<seconds> flags
 var (
 	isWaitMinVersion        = versioncheck.MustCompile(">=1.4.20")
@@ -1128,6 +1136,8 @@ func (m *manager) addProxyRules(prog runnable, ip string, proxyPort uint16, name
 }
 
 func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, port *lb.L4Addr) error {
+	const noTrackNodeLocalDNS = "node-local-dns"
+
 	var err error
 
 	protocol := strings.ToLower(port.Protocol)
@@ -1143,123 +1153,51 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 	// 3. From a hostNetwork pod to the node-local-dns pod
 	// 4. From the node-local-dns pod to a hostNetwork pod
 
-	// 1. The following 2 rules cover packets from non-host pod to node-local-dns
-	if err = prog.runProg([]string{
-		"-t", "raw",
-		cmd, ciliumPreRawChain,
-		"-p", protocol,
-		"-d", IP,
-		"--dport", p,
-		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
-		"-j", "CT",
-		"--notrack"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumForwardChain,
-		"-p", protocol,
-		"-d", IP,
-		"--dport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
+	toEndpoint := []string{"-d", IP, "--dport", p}
+	fromEndpoint := []string{"-s", IP, "--sport", p}
 
-	// 2. The following 2 rules cover packets from node-local-dns to
-	// non-host pod
-	if err = prog.runProg([]string{
-		"-t", "raw",
-		cmd, ciliumPreRawChain,
-		"-p", protocol,
-		"-s", IP,
-		"--sport", p,
-		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
-		"-j", "CT",
-		"--notrack"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumForwardChain,
-		"-p", protocol,
-		"-s", IP,
-		"--sport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
+	notrack := slices.Concat(
+		formatComment("NOTRACK", noTrackNodeLocalDNS),
+		[]string{"-j", "CT", "--notrack"})
+	accept := slices.Concat(
+		formatComment("ACCEPT", noTrackNodeLocalDNS),
+		[]string{"-j", "ACCEPT"})
 
-	// 3. The following 2 rules cover packets from host namespaced pod to
-	// node-local-dns
-	if err = prog.runProg([]string{
-		"-t", "raw",
-		cmd, ciliumOutputRawChain,
-		"-p", protocol,
-		"-d", IP,
-		"--dport", p,
-		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
-		"-j", "CT",
-		"--notrack"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumOutputChain,
-		"-p", protocol,
-		"-d", IP,
-		"--dport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
+	for _, rule := range []struct {
+		table  string
+		chain  string
+		match  []string
+		action []string
+	}{
+		// 1. From a non-host pod to node-local-dns.
+		{"raw", ciliumPreRawChain, toEndpoint, notrack},
+		{"filter", ciliumForwardChain, toEndpoint, accept},
 
-	// 4. The following rule (and the prerouting rule in case 2)
-	// covers packets from node-local-dns to host namespaced pod
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumInputChain,
-		"-p", protocol,
-		"-s", IP,
-		"--sport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
+		// 2. From node-local-dns to a non-host pod.
+		{"raw", ciliumPreRawChain, fromEndpoint, notrack},
+		{"filter", ciliumForwardChain, fromEndpoint, accept},
 
-	// The following rules are kept for compatibility with host-namespaced
-	// node-local-dns if user already deploys in the legacy mode without
-	// LRP.
-	if err = prog.runProg([]string{
-		"-t", "raw",
-		cmd, ciliumOutputRawChain,
-		"-p", protocol,
-		"-s", IP,
-		"--sport", p,
-		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
-		"-j", "CT",
-		"--notrack"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumOutputChain,
-		"-p", protocol,
-		"-s", IP,
-		"--sport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
-	}
-	if err = prog.runProg([]string{
-		"-t", "filter",
-		cmd, ciliumInputChain,
-		"-p", protocol,
-		"-d", IP,
-		"--dport", p,
-		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
-		"-j", "ACCEPT"}); err != nil {
-		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
+		// 3. From a host namespaced pod to node-local-dns.
+		{"raw", ciliumOutputRawChain, toEndpoint, notrack},
+		{"filter", ciliumOutputChain, toEndpoint, accept},
+
+		// 4. From node-local-dns to a host namespaced pod, together with the
+		// prerouting rule of case 2.
+		{"filter", ciliumInputChain, fromEndpoint, accept},
+
+		// The following rules are kept for compatibility with host-namespaced
+		// node-local-dns if user already deploys in the legacy mode without
+		// LRP.
+		{"raw", ciliumOutputRawChain, fromEndpoint, notrack},
+		{"filter", ciliumOutputChain, fromEndpoint, accept},
+		{"filter", ciliumInputChain, toEndpoint, accept},
+	} {
+		if err = prog.runProg(slices.Concat(
+			[]string{"-t", rule.table, cmd, rule.chain, "-p", protocol},
+			rule.match,
+			rule.action)); err != nil {
+			m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
+		}
 	}
 	return err
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -6,6 +6,7 @@ package iptables
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -1138,7 +1139,7 @@ func (m *manager) addProxyRules(prog runnable, ip string, proxyPort uint16, name
 func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, port *lb.L4Addr) error {
 	const noTrackNodeLocalDNS = "node-local-dns"
 
-	var err error
+	var errs []error
 
 	protocol := strings.ToLower(port.Protocol)
 	p := strconv.FormatUint(uint64(port.Port), 10)
@@ -1192,14 +1193,15 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		{"filter", ciliumOutputChain, fromEndpoint, accept},
 		{"filter", ciliumInputChain, toEndpoint, accept},
 	} {
-		if err = prog.runProg(slices.Concat(
+		if err := prog.runProg(slices.Concat(
 			[]string{"-t", rule.table, cmd, rule.chain, "-p", protocol},
 			rule.match,
 			rule.action)); err != nil {
 			m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
+			errs = append(errs, err)
 		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 // InstallNoTrackRules is explicitly called when a pod has valid "policy.cilium.io/no-track-port" annotation.

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -1302,6 +1302,7 @@ func TestEndpointNoTrackRules(t *testing.T) {
 		port      *loadbalancer.L4Addr
 		wantProto string
 		wantPort  string
+		failAt    []int
 	}{
 		{
 			name:      "add rules for a non-default port",
@@ -1321,19 +1322,38 @@ func TestEndpointNoTrackRules(t *testing.T) {
 			wantProto: "udp",
 			wantPort:  "53",
 		},
+		{
+			name:      "every failure is reported",
+			prog:      "iptables",
+			cmd:       "-A",
+			ip:        "10.0.0.1",
+			port:      &loadbalancer.L4Addr{Protocol: loadbalancer.TCP, Port: 53},
+			wantProto: "tcp",
+			wantPort:  "53",
+			failAt:    []int{0, 4},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockProg := &mockIptables{
-				t:            t,
-				prog:         tt.prog,
-				expectations: endpointNoTrackExpectations(tt.cmd, tt.ip, tt.wantProto, tt.wantPort),
+			exp := endpointNoTrackExpectations(tt.cmd, tt.ip, tt.wantProto, tt.wantPort)
+			wantErrs := make([]error, 0, len(tt.failAt))
+			for _, i := range tt.failAt {
+				e := fmt.Errorf("rule %d failed", i)
+				exp[i].err = e
+				wantErrs = append(wantErrs, e)
 			}
 
+			mockProg := &mockIptables{t: t, prog: tt.prog, expectations: exp}
 			testMgr := &manager{logger: hivetest.Logger(t)}
 
-			require.NoError(t, testMgr.endpointNoTrackRules(mockProg, tt.cmd, tt.ip, tt.port))
+			err := testMgr.endpointNoTrackRules(mockProg, tt.cmd, tt.ip, tt.port)
+			if len(wantErrs) == 0 {
+				require.NoError(t, err)
+			}
+			for _, wantErr := range wantErrs {
+				require.ErrorIs(t, err, wantErr)
+			}
 			require.NoError(t, mockProg.checkExpectations())
 		})
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
@@ -1267,6 +1268,169 @@ func TestAddNoTrackPodTrafficRules(t *testing.T) {
 	err := testMgr.addNoTrackPodTrafficRules(mockIp4, podsCIDR)
 	assert.NoError(t, err)
 	assert.NoError(t, mockIp4.checkExpectations())
+}
+
+func endpointNoTrackExpectations(cmd, ip, proto, port string) []expectation {
+	// Spelled out rather than built with formatComment: deriving the expected
+	// value from the helper under test would assert nothing.
+	const (
+		notrack = "cilium: NOTRACK for node-local-dns"
+		accept  = "cilium: ACCEPT for node-local-dns"
+	)
+	return []expectation{
+		{args: fmt.Sprintf("-t raw %s CILIUM_PRE_raw -p %s -d %s --dport %s -m comment --comment %s -j CT --notrack", cmd, proto, ip, port, notrack)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_FORWARD -p %s -d %s --dport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+		{args: fmt.Sprintf("-t raw %s CILIUM_PRE_raw -p %s -s %s --sport %s -m comment --comment %s -j CT --notrack", cmd, proto, ip, port, notrack)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_FORWARD -p %s -s %s --sport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+		{args: fmt.Sprintf("-t raw %s CILIUM_OUTPUT_raw -p %s -d %s --dport %s -m comment --comment %s -j CT --notrack", cmd, proto, ip, port, notrack)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_OUTPUT -p %s -d %s --dport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_INPUT -p %s -s %s --sport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+		{args: fmt.Sprintf("-t raw %s CILIUM_OUTPUT_raw -p %s -s %s --sport %s -m comment --comment %s -j CT --notrack", cmd, proto, ip, port, notrack)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_OUTPUT -p %s -s %s --sport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+		{args: fmt.Sprintf("-t filter %s CILIUM_INPUT -p %s -d %s --dport %s -m comment --comment %s -j ACCEPT", cmd, proto, ip, port, accept)},
+	}
+}
+
+// TestEndpointNoTrackRules covers the exact rule set emitted for one address,
+// protocol and port.
+func TestEndpointNoTrackRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		prog      string
+		cmd       string
+		ip        string
+		port      *loadbalancer.L4Addr
+		wantProto string
+		wantPort  string
+	}{
+		{
+			name:      "add rules for a non-default port",
+			prog:      "iptables",
+			cmd:       "-A",
+			ip:        "10.0.0.1",
+			port:      &loadbalancer.L4Addr{Protocol: loadbalancer.TCP, Port: 5353},
+			wantProto: "tcp",
+			wantPort:  "5353",
+		},
+		{
+			name:      "delete rules matching the comment used to add them",
+			prog:      "iptables",
+			cmd:       "-D",
+			ip:        "10.0.0.1",
+			port:      &loadbalancer.L4Addr{Protocol: loadbalancer.UDP, Port: 53},
+			wantProto: "udp",
+			wantPort:  "53",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockProg := &mockIptables{
+				t:            t,
+				prog:         tt.prog,
+				expectations: endpointNoTrackExpectations(tt.cmd, tt.ip, tt.wantProto, tt.wantPort),
+			}
+
+			testMgr := &manager{logger: hivetest.Logger(t)}
+
+			require.NoError(t, testMgr.endpointNoTrackRules(mockProg, tt.cmd, tt.ip, tt.port))
+			require.NoError(t, mockProg.checkExpectations())
+		})
+	}
+}
+
+// TestInstallRemoveNoTrackRules covers the paths driven by the
+// "policy.cilium.io/no-track-port" annotation.
+func TestInstallRemoveNoTrackRules(t *testing.T) {
+	const port = 53
+
+	v4Rules := func(cmd string) []expectation {
+		return append(
+			endpointNoTrackExpectations(cmd, "10.0.0.1", "tcp", "53"),
+			endpointNoTrackExpectations(cmd, "10.0.0.1", "udp", "53")...,
+		)
+	}
+	v6Rules := func(cmd string) []expectation {
+		return append(
+			endpointNoTrackExpectations(cmd, "fd00::1", "tcp", "53"),
+			endpointNoTrackExpectations(cmd, "fd00::1", "udp", "53")...,
+		)
+	}
+
+	t.Run("install and remove", func(t *testing.T) {
+		mockIp4tables := &mockIptables{t: t, prog: "iptables", expectations: append(v4Rules("-A"), v4Rules("-D")...)}
+		mockIp6tables := &mockIptables{t: t, prog: "ip6tables", expectations: append(v6Rules("-A"), v6Rules("-D")...)}
+
+		testMgr := &manager{
+			logger: hivetest.Logger(t),
+			sharedCfg: SharedConfig{
+				InstallIptRules: true,
+				EnableIPv4:      true,
+				EnableIPv6:      true,
+			},
+			ip4tables: mockIp4tables,
+			ip6tables: mockIp6tables,
+		}
+
+		require.NoError(t, testMgr.installNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, testMgr.removeNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, mockIp4tables.checkExpectations())
+
+		require.NoError(t, testMgr.installNoTrackRules(netip.MustParseAddr("fd00::1"), port))
+		require.NoError(t, testMgr.removeNoTrackRules(netip.MustParseAddr("fd00::1"), port))
+		require.NoError(t, mockIp6tables.checkExpectations())
+	})
+
+	t.Run("skipped for ipv4 when conntrack is already skipped for all pod traffic", func(t *testing.T) {
+		mockIp4tables := &mockIptables{t: t, prog: "iptables"}
+
+		testMgr := &manager{
+			logger: hivetest.Logger(t),
+			sharedCfg: SharedConfig{
+				InstallIptRules:            true,
+				InstallNoConntrackIptRules: true,
+				EnableIPv4:                 true,
+			},
+			ip4tables: mockIp4tables,
+		}
+
+		require.NoError(t, testMgr.installNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, testMgr.removeNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, mockIp4tables.checkExpectations())
+	})
+
+	t.Run("not skipped for ipv6 when conntrack is already skipped for all pod traffic", func(t *testing.T) {
+		mockIp6tables := &mockIptables{t: t, prog: "ip6tables", expectations: append(v6Rules("-A"), v6Rules("-D")...)}
+
+		testMgr := &manager{
+			logger: hivetest.Logger(t),
+			sharedCfg: SharedConfig{
+				InstallIptRules:            true,
+				InstallNoConntrackIptRules: true,
+				EnableIPv4:                 true,
+				EnableIPv6:                 true,
+			},
+			ip6tables: mockIp6tables,
+		}
+
+		require.NoError(t, testMgr.installNoTrackRules(netip.MustParseAddr("fd00::1"), port))
+		require.NoError(t, testMgr.removeNoTrackRules(netip.MustParseAddr("fd00::1"), port))
+		require.NoError(t, mockIp6tables.checkExpectations())
+	})
+
+	t.Run("skipped when iptables rules are disabled", func(t *testing.T) {
+		mockIp4tables := &mockIptables{t: t, prog: "iptables"}
+
+		testMgr := &manager{
+			logger:    hivetest.Logger(t),
+			sharedCfg: SharedConfig{EnableIPv4: true},
+			ip4tables: mockIp4tables,
+		}
+
+		require.NoError(t, testMgr.installNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, testMgr.removeNoTrackRules(netip.MustParseAddr("10.0.0.1"), port))
+		require.NoError(t, mockIp4tables.checkExpectations())
+	})
 }
 
 // TestAllEgressMasqueradeCmdsRandomFully specifically tests the --random-fully


### PR DESCRIPTION
Follow-up to #47191, which added the `cilium:` comment to the per-endpoint NOTRACK/ACCEPT rules. Two review items were deferred there: 
- make the rule description an argument to `endpointNoTrackRules` 
- add the missing test coverage for this set of rules. 

The first two commits do both. Parameterize `endpointNoTrackRules` using `formatComment`, so the wording of a comment lives in exactly one place. 
Writing those tests surfaced a separate bug, fixed in the third commit. `endpointNoTrackRules` assigns all ten rule results to one shared `err` and only logs a warning on failure, so the final `return err` reports just the tenth rule. If rules 1-9 fail and rule 10 succeeds it returns `nil`, the reconciler declares the incremental install a success, and the full reconciliation that would reinstall the missing rules is never scheduled, leaving the endpoint with a partial NOTRACK rule set for up to 30 minutes. Check the commit message for details.

AIL: 3. I personally verified each commit builds and passes

```release-note
iptables: parameterize endpoint NOTRACK rule description and report every rule failure
```