### PR TITLE
iptables: keep all proxy rules across an agent restart, not just DNS

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1030,7 +1030,7 @@ func (m *manager) installStaticProxyRules(ifName, localDeliveryInterface string)
 	return nil
 }
 
-func (m *manager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, match, oldChain, newChain string) error {
+func (m *manager) doCopyProxyRules(prog iptablesInterface, table string, re *regexp.Regexp, oldChain, newChain string) error {
 	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
 	if err != nil {
 		return err
@@ -1039,7 +1039,7 @@ func (m *manager) doCopyProxyRules(prog iptablesInterface, table string, re *reg
 	scanner := bufio.NewScanner(strings.NewReader(rules))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		if !re.MatchString(rule) || !strings.Contains(rule, match) {
+		if !re.MatchString(rule) {
 			continue
 		}
 
@@ -1067,15 +1067,15 @@ func (m *manager) doCopyProxyRules(prog iptablesInterface, table string, re *reg
 var tproxyMatch = regexp.MustCompile("CILIUM_PRE_mangle .*cilium: TPROXY")
 
 // copies old proxy rules
-func (m *manager) copyProxyRules(oldChain string, match string) error {
+func (m *manager) copyProxyRules(oldChain string) error {
 	if m.sharedCfg.EnableIPv4 {
-		if err := m.doCopyProxyRules(m.ip4tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain); err != nil {
+		if err := m.doCopyProxyRules(m.ip4tables, "mangle", tproxyMatch, oldChain, ciliumPreMangleChain); err != nil {
 			return err
 		}
 	}
 
 	if m.sharedCfg.EnableIPv6 {
-		if err := m.doCopyProxyRules(m.ip6tables, "mangle", tproxyMatch, match, oldChain, ciliumPreMangleChain); err != nil {
+		if err := m.doCopyProxyRules(m.ip6tables, "mangle", tproxyMatch, oldChain, ciliumPreMangleChain); err != nil {
 			return err
 		}
 	}
@@ -1801,9 +1801,12 @@ func (m *manager) doInstallRules(state desiredState, firstInit bool) error {
 			return fmt.Errorf("failed to install rules: %w", err)
 		}
 
-		// copy old proxy rules over at initialization
+		// Copy the previous instance's proxy rules over at initialization. The
+		// restored proxy ports are still the ones the BPF policy map redirects
+		// to, so every one of these rules is needed until the corresponding
+		// proxy re-acks its port and reinstalls it.
 		if firstInit {
-			if err := m.copyProxyRules(oldCiliumPrefix+ciliumPreMangleChain, "cilium-dns-egress"); err != nil {
+			if err := m.copyProxyRules(oldCiliumPrefix + ciliumPreMangleChain); err != nil {
 				return fmt.Errorf("cannot copy old proxy rules, disruption to traffic selected by L7 policy possible: %w", err)
 			}
 		}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -147,12 +147,14 @@ func TestCopyProxyRulesv4(t *testing.T) {
 		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
 		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-random-proxy proxy -j TPROXY --on-port 43499 --on-ip 0.0.0.0 --tproxy-mark 0x200/0xffffffff",
+		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
-	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
-	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	// Copies every proxy rule from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp4tables, "mangle", tproxyMatch, "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp4tables.checkExpectations()
 	if err != nil {
 		t.Fatal(err)
@@ -184,12 +186,14 @@ func TestCopyProxyRulesv6(t *testing.T) {
 		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
 		}, {
+			args: "-t mangle -A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-random-proxy proxy -j TPROXY --on-port 43499 --on-ip :: --tproxy-mark 0x200/0xffffffff",
+		}, {
 			args: "-t mangle -A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
-	// Copies DNS proxy rules from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
-	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "cilium-dns-egress", "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
+	// Copies every proxy rule from OLD_CILIUM_PRE_mangle to CILIUM_PRE_mangle
+	mockManager.doCopyProxyRules(mockIp6tables, "mangle", tproxyMatch, "OLD_"+ciliumPreMangleChain, ciliumPreMangleChain)
 	err := mockIp6tables.checkExpectations()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
On the first reconciliation after a restart the agent renames CILIUM_* to
OLD_CILIUM_*, installs fresh chains, copies the old proxy rules over, then
deletes the old chains. The copy only took rules containing
"cilium-dns-egress", and the proxies it would otherwise reinstall from
state.proxies are not known yet: the reconciler runs this first pass with an
empty map, before the loop that receives proxy updates. So every non-DNS
TPROXY rule is dropped and the originals are then removed.

The proxy ports themselves survive. They are restored from the checkpoint and
AllocatePort keeps a restored port on the first attempt, so the BPF policy map
still redirects to them, and with an external Envoy the proxy is still
listening on them. Only the iptables rule that would deliver those packets is
missing, and it comes back per proxy via ackProxyPort -> InstallProxyRules,
driven by the first endpoint regeneration.

Until then a NEW connection selected by an L7 policy is marked but matches no
TPROXY rule, so it keeps the proxy mark, matches the ip rule for that mark and
is delivered locally at its original destination, where nothing is bound, and
the kernel resets it. The client does not see the reset, because the reply is
bounced back to the proxy as a redirected reply, so it retransmits until the
rule returns. Established connections keep working throughout via the
"-m socket --transparent" rule. On a busy node that lasted 32s, long enough to
outlast an application timeout.

Copy every rule the TPROXY regexp matches. A copied rule whose proxy did not
come back on the same port is removed by addProxyRules, which already deletes
the other rules for a proxy name when it installs one, so a stale copy is no
worse than the missing rule it replaces.

The test fixture already carried a cilium-random-proxy rule that was not being
copied; assert that it is.

Seen on the wireguard-7 leg of
https://github.com/cilium/cilium/actions/runs/33017666720/job/98340047927,
where the reinstalled rule shows a single matched SYN although four were
routed to it, and the connection only established once endpoint restoration
had completed 32s later.

```release-note
Fix new connections selected by an L7 policy being reset for the duration of endpoint restoration after a cilium-agent restart, because all non-DNS proxy TPROXY rules were discarded at startup.
```

This PR was prepared with AIL:3.
