### PR TITLE
bpf: never put a node-local identity in the tunnel id

### DIFF
--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -344,6 +344,20 @@ static __always_inline bool identity_is_local(__u32 identity)
 
 static __always_inline __u32 get_tunnel_id(__u32 identity)
 {
+	/* The tunnel id is only 24 bits wide, so a node-local identity would
+	 * lose its scope byte on the wire and the peer would decode an
+	 * unrelated identity. Collapse it into the identity the peer can
+	 * actually act on.
+	 */
+	switch (identity & IDENTITY_LOCAL_SCOPE_MASK) {
+	case 0:
+		break;
+	case IDENTITY_LOCAL_SCOPE_REMOTE_NODE:
+		return REMOTE_NODE_ID;
+	default:
+		return WORLD_ID;
+	}
+
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 	if (identity == WORLD_IPV4_ID || identity == WORLD_IPV6_ID)
 		return WORLD_ID;

--- a/bpf/tests/from_host_tunnel_id.c
+++ b/bpf/tests/from_host_tunnel_id.c
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Drives the from-host encap path that CI tripped over and inspects the
+ * bpf_tunnel_key the datapath hands to the kernel.
+ *
+ * cil_from_host resolves the source identity from the ipcache
+ * (resolve_srcid_ipv4), so external traffic carries whatever local identity the
+ * agent allocated for the source address, and hands it to
+ * encap_and_redirect_with_nodeid -> ctx_set_encap_info4 ->
+ * key.tunnel_id = get_tunnel_id(seclabel) -> skb_set_tunnel_key.
+ *
+ * The tunnel id ends up in the VXLAN/Geneve VNI, which is 24 bits wide, so a
+ * node-local identity loses its scope byte. 0x01000001, the first local
+ * identity a node allocates, arrives as 1 == HOST_ID and cil_from_overlay
+ * drops it with DROP_INVALID_IDENTITY.
+ *
+ * The 5-tuple is the one from the CI sysdump: an egress gateway reply,
+ * 172.20.0.3:8194 -> 10.244.1.165:48368, FIN+ACK.
+ */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Datapath configuration: VXLAN tunneling, dual stack as in the CI cluster. */
+#define ENCAP_IFINDEX 1
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define TUNNEL_MODE
+
+#define SRC_MAC mac_one
+#define DST_MAC mac_two
+#define SRC_IPV4 IPV4(172, 20, 0, 3)
+#define DST_IPV4 IPV4(10, 244, 1, 165)
+#define SRC_TCP_PORT __bpf_htons(8194)
+#define DST_TCP_PORT __bpf_htons(48368)
+
+#define DST_IDENTITY 1230
+
+/* Record what the datapath passes to skb_set_tunnel_key. The map holds the
+ * whole key so the check can look at the tunnel endpoint too.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct bpf_tunnel_key));
+	__uint(max_entries, 1);
+} tunnel_key_map __section_maps_btf;
+
+bool tunnel_key_set;
+
+#define skb_set_tunnel_key mock_skb_set_tunnel_key
+static __always_inline int
+mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			const struct bpf_tunnel_key *from,
+			__maybe_unused __u32 size,
+			__maybe_unused __u32 flags)
+{
+	__u32 map_key = 0;
+	struct bpf_tunnel_key *mock_key = map_lookup_elem(&tunnel_key_map, &map_key);
+
+	if (mock_key) {
+		memcpy(mock_key, from, sizeof(*mock_key));
+		tunnel_key_set = true;
+	}
+
+	return 0;
+}
+
+#include "lib/bpf_host.h"
+#include "lib/ipcache.h"
+
+/* Hybrid routing would send the packet out without a tunnel. */
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, false)
+
+static __always_inline int
+pktgen_from_host(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)SRC_MAC, (__u8 *)DST_MAC,
+					  SRC_IPV4, DST_IPV4,
+					  SRC_TCP_PORT, DST_TCP_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	/* The CI packet was a FIN+ACK. */
+	l4->syn = 0;
+	l4->fin = 1;
+	l4->ack = 1;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+static __always_inline int
+setup(struct __ctx_buff *ctx, __u32 src_identity)
+{
+	/* The source is external, so the agent holds a node-local identity for
+	 * it and no tunnel endpoint.
+	 */
+	ipcache_v4_add_entry(SRC_IPV4, 0, src_identity, 0, 0);
+
+	/* The destination is a pod on another node, reached through a tunnel. */
+	ipcache_v4_add_entry(DST_IPV4, 0, DST_IDENTITY, v4_node_two, 0);
+
+	return host_send_packet(ctx);
+}
+
+static __always_inline int
+check_tunnel_key(const struct __ctx_buff *ctx, __u32 expected_id)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	__u32 map_key = 0;
+	struct bpf_tunnel_key *key;
+	__u32 tunnel_id;
+	__be32 vni;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* The packet has to have been encapsulated, otherwise there is no
+	 * tunnel key to look at and the rest of the test is vacuous.
+	 */
+	if (*status_code != CTX_ACT_REDIRECT)
+		test_fatal("not encapsulated, status %lu", *status_code);
+
+	if (!tunnel_key_set)
+		test_fatal("skb_set_tunnel_key not called");
+
+	key = map_lookup_elem(&tunnel_key_map, &map_key);
+	if (!key)
+		test_fatal("no tunnel key recorded");
+
+	if (key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("wrong tunnel ep %lx", key->remote_ipv4);
+
+	tunnel_id = key->tunnel_id;
+
+	/* The kernel copies the low 24 bits of the tunnel id into the VNI, and
+	 * cilium decodes the VNI back with tunnel_vni_to_sec_identity(). An id
+	 * that does not survive that round trip reaches the peer as a
+	 * different identity.
+	 */
+	vni = sec_identity_to_tunnel_vni(tunnel_id);
+
+	if (tunnel_vni_to_sec_identity(vni) != tunnel_id)
+		test_fatal("id %lx arrives as %lx", tunnel_id,
+			   tunnel_vni_to_sec_identity(vni));
+
+	/* The same statement without the encoding: the scope byte has to be
+	 * gone before the id is handed to the kernel.
+	 */
+	if (identity_is_local(tunnel_id))
+		test_fatal("local id %lx in tunnel key", tunnel_id);
+
+	if (tunnel_id != expected_id)
+		test_fatal("tunnel id %lx, want %lx", tunnel_id, expected_id);
+
+	test_finish();
+}
+
+/* The identity from the CI failure, 16777217. It used to reach the peer as
+ * HOST_ID, which cil_from_overlay rejects with DROP_INVALID_IDENTITY.
+ */
+PKTGEN(PROG_TYPE, "01_cidr_scope_source")
+int cidr_scope_source_pktgen(struct __ctx_buff *ctx)
+{
+	return pktgen_from_host(ctx);
+}
+
+SETUP(PROG_TYPE, "01_cidr_scope_source")
+int cidr_scope_source_setup(struct __ctx_buff *ctx)
+{
+	return setup(ctx, IDENTITY_LOCAL_SCOPE_CIDR | 1);
+}
+
+CHECK(PROG_TYPE, "01_cidr_scope_source")
+int cidr_scope_source_check(const struct __ctx_buff *ctx)
+{
+	return check_tunnel_key(ctx, WORLD_ID);
+}
+
+/* A remote node scope source used to arrive as KUBE_APISERVER_NODE_ID. */
+PKTGEN(PROG_TYPE, "02_remote_node_scope_source")
+int remote_node_scope_source_pktgen(struct __ctx_buff *ctx)
+{
+	return pktgen_from_host(ctx);
+}
+
+SETUP(PROG_TYPE, "02_remote_node_scope_source")
+int remote_node_scope_source_setup(struct __ctx_buff *ctx)
+{
+	return setup(ctx, IDENTITY_LOCAL_SCOPE_REMOTE_NODE | 7);
+}
+
+CHECK(PROG_TYPE, "02_remote_node_scope_source")
+int remote_node_scope_source_check(const struct __ctx_buff *ctx)
+{
+	return check_tunnel_key(ctx, REMOTE_NODE_ID);
+}

