### PR TITLE
loadbalancer: demote topology-de-preferred backends instead of evicti…

### DIFF
--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -65,6 +65,15 @@ type Backend struct {
 	// +deepequal-gen=false
 	UnhealthyUpdatedAt *time.Time
 
+	// TopologyDemoted marks a backend that was de-preferred by topology-aware
+	// selection (trafficDistribution / topology hints) on this node. A demoted
+	// backend is kept in the datapath maps so that its established connections
+	// keep working, but it is placed outside the new-connection selection
+	// range (slots beyond Count, like quarantined backends).
+	// This field is only set on the per-frontend copies yielded by
+	// [writer.Writer]'s backend selection, never on the backends table itself.
+	TopologyDemoted bool `json:",omitempty" yaml:",omitempty"`
+
 	// sourcePriority is the priority of [Source]. Filled in by the [writer.Writer].
 	// This along with [ServiceName] and [Address] form the unique primary key ([BackendKey])
 	// for the backends table.

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -230,6 +230,9 @@ func showBackends(bes BackendsSeq2) string {
 	for be := range bes {
 		if count < maxToShow {
 			b.WriteString(be.Address.String())
+			if be.TopologyDemoted {
+				b.WriteString(" (demoted)")
+			}
 			b.WriteString(", ")
 		}
 		count++

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -1044,10 +1044,14 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 		}
 
 		state := be.State
-		if be.Unhealthy {
-			// We only care about [be.Unhealthy] for the Count/QCount and not for
-			// the state in the backend maps as the backend might be healthy for some
-			// service and unhealthy for another.
+		if be.Unhealthy || be.TopologyDemoted {
+			// We only care about [be.Unhealthy] and [be.TopologyDemoted] for
+			// the Count/QCount and not for the state in the backend maps as
+			// the backend might be healthy for some service and unhealthy for
+			// another, or demoted for this node's topology only. Counting a
+			// demoted backend as quarantined keeps it in the maps (slots
+			// beyond Count) so established connections drain, while new
+			// connections only pick from slots 1..Count.
 			state = loadbalancer.BackendStateQuarantined
 		}
 
@@ -1626,10 +1630,14 @@ func (ops *BPFOps) sortedBackends(fe *loadbalancer.Frontend) []backendWithRevisi
 	}
 	sort.Slice(bes, func(i, j int) bool {
 		a, b := bes[i], bes[j]
+		// Demoted backends sort last together with unhealthy ones so that
+		// slots 1..Count only contain selectable backends.
+		aInactive := a.Unhealthy || a.TopologyDemoted
+		bInactive := b.Unhealthy || b.TopologyDemoted
 		switch {
-		case !a.Unhealthy && b.Unhealthy:
+		case !aInactive && bInactive:
 			return true
-		case a.Unhealthy && !b.Unhealthy:
+		case aInactive && !bInactive:
 			return false
 		case a.State < b.State:
 			return true

--- a/pkg/loadbalancer/tests/testdata/prefer-same-node.txtar
+++ b/pkg/loadbalancer/tests/testdata/prefer-same-node.txtar
@@ -12,7 +12,9 @@ hive start
 k8s/add service.yaml
 k8s/add endpointslice.yaml endpointslice2.yaml
 
-# With PreferSameNode, only the local-node backend should be selected.
+# With PreferSameNode, only the local-node backend is a new-connection
+# candidate; the remote backend stays selected but demoted (kept in the maps
+# outside the new-connection range so established connections can drain).
 db/cmp backends backends.table
 db/cmp frontends frontends-local.table
 
@@ -49,7 +51,7 @@ test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferSameNod
 
 -- frontends-local.table --
 Address               Type        ServiceName   PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP (demoted)
 
 -- frontends-remote.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
@@ -28,7 +28,8 @@ db/cmp frontends frontends-both.table
 # the real EndpointSlice controller would produce for a non-Ready Pod.
 # Pre-fix this would have fallen back to all backends (missingHints=true);
 # post-fix the safeguard ignores the terminating backend and only the
-# Ready zone-local endpoint is selected.
+# Ready zone-local endpoint is a new-connection candidate. The terminating
+# backend stays selected but demoted so its connections can drain.
 cp endpointslice2.yaml endpointslice2-terminating.yaml
 sed 'ready: true' 'ready: false' endpointslice2-terminating.yaml
 sed 'terminating: false' 'terminating: true' endpointslice2-terminating.yaml
@@ -81,7 +82,7 @@ Address               Type        ServiceName   PortName   Status  Backends
 
 -- frontends-only-eps1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP (demoted)
 
 -- frontends-both-terminating.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/tests/testdata/topology-aware.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware.txtar
@@ -72,7 +72,7 @@ test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferClose
 
 -- frontends-foo.table --
 Address               Type        ServiceName   PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP (demoted)
 
 -- frontends-none.table --
 Address               Type        ServiceName   PortName   Status   Backends

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -499,14 +499,18 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 		if candidatesFound {
 			return func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
 				for be, rev := range bes {
-					if be.NodeName != w.nodeName {
-						continue
-					}
 					if !matchesFrontend(be, fe) {
 						continue
 					}
-					if !w.topologyPreferenceCandidate(svc, be) {
-						continue
+					if be.NodeName != w.nodeName ||
+						!w.topologyPreferenceCandidate(svc, be) {
+						// Demote instead of drop: dropping the backend would
+						// remove it from the datapath maps and reset its
+						// established connections. Keep it selected but
+						// outside the new-connection range (see the Count
+						// handling in the BPF reconciler).
+						be = be.Clone()
+						be.TopologyDemoted = true
 					}
 					if !yield(be, rev) {
 						return
@@ -580,7 +584,9 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 			if checkZoneHints {
 				if be.Zone == nil ||
 					!slices.Contains(be.Zone.ForZones, *thisZone) {
-					continue
+					// Demote instead of drop, see above.
+					be = be.Clone()
+					be.TopologyDemoted = true
 				}
 			}
 			if !yield(be, rev) {

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -989,10 +989,17 @@ func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints(t *t
 	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
 
 	// Topology safeguard must remain engaged: only the zone-a Active backend
-	// should be selected. Terminating backends are filtered from primary traffic
-	// because their (possibly empty / nil) ForZones cannot match the local zone.
-	require.Len(t, selected, 1)
-	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
+	// is a new-connection candidate. All other backends stay selected but
+	// demoted so that they remain in the datapath maps (outside the
+	// new-connection range) and their established connections can drain.
+	require.Len(t, selected, 4)
+	for _, be := range selected {
+		if be.Address == activeLocalAddr {
+			assert.False(t, be.TopologyDemoted, "local-zone active backend must not be demoted")
+		} else {
+			assert.True(t, be.TopologyDemoted, "backend %s must be demoted", be.Address.String())
+		}
+	}
 }
 
 // TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating verifies that
@@ -1103,8 +1110,15 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
 
 	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
 
-	// Only the active local backend should be selected.
-	// Terminating local backend must be filtered out.
-	require.Len(t, selected, 1)
-	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
+	// Only the active local backend is a new-connection candidate. The
+	// terminating local backend stays selected but demoted so that it remains
+	// in the datapath maps and its established connections can drain.
+	require.Len(t, selected, 2)
+	for _, be := range selected {
+		if be.Address == activeLocalAddr {
+			assert.False(t, be.TopologyDemoted, "active local backend must not be demoted")
+		} else {
+			assert.True(t, be.TopologyDemoted, "backend %s must be demoted", be.Address.String())
+		}
+	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

**This is a draft PR intended as a discussion vehicle for #<TODO-issue-B-번호>
(design issue). Please read the issue first — it has the evidence and the open
questions.**

When topology-aware routing (`trafficDistribution` / topology hints) de-prefers
a backend, `DefaultSelectBackends` currently drops it from the selection, which
removes it from the BPF maps and resets its established connections (the
datapath re-selects a new backend mid-stream, which RSTs the unknown flow).
This hits healthy Ready cross-zone backends whenever the missing-hints
safeguard re-enables the zone filter at the end of a rolling update, and
terminating backends whenever the filter is engaged.

Instead of dropping, yield the de-preferred backend as a clone marked
`TopologyDemoted`. The BPF reconciler counts demoted backends like quarantined
ones: they stay in the service slots beyond `Count` (and therefore in the
backends map) so established connections keep forwarding, while new
connections are still only picked from slots `1..Count` — preserving the
topology preference. No datapath/BPF changes.

Existing writer unit tests and loadbalancer script tests pass with
expectations updated from "dropped" to "demoted". Known follow-ups if the
direction is agreed (details in the issue): where the per-node demoted
attribute should live, optional grace-period draining, and excluding demoted
backends from quarantine restoration on agent restart.

This PR was prepared with AIL:3 — the patch was drafted with LLM assistance;
the approach, every line of the diff, and the test updates were reviewed by
me, and validated against the upstream unit/script test suites and a live
multi-zone cluster reproduction of the disruption.

Fixes: https://github.com/cilium/cilium/issues/48259
```release-note
Backends de-preferred by topology aware routing (trafficDistribution) are kept
in the load-balancer maps for connection draining instead of being evicted,
so rolling updates no longer reset established cross-zone connections.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