--- a/bpf/tests/identity_test.c
+++ b/bpf/tests/identity_test.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Both families are needed, otherwise WORLD_IPV4_ID and WORLD_IPV6_ID collapse
+ * to WORLD_ID and the branches under test are compiled out.
+ */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+
+#include <bpf/ctx/xdp.h>
+#include "common.h"
+#include <bpf/config/node.h>
+
+#include <lib/identity.h>
+
+/* Width of the VXLAN/Geneve VNI, which is what overloadable_{skb,xdp}.h store
+ * the tunnel id in.
+ */
+#define VNI_MASK 0x00ffffffU
+
+/* The identity as the peer reads it back out of the tunnel header. */
+static __always_inline __u32 on_the_wire(__u32 identity)
+{
+	return get_tunnel_id(identity) & VNI_MASK;
+}
+
+/* Tables live at file scope because TEST() is a two argument macro: a brace
+ * initializer inside its body would be split on its commas.
+ */
+static const __u32 scopes[] = {
+	0,
+	IDENTITY_LOCAL_SCOPE_CIDR,
+	IDENTITY_LOCAL_SCOPE_REMOTE_NODE,
+	0x03000000, /* unallocated today */
+	0x7f000000,
+	IDENTITY_LOCAL_SCOPE_MASK,
+};
+
+static const __u32 low[] = {
+	0, HOST_ID, WORLD_ID, UNMANAGED_ID, HEALTH_ID, INIT_ID,
+	REMOTE_NODE_ID, KUBE_APISERVER_NODE_ID, INGRESS_ID,
+	WORLD_IPV4_ID, WORLD_IPV6_ID,
+	100, 400, 0xaabb, 0xffff, 0x00010000, 0x0001aabb,
+	VNI_MASK,
+};
+
+static const __u32 global_ids[] = {
+	HOST_ID, HEALTH_ID, REMOTE_NODE_ID, KUBE_APISERVER_NODE_ID,
+	INGRESS_ID, 400, 0x0001aabb,
+};
+
+CHECK(PROG_TYPE, "get_tunnel_id")
+int bpf_test_get_tunnel_id(__maybe_unused struct xdp_md *ctx)
+{
+	test_init();
+
+	TEST("pass-through", {
+		assert(get_tunnel_id(HOST_ID) == HOST_ID);
+		assert(get_tunnel_id(WORLD_ID) == WORLD_ID);
+		assert(get_tunnel_id(HEALTH_ID) == HEALTH_ID);
+		assert(get_tunnel_id(REMOTE_NODE_ID) == REMOTE_NODE_ID);
+		assert(get_tunnel_id(KUBE_APISERVER_NODE_ID) == KUBE_APISERVER_NODE_ID);
+		assert(get_tunnel_id(INGRESS_ID) == INGRESS_ID);
+		assert(get_tunnel_id(400) == 400);
+
+		/* cluster 1, endpoint 0xaabb */
+		assert(get_tunnel_id(0x0001aabb) == 0x0001aabb);
+		/* the largest identity that still fits in the VNI */
+		assert(get_tunnel_id(VNI_MASK) == VNI_MASK);
+	});
+
+	TEST("world-ipv4-ipv6", {
+		assert(get_tunnel_id(WORLD_IPV4_ID) == WORLD_ID);
+		assert(get_tunnel_id(WORLD_IPV6_ID) == WORLD_ID);
+	});
+
+	/* The first local identity a node allocates used to reach the peer as
+	 * HOST_ID, which cil_from_overlay rejects with DROP_INVALID_IDENTITY.
+	 */
+	TEST("cidr-scope-identity", {
+		__u32 id = IDENTITY_LOCAL_SCOPE_CIDR | 1; /* 16777217 */
+
+		assert(get_tunnel_id(id) == WORLD_ID);
+		assert(on_the_wire(id) == get_tunnel_id(id));
+		assert(on_the_wire(id) != HOST_ID);
+	});
+
+	/* Truncation does not only drop, it aliases: left as is, these three
+	 * arrive as REMOTE_NODE_ID, WORLD_ID and INGRESS_ID.
+	 */
+	TEST("cidr-scope-identity-aliasing", {
+		__u32 alias_node = IDENTITY_LOCAL_SCOPE_CIDR | REMOTE_NODE_ID;
+		__u32 alias_world = IDENTITY_LOCAL_SCOPE_CIDR | WORLD_ID;
+		__u32 alias_ingress = IDENTITY_LOCAL_SCOPE_CIDR | INGRESS_ID;
+
+		assert(get_tunnel_id(alias_node) == WORLD_ID);
+		assert(on_the_wire(alias_node) == WORLD_ID);
+		assert(!identity_is_remote_node(on_the_wire(alias_node)));
+
+		assert(get_tunnel_id(alias_world) == WORLD_ID);
+		assert(on_the_wire(alias_world) == WORLD_ID);
+
+		assert(get_tunnel_id(alias_ingress) == WORLD_ID);
+		assert(on_the_wire(alias_ingress) == WORLD_ID);
+		assert(!identity_is_ingress(on_the_wire(alias_ingress)));
+	});
+
+	TEST("remote-node-scope-identity", {
+		__u32 id = IDENTITY_LOCAL_SCOPE_REMOTE_NODE | 7;
+
+		assert(get_tunnel_id(IDENTITY_LOCAL_SCOPE_REMOTE_NODE) == REMOTE_NODE_ID);
+		assert(get_tunnel_id(id) == REMOTE_NODE_ID);
+		assert(on_the_wire(id) == get_tunnel_id(id));
+		assert(identity_is_remote_node(on_the_wire(id)));
+	});
+
+	/* The invariant rather than the examples: whatever comes out has to fit
+	 * in the VNI, including for scopes that do not exist yet.
+	 */
+	TEST("fits-in-vni", {
+		__u32 bad_in = 0;
+		__u32 bad_out = 0;
+		__u32 i;
+		__u32 j;
+
+		for (i = 0; i < ARRAY_SIZE(scopes); i++) {
+			for (j = 0; j < ARRAY_SIZE(low); j++) {
+				__u32 id = scopes[i] | low[j];
+				__u32 tunnel_id = get_tunnel_id(id);
+
+				if (identity_is_local(tunnel_id) && !bad_out) {
+					bad_in = id;
+					bad_out = tunnel_id;
+				}
+			}
+		}
+
+		if (bad_out)
+			test_fatal("id %lx became %lx", bad_in, bad_out);
+	});
+
+	test_finish();
+}
+
+CHECK(PROG_TYPE, "get_id_from_tunnel_id")
+int bpf_test_get_id_from_tunnel_id(__maybe_unused struct xdp_md *ctx)
+{
+	__be16 v4 = bpf_htons(ETH_P_IP);
+	__be16 v6 = bpf_htons(ETH_P_IPV6);
+
+	test_init();
+
+	TEST("world-round-trip", {
+		assert(get_id_from_tunnel_id(get_tunnel_id(WORLD_IPV4_ID), v4) == WORLD_IPV4_ID);
+		assert(get_id_from_tunnel_id(get_tunnel_id(WORLD_IPV6_ID), v6) == WORLD_IPV6_ID);
+
+		/* a CIDR scope identity degrades to the world identity of the
+		 * family the packet carries
+		 */
+		assert(get_id_from_tunnel_id(get_tunnel_id(IDENTITY_LOCAL_SCOPE_CIDR | 1), v4) ==
+		       WORLD_IPV4_ID);
+		assert(get_id_from_tunnel_id(get_tunnel_id(IDENTITY_LOCAL_SCOPE_CIDR | 1), v6) ==
+		       WORLD_IPV6_ID);
+	});
+
+	TEST("identity-round-trip", {
+		__u32 i;
+
+		for (i = 0; i < ARRAY_SIZE(global_ids); i++) {
+			__u32 id = global_ids[i];
+
+			if (get_id_from_tunnel_id(get_tunnel_id(id), v4) != id)
+				test_fatal("id %lx broke over IPv4", id);
+			if (get_id_from_tunnel_id(get_tunnel_id(id), v6) != id)
+				test_fatal("id %lx broke over IPv6", id);
+		}
+	});
+
+	TEST("remote-node-round-trip", {
+		__u32 id = IDENTITY_LOCAL_SCOPE_REMOTE_NODE | 7;
+
+		assert(get_id_from_tunnel_id(get_tunnel_id(id), v4) == REMOTE_NODE_ID);
+		assert(get_id_from_tunnel_id(get_tunnel_id(id), v6) == REMOTE_NODE_ID);
+	});
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/xdp_tunnel_vni.c
+++ b/bpf/tests/xdp_tunnel_vni.c
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* The VXLAN VNI is 24 bits wide, so it cannot carry a node-local security
+ * identity. These tests encapsulate a packet whose source identity comes out
+ * of the ipcache, the way the from-host path feeds an encap, and then read the
+ * literal VNI bytes back out of the packet cilium built. The XDP encoder writes
+ * the VNI itself, so the bytes are there to look at; on the skb path the kernel
+ * writes them, see from_host_tunnel_id.c.
+ */
+
+#include <bpf/ctx/xdp.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_NODEPORT_ACCELERATION
+#define TUNNEL_MODE
+
+#define ENCAP_IFINDEX		42
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define POD_IP			v4_pod_one_on_node_two
+#define POD_PORT		__bpf_htons(8080)
+#define POD_NODE_IP		v4_node_two
+#define POD_ID			0xaabb
+
+#define LOCAL_NODE_IP		v4_node_one
+
+/* The first local identity a node allocates. Truncated to 24 bits it is
+ * HOST_ID, which cil_from_overlay rejects with DROP_INVALID_IDENTITY.
+ */
+#define CIDR_ID			(IDENTITY_LOCAL_SCOPE_CIDR | 1)
+
+/* Truncated to 24 bits this one is INGRESS_ID, a valid identity, so the peer
+ * does not drop the packet at all: it enforces the wrong ingress policy.
+ */
+#define CIDR_ID_ALIAS		(IDENTITY_LOCAL_SCOPE_CIDR | INGRESS_ID)
+
+#include "lib/bpf_xdp.h"
+#include "lib/ipcache.h"
+
+ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_VXLAN)
+ASSIGN_CONFIG(union v4addr, ipv4_direct_routing, { .be32 = LOCAL_NODE_IP })
+
+#include "nodeport_defaults.h"
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *node_mac = mac_two;
+
+struct encap_view {
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct udphdr *l4;
+	struct vxlanhdr *vxlan;
+	struct iphdr *inner_l3;
+};
+
+static __always_inline bool
+encap_parse(const struct __ctx_buff *ctx, struct encap_view *view)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	struct ethhdr *inner_l2;
+	struct ethhdr *l2;
+
+	if (data + sizeof(__u32) > data_end)
+		return false;
+
+	view->status_code = data;
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(*l2) > data_end)
+		return false;
+
+	view->l3 = (void *)l2 + sizeof(*l2);
+	if ((void *)view->l3 + sizeof(*view->l3) > data_end)
+		return false;
+
+	view->l4 = (void *)view->l3 + sizeof(*view->l3);
+	if ((void *)view->l4 + sizeof(*view->l4) > data_end)
+		return false;
+
+	view->vxlan = (void *)view->l4 + sizeof(*view->l4);
+	if ((void *)view->vxlan + sizeof(*view->vxlan) > data_end)
+		return false;
+
+	inner_l2 = (void *)view->vxlan + sizeof(*view->vxlan);
+	if ((void *)inner_l2 + sizeof(*inner_l2) > data_end)
+		return false;
+
+	view->inner_l3 = (void *)inner_l2 + sizeof(*inner_l2);
+	if ((void *)view->inner_l3 + sizeof(*view->inner_l3) > data_end)
+		return false;
+
+	return true;
+}
+
+static __always_inline int
+tunnel_vni_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, POD_IP,
+					  CLIENT_PORT, POD_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+/* Give the source address a node-local identity in the ipcache, read it back
+ * the way bpf_host does, and hand it to the tunnel encap.
+ */
+static __always_inline int
+tunnel_vni_setup(struct __ctx_buff *ctx, __u32 identity)
+{
+	const struct remote_endpoint_info *info;
+	__u32 src_sec_identity;
+	int ifindex = 0;
+
+	ipcache_v4_add_entry(CLIENT_IP, 0, identity, 0, 0);
+	ipcache_v4_add_entry(POD_IP, 0, POD_ID, POD_NODE_IP, 0);
+
+	info = lookup_ip4_remote_endpoint(CLIENT_IP, 0);
+	if (!info)
+		return TEST_ERROR;
+
+	src_sec_identity = info->sec_identity;
+	if (src_sec_identity != identity)
+		return TEST_ERROR;
+
+	info = lookup_ip4_remote_endpoint(POD_IP, 0);
+	if (!info || !info->flag_has_tunnel_ep)
+		return TEST_ERROR;
+
+	return nodeport_add_tunnel_encap(ctx, CONFIG(ipv4_direct_routing).be32,
+					 CLIENT_PORT, info, src_sec_identity,
+					 (enum trace_reason)CT_NEW, 0, &ifindex,
+					 bpf_htons(ETH_P_IP));
+}
+
+PKTGEN(PROG_TYPE, "xdp_tunnel_vni_cidr_id")
+int tunnel_vni_cidr_id_pktgen(struct __ctx_buff *ctx)
+{
+	return tunnel_vni_pktgen(ctx);
+}
+
+SETUP(PROG_TYPE, "xdp_tunnel_vni_cidr_id")
+int tunnel_vni_cidr_id_setup(struct __ctx_buff *ctx)
+{
+	return tunnel_vni_setup(ctx, CIDR_ID);
+}
+
+CHECK(PROG_TYPE, "xdp_tunnel_vni_cidr_id")
+int tunnel_vni_cidr_id_check(const struct __ctx_buff *ctx)
+{
+	struct encap_view view;
+	__be32 want_vni;
+	__be32 got_vni;
+	__u8 *vni_bytes;
+	__u32 peer_id;
+
+	test_init();
+
+	if (!encap_parse(ctx, &view))
+		test_fatal("encapsulated packet is truncated");
+
+	TEST("encapsulated", {
+		assert(*view.status_code == CTX_ACT_REDIRECT);
+
+		if (view.l3->protocol != IPPROTO_UDP)
+			test_fatal("outer IP is not UDP");
+		if (view.l3->saddr != LOCAL_NODE_IP)
+			test_fatal("outerSrcIP is not the local node");
+		if (view.l3->daddr != POD_NODE_IP)
+			test_fatal("outerDstIP is not the pod node");
+		if (view.l4->dest != bpf_htons(CONFIG(tunnel_port)))
+			test_fatal("outerDstPort is not the tunnel port");
+
+		if (view.inner_l3->saddr != CLIENT_IP)
+			test_fatal("innerSrcIP is not the client");
+		if (view.inner_l3->daddr != POD_IP)
+			test_fatal("innerDstIP is not the pod");
+	});
+
+	/* The three identity bytes of the VNI, in wire order, plus the
+	 * reserved byte that follows them.
+	 */
+	TEST("vni-bytes", {
+		vni_bytes = (__u8 *)&view.vxlan->vx_vni;
+
+		if (vni_bytes[0] != 0 || vni_bytes[1] != 0 ||
+		    vni_bytes[2] != WORLD_ID || vni_bytes[3] != 0)
+			test_fatal("vni %lx %lx %lx rsvd %lx",
+				   vni_bytes[0], vni_bytes[1], vni_bytes[2],
+				   vni_bytes[3]);
+	});
+
+	TEST("vni-word", {
+		want_vni = sec_identity_to_tunnel_vni(WORLD_ID);
+		got_vni = view.vxlan->vx_vni;
+
+		if (got_vni != want_vni)
+			test_fatal("vni is %lx, want %lx",
+				   bpf_ntohl(got_vni), bpf_ntohl(want_vni));
+	});
+
+	/* Same value, stated as the identity the peer reads back out. */
+	TEST("vni-identity", {
+		peer_id = tunnel_vni_to_sec_identity(view.vxlan->vx_vni);
+
+		if (peer_id == HOST_ID)
+			test_fatal("peer reads HOST_ID from vni %lx",
+				   bpf_ntohl(view.vxlan->vx_vni));
+
+		if (peer_id != WORLD_ID)
+			test_fatal("peer reads id %lu, want %lu",
+				   peer_id, (__u32)WORLD_ID);
+	});
+
+	test_finish();
+}
+
+PKTGEN(PROG_TYPE, "xdp_tunnel_vni_alias_id")
+int tunnel_vni_alias_id_pktgen(struct __ctx_buff *ctx)
+{
+	return tunnel_vni_pktgen(ctx);
+}
+
+SETUP(PROG_TYPE, "xdp_tunnel_vni_alias_id")
+int tunnel_vni_alias_id_setup(struct __ctx_buff *ctx)
+{
+	return tunnel_vni_setup(ctx, CIDR_ID_ALIAS);
+}
+
+CHECK(PROG_TYPE, "xdp_tunnel_vni_alias_id")
+int tunnel_vni_alias_id_check(const struct __ctx_buff *ctx)
+{
+	struct encap_view view;
+	__u32 peer_id;
+
+	test_init();
+
+	if (!encap_parse(ctx, &view))
+		test_fatal("encapsulated packet is truncated");
+
+	TEST("vni-identity-not-aliased", {
+		assert(*view.status_code == CTX_ACT_REDIRECT);
+
+		peer_id = tunnel_vni_to_sec_identity(view.vxlan->vx_vni);
+
+		if (peer_id == INGRESS_ID)
+			test_fatal("peer reads INGRESS_ID from vni %lx",
+				   bpf_ntohl(view.vxlan->vx_vni));
+
+		if (peer_id != WORLD_ID)
+			test_fatal("peer reads id %lu, want %lu",
+				   peer_id, (__u32)WORLD_ID);
+	});
+
+	test_finish();
+}


### PR DESCRIPTION
The tunnel id carries the source security identity to the peer node and
is only 24 bits wide, since overloadable_skb.h and overloadable_xdp.h
write get_tunnel_id(seclabel) into the VXLAN or Geneve VNI. A node-local
identity does not fit there, so its scope byte is silently truncated and
the peer decodes an unrelated identity.

The from-host encap path forwards whatever the ipcache holds for the
source address, which for external traffic can be a CIDR or a toFQDNs
identity. The first local identity a node allocates is 0x01000001, which
arrives as HOST_ID and cil_from_overlay drops it as
DROP_INVALID_IDENTITY. That is how CI found this, as four INGRESS
"Invalid identity" drops in the egress gateway L7 test. Truncation also
aliases onto REMOTE_NODE_ID, WORLD_ID and INGRESS_ID, and onto real
endpoint identities once a node holds more than 256 local ones, so the
peer can just as well enforce the wrong ingress policy with no drop.

Collapse local identities in get_tunnel_id(), the only place a tunnel id
is derived from a security identity. Remote node scope becomes
REMOTE_NODE_ID, which the receiver refines from its own ipcache anyway,
and the rest becomes WORLD_ID, which is what identity_is_world() already
classifies a CIDR identity as and what the egress gateway reply redirect
puts on the wire itself. That loses precision for the CIDR scope, but
the peer never had a usable identity there to begin with.

```release-note
Fix dropped and misclassified tunneled traffic whose source address holds a node-local CIDR or FQDN identity
```

This PR was prepared with AIL:3.
