### PR TITLE
vendor: Bump to StateDB v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v1.0.4
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
-	github.com/cilium/statedb v0.8.4
+	github.com/cilium/statedb v0.9.0
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1 h1:F+SGcs1IpZTuy1bGWBVZQgyr65NiiTOjHli7WExSHnU=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1/go.mod h1:GEiA7dAvPLMMt5drHzjQDAwRtVFcHbVR4ExTN5ISRyg=
-github.com/cilium/statedb v0.8.4 h1:JRexp9zUmGyDVVME3FkU2UcnE4HF54dEDkeUzyroWEI=
-github.com/cilium/statedb v0.8.4/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
+github.com/cilium/statedb v0.9.0 h1:Tnts7Kerm/pfr5pZohjlQsY8tQduHF5iiaLo4Opdfso=
+github.com/cilium/statedb v0.9.0/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/vendor/github.com/cilium/statedb/any_table.go
+++ b/vendor/github.com/cilium/statedb/any_table.go
@@ -22,8 +22,13 @@ func (t AnyTable) NumObjects(txn ReadTxn) int {
 }
 
 func (t AnyTable) All(txn ReadTxn) iter.Seq2[any, Revision] {
-	all, _ := t.AllWatch(txn)
-	return all
+	indexTxn := txn.mustIndexReadTxn(t.Meta, PrimaryIndexPos)
+	all := indexTxn.allNoWatch()
+	return func(yield func(any, Revision) bool) {
+		all.All(func(_ []byte, iobj object) bool {
+			return yield(iobj.data, iobj.revision)
+		})
+	}
 }
 
 func (t AnyTable) AllWatch(txn ReadTxn) (iter.Seq2[any, Revision], <-chan struct{}) {
@@ -42,7 +47,7 @@ func (t AnyTable) UnmarshalYAML(data []byte) (any, error) {
 
 func (t AnyTable) Insert(txn WriteTxn, obj any) (old any, hadOld bool, err error) {
 	var iobj object
-	iobj, hadOld, _, err = txn.unwrap().insert(t.Meta, Revision(0), obj)
+	iobj, hadOld, _, err = txn.unwrap().insert(t.Meta, Revision(0), obj, false)
 	if hadOld {
 		old = iobj.data
 	}
@@ -63,7 +68,7 @@ func (t AnyTable) Get(txn ReadTxn, index string, key string) (any, Revision, boo
 	if err != nil {
 		return nil, 0, false, err
 	}
-	obj, _, found := itxn.get(rawKey)
+	obj, found := itxn.getNoWatch(rawKey)
 	if found {
 		return obj.data, obj.revision, found, nil
 	}
@@ -75,7 +80,7 @@ func (t AnyTable) Prefix(txn ReadTxn, index string, key string) (iter.Seq2[any, 
 	if err != nil {
 		return nil, err
 	}
-	iter, _ := itxn.prefix(rawKey)
+	iter := itxn.prefixNoWatch(rawKey)
 	return objSeq[any](iter), nil
 }
 
@@ -84,7 +89,7 @@ func (t AnyTable) LowerBound(txn ReadTxn, index string, key string) (iter.Seq2[a
 	if err != nil {
 		return nil, err
 	}
-	iter, _ := itxn.lowerBound(rawKey)
+	iter := itxn.lowerBoundNoWatch(rawKey)
 	return objSeq[any](iter), nil
 }
 
@@ -93,7 +98,7 @@ func (t AnyTable) List(txn ReadTxn, index string, key string) (iter.Seq2[any, Re
 	if err != nil {
 		return nil, err
 	}
-	iter, _ := itxn.list(rawKey)
+	iter := itxn.listNoWatch(rawKey)
 	return objSeq[any](iter), nil
 }
 

--- a/vendor/github.com/cilium/statedb/deletetracker.go
+++ b/vendor/github.com/cilium/statedb/deletetracker.go
@@ -37,7 +37,7 @@ func (dt *deleteTracker[Obj]) getRevision() uint64 {
 // called!
 func (dt *deleteTracker[Obj]) deleted(txn ReadTxn, minRevision Revision) *iterator[Obj] {
 	indexEntry := txn.root()[dt.table.tablePos()].indexes[GraveyardRevisionIndexPos]
-	objs, _ := indexEntry.lowerBoundNext(index.Uint64(minRevision))
+	objs := indexEntry.lowerBoundNextNoWatch(index.Uint64(minRevision))
 	return &iterator[Obj]{objs}
 }
 

--- a/vendor/github.com/cilium/statedb/errors.go
+++ b/vendor/github.com/cilium/statedb/errors.go
@@ -20,6 +20,12 @@ var (
 	// ErrPrimaryIndexNotUnique indicates that the primary index for the table is not marked unique.
 	ErrPrimaryIndexNotUnique = errors.New("primary index not unique")
 
+	// ErrPrimaryIndexNotSupported indicates that the index type cannot be used as a primary index.
+	ErrPrimaryIndexNotSupported = errors.New("index type cannot be used as primary index")
+
+	// ErrEmptyIndexName indicates that a table index has an empty name.
+	ErrEmptyIndexName = errors.New("index name is empty")
+
 	// ErrDuplicateIndex indicates that the table has two or more indexers that share the same name.
 	ErrDuplicateIndex = errors.New("index name already in use")
 

--- a/vendor/github.com/cilium/statedb/graveyard.go
+++ b/vendor/github.com/cilium/statedb/graveyard.go
@@ -63,7 +63,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			// to the low watermark.
 			indexTree := rtxn.mustIndexReadTxn(table.meta, GraveyardRevisionIndexPos)
 
-			iter, _ := indexTree.all()
+			iter := indexTree.allNoWatch()
 			for key, obj := range iter.All {
 				if obj.revision > lowWatermark {
 					break

--- a/vendor/github.com/cilium/statedb/http.go
+++ b/vendor/github.com/cilium/statedb/http.go
@@ -131,9 +131,9 @@ type QueryResponse struct {
 func runQuery(reader tableIndexReader, lowerbound bool, queryKey index.Key, onObject func(object) error) {
 	var iter tableIndexIterator
 	if lowerbound {
-		iter, _ = reader.lowerBound(queryKey)
+		iter = reader.lowerBoundNoWatch(queryKey)
 	} else {
-		iter, _ = reader.list(queryKey)
+		iter = reader.listNoWatch(queryKey)
 	}
 	for _, obj := range iter.All {
 		if err := onObject(obj); err != nil {
@@ -170,6 +170,7 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer changeIter.Close()
 
 	w.WriteHeader(http.StatusOK)
 

--- a/vendor/github.com/cilium/statedb/index/set.go
+++ b/vendor/github.com/cilium/statedb/index/set.go
@@ -10,12 +10,12 @@ func Set[T any](s part.Set[T]) KeySet {
 	toBytes := s.ToBytesFunc()
 	switch s.Len() {
 	case 0:
-		return NewKeySet()
+		return KeySet{}
 	case 1:
-		for v := range s.All() {
-			return NewKeySet(toBytes(v))
+		if v, ok := s.First(); ok {
+			return KeySet{head: toBytes(v)}
 		}
-		panic("BUG: Set.Len() == 1, but ranging returned nothing")
+		panic("BUG: Set.Len() == 1, but First returned nothing")
 	default:
 		keys := make([]Key, 0, s.Len())
 		for v := range s.All() {

--- a/vendor/github.com/cilium/statedb/iterator.go
+++ b/vendor/github.com/cilium/statedb/iterator.go
@@ -172,7 +172,7 @@ func (it *changeIterator[Obj]) refresh(txn ReadTxn) {
 		panic(fmt.Sprintf("Table[%T].Changes().Next() called with the target table locked. This is not supported.", obj))
 	}
 	indexEntry := tableEntry.indexes[RevisionIndexPos]
-	updated, _ := indexEntry.lowerBoundNext(index.Uint64(it.revision + 1))
+	updated := indexEntry.lowerBoundNextNoWatch(index.Uint64(it.revision + 1))
 	updateIter := &iterator[Obj]{updated}
 	deleteIter := it.dt.deleted(txn, it.deleteRevision+1)
 	it.iter = newDualIterator(deleteIter, updateIter)
@@ -261,4 +261,5 @@ func (it *changeIterator[Obj]) Close() {
 
 type anyChangeIterator interface {
 	nextAny(ReadTxn) (iter.Seq2[Change[any], Revision], <-chan struct{})
+	Close()
 }

--- a/vendor/github.com/cilium/statedb/lpm/key.go
+++ b/vendor/github.com/cilium/statedb/lpm/key.go
@@ -11,33 +11,61 @@ import (
 	"github.com/cilium/statedb/index"
 )
 
+// NetIPPrefixToIndexKey encodes prefix as an LPM index key. IPv4-mapped IPv6
+// prefixes contained in ::ffff:0:0/96 are canonicalized to IPv4.
 func NetIPPrefixToIndexKey(prefix netip.Prefix) index.Key {
-	addr := prefix.Addr().As16()
-	bits := prefix.Bits()
-	if prefix.Addr().Is4() {
-		// As we're working with the 16-byte format we'll need to add
-		// the 12 bytes of the IPv4-mapped IPv6 address prefix (::FFFF:).
-		bits += 12 * 8
-	}
-	return EncodeLPMKey(
-		addr[:],
-		PrefixLen(bits),
+	const (
+		familyBits           = 8
+		mappedIPv4PrefixBits = 96
 	)
+
+	prefix = prefix.Masked()
+	if prefix.Bits() >= mappedIPv4PrefixBits && prefix.Addr().Is4In6() {
+		prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-mappedIPv4PrefixBits)
+	}
+
+	addr := prefix.Addr()
+	var data [1 + 16]byte
+	if addr.Is4() {
+		data[0] = 4
+		addr4 := addr.As4()
+		copy(data[1:], addr4[:])
+		return mustEncodeLPMKey(data[:1+len(addr4)], PrefixLen(familyBits+prefix.Bits()))
+	}
+
+	data[0] = 6
+	addr16 := addr.As16()
+	copy(data[1:], addr16[:])
+	return mustEncodeLPMKey(data[:1+len(addr16)], PrefixLen(familyBits+prefix.Bits()))
 }
 
 func NetIPPrefix4ToIndexKey(prefix netip.Prefix) index.Key {
 	addr := prefix.Addr().As4()
 	bits := prefix.Bits()
-	return EncodeLPMKey(
+	return mustEncodeLPMKey(
 		addr[:],
 		PrefixLen(bits),
 	)
 }
 
-func EncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
-	dataLen := (prefixLen + 7) / 8
-	if int(dataLen) > len(data) {
-		panic(fmt.Sprintf("invalid LPM key, data too short (%d) for prefix length (%d)", len(data), prefixLen))
+func mustEncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
+	key, err := EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func lpmDataLen(prefixLen PrefixLen) int {
+	return (int(prefixLen) + 7) / 8
+}
+
+// EncodeLPMKey encodes data and its prefix length as an LPM index key. It
+// returns an error if data does not contain enough bits for prefixLen.
+func EncodeLPMKey(data []byte, prefixLen PrefixLen) (index.Key, error) {
+	dataLen := lpmDataLen(prefixLen)
+	if dataLen > len(data) {
+		return nil, fmt.Errorf("invalid LPM key, data too short (%d) for prefix length (%d)", len(data), prefixLen)
 	}
 	key := make(index.Key, dataLen, dataLen+2)
 	copy(key, data[:dataLen])
@@ -46,7 +74,7 @@ func EncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
 			key[dataLen-1] &= 0xff << (8 - rem)
 		}
 	}
-	return binary.BigEndian.AppendUint16(key, prefixLen)
+	return binary.BigEndian.AppendUint16(key, prefixLen), nil
 }
 
 func DecodeLPMKey(key index.Key) (data []byte, prefixLen PrefixLen) {
@@ -55,7 +83,7 @@ func DecodeLPMKey(key index.Key) (data []byte, prefixLen PrefixLen) {
 	}
 	data = key[:len(key)-2]
 	prefixLen = binary.BigEndian.Uint16(key[len(key)-2:])
-	if int((prefixLen+7)/8) > len(data) {
+	if lpmDataLen(prefixLen) > len(data) {
 		panic("prefix length too long in LPM key")
 	}
 	return

--- a/vendor/github.com/cilium/statedb/lpm/trie.go
+++ b/vendor/github.com/cilium/statedb/lpm/trie.go
@@ -232,9 +232,13 @@ func (txn *Txn[T]) Insert(key index.Key, value T) error {
 	// We found a [node] with which we matched fewer bits than are in the [key].
 	// As they can't exist in the same location we'll need to fork the tree
 	// with an imaginary node at the point where their prefixes diverge.
+	imaginaryKey, err := EncodeLPMKey(node.key, matchLen)
+	if err != nil {
+		return err
+	}
 	txn.size++
 	imaginary := &lpmNode[T]{
-		key:       EncodeLPMKey(node.key, matchLen),
+		key:       imaginaryKey,
 		imaginary: true,
 		txnID:     txn.txnID,
 	}
@@ -394,15 +398,15 @@ func (txn *Txn[T]) Prefix(key index.Key) *Iterator[T] {
 	var matchLen PrefixLen
 	for node != nil {
 		matchLen = longestMatch(matchLen, node, data, prefixLen)
-		if matchLen == prefixLen || matchLen < node.prefixLen() {
-			break
+		if matchLen == prefixLen {
+			return &Iterator[T]{start: node}
+		}
+		if matchLen < node.prefixLen() {
+			return nil
 		}
 		node = node.children[getBitAt(data, node.prefixLen())]
 	}
-	if node == nil {
-		return nil
-	}
-	return &Iterator[T]{start: node}
+	return nil
 }
 
 func (txn *Txn[T]) LowerBound(key index.Key) *Iterator[T] {
@@ -477,7 +481,10 @@ func lpmLookup[T any](root *lpmNode[T], key index.Key) (value T, ok bool) {
 		nodePrefixLen := node.prefixLen()
 		matchLen := longestMatch(currentLen, node, keyData, keyPrefixLen)
 		if matchLen == keyPrefixLen {
-			return node.value, !node.imaginary
+			if matchLen == nodePrefixLen && !node.imaginary {
+				return node.value, true
+			}
+			break
 		}
 		if matchLen < nodePrefixLen {
 			break

--- a/vendor/github.com/cilium/statedb/lpm/validate.go
+++ b/vendor/github.com/cilium/statedb/lpm/validate.go
@@ -43,7 +43,7 @@ func validateTrie[T any](node *lpmNode[T], parents []*lpmNode[T], maxTxnID uint6
 	}
 
 	data, prefixLen := DecodeLPMKey(node.key)
-	dataLen := int((prefixLen + 7) / 8)
+	dataLen := lpmDataLen(prefixLen)
 	assert(len(node.key) == dataLen+2, "key length mismatch for %s", showKey(node.key))
 	assert(len(data) == dataLen, "key data length mismatch for %s", showKey(node.key))
 

--- a/vendor/github.com/cilium/statedb/lpm_index.go
+++ b/vendor/github.com/cilium/statedb/lpm_index.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cilium/statedb/lpm"
 )
 
-// NetIPPrefixIndex indexes objects with a [netip.Prefix] in a LPM
-// index.
+// NetIPPrefixIndex indexes objects with a [netip.Prefix] in a LPM index.
+// IPv4-mapped IPv6 addresses and prefixes are canonicalized to IPv4.
 type NetIPPrefixIndex[Obj any] struct {
 	// Name of the index
 	Name string
@@ -29,10 +29,9 @@ type NetIPPrefixIndex[Obj any] struct {
 }
 
 func (a NetIPPrefixIndex[Obj]) Query(addr netip.Addr) Query[Obj] {
-	addr16 := addr.As16()
 	return Query[Obj]{
 		index: a.Name,
-		key:   lpm.EncodeLPMKey(addr16[:], 128),
+		key:   lpm.NetIPPrefixToIndexKey(netip.PrefixFrom(addr, addr.BitLen())),
 	}
 }
 
@@ -85,6 +84,8 @@ func (a NetIPPrefixIndex[Obj]) isIndexerOf(Obj) {
 	panic("isIndexerOf")
 }
 
+func (a NetIPPrefixIndex[Obj]) secondaryOnly() {}
+
 func (i NetIPPrefixIndex[Obj]) isUnique() bool {
 	return i.Unique
 }
@@ -128,13 +129,15 @@ func (l LPMIndex[Obj]) isIndexerOf(Obj) {
 	panic("isIndexerOf")
 }
 
+func (l LPMIndex[Obj]) secondaryOnly() {}
+
 // fromString implements Indexer.
 func (l LPMIndex[Obj]) fromString(s string) (index.Key, error) {
 	data, plen, err := l.FromString(s)
 	if err != nil {
 		return index.Key{}, err
 	}
-	return lpm.EncodeLPMKey(data, plen), nil
+	return lpm.EncodeLPMKey(data, plen)
 }
 
 // indexName implements Indexer.
@@ -149,19 +152,24 @@ func (l LPMIndex[Obj]) ObjectToKey(obj Obj) index.Key {
 	return nil
 }
 
-// Query constructs a query against the index with the given prefix.
-func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) Query[Obj] {
+// Query constructs a query against the index with the given prefix. It returns
+// an error if data does not contain enough bits for prefixLen.
+func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) (Query[Obj], error) {
+	key, err := lpm.EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		return Query[Obj]{}, err
+	}
 	return Query[Obj]{
 		index: l.Name,
-		key:   lpm.EncodeLPMKey(data, prefixLen),
-	}
+		key:   key,
+	}, nil
 }
 
 func (l LPMIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
 	for key, length := range l.FromObject(obj) {
 		return Query[Obj]{
 			index: l.Name,
-			key:   lpm.EncodeLPMKey(key, length),
+			key:   mustEncodeLPMKey(key, length),
 		}
 	}
 	return Query[Obj]{}
@@ -175,7 +183,7 @@ func (l LPMIndex[Obj]) newTableIndex() tableIndex {
 		objectToKeys: func(obj object) index.KeySet {
 			keys := make([]index.Key, 0, 2)
 			for data, prefixLen := range l.FromObject(obj.data.(Obj)) {
-				keys = append(keys, lpm.EncodeLPMKey(data, prefixLen))
+				keys = append(keys, mustEncodeLPMKey(data, prefixLen))
 			}
 			return index.NewKeySet(keys...)
 		},
@@ -185,6 +193,14 @@ func (l LPMIndex[Obj]) newTableIndex() tableIndex {
 
 func (l LPMIndex[Obj]) isUnique() bool {
 	return l.Unique
+}
+
+func mustEncodeLPMKey(data []byte, prefixLen lpm.PrefixLen) index.Key {
+	key, err := lpm.EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		panic(err)
+	}
+	return key
 }
 
 var _ Indexer[struct{}] = LPMIndex[struct{}]{}
@@ -200,7 +216,11 @@ type lpmIndex struct {
 
 // all implements tableIndex.
 func (l lpmIndex) all() (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.All()), l.watch
+	return newLPMIterator(l.lpm.All(), !l.unique), l.watch
+}
+
+func (l lpmIndex) allNoWatch() tableIndexIterator {
+	return newLPMIterator(l.lpm.All(), !l.unique)
 }
 
 // get implements tableIndex.
@@ -213,6 +233,14 @@ func (l lpmIndex) get(ikey index.Key) (object, <-chan struct{}, bool) {
 		return obj, l.watch, true
 	}
 	return object{}, l.watch, false
+}
+
+func (l lpmIndex) getNoWatch(ikey index.Key) (object, bool) {
+	entry, found := l.lpm.Lookup(ikey)
+	if !found {
+		return object{}, false
+	}
+	return entry.first()
 }
 
 // len implements tableIndex.
@@ -229,14 +257,30 @@ func (l lpmIndex) list(key index.Key) (tableIndexIterator, <-chan struct{}) {
 	return &entry, l.watch
 }
 
+func (l lpmIndex) listNoWatch(key index.Key) tableIndexIterator {
+	entry, found := l.lpm.Lookup(key)
+	if !found || entry.len() == 0 {
+		return emptyTableIndexIterator
+	}
+	return &entry
+}
+
 // lowerBound implements tableIndex.
 func (l lpmIndex) lowerBound(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.LowerBound(key)), l.watch
+	return newLPMIterator(l.lpm.LowerBound(key), !l.unique), l.watch
+}
+
+func (l lpmIndex) lowerBoundNoWatch(key index.Key) tableIndexIterator {
+	return newLPMIterator(l.lpm.LowerBound(key), !l.unique)
 }
 
 // lowerBoundNext implements tableIndexTxn.
 func (l lpmIndex) lowerBoundNext(key index.Key) (func() ([]byte, object, bool), <-chan struct{}) {
 	return newLPMNextFunc(l.lpm.LowerBound(key)), l.watch
+}
+
+func (l lpmIndex) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, bool) {
+	return newLPMNextFunc(l.lpm.LowerBound(key))
 }
 
 // objectToKey implements tableIndex.
@@ -246,7 +290,11 @@ func (l lpmIndex) objectToKey(obj object) index.Key {
 
 // prefix implements tableIndex.
 func (l lpmIndex) prefix(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.Prefix(key)), l.watch
+	return newLPMIterator(l.lpm.Prefix(key), !l.unique), l.watch
+}
+
+func (l lpmIndex) prefixNoWatch(key index.Key) tableIndexIterator {
+	return newLPMIterator(l.lpm.Prefix(key), !l.unique)
 }
 
 // rootWatch implements tableIndex.
@@ -284,7 +332,11 @@ type lpmIndexTxn struct {
 
 // all implements tableIndexTxn.
 func (l *lpmIndexTxn) all() (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.All()), l.index.watch
+	return newLPMIterator(l.tx.All(), !l.index.unique), l.index.watch
+}
+
+func (l *lpmIndexTxn) allNoWatch() tableIndexIterator {
+	return newLPMIterator(l.tx.All(), !l.index.unique)
 }
 
 // commit implements tableIndexTxn.
@@ -311,8 +363,16 @@ func (l *lpmIndexTxn) insert(key index.Key, obj object) (old object, hadOld bool
 	panic("LPM index cannot be the primary index")
 }
 
+func (l *lpmIndexTxn) insertNoWatch(key index.Key, obj object) (old object, hadOld bool) {
+	panic("LPM index cannot be the primary index")
+}
+
 // modify implements tableIndexTxn.
 func (l *lpmIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool, watch <-chan struct{}) {
+	panic("LPM index cannot be the primary index")
+}
+
+func (l *lpmIndexTxn) modifyNoWatch(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool) {
 	panic("LPM index cannot be the primary index")
 }
 
@@ -326,6 +386,14 @@ func (l *lpmIndexTxn) get(key index.Key) (object, <-chan struct{}, bool) {
 		return obj, l.index.watch, true
 	}
 	return object{}, l.index.watch, false
+}
+
+func (l *lpmIndexTxn) getNoWatch(key index.Key) (object, bool) {
+	entry, found := l.tx.Lookup(key)
+	if !found {
+		return object{}, false
+	}
+	return entry.first()
 }
 
 // len implements tableIndexTxn.
@@ -342,14 +410,30 @@ func (l *lpmIndexTxn) list(key index.Key) (tableIndexIterator, <-chan struct{}) 
 	return &entry, l.index.watch
 }
 
+func (l *lpmIndexTxn) listNoWatch(key index.Key) tableIndexIterator {
+	entry, found := l.tx.Lookup(key)
+	if !found || entry.len() == 0 {
+		return emptyTableIndexIterator
+	}
+	return &entry
+}
+
 // lowerBound implements tableIndexTxn.
 func (l *lpmIndexTxn) lowerBound(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.LowerBound(key)), l.index.watch
+	return newLPMIterator(l.tx.LowerBound(key), !l.index.unique), l.index.watch
+}
+
+func (l *lpmIndexTxn) lowerBoundNoWatch(key index.Key) tableIndexIterator {
+	return newLPMIterator(l.tx.LowerBound(key), !l.index.unique)
 }
 
 // lowerBoundNext implements tableIndexTxn.
 func (l *lpmIndexTxn) lowerBoundNext(key index.Key) (func() ([]byte, object, bool), <-chan struct{}) {
 	return newLPMNextFunc(l.tx.LowerBound(key)), l.index.watch
+}
+
+func (l *lpmIndexTxn) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, bool) {
+	return newLPMNextFunc(l.tx.LowerBound(key))
 }
 
 // notify implements tableIndexTxn.
@@ -367,7 +451,11 @@ func (l *lpmIndexTxn) objectToKey(obj object) index.Key {
 
 // prefix implements tableIndexTxn.
 func (l *lpmIndexTxn) prefix(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.Prefix(key)), l.index.watch
+	return newLPMIterator(l.tx.Prefix(key), !l.index.unique), l.index.watch
+}
+
+func (l *lpmIndexTxn) prefixNoWatch(key index.Key) tableIndexIterator {
+	return newLPMIterator(l.tx.Prefix(key), !l.index.unique)
 }
 
 // reindex implements tableIndexTxn.
@@ -498,12 +586,14 @@ func (e *lpmEntry) upsert(primaryKey index.Key, obj object) bool {
 	case -1:
 		oldHead := e.head
 		e.head = lpmEntryObject{primary: primaryKey, obj: obj}
+		e.tail = slices.Clone(e.tail)
 		e.tail = append(e.tail, lpmEntryObject{})
 		copy(e.tail[1:], e.tail[:len(e.tail)-1])
 		e.tail[0] = oldHead
 		return true
 	}
 	idx, found := e.searchTail(primaryKey)
+	e.tail = slices.Clone(e.tail)
 	if found {
 		e.tail[idx].obj = obj
 		return false
@@ -583,17 +673,38 @@ func (e *lpmEntry) appendObjects(dst []object) []object {
 }
 
 type lpmIteratorAdapter struct {
-	iter *lpm.Iterator[lpmEntry]
+	iter        *lpm.Iterator[lpmEntry]
+	deduplicate bool
 }
 
-func newLPMIterator(iter *lpm.Iterator[lpmEntry]) tableIndexIterator {
-	return &lpmIteratorAdapter{iter: iter}
+func newLPMIterator(iter *lpm.Iterator[lpmEntry], deduplicate bool) tableIndexIterator {
+	return &lpmIteratorAdapter{iter: iter, deduplicate: deduplicate}
 }
 
 func (l *lpmIteratorAdapter) All(yield func([]byte, object) bool) {
+	var visited map[string]struct{}
+	if l.deduplicate {
+		visited = map[string]struct{}{}
+	}
+	emit := func(key []byte, entry lpmEntryObject) bool {
+		if visited != nil {
+			primary := string(entry.primary)
+			if _, found := visited[primary]; found {
+				return true
+			}
+			visited[primary] = struct{}{}
+		}
+		return yield(key, entry.obj)
+	}
 	l.iter.All(func(key []byte, entry lpmEntry) bool {
-		for _, obj := range entry.All {
-			if !yield(key, obj) {
+		if !entry.used {
+			return true
+		}
+		if !emit(key, entry.head) {
+			return false
+		}
+		for _, obj := range entry.tail {
+			if !emit(key, obj) {
 				return false
 			}
 		}

--- a/vendor/github.com/cilium/statedb/part/iterator.go
+++ b/vendor/github.com/cilium/statedb/part/iterator.go
@@ -138,7 +138,7 @@ func newIterator[T any](start *header[T]) Iterator[T] {
 	return Iterator[T]{start: start}
 }
 
-func prefixSearch[T any](root *header[T], rootWatch <-chan struct{}, prefix []byte) (Iterator[T], <-chan struct{}) {
+func prefixSearch[T any](root *header[T], rootWatch *watchState, prefix []byte) (Iterator[T], *watchState) {
 	if root == nil {
 		return newIterator[T](nil), rootWatch
 	}

--- a/vendor/github.com/cilium/statedb/part/map.go
+++ b/vendor/github.com/cilium/statedb/part/map.go
@@ -75,7 +75,7 @@ func (m Map[K, V]) Get(key K) (value V, found bool) {
 	if !m.hasTree {
 		return
 	}
-	kv, _, found := m.tree.Get(m.keyToBytes(key))
+	kv, found := m.tree.Get(m.keyToBytes(key))
 	return kv.Value, found
 }
 
@@ -178,7 +178,7 @@ func (m Map[K, V]) Prefix(prefix K) iter.Seq2[K, V] {
 	if !m.hasTree {
 		return toSeq2[K, V](Iterator[mapKVPair[K, V]]{})
 	}
-	iter, _ := m.tree.Prefix(m.keyToBytes(prefix))
+	iter := m.tree.Prefix(m.keyToBytes(prefix))
 	return toSeq2(iter)
 }
 
@@ -442,14 +442,14 @@ func (txn MapTxn[K, V]) Delete(key K) bool {
 
 // Get a value from the map by its key.
 func (txn MapTxn[K, V]) Get(key K) (value V, found bool) {
-	kv, _, found := txn.txn.Get(txn.bytesFromKeyFunc(key))
+	kv, found := txn.txn.Get(txn.bytesFromKeyFunc(key))
 	return kv.Value, found
 }
 
 // Prefix iterates in order over all keys that start with
 // the given prefix.
 func (txn MapTxn[K, V]) Prefix(prefix K) iter.Seq2[K, V] {
-	iter, _ := txn.txn.Prefix(txn.bytesFromKeyFunc(prefix))
+	iter := txn.txn.Prefix(txn.bytesFromKeyFunc(prefix))
 	return toSeq2(iter)
 }
 

--- a/vendor/github.com/cilium/statedb/part/node.go
+++ b/vendor/github.com/cilium/statedb/part/node.go
@@ -6,6 +6,7 @@ package part
 import (
 	"bytes"
 	"fmt"
+	"math/bits"
 	"strings"
 	"unsafe"
 )
@@ -17,7 +18,8 @@ const (
 	nodeKindLeaf
 	nodeKind4
 	nodeKind16
-	nodeKind48
+	nodeKind64
+	nodeKind128
 	nodeKind256
 )
 
@@ -25,8 +27,8 @@ const (
 type header[T any] struct {
 	flags     uint16 // kind(4b) | unused(3b) | size(9b)
 	prefixLen uint16
-	prefixP   *byte         // the compressed prefix, [0] is the key
-	watch     chan struct{} // watch channel that is closed when this node mutates
+	prefixP   *byte       // the compressed prefix, [0] is the key
+	watch     *watchState // watch that is closed when this node mutates
 }
 
 func (n *header[T]) key() byte {
@@ -70,8 +72,10 @@ func (n *header[T]) cap() int {
 		return 4
 	case nodeKind16:
 		return 16
-	case nodeKind48:
-		return 48
+	case nodeKind64:
+		return 64
+	case nodeKind128:
+		return 128
 	case nodeKind256:
 		return 256
 	default:
@@ -91,8 +95,10 @@ func (n *header[T]) getLeaf() *leaf[T] {
 		return n.node4().leaf
 	case nodeKind16:
 		return n.node16().leaf
-	case nodeKind48:
-		return n.node48().leaf
+	case nodeKind64:
+		return n.node64().leaf
+	case nodeKind128:
+		return n.node128().leaf
 	case nodeKind256:
 		return n.node256().leaf
 	default:
@@ -108,8 +114,10 @@ func (n *header[T]) setLeaf(l *leaf[T]) {
 		n.node4().leaf = l
 	case nodeKind16:
 		n.node16().leaf = l
-	case nodeKind48:
-		n.node48().leaf = l
+	case nodeKind64:
+		n.node64().leaf = l
+	case nodeKind128:
+		n.node128().leaf = l
 	case nodeKind256:
 		n.node256().leaf = l
 	default:
@@ -137,8 +145,12 @@ func (n *header[T]) node16() *node16[T] {
 	return (*node16[T])(unsafe.Pointer(n))
 }
 
-func (n *header[T]) node48() *node48[T] {
-	return (*node48[T])(unsafe.Pointer(n))
+func (n *header[T]) node64() *node64[T] {
+	return (*node64[T])(unsafe.Pointer(n))
+}
+
+func (n *header[T]) node128() *node128[T] {
+	return (*node128[T])(unsafe.Pointer(n))
 }
 
 func (n *header[T]) node256() *node256[T] {
@@ -153,8 +165,10 @@ func (n *header[T]) txnID() uint64 {
 		return n.node4().txnID
 	case nodeKind16:
 		return n.node16().txnID
-	case nodeKind48:
-		return n.node48().txnID
+	case nodeKind64:
+		return n.node64().txnID
+	case nodeKind128:
+		return n.node128().txnID
 	case nodeKind256:
 		return n.node256().txnID
 	default:
@@ -170,8 +184,10 @@ func (n *header[T]) setTxnID(txnID uint64) {
 		n.node4().txnID = txnID
 	case nodeKind16:
 		n.node16().txnID = txnID
-	case nodeKind48:
-		n.node48().txnID = txnID
+	case nodeKind64:
+		n.node64().txnID = txnID
+	case nodeKind128:
+		n.node128().txnID = txnID
 	case nodeKind256:
 		n.node256().txnID = txnID
 	default:
@@ -194,9 +210,12 @@ func (n *header[T]) clone(watch bool) *header[T] {
 	case nodeKind16:
 		n16 := *n.node16()
 		nCopy = (&n16).self()
-	case nodeKind48:
-		n48 := *n.node48()
-		nCopy = (&n48).self()
+	case nodeKind64:
+		n64 := *n.node64()
+		nCopy = (&n64).self()
+	case nodeKind128:
+		n128 := *n.node128()
+		nCopy = (&n128).self()
 	case nodeKind256:
 		nCopy256 := *n.node256()
 		nCopy = (&nCopy256).self()
@@ -204,7 +223,7 @@ func (n *header[T]) clone(watch bool) *header[T] {
 		panic(fmt.Sprintf("unknown node kind: %x", n.kind()))
 	}
 	if watch {
-		nCopy.watch = make(chan struct{})
+		nCopy.watch = newWatchState()
 	} else {
 		nCopy.watch = nil
 	}
@@ -221,7 +240,7 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 		node4.txnID = txnID
 		node4.setKind(nodeKind4)
 		if n.watch != nil {
-			node4.watch = make(chan struct{})
+			node4.watch = newWatchState()
 		}
 		return node4.self()
 	case nodeKind4:
@@ -234,25 +253,37 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 		copy(node16.children[:], node4.children[:size])
 		copy(node16.keys[:], node4.keys[:size])
 		if n.watch != nil {
-			node16.watch = make(chan struct{})
+			node16.watch = newWatchState()
 		}
 		return node16.self()
 	case nodeKind16:
 		node16 := n.node16()
-		node48 := &node48[T]{header: *n}
-		node48.txnID = txnID
-		node48.setKind(nodeKind48)
-		node48.leaf = n.getLeaf()
-		copy(node48.children[:], node16.children[:node16.size()])
-		for i, k := range node16.keys[:node16.size()] {
-			node48.index[k] = uint8(i + 1)
+		node64 := &node64[T]{header: *n}
+		node64.txnID = txnID
+		node64.setKind(nodeKind64)
+		node64.leaf = n.getLeaf()
+		copy(node64.children[:], node16.children[:node16.size()])
+		for _, k := range node16.keys[:node16.size()] {
+			node64.bitmap[k/64] |= uint64(1) << (k % 64)
 		}
 		if n.watch != nil {
-			node48.watch = make(chan struct{})
+			node64.watch = newWatchState()
 		}
-		return node48.self()
-	case nodeKind48:
-		node48 := n.node48()
+		return node64.self()
+	case nodeKind64:
+		node64 := n.node64()
+		node128 := &node128[T]{header: *n}
+		node128.txnID = txnID
+		node128.setKind(nodeKind128)
+		node128.leaf = n.getLeaf()
+		copy(node128.children[:], node64.children[:node64.size()])
+		node128.bitmap = node64.bitmap
+		if n.watch != nil {
+			node128.watch = newWatchState()
+		}
+		return node128.self()
+	case nodeKind128:
+		node128 := n.node128()
 		node256 := &node256[T]{header: *n}
 		node256.txnID = txnID
 		node256.setKind(nodeKind256)
@@ -260,11 +291,11 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 
 		// Since Node256 has children indexed directly, iterate over the children
 		// to assign them to the right index.
-		for _, child := range node48.children[:node48.size()] {
+		for _, child := range node128.children[:node128.size()] {
 			node256.children[child.prefix()[0]] = child
 		}
 		if n.watch != nil {
-			node256.watch = make(chan struct{})
+			node256.watch = newWatchState()
 		}
 		return node256.self()
 	case nodeKind256:
@@ -274,13 +305,24 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 	}
 }
 
-func isClosedChan(ch <-chan struct{}) bool {
-	select {
-	case <-ch:
-		return true
-	default:
-		return false
+// bitmapIndex returns the packed child index for key and whether key is present.
+func bitmapIndex(bitmap *[4]uint64, key byte) (idx int, found bool) {
+	word := key / 64
+	bit := uint(key % 64)
+	mask := uint64(1) << bit
+	found = bitmap[word]&mask != 0
+	idx = bits.OnesCount64(bitmap[word] & (mask - 1))
+	switch word {
+	case 3:
+		idx += bits.OnesCount64(bitmap[2])
+		fallthrough
+	case 2:
+		idx += bits.OnesCount64(bitmap[1])
+		fallthrough
+	case 1:
+		idx += bits.OnesCount64(bitmap[0])
 	}
+	return
 }
 
 func (n *header[T]) printTree(level int) {
@@ -299,9 +341,12 @@ func (n *header[T]) printTree(level int) {
 	case nodeKind16:
 		fmt.Printf("node16[%x]:", n.prefix())
 		children = n.node16().children[:n.size()]
-	case nodeKind48:
-		fmt.Printf("node48[%x]:", n.prefix())
-		children = n.node48().children[:n.size()]
+	case nodeKind64:
+		fmt.Printf("node64[%x]:", n.prefix())
+		children = n.node64().children[:n.size()]
+	case nodeKind128:
+		fmt.Printf("node128[%x]:", n.prefix())
+		children = n.node128().children[:n.size()]
 	case nodeKind256:
 		fmt.Printf("node256[%x]:", n.prefix())
 		children = n.node256().children[:]
@@ -309,9 +354,9 @@ func (n *header[T]) printTree(level int) {
 		panic("unknown node kind")
 	}
 	if leaf := n.getLeaf(); leaf != nil {
-		fmt.Printf(" %x -> %v (L:%p W:%p %v)", leaf.fullKey(), leaf.value, leaf, leaf.watch, isClosedChan(leaf.watch))
+		fmt.Printf(" %x -> %v (L:%p W:%p %v)", leaf.fullKey(), leaf.value, leaf, leaf.watch, leaf.watch.isClosed())
 	}
-	fmt.Printf(" (N:%p, W:%p %v)\n", n, n.watch, isClosedChan(n.watch))
+	fmt.Printf(" (N:%p, W:%p %v)\n", n, n.watch, n.watch.isClosed())
 
 	for _, child := range children {
 		if child != nil {
@@ -328,8 +373,10 @@ func (n *header[T]) children() []*header[T] {
 		return n.node4().children[0:n.size():4]
 	case nodeKind16:
 		return n.node16().children[0:n.size():16]
-	case nodeKind48:
-		return n.node48().children[0:n.size():48]
+	case nodeKind64:
+		return n.node64().children[0:n.size():64]
+	case nodeKind128:
+		return n.node128().children[0:n.size():128]
 	case nodeKind256:
 		return n.node256().children[:]
 	default:
@@ -372,35 +419,20 @@ func (n *header[T]) findIndex(key byte) (*header[T], int) {
 			}
 		}
 		return nil, size
-	case nodeKind48:
-		n48 := n.node48()
-		// Check for exact match first
-		if idx := n48.index[key]; idx != 0 {
-			i := int(idx - 1)
-			return n48.children[i], i
+	case nodeKind64:
+		n64 := n.node64()
+		idx, found := bitmapIndex(&n64.bitmap, key)
+		if found {
+			return n64.children[idx], idx
 		}
-		// No exact match. Binary search to find insertion point.
-		size := n48.size()
-		children := n48.children[:size]
-		// Is the key between smallest and highest?
-		switch {
-		case key < children[0].key():
-			return nil, 0
-		case key > children[size-1].key():
-			return nil, size
+		return nil, idx
+	case nodeKind128:
+		n128 := n.node128()
+		idx, found := bitmapIndex(&n128.bitmap, key)
+		if found {
+			return n128.children[idx], idx
 		}
-		// No exact match, but key is in range. Binary search to find insertion point.
-		// We're not using sort.Search as that requires a function closure.
-		lo, hi := 0, size
-		for lo < hi {
-			mid := int(uint(lo+hi) / 2)
-			if children[mid].key() < key {
-				lo = mid + 1
-			} else {
-				hi = mid
-			}
-		}
-		return nil, lo
+		return nil, idx
 	case nodeKind256:
 		return n.node256().children[key], int(key)
 	default:
@@ -432,13 +464,20 @@ func (n *header[T]) find(key byte) *header[T] {
 			return n16.children[idx]
 		}
 		return nil
-	case nodeKind48:
-		n48 := n.node48()
-		idx := n48.index[key]
-		if idx == 0 {
+	case nodeKind64:
+		n64 := n.node64()
+		idx, found := bitmapIndex(&n64.bitmap, key)
+		if !found {
 			return nil
 		}
-		return n48.children[idx-1]
+		return n64.children[idx]
+	case nodeKind128:
+		n128 := n.node128()
+		idx, found := bitmapIndex(&n128.bitmap, key)
+		if !found {
+			return nil
+		}
+		return n128.children[idx]
 	case nodeKind256:
 		return n.node256().children[key]
 	default:
@@ -464,16 +503,20 @@ func (n *header[T]) insert(idx int, child *header[T]) {
 		copy(n16.keys[idx+1:newSize], n16.keys[idx:newSize])
 		n16.children[idx] = child
 		n16.keys[idx] = child.key()
-	case nodeKind48:
+	case nodeKind64:
 		// Shift to make room
-		n48 := n.node48()
-		for i := size - 1; i >= idx; i-- {
-			c := n48.children[i]
-			n48.index[c.key()] = uint8(i + 2)
-			n48.children[i+1] = c
-		}
-		n48.children[idx] = child
-		n48.index[child.key()] = uint8(idx + 1)
+		n64 := n.node64()
+		copy(n64.children[idx+1:newSize], n64.children[idx:size])
+		n64.children[idx] = child
+		key := child.key()
+		n64.bitmap[key/64] |= uint64(1) << (key % 64)
+	case nodeKind128:
+		// Shift to make room
+		n128 := n.node128()
+		copy(n128.children[idx+1:newSize], n128.children[idx:size])
+		n128.children[idx] = child
+		key := child.key()
+		n128.bitmap[key/64] |= uint64(1) << (key % 64)
 	case nodeKind256:
 		n.node256().children[child.key()] = child
 	default:
@@ -499,16 +542,19 @@ func (n *header[T]) remove(idx int) {
 		copy(n16.children[idx:size], n16.children[idx+1:size])
 		n16.children[newSize] = nil
 		n16.keys[newSize] = 255
-	case nodeKind48:
+	case nodeKind64:
 		children := n.children()
 		key := children[idx].key()
-		n48 := n.node48()
-		for i := idx; i < newSize; i++ {
-			child := children[i+1]
-			children[i] = child
-			n48.index[child.key()] = uint8(i + 1)
-		}
-		n48.index[key] = 0
+		n64 := n.node64()
+		copy(children[idx:newSize], children[idx+1:newSize+1])
+		n64.bitmap[key/64] &^= uint64(1) << (key % 64)
+		children[newSize] = nil
+	case nodeKind128:
+		children := n.children()
+		key := children[idx].key()
+		n128 := n.node128()
+		copy(children[idx:newSize], children[idx+1:newSize+1])
+		n128.bitmap[key/64] &^= uint64(1) << (key % 64)
 		children[newSize] = nil
 	case nodeKind256:
 		n.node256().children[idx] = nil
@@ -538,7 +584,7 @@ func newLeaf[T any](o options, prefix, key []byte, value T) *leaf[T] {
 	leaf.setPrefix(prefix)
 	leaf.setKind(nodeKindLeaf)
 	if !o.rootOnlyWatch() {
-		leaf.watch = make(chan struct{})
+		leaf.watch = newWatchState()
 	}
 
 	return leaf
@@ -560,12 +606,20 @@ type node16[T any] struct {
 	keys     [16]byte
 }
 
-type node48[T any] struct {
+type node64[T any] struct {
 	header[T]
 	txnID    uint64 // transaction ID that last mutated this node
-	children [48]*header[T]
-	leaf     *leaf[T]   // non-nil if this node contains a value
-	index    [256]uint8 // 1-based index for key in [children] (0 is absent, 1 is children[0])
+	children [64]*header[T]
+	leaf     *leaf[T] // non-nil if this node contains a value
+	bitmap   [4]uint64
+}
+
+type node128[T any] struct {
+	header[T]
+	txnID    uint64 // transaction ID that last mutated this node
+	children [128]*header[T]
+	leaf     *leaf[T] // non-nil if this node contains a value
+	bitmap   [4]uint64
 }
 
 type node256[T any] struct {
@@ -575,7 +629,7 @@ type node256[T any] struct {
 	children [256]*header[T]
 }
 
-func search[T any](root *header[T], rootWatch <-chan struct{}, key []byte) (value T, watch <-chan struct{}, ok bool) {
+func search[T any](root *header[T], rootWatch *watchState, key []byte) (value T, watch *watchState, ok bool) {
 	this := root
 	watch = rootWatch
 	if root == nil {

--- a/vendor/github.com/cilium/statedb/part/ops.go
+++ b/vendor/github.com/cilium/statedb/part/ops.go
@@ -10,15 +10,19 @@ type Ops[T any] interface {
 	Len() int
 
 	// Get fetches the value associated with the given key.
-	// Returns the value, a watch channel (which is closed on
-	// modification to the key) and boolean which is true if
-	// value was found.
-	Get(key []byte) (T, <-chan struct{}, bool)
+	Get(key []byte) (T, bool)
 
-	// Prefix returns an iterator for all objects that starts with the
-	// given prefix, and a channel that closes when any objects matching
-	// the given prefix are upserted or deleted.
-	Prefix(key []byte) (Iterator[T], <-chan struct{})
+	// GetWatch fetches the value and returns a channel that closes when the
+	// key is modified.
+	GetWatch(key []byte) (T, <-chan struct{}, bool)
+
+	// Prefix returns an iterator for all objects that start with the given
+	// prefix.
+	Prefix(key []byte) Iterator[T]
+
+	// PrefixWatch returns matching objects and a channel that closes when any
+	// matching object is upserted or deleted.
+	PrefixWatch(key []byte) (Iterator[T], <-chan struct{})
 
 	// LowerBound returns an iterator for all objects that have a
 	// key equal or higher than the given 'key'.

--- a/vendor/github.com/cilium/statedb/part/registry.go
+++ b/vendor/github.com/cilium/statedb/part/registry.go
@@ -10,12 +10,15 @@ import (
 	"reflect"
 	"sync"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // keyTypeRegistry is a registry of functions to convert to/from keys (of type K).
 // This mechanism enables use of zero value and JSON marshalling and unmarshalling
 // with Map and Set.
 var keyTypeRegistry sync.Map // map[reflect.Type]func(K) []byte
+
+var emptyStringKey = []byte{}
 
 // RegisterKeyType registers a new key type to be used with the Map and Set types.
 // Intended to be called from init() functions.
@@ -39,7 +42,13 @@ func lookupKeyType[K any]() func(K) []byte {
 
 func init() {
 	// Register common key types.
-	RegisterKeyType[string](func(s string) []byte { return []byte(s) })
+	RegisterKeyType[string](func(s string) []byte {
+		// Keys are immutable, so it is safe to avoid copying the string.
+		if len(s) == 0 {
+			return emptyStringKey
+		}
+		return unsafe.Slice(unsafe.StringData(s), len(s))
+	})
 	RegisterKeyType[[]byte](func(b []byte) []byte { return b })
 	RegisterKeyType[byte](func(b byte) []byte { return []byte{b} })
 	RegisterKeyType[rune](func(r rune) []byte { return utf8.AppendRune(nil, r) })

--- a/vendor/github.com/cilium/statedb/part/set.go
+++ b/vendor/github.com/cilium/statedb/part/set.go
@@ -20,9 +20,10 @@ import (
 // function for T have been registered with RegisterKeyType.
 // For Set-only use only [bytesFromKey] needs to be defined.
 type Set[T any] struct {
-	toBytes func(T) []byte
-	tree    Tree[T]
-	hasTree bool
+	toBytes   func(T) []byte
+	singleton *T
+	tree      Tree[T]
+	hasTree   bool
 }
 
 // NewSet creates a new set of T.
@@ -31,7 +32,12 @@ func NewSet[T any](values ...T) Set[T] {
 	if len(values) == 0 {
 		return Set[T]{}
 	}
-	s := Set[T]{}
+	s := Set[T]{toBytes: lookupKeyType[T]()}
+	if len(values) == 1 {
+		value := values[0]
+		s.singleton = &value
+		return s
+	}
 	s.ensureTree()
 	txn := s.tree.Txn()
 	for _, v := range values {
@@ -46,14 +52,34 @@ func (s *Set[T]) ensureTree() {
 		s.tree = New[T](RootOnlyWatch)
 		s.hasTree = true
 	}
-	s.toBytes = lookupKeyType[T]()
+	if s.toBytes == nil {
+		s.toBytes = lookupKeyType[T]()
+	}
+}
+
+func (s *Set[T]) keyToBytes(v T) []byte {
+	if s.toBytes == nil {
+		s.toBytes = lookupKeyType[T]()
+	}
+	return s.toBytes(v)
 }
 
 // Set a value. Returns a new set. Original is unchanged.
 func (s Set[T]) Set(v T) Set[T] {
+	key := s.keyToBytes(v)
+	if (!s.hasTree && s.singleton == nil) ||
+		(s.singleton != nil && bytes.Equal(key, s.keyToBytes(*s.singleton))) {
+		s.singleton = &v
+		return s
+	}
+
 	s.ensureTree()
 	txn := s.tree.Txn()
-	txn.Insert(s.toBytes(v), v)
+	txn.Insert(key, v)
+	if s.singleton != nil {
+		txn.Insert(s.keyToBytes(*s.singleton), *s.singleton)
+		s.singleton = nil
+	}
 	s.tree = txn.Commit() // As Set is passed by value we can just modify it.
 	return s
 }
@@ -61,26 +87,56 @@ func (s Set[T]) Set(v T) Set[T] {
 // Delete returns a new set without the value. The original
 // set is unchanged.
 func (s Set[T]) Delete(v T) Set[T] {
+	if s.singleton != nil {
+		if bytes.Equal(s.keyToBytes(*s.singleton), s.keyToBytes(v)) {
+			s.singleton = nil
+		}
+		return s
+	}
 	if !s.hasTree {
 		return s
 	}
 	txn := s.tree.Txn()
-	txn.Delete(s.toBytes(v))
-	s.tree = txn.Commit()
-	if s.tree.Len() == 0 {
+	txn.Delete(s.keyToBytes(v))
+	switch txn.Len() {
+	case 0:
 		s.tree = Tree[T]{}
 		s.hasTree = false
+	case 1:
+		iter := txn.Iterator()
+		_, value, _ := iter.Next()
+		s.singleton = &value
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	default:
+		s.tree = txn.Commit()
 	}
 	return s
 }
 
 // Has returns true if the set has the value.
 func (s Set[T]) Has(v T) bool {
+	if s.singleton != nil {
+		return bytes.Equal(s.keyToBytes(*s.singleton), s.keyToBytes(v))
+	}
 	if !s.hasTree {
 		return false
 	}
-	_, _, found := s.tree.Get(s.toBytes(v))
+	_, found := s.tree.Get(s.keyToBytes(v))
 	return found
+}
+
+// First returns the first value in key order, or false if the set is empty.
+func (s Set[T]) First() (value T, ok bool) {
+	if s.singleton != nil {
+		return *s.singleton, true
+	}
+	if !s.hasTree {
+		return value, false
+	}
+	iter := s.tree.Iterator()
+	_, value, ok = iter.Next()
+	return value, ok
 }
 
 func emptySeq[T any](yield func(T) bool) {
@@ -88,31 +144,47 @@ func emptySeq[T any](yield func(T) bool) {
 
 // All returns an iterator for all values.
 func (s Set[T]) All() iter.Seq[T] {
-	if !s.hasTree {
+	if !s.hasTree && s.singleton == nil {
 		return emptySeq[T]
 	}
 	return s.yieldAll
 }
 
 func (s Set[T]) yieldAll(yield func(v T) bool) {
+	if s.singleton != nil {
+		yield(*s.singleton)
+		return
+	}
 	for _, v := range s.tree.Iterator().All {
-		yield(v)
+		if !yield(v) {
+			return
+		}
 	}
 }
 
 // Union returns a set that is the union of the values
 // in the input sets.
 func (s Set[T]) Union(s2 Set[T]) Set[T] {
-	if !s2.hasTree {
+	if s2.Len() == 0 {
 		return s
 	}
-	if !s.hasTree {
+	if s.Len() == 0 {
 		return s2
 	}
+
+	s.ensureTree()
 	txn := s.tree.Txn()
-	iter := s2.tree.Iterator()
-	for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
-		txn.Insert(k, v)
+	if s.singleton != nil {
+		txn.Insert(s.keyToBytes(*s.singleton), *s.singleton)
+		s.singleton = nil
+	}
+	if s2.singleton != nil {
+		txn.Insert(s2.keyToBytes(*s2.singleton), *s2.singleton)
+	} else {
+		iter := s2.tree.Iterator()
+		for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
+			txn.Insert(k, v)
+		}
 	}
 	s.tree = txn.Commit()
 	return s
@@ -121,21 +193,46 @@ func (s Set[T]) Union(s2 Set[T]) Set[T] {
 // Difference returns a set with values that only
 // appear in the first set.
 func (s Set[T]) Difference(s2 Set[T]) Set[T] {
-	if !s.hasTree || !s2.hasTree {
+	if s.Len() == 0 || s2.Len() == 0 {
+		return s
+	}
+	if s.singleton != nil {
+		if s2.Has(*s.singleton) {
+			s.singleton = nil
+		}
 		return s
 	}
 
 	txn := s.tree.Txn()
-	iter := s2.tree.Iterator()
-	for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
-		txn.Delete(k)
+	if s2.singleton != nil {
+		txn.Delete(s2.keyToBytes(*s2.singleton))
+	} else {
+		iter := s2.tree.Iterator()
+		for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
+			txn.Delete(k)
+		}
 	}
-	s.tree = txn.Commit()
+	switch txn.Len() {
+	case 0:
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	case 1:
+		iter := txn.Iterator()
+		_, value, _ := iter.Next()
+		s.singleton = &value
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	default:
+		s.tree = txn.Commit()
+	}
 	return s
 }
 
 // Len returns the number of values in the set.
 func (s Set[T]) Len() int {
+	if s.singleton != nil {
+		return 1
+	}
 	if !s.hasTree {
 		return 0
 	}
@@ -145,10 +242,14 @@ func (s Set[T]) Len() int {
 // Equal returns true if the two sets contain the equal keys.
 func (s Set[T]) Equal(other Set[T]) bool {
 	switch {
-	case !s.hasTree && !other.hasTree:
-		return true
 	case s.Len() != other.Len():
 		return false
+	case s.Len() == 0:
+		return true
+	case s.Len() == 1:
+		v1, _ := s.First()
+		v2, _ := other.First()
+		return bytes.Equal(s.keyToBytes(v1), other.keyToBytes(v2))
 	default:
 		iter1 := s.tree.Iterator()
 		iter2 := other.tree.Iterator()
@@ -175,11 +276,21 @@ func (s Set[T]) ToBytesFunc() func(T) []byte {
 }
 
 func (s Set[T]) MarshalJSON() ([]byte, error) {
-	if !s.hasTree {
+	if !s.hasTree && s.singleton == nil {
 		return []byte("[]"), nil
 	}
 	var b bytes.Buffer
 	b.WriteRune('[')
+	if s.singleton != nil {
+		bs, err := json.Marshal(*s.singleton)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(bs)
+		b.WriteRune(']')
+		return b.Bytes(), nil
+	}
+
 	iter := s.tree.Iterator()
 	_, v, ok := iter.Next()
 	for ok {
@@ -198,6 +309,8 @@ func (s Set[T]) MarshalJSON() ([]byte, error) {
 }
 
 func (s *Set[T]) UnmarshalJSON(data []byte) error {
+	*s = Set[T]{}
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	t, err := dec.Token()
 	if err != nil {
@@ -207,22 +320,30 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%T.UnmarshalJSON: expected '[' got %v", s, t)
 	}
 
-	*s = Set[T]{}
-	s.ensureTree()
-	txn := s.tree.Txn()
-
-	for dec.More() {
-		var x T
-		err := dec.Decode(&x)
-		if err != nil {
-			return err
-		}
-		txn.Insert(s.toBytes(x), x)
+	if !dec.More() {
+		_, err = dec.Token()
+		return err
 	}
-	s.tree = txn.Commit()
-	if s.tree.Len() == 0 {
-		s.tree = Tree[T]{}
-		s.hasTree = false
+
+	var first T
+	if err := dec.Decode(&first); err != nil {
+		return err
+	}
+	if !dec.More() {
+		s.toBytes = lookupKeyType[T]()
+		s.singleton = &first
+	} else {
+		s.ensureTree()
+		txn := s.tree.Txn()
+		txn.Insert(s.keyToBytes(first), first)
+		for dec.More() {
+			var x T
+			if err := dec.Decode(&x); err != nil {
+				return err
+			}
+			txn.Insert(s.keyToBytes(x), x)
+		}
+		s.tree = txn.Commit()
 	}
 
 	t, err = dec.Token()
@@ -246,6 +367,19 @@ func (s *Set[T]) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	*s = Set[T]{}
+	switch len(value.Content) {
+	case 0:
+		return nil
+	case 1:
+		var v T
+		if err := value.Content[0].Decode(&v); err != nil {
+			return err
+		}
+		s.toBytes = lookupKeyType[T]()
+		s.singleton = &v
+		return nil
+	}
+
 	s.ensureTree()
 	txn := s.tree.Txn()
 

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -15,7 +15,7 @@ import (
 // This allows watching any part of the tree (any prefix) for changes.
 type Tree[T any] struct {
 	root      *header[T]
-	rootWatch chan struct{}
+	rootWatch *watchState
 	size      int // the number of objects in the tree
 	opts      options
 	prevTxn   *atomic.Pointer[Txn[T]] // the previous txn for reusing the allocation
@@ -30,7 +30,7 @@ func New[T any](opts ...Option) Tree[T] {
 	}
 	t := Tree[T]{
 		root:      nil,
-		rootWatch: make(chan struct{}),
+		rootWatch: newWatchState(),
 		size:      0,
 		opts:      o,
 		prevTxn:   &atomic.Pointer[Txn[T]]{},
@@ -46,9 +46,7 @@ type Option func(*options)
 var RootOnlyWatch = (*options).setRootOnlyWatch
 
 func newTxn[T any](o options) *Txn[T] {
-	txn := &Txn[T]{
-		watches: make(map[chan struct{}]struct{}),
-	}
+	txn := &Txn[T]{}
 	txn.deleteParentsCache = make([]deleteParent[T], 0, 32)
 	txn.opts = o
 	return txn
@@ -64,6 +62,7 @@ func (t *Tree[T]) Txn() *Txn[T] {
 	if prevTxn := t.prevTxn.Swap(nil); prevTxn != nil {
 		txn = prevTxn
 		clear(txn.watches)
+		txn.watches = txn.watches[:0]
 		txn.dirty = false
 	} else {
 		txn = newTxn[T](t.opts)
@@ -84,26 +83,37 @@ func (t *Tree[T]) Len() int {
 }
 
 // Get fetches the value associated with the given key.
-// Returns the value, a watch channel (which is closed on
-// modification to the key) and boolean which is true if
-// value was found.
-func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
-	value, watch, ok := search(t.root, t.rootWatch, key)
-	return value, watch, ok
+func (t *Tree[T]) Get(key []byte) (T, bool) {
+	value, _, ok := search(t.root, t.rootWatch, key)
+	return value, ok
 }
 
-// Prefix returns an iterator for all objects that starts with the
-// given prefix, and a channel that closes when any objects matching
-// the given prefix are upserted or deleted.
-func (t *Tree[T]) Prefix(prefix []byte) (Iterator[T], <-chan struct{}) {
-	return prefixSearch(t.root, t.rootWatch, prefix)
+// GetWatch fetches the value associated with the given key and returns a watch
+// channel that closes when the key is modified.
+func (t *Tree[T]) GetWatch(key []byte) (T, <-chan struct{}, bool) {
+	value, watch, ok := search(t.root, t.rootWatch, key)
+	return value, watch.channel(), ok
+}
+
+// Prefix returns an iterator for all objects that start with the given prefix.
+func (t *Tree[T]) Prefix(prefix []byte) Iterator[T] {
+	iter, _ := prefixSearch(t.root, t.rootWatch, prefix)
+	return iter
+}
+
+// PrefixWatch returns an iterator for all objects that start with the given
+// prefix and a channel that closes when any matching object is upserted or
+// deleted.
+func (t *Tree[T]) PrefixWatch(prefix []byte) (Iterator[T], <-chan struct{}) {
+	iter, watch := prefixSearch(t.root, t.rootWatch, prefix)
+	return iter, watch.channel()
 }
 
 // RootWatch returns a watch channel for the root of the tree.
 // Since this is the channel associated with the root, this closes
 // when there are any changes to the tree.
 func (t *Tree[T]) RootWatch() <-chan struct{} {
-	return t.rootWatch
+	return t.rootWatch.channel()
 }
 
 // LowerBound returns an iterator for all keys that have a value
@@ -153,6 +163,6 @@ func (t *Tree[T]) All(yield func([]byte, T) bool) {
 
 // PrintTree to the standard output. For debugging.
 func (t *Tree[T]) PrintTree() {
-	fmt.Printf("rootWatch: %p %v\n", t.rootWatch, isClosedChan(t.rootWatch))
+	fmt.Printf("rootWatch: %p %v\n", t.rootWatch, t.rootWatch.isClosed())
 	t.root.printTree(0)
 }

--- a/vendor/github.com/cilium/statedb/part/txn.go
+++ b/vendor/github.com/cilium/statedb/part/txn.go
@@ -16,7 +16,7 @@ import (
 type Txn[T any] struct {
 	root      *header[T]
 	oldRoot   *header[T]
-	rootWatch chan struct{}
+	rootWatch *watchState
 	prevTxn   *atomic.Pointer[Txn[T]]
 
 	dirty bool
@@ -35,7 +35,7 @@ type Txn[T any] struct {
 
 	// watches contains the channels of cloned nodes that should be closed
 	// when transaction is committed.
-	watches map[chan struct{}]struct{}
+	watches []*watchState
 
 	// deleteParentsCache keeps the last allocated slice to avoid
 	// reallocating it on every deletion.
@@ -72,7 +72,11 @@ func (txn *Txn[T]) Clone() Tree[T] {
 // Insert or update the tree with the given key and value.
 // Returns the old value if it exists.
 func (txn *Txn[T]) Insert(key []byte, value T) (old T, hadOld bool) {
-	old, hadOld, _ = txn.InsertWatch(key, value)
+	old, _, hadOld, _, txn.root = txn.insert(txn.root, key, value)
+	validateTree(txn.root, nil, txn.watches, txn.txnID)
+	if !hadOld {
+		txn.size++
+	}
 	return
 }
 
@@ -80,14 +84,16 @@ func (txn *Txn[T]) Insert(key []byte, value T) (old T, hadOld bool) {
 // Returns the old value if it exists and a watch channel that closes when the
 // key changes again.
 func (txn *Txn[T]) InsertWatch(key []byte, value T) (old T, hadOld bool, watch <-chan struct{}) {
-	old, _, hadOld, watch, txn.root = txn.insert(txn.root, key, value)
+	var state *watchState
+	old, _, hadOld, state, txn.root = txn.insert(txn.root, key, value)
 	validateTree(txn.root, nil, txn.watches, txn.txnID)
 	if !hadOld {
 		txn.size++
 	}
 	if txn.opts.rootOnlyWatch() {
-		watch = txn.rootWatch
+		state = txn.rootWatch
 	}
+	watch = state.channel()
 	return
 }
 
@@ -95,7 +101,11 @@ func (txn *Txn[T]) InsertWatch(key []byte, value T) (old T, hadOld bool, watch <
 // caller to not mutate the value in-place and to return a clone.
 // Returns the old value (if it exists) and the new possibly merged value.
 func (txn *Txn[T]) Modify(key []byte, value T, mod func(T, T) T) (old T, newValue T, hadOld bool) {
-	old, newValue, hadOld, _ = txn.ModifyWatch(key, value, mod)
+	old, newValue, hadOld, _, txn.root = txn.modify(txn.root, key, value, mod)
+	validateTree(txn.root, nil, txn.watches, txn.txnID)
+	if !hadOld {
+		txn.size++
+	}
 	return
 }
 
@@ -105,14 +115,16 @@ func (txn *Txn[T]) Modify(key []byte, value T, mod func(T, T) T) (old T, newValu
 // Returns the old value (if it exists) and the new possibly merged value,
 // and a watch channel that closes when the key changes again.
 func (txn *Txn[T]) ModifyWatch(key []byte, value T, mod func(T, T) T) (old T, newValue T, hadOld bool, watch <-chan struct{}) {
-	old, newValue, hadOld, watch, txn.root = txn.modify(txn.root, key, value, mod)
+	var state *watchState
+	old, newValue, hadOld, state, txn.root = txn.modify(txn.root, key, value, mod)
 	validateTree(txn.root, nil, txn.watches, txn.txnID)
 	if !hadOld {
 		txn.size++
 	}
 	if txn.opts.rootOnlyWatch() {
-		watch = txn.rootWatch
+		state = txn.rootWatch
 	}
+	watch = state.channel()
 	return
 }
 
@@ -131,25 +143,38 @@ func (txn *Txn[T]) Delete(key []byte) (old T, hadOld bool) {
 // Since this is the channel associated with the root, this closes
 // when there are any changes to the tree.
 func (txn *Txn[T]) RootWatch() <-chan struct{} {
-	return txn.rootWatch
+	return txn.rootWatch.channel()
 }
 
 // Get fetches the value associated with the given key.
-// Returns the value, a watch channel (which is closed on
-// modification to the key) and boolean which is true if
-// value was found.
-func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
-	value, watch, ok := search(txn.root, txn.rootWatch, key)
-	return value, watch, ok
+func (txn *Txn[T]) Get(key []byte) (T, bool) {
+	value, _, ok := search(txn.root, txn.rootWatch, key)
+	return value, ok
 }
 
-// Prefix returns an iterator for all objects that starts with the
-// given prefix, and a channel that closes when any objects matching
-// the given prefix are upserted or deleted.
-func (txn *Txn[T]) Prefix(key []byte) (Iterator[T], <-chan struct{}) {
+// GetWatch fetches the value associated with the given key and returns a watch
+// channel that closes when the key is modified.
+func (txn *Txn[T]) GetWatch(key []byte) (T, <-chan struct{}, bool) {
+	value, watch, ok := search(txn.root, txn.rootWatch, key)
+	return value, watch.channel(), ok
+}
+
+// Prefix returns an iterator for all objects that start with the given prefix.
+func (txn *Txn[T]) Prefix(key []byte) Iterator[T] {
 	// Bump txnID in order to freeze the current tree.
 	txn.txnID++
-	return prefixSearch(txn.root, txn.rootWatch, key)
+	iter, _ := prefixSearch(txn.root, txn.rootWatch, key)
+	return iter
+}
+
+// PrefixWatch returns an iterator for all objects that start with the given
+// prefix and a channel that closes when any matching object is upserted or
+// deleted.
+func (txn *Txn[T]) PrefixWatch(key []byte) (Iterator[T], <-chan struct{}) {
+	// Bump txnID in order to freeze the current tree.
+	txn.txnID++
+	iter, watch := prefixSearch(txn.root, txn.rootWatch, key)
+	return iter, watch.channel()
 }
 
 // LowerBound returns an iterator for all objects that have a
@@ -181,7 +206,7 @@ func (txn *Txn[T]) CommitAndNotify() Tree[T] {
 func (txn *Txn[T]) Commit() Tree[T] {
 	newRootWatch := txn.rootWatch
 	if txn.dirty {
-		newRootWatch = make(chan struct{})
+		newRootWatch = newWatchState()
 		validateTree(txn.oldRoot, nil, nil, txn.txnID)
 		validateTree(txn.root, nil, txn.watches, txn.txnID)
 	}
@@ -199,28 +224,31 @@ func (txn *Txn[T]) Commit() Tree[T] {
 	return t
 }
 
-// watchesReuseThreshold is the threshold at which the [txn.watches] hash
-// map is reused for next transaction.
-const watchesReuseThreshold = 64
+// watchesReuseThreshold is the largest [txn.watches] backing array retained
+// for the next transaction. At the threshold this retains roughly 8KB.
+const watchesReuseThreshold = 1024
 
 // Notify closes the watch channels of nodes that were
 // mutated as part of this transaction. Must be called before
 // Tree.Txn() is used again.
 func (txn *Txn[T]) Notify() {
-	for ch := range txn.watches {
-		close(ch)
+	for _, watch := range txn.watches {
+		watch.close()
 	}
 	if !txn.dirty && len(txn.watches) > 0 {
 		panic("BUG: watch channels marked but txn not dirty")
 	}
-	// Clear or reallocate the watches hash map for the next transaction.
-	if len(txn.watches) <= watchesReuseThreshold {
-		clear(txn.watches)
+	// Clear the channels to allow them to be collected. Avoid retaining an
+	// unusually large backing array on the transaction.
+	numWatches := len(txn.watches)
+	clear(txn.watches)
+	if numWatches <= watchesReuseThreshold {
+		txn.watches = txn.watches[:0]
 	} else {
-		txn.watches = make(map[chan struct{}]struct{})
+		txn.watches = nil
 	}
 	if txn.dirty && txn.rootWatch != nil {
-		close(txn.rootWatch)
+		txn.rootWatch.close()
 		txn.rootWatch = nil
 	}
 	if !txn.opts.rootOnlyWatch() {
@@ -232,7 +260,7 @@ func (txn *Txn[T]) Notify() {
 func (txn *Txn[T]) PrintTree() {
 	txn.root.printTree(0)
 	fmt.Printf("watches: ")
-	for watch := range txn.watches {
+	for _, watch := range txn.watches {
 		fmt.Printf("%p ", watch)
 	}
 	fmt.Println()
@@ -244,19 +272,24 @@ func (txn *Txn[T]) cloneNode(n *header[T]) *header[T] {
 		// be mutated in-place.
 		return n
 	}
-	if n.watch != nil {
-		txn.watches[n.watch] = struct{}{}
-	}
+	txn.addWatch(n.watch)
 	n = n.clone(!txn.opts.rootOnlyWatch())
 	n.setTxnID(txn.txnID)
 	return n
 }
 
-func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, newValue T, hadOld bool, watch <-chan struct{}, newRoot *header[T]) {
+func (txn *Txn[T]) addWatch(watch *watchState) {
+	if watch == nil {
+		return
+	}
+	txn.watches = append(txn.watches, watch)
+}
+
+func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, newValue T, hadOld bool, watch *watchState, newRoot *header[T]) {
 	return txn.modify(root, key, value, nil)
 }
 
-func (txn *Txn[T]) modify(root *header[T], key []byte, newValue T, mod func(T, T) T) (oldValue T, newValueOut T, hadOld bool, watch <-chan struct{}, newRoot *header[T]) {
+func (txn *Txn[T]) modify(root *header[T], key []byte, newValue T, mod func(T, T) T) (oldValue T, newValueOut T, hadOld bool, watch *watchState, newRoot *header[T]) {
 	txn.dirty = true
 	fullKey := key
 	newValueOut = newValue
@@ -290,9 +323,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, newValue T, mod func(T, T
 			// We've found a free slot where to insert the key.
 			if this.size()+1 > this.cap() {
 				// Node too small, promote it to the next size.
-				if this.watch != nil {
-					txn.watches[this.watch] = struct{}{}
-				}
+				txn.addWatch(this.watch)
 				this = this.promote(txn.txnID)
 			} else {
 				// Node is big enough, clone it so we can mutate it
@@ -368,7 +399,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, newValue T, mod func(T, T
 	newNode.setPrefix(common)
 	newNode.setKind(nodeKind4)
 	if !txn.opts.rootOnlyWatch() {
-		newNode.watch = make(chan struct{})
+		newNode.watch = newWatchState()
 	}
 
 	switch {
@@ -461,22 +492,18 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	hadOld = true
 
 	// Mark the watch channel of the target for closing.
-	if leaf.watch != nil {
-		txn.watches[leaf.watch] = struct{}{}
+	if !target.isLeaf() {
+		txn.addWatch(leaf.watch)
 	}
 
 	if target == root {
 		switch {
 		case root.isLeaf() || root.size() == 0:
-			if root.watch != nil {
-				txn.watches[root.watch] = struct{}{}
-			}
+			txn.addWatch(root.watch)
 			// Root is a leaf or node without children
 			newRoot = nil
 		case root.size() == 1:
-			if root.watch != nil {
-				txn.watches[root.watch] = struct{}{}
-			}
+			txn.addWatch(root.watch)
 			// Root is a non-leaf node with single child. We can replace
 			// the root with the child.
 			child := root.children()[0]
@@ -501,9 +528,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	if this.node.size() == 1 {
 		// The target node is not a leaf node and has only a single
 		// child. Shift the child up.
-		if this.node.watch != nil {
-			txn.watches[this.node.watch] = struct{}{}
-		}
+		txn.addWatch(this.node.watch)
 		child := this.node.children()[0]
 		childClone := child.clone(false)
 		childClone.watch = child.watch
@@ -520,9 +545,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	} else {
 		// The target node is a leaf node or a non-leaf node without any
 		// children. We can just drop it from the parent.
-		if this.node.watch != nil {
-			txn.watches[this.node.watch] = struct{}{}
-		}
+		txn.addWatch(this.node.watch)
 		parent.node = txn.removeChild(parent.node, this.index)
 	}
 
@@ -575,9 +598,7 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[
 			remainingIndex = 1
 		}
 
-		if parent.watch != nil {
-			txn.watches[parent.watch] = struct{}{}
-		}
+		txn.addWatch(parent.watch)
 
 		child := parent.node4().children[remainingIndex]
 		// Clone for prefix adjustment, but leave watch alone.
@@ -588,28 +609,48 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[
 		childClone.setPrefix(slices.Concat(parent.prefix(), childClone.prefix()))
 		return childClone
 
-	case parent.kind() == nodeKind256 && size <= 49:
-		demoted := (&node48[T]{header: *parent}).self()
+	case parent.kind() == nodeKind256 && size <= 129:
+		demoted := (&node128[T]{header: *parent}).self()
 		if parent.watch != nil {
-			demoted.watch = make(chan struct{})
+			demoted.watch = newWatchState()
 		}
-		demoted.setKind(nodeKind48)
+		demoted.setKind(nodeKind128)
 		demoted.setSize(size - 1)
 		demoted.setTxnID(txn.txnID)
-			n48 := demoted.node48()
-			n48.leaf = parent.getLeaf()
-			children := n48.children[:0]
-			for k, n := range parent.node256().children[:] {
-				if k != index && n != nil {
-					n48.index[k] = uint8(len(children) + 1)
-					children = append(children, n)
-				}
+		n128 := demoted.node128()
+		n128.leaf = parent.getLeaf()
+		children := n128.children[:0]
+		for k, n := range parent.node256().children[:] {
+			if k != index && n != nil {
+				n128.bitmap[k/64] |= uint64(1) << (k % 64)
+				children = append(children, n)
 			}
+		}
 		newParent = demoted
-	case parent.kind() == nodeKind48 && size <= 17:
+	case parent.kind() == nodeKind128 && size <= 65:
+		demoted := (&node64[T]{header: *parent}).self()
+		if parent.watch != nil {
+			demoted.watch = newWatchState()
+		}
+		demoted.setKind(nodeKind64)
+		demoted.setSize(size - 1)
+		demoted.setTxnID(txn.txnID)
+		n64 := demoted.node64()
+		n64.leaf = parent.getLeaf()
+		idx := 0
+		for i, child := range parent.children() {
+			if i != index {
+				n64.children[idx] = child
+				key := child.key()
+				n64.bitmap[key/64] |= uint64(1) << (key % 64)
+				idx++
+			}
+		}
+		newParent = demoted
+	case parent.kind() == nodeKind64 && size <= 17:
 		demoted := (&node16[T]{header: *parent}).self()
 		if parent.watch != nil {
-			demoted.watch = make(chan struct{})
+			demoted.watch = newWatchState()
 		}
 		demoted.setKind(nodeKind16)
 		demoted.setSize(size - 1)
@@ -628,7 +669,7 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[
 	case parent.kind() == nodeKind16 && size <= 5:
 		demoted := (&node4[T]{header: *parent}).self()
 		if parent.watch != nil {
-			demoted.watch = make(chan struct{})
+			demoted.watch = newWatchState()
 		}
 		demoted.setKind(nodeKind4)
 		demoted.setSize(size - 1)
@@ -650,9 +691,7 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[
 		newParent.remove(index)
 		return newParent
 	}
-	if parent.watch != nil {
-		txn.watches[parent.watch] = struct{}{}
-	}
+	txn.addWatch(parent.watch)
 	return newParent
 }
 
@@ -660,7 +699,7 @@ var runValidation = os.Getenv("STATEDB_VALIDATE") != ""
 
 // validateTree checks that the resulting tree is well-formed and panics
 // if it is not.
-func validateTree[T any](node *header[T], parents []*header[T], watches map[chan struct{}]struct{}, maxTxnID uint64) {
+func validateTree[T any](node *header[T], parents []*header[T], watches []*watchState, maxTxnID uint64) {
 	if !runValidation {
 		return
 	}
@@ -690,8 +729,8 @@ func validateTree[T any](node *header[T], parents []*header[T], watches map[chan
 		// If a leaf's watch channel is to be closed then parent's should be
 		// marked closed too. The case where node is a leaf is handled below.
 		if !node.isLeaf() {
-			if _, found := watches[leaf.watch]; found {
-				_, found := watches[node.watch]
+			if found := slices.Contains(watches, leaf.watch); found {
+				found := slices.Contains(watches, node.watch)
 				assert(found, "node's watch channel not marked for closing when leaf is")
 			}
 		}
@@ -717,22 +756,23 @@ func validateTree[T any](node *header[T], parents []*header[T], watches map[chan
 	// Node16 must have occupancy higher than 4
 	assert(node.kind() != nodeKind16 || node.size() > 4, "node16 has fewer children than 5")
 
-	// Node48 must have occupancy higher than 16
-	assert(node.kind() != nodeKind48 || node.size() > 16, "node48 has fewer children than 17")
+	// Node64 must have occupancy higher than 16
+	assert(node.kind() != nodeKind64 || node.size() > 16, "node64 has fewer children than 17")
 
-	// Node256 must have occupancy higher than 48
-	assert(node.kind() != nodeKind256 || node.size() > 48, "node256 has fewer children than 49")
+	// Node128 must have occupancy higher than 64
+	assert(node.kind() != nodeKind128 || node.size() > 64, "node128 has fewer children than 65")
+
+	// Node256 must have occupancy higher than 128
+	assert(node.kind() != nodeKind256 || node.size() > 128, "node256 has fewer children than 129")
 
 	// Nodes that have a watch channel that is to be closed must
 	// also have all their parent's watch channels to be closed.
-	if _, found := watches[node.watch]; found {
-		select {
-		case <-node.watch:
+	if found := slices.Contains(watches, node.watch); found {
+		if node.watch.isClosed() {
 			panic("node's watch channel marked for closing but is already closed!")
-		default:
 		}
 		for i, p := range parents {
-			_, found := watches[p.watch]
+			found := slices.Contains(watches, p.watch)
 			if !found {
 				p.printTree(0)
 				panic(fmt.Sprintf("parent %p (%d) watch channel (%p) not marked for closing (child %p, watch %p)", p, i, p.watch, node, node.watch))
@@ -743,17 +783,13 @@ func validateTree[T any](node *header[T], parents []*header[T], watches map[chan
 
 	// If a node's watch channel is closed then all the parents must be
 	// closed as well.
-	select {
-	case <-node.watch:
+	if node.watch.isClosed() {
 		for _, p := range parents {
-			select {
-			case <-p.watch:
-			default:
+			if !p.watch.isClosed() {
 				p.printTree(0)
 				panic(fmt.Sprintf("parent watch channel (%p) not marked for closing (child %p)", p.watch, node.watch))
 			}
 		}
-	default:
 	}
 
 	parents = append(parents, node)
@@ -801,8 +837,8 @@ func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
 		}
 	}
 
-	var collectWatches func(depth int, watches map[<-chan struct{}]func() string, node *header[T])
-	collectWatches = func(depth int, watches map[<-chan struct{}]func() string, node *header[T]) {
+	var collectWatches func(depth int, watches map[*watchState]func() string, node *header[T])
+	collectWatches = func(depth int, watches map[*watchState]func() string, node *header[T]) {
 		if node == nil {
 			return
 		}
@@ -820,9 +856,9 @@ func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
 		}
 	}
 
-	oldWatches := map[<-chan struct{}]func() string{}
+	oldWatches := map[*watchState]func() string{}
 	collectWatches(0, oldWatches, oldRoot)
-	newWatches := map[<-chan struct{}]func() string{}
+	newWatches := map[*watchState]func() string{}
 	collectWatches(0, newWatches, newRoot)
 
 	// Check that any nodes that kept the old watch channel have exactly
@@ -845,9 +881,7 @@ func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
 	}
 
 	for watch, desc := range oldWatches {
-		select {
-		case <-watch:
-		default:
+		if !watch.isClosed() {
 			oldRoot.printTree(0)
 			fmt.Println("---")
 			newRoot.printTree(0)

--- a/vendor/github.com/cilium/statedb/part/watch.go
+++ b/vendor/github.com/cilium/statedb/part/watch.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import "sync/atomic"
+
+// watchState is the identity of a logical watch. The channel itself is
+// allocated lazily when channel() is first called. A watchState may be shared
+// by multiple physical nodes when an ART rewrite only changes a compressed
+// prefix and leaves the watched subtree unchanged.
+type watchState struct {
+	value atomic.Pointer[watchChannel]
+}
+
+type watchChannel struct {
+	ch chan struct{}
+}
+
+var closedWatchChannel = func() *watchChannel {
+	w := &watchChannel{ch: make(chan struct{})}
+	close(w.ch)
+	return w
+}()
+
+func newWatchState() *watchState {
+	return &watchState{}
+}
+
+// channel returns the stable channel for this watch. It is safe to race with
+// close: either the newly installed channel is closed by close, or this returns
+// the shared already-closed channel.
+func (w *watchState) channel() <-chan struct{} {
+	if w == nil {
+		return nil
+	}
+	for {
+		if value := w.value.Load(); value != nil {
+			return value.ch
+		}
+
+		candidate := &watchChannel{ch: make(chan struct{})}
+		if w.value.CompareAndSwap(nil, candidate) {
+			return candidate.ch
+		}
+	}
+}
+
+// close closes the watch, including when it races with the first call to
+// channel. It is idempotent so a shared watchState is safe to encounter more
+// than once while rebuilding a tree.
+func (w *watchState) close() {
+	if w == nil {
+		return
+	}
+	old := w.value.Swap(closedWatchChannel)
+	if old != nil && old != closedWatchChannel {
+		close(old.ch)
+	}
+}
+
+func (w *watchState) isClosed() bool {
+	return w != nil && w.value.Load() == closedWatchChannel
+}

--- a/vendor/github.com/cilium/statedb/part_index.go
+++ b/vendor/github.com/cilium/statedb/part_index.go
@@ -118,13 +118,17 @@ func (r *partIndex) list(key index.Key) (tableIndexIterator, <-chan struct{}) {
 	return partList(r.unique, &r.tree, key)
 }
 
+func (r *partIndex) listNoWatch(key index.Key) tableIndexIterator {
+	return partListNoWatch(r.unique, &r.tree, key)
+}
+
 var emptyTableIndexIterator = &singletonTableIndexIterator{}
 
 func partList(unique bool, tree part.Ops[object], key index.Key) (tableIndexIterator, <-chan struct{}) {
 	if unique {
 		// Unique index means that there can be only a single matching object.
 		// Doing a Get() is more efficient than constructing an iterator.
-		obj, watch, ok := tree.Get(key)
+		obj, watch, ok := tree.GetWatch(key)
 		if ok {
 			return &singletonTableIndexIterator{key, obj}, watch
 		}
@@ -137,8 +141,22 @@ func partList(unique bool, tree part.Ops[object], key index.Key) (tableIndexIter
 	// form <secondary key><primary key><secondary key length>, and thus the
 	// iteration will continue until key length mismatches, e.g. we hit a
 	// longer key sharing the same prefix.
-	iter, watch := tree.Prefix(key)
+	iter, watch := tree.PrefixWatch(key)
 	return newNonUniquePartIterator(iter, false, key), watch
+}
+
+func partListNoWatch(unique bool, tree part.Ops[object], key index.Key) tableIndexIterator {
+	if unique {
+		obj, ok := tree.Get(key)
+		if ok {
+			return &singletonTableIndexIterator{key, obj}
+		}
+		return emptyTableIndexIterator
+	}
+
+	key = encodeNonUniqueBytes(key)
+	iter := tree.Prefix(key)
+	return newNonUniquePartIterator(iter, false, key)
 }
 
 // rootWatch implements tableIndex.
@@ -159,17 +177,21 @@ func (r *partIndex) get(ikey index.Key) (iobj object, watch <-chan struct{}, fou
 	return partGet(r.unique, &r.tree, ikey)
 }
 
+func (r *partIndex) getNoWatch(ikey index.Key) (iobj object, found bool) {
+	return partGetNoWatch(r.unique, &r.tree, ikey)
+}
+
 func partGet(unique bool, tree part.Ops[object], ikey index.Key) (iobj object, watch <-chan struct{}, found bool) {
 	searchKey := ikey
 	if unique {
 		// On a unique index we can do a direct get rather than a prefix search.
-		return tree.Get(searchKey)
+		return tree.GetWatch(searchKey)
 	}
 
 	searchKey = encodeNonUniqueBytes(searchKey)
 
 	// For a non-unique index we need to do a prefix search.
-	iter, watch := tree.Prefix(searchKey)
+	iter, watch := tree.PrefixWatch(searchKey)
 	for {
 		var key []byte
 		key, iobj, found = iter.Next()
@@ -185,6 +207,23 @@ func partGet(unique bool, tree part.Ops[object], ikey index.Key) (iobj object, w
 	return iobj, watch, found
 }
 
+func partGetNoWatch(unique bool, tree part.Ops[object], ikey index.Key) (iobj object, found bool) {
+	searchKey := ikey
+	if unique {
+		return tree.Get(searchKey)
+	}
+
+	searchKey = encodeNonUniqueBytes(searchKey)
+	iter := tree.Prefix(searchKey)
+	for {
+		var key []byte
+		key, iobj, found = iter.Next()
+		if !found || nonUniqueKey(key).secondaryLen() == len(searchKey) {
+			return
+		}
+	}
+}
+
 // len implements tableIndex.
 func (r *partIndex) len() int {
 	return r.tree.Len()
@@ -194,25 +233,48 @@ func (r *partIndex) all() (tableIndexIterator, <-chan struct{}) {
 	return &r.tree, r.rootWatch()
 }
 
+func (r *partIndex) allNoWatch() tableIndexIterator {
+	return &r.tree
+}
+
 // prefix implements tableIndex.
 func (r *partIndex) prefix(ikey index.Key) (tableIndexIterator, <-chan struct{}) {
 	return partPrefix(r.unique, &r.tree, ikey)
+}
+
+func (r *partIndex) prefixNoWatch(ikey index.Key) tableIndexIterator {
+	return partPrefixNoWatch(r.unique, &r.tree, ikey)
 }
 
 func partPrefix(unique bool, tree part.Ops[object], key index.Key) (tableIndexIterator, <-chan struct{}) {
 	if !unique {
 		key = encodeNonUniqueBytes(key)
 	}
-	iter, watch := tree.Prefix(key)
+	iter, watch := tree.PrefixWatch(key)
 	if unique {
 		return iter, watch
 	}
 	return newNonUniquePartIterator(iter, true, key), watch
 }
 
+func partPrefixNoWatch(unique bool, tree part.Ops[object], key index.Key) tableIndexIterator {
+	if !unique {
+		key = encodeNonUniqueBytes(key)
+	}
+	iter := tree.Prefix(key)
+	if unique {
+		return &iter
+	}
+	return newNonUniquePartIterator(iter, true, key)
+}
+
 // lowerBound implements tableIndexTxn.
 func (r *partIndex) lowerBound(ikey index.Key) (tableIndexIterator, <-chan struct{}) {
 	return partLowerBound(r.unique, &r.tree, ikey), r.rootWatch()
+}
+
+func (r *partIndex) lowerBoundNoWatch(ikey index.Key) tableIndexIterator {
+	return partLowerBound(r.unique, &r.tree, ikey)
 }
 
 // lowerBoundNext implements tableIndexTxn.
@@ -225,6 +287,17 @@ func (r *partIndex) lowerBoundNext(key index.Key) (func() ([]byte, object, bool)
 		return iter.Next, r.rootWatch()
 	}
 	return newNonUniqueLowerBoundPartIterator(iter, key).Next, r.rootWatch()
+}
+
+func (r *partIndex) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, bool) {
+	if !r.unique {
+		key = encodeNonUniqueBytes(key)
+	}
+	iter := r.tree.LowerBound(key)
+	if r.unique {
+		return iter.Next
+	}
+	return newNonUniqueLowerBoundPartIterator(iter, key).Next
 }
 
 func partLowerBound(unique bool, tree part.Ops[object], key index.Key) tableIndexIterator {
@@ -259,16 +332,31 @@ func (r *partIndexTxn) all() (tableIndexIterator, <-chan struct{}) {
 	return &snapshot, r.rootWatch()
 }
 
+func (r *partIndexTxn) allNoWatch() tableIndexIterator {
+	snapshot := r.tx.Clone()
+	return &snapshot
+}
+
 // list implements tableIndexTxn.
 func (r *partIndexTxn) list(ikey index.Key) (tableIndexIterator, <-chan struct{}) {
 	snapshot := r.tx.Clone()
 	return partList(r.unique, &snapshot, ikey)
 }
 
+func (r *partIndexTxn) listNoWatch(ikey index.Key) tableIndexIterator {
+	snapshot := r.tx.Clone()
+	return partListNoWatch(r.unique, &snapshot, ikey)
+}
+
 // lowerBound implements tableIndexTxn.
 func (r *partIndexTxn) lowerBound(ikey index.Key) (tableIndexIterator, <-chan struct{}) {
 	snapshot := r.tx.Clone()
 	return partLowerBound(r.unique, &snapshot, ikey), r.rootWatch()
+}
+
+func (r *partIndexTxn) lowerBoundNoWatch(ikey index.Key) tableIndexIterator {
+	snapshot := r.tx.Clone()
+	return partLowerBound(r.unique, &snapshot, ikey)
 }
 
 // lowerBoundNext implements tableIndexTxn.
@@ -282,6 +370,18 @@ func (r *partIndexTxn) lowerBoundNext(key index.Key) (func() ([]byte, object, bo
 		return iter.Next, r.rootWatch()
 	}
 	return newNonUniqueLowerBoundPartIterator(iter, key).Next, r.rootWatch()
+}
+
+func (r *partIndexTxn) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, bool) {
+	if !r.unique {
+		key = encodeNonUniqueBytes(key)
+	}
+	snapshot := r.tx.Clone()
+	iter := snapshot.LowerBound(key)
+	if r.unique {
+		return iter.Next
+	}
+	return newNonUniqueLowerBoundPartIterator(iter, key).Next
 }
 
 // rootWatch implements tableIndexTxn.
@@ -310,9 +410,17 @@ func (r *partIndexTxn) get(key index.Key) (iobj object, watch <-chan struct{}, o
 	return partGet(r.unique, r.tx, key)
 }
 
+func (r *partIndexTxn) getNoWatch(key index.Key) (iobj object, ok bool) {
+	return partGetNoWatch(r.unique, r.tx, key)
+}
+
 // insert implements tableIndexTxn.
 func (r *partIndexTxn) insert(key index.Key, obj object) (old object, hadOld bool, watch <-chan struct{}) {
 	return r.tx.InsertWatch(key, obj)
+}
+
+func (r *partIndexTxn) insertNoWatch(key index.Key, obj object) (old object, hadOld bool) {
+	return r.tx.Insert(key, obj)
 }
 
 // len implements tableIndexTxn.
@@ -323,6 +431,10 @@ func (r *partIndexTxn) len() int {
 // modify implements tableIndexTxn.
 func (r *partIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool, watch <-chan struct{}) {
 	return r.tx.ModifyWatch(key, obj, mod)
+}
+
+func (r *partIndexTxn) modifyNoWatch(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool) {
+	return r.tx.Modify(key, obj, mod)
 }
 
 // notify implements tableIndexTxn.
@@ -337,6 +449,11 @@ func (r *partIndexTxn) notify() {
 func (r *partIndexTxn) prefix(ikey index.Key) (tableIndexIterator, <-chan struct{}) {
 	snapshot := r.tx.Clone()
 	return partPrefix(r.unique, &snapshot, ikey)
+}
+
+func (r *partIndexTxn) prefixNoWatch(ikey index.Key) tableIndexIterator {
+	snapshot := r.tx.Clone()
+	return partPrefixNoWatch(r.unique, &snapshot, ikey)
 }
 
 func (r *partIndexTxn) objectToKey(obj object) index.Key {

--- a/vendor/github.com/cilium/statedb/read_txn.go
+++ b/vendor/github.com/cilium/statedb/read_txn.go
@@ -88,7 +88,7 @@ func marshalJSON(data any) (out []byte) {
 
 func writeTableAsJSON(buf *bufio.Writer, txn ReadTxn, table *tableEntry) (err error) {
 	indexTxn := txn.mustIndexReadTxn(table.meta, PrimaryIndexPos)
-	iter, _ := indexTxn.all()
+	iter := indexTxn.allNoWatch()
 
 	writeString := func(s string) {
 		if err != nil {

--- a/vendor/github.com/cilium/statedb/reconciler/retries.go
+++ b/vendor/github.com/cilium/statedb/reconciler/retries.go
@@ -183,6 +183,10 @@ func (rq *retries) Add(obj any, rev statedb.Revision, origRev statedb.Revision, 
 }
 
 func (rq *retries) Clear(obj any) {
+	if len(rq.items) == 0 {
+		return
+	}
+
 	key := rq.objectToKey(obj)
 	if item, ok := rq.items[string(key)]; ok {
 		// Remove the object from the queue if it is still there.

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -285,12 +285,12 @@ func StatusError(err error) Status {
 	}
 }
 
-// StatusSet is a set of named statuses. This allows for the use of
-// multiple reconcilers per object when the reconcilers are not known
+// StatusSet is a set of named statuses. This allows an object to be
+// reconciled by multiple reconcilers, whether or not their names are known
 // up front.
 type StatusSet struct {
 	id        uint64
-	createdAt time.Time
+	updatedAt time.Time
 	statuses  []namedStatus
 }
 
@@ -299,30 +299,54 @@ type namedStatus struct {
 	name string
 }
 
+func (s StatusSet) find(name string) (int, bool) {
+	return slices.BinarySearchFunc(
+		s.statuses,
+		name,
+		func(status namedStatus, name string) int {
+			return cmp.Compare(status.name, name)
+		})
+}
+
 func NewStatusSet() StatusSet {
 	return StatusSet{
 		id:        nextID(),
-		createdAt: time.Now(),
+		updatedAt: time.Now(),
 		statuses:  nil,
 	}
 }
 
-// Pending returns a new pending status set.
-// The names of reconcilers are reused to be able to show which
-// are still pending.
-func (s StatusSet) Pending() StatusSet {
+// Pending returns a new pending status set with an optional default set of
+// reconciler names.
+//
+// Reconciler names from previous statuses are merged with the
+// given optional set of names.
+func (s StatusSet) Pending(names ...string) StatusSet {
 	// Generate a new id. This lets an individual reconciler
 	// differentiate between the status changing in an object
 	// versus the data itself, which is needed when the reconciler
 	// writes back the reconciliation status and the object has
 	// changed.
 	s.id = nextID()
-	s.createdAt = time.Now()
+	s.updatedAt = time.Now()
+
+	pending := Status{
+		Kind:      StatusKindPending,
+		UpdatedAt: s.updatedAt,
+		ID:        s.id,
+	}
 
 	s.statuses = slices.Clone(s.statuses)
 	for i := range s.statuses {
-		s.statuses[i].Kind = StatusKindPending
-		s.statuses[i].ID = s.id
+		s.statuses[i].Status = pending
+	}
+
+	for _, name := range names {
+		i, found := s.find(name)
+		if !found {
+			s.statuses = slices.Insert(
+				s.statuses, i, namedStatus{Status: pending, name: name})
+		}
 	}
 	return s
 }
@@ -375,20 +399,19 @@ func (s StatusSet) String() string {
 	return b.String()
 }
 
-// Set the reconcilation status of the named reconciler.
+// Set the reconciliation status of the named reconciler.
 // Use this to implement 'SetObjectStatus' for your reconciler.
 func (s StatusSet) Set(name string, status Status) StatusSet {
-	idx := slices.IndexFunc(
-		s.statuses,
-		func(st namedStatus) bool { return st.name == name })
-
-	s.statuses = slices.Clone(s.statuses)
-	if idx >= 0 {
-		s.statuses[idx] = namedStatus{status, name}
+	i, found := s.find(name)
+	if found {
+		s.statuses = slices.Clone(s.statuses)
+		s.statuses[i].Status = status
 	} else {
-		s.statuses = append(s.statuses, namedStatus{status, name})
-		slices.SortFunc(s.statuses,
-			func(a, b namedStatus) int { return cmp.Compare(a.name, b.name) })
+		statuses := make([]namedStatus, len(s.statuses)+1)
+		copy(statuses, s.statuses[:i])
+		statuses[i] = namedStatus{Status: status, name: name}
+		copy(statuses[i+1:], s.statuses[i:])
+		s.statuses = statuses
 	}
 	return s
 }
@@ -397,17 +420,31 @@ func (s StatusSet) Set(name string, status Status) StatusSet {
 // Use this to implement 'GetObjectStatus' for your reconciler.
 // If this reconciler is new the status is pending.
 func (s StatusSet) Get(name string) Status {
-	idx := slices.IndexFunc(
-		s.statuses,
-		func(st namedStatus) bool { return st.name == name })
-	if idx < 0 {
+	i, found := s.find(name)
+	if !found {
 		return Status{
 			Kind:      StatusKindPending,
-			UpdatedAt: s.createdAt,
+			UpdatedAt: s.updatedAt,
 			ID:        s.id,
 		}
 	}
-	return s.statuses[idx].Status
+	return s.statuses[i].Status
+}
+
+// Delete returns a new status set without the named reconciler.
+// A subsequent Pending call will not mark the reconciler pending unless its
+// name is passed to Pending again.
+func (s StatusSet) Delete(name string) StatusSet {
+	i, found := s.find(name)
+	if !found {
+		return s
+	}
+
+	statuses := make([]namedStatus, len(s.statuses)-1)
+	copy(statuses, s.statuses[:i])
+	copy(statuses[i:], s.statuses[i+1:])
+	s.statuses = statuses
+	return s
 }
 
 func (s StatusSet) All() map[string]Status {

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -818,6 +818,7 @@ func WatchCmd(db *DB) script.Cmd {
 			if err != nil {
 				return nil, err
 			}
+			defer iter.Close()
 
 			header := tbl.TableHeader()
 			if header == nil {

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -80,6 +80,20 @@ func NewTableAny[Obj any](
 		return nil, err
 	}
 
+	// Index name must be non-empty
+	if primaryIndexer.indexName() == "" {
+		return nil, tableError(tableName, ErrEmptyIndexName)
+	}
+
+	if _, secondaryOnly := primaryIndexer.(secondaryOnlyIndexer); secondaryOnly {
+		return nil, tableError(tableName, ErrPrimaryIndexNotSupported)
+	}
+
+	// Primary index must always be unique
+	if !primaryIndexer.isUnique() {
+		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
+	}
+
 	toAnyIndexer := func(idx Indexer[Obj], pos int) anyIndexer {
 		return anyIndexer{
 			name:          idx.indexName(),
@@ -111,15 +125,14 @@ func NewTableAny[Obj any](
 	indexPos := SecondaryIndexStartPos
 	for _, indexer := range secondaryIndexers {
 		name := indexer.indexName()
+		// Index name must be non-empty
+		if name == "" {
+			return nil, tableError(tableName, ErrEmptyIndexName)
+		}
 		anyIndexer := toAnyIndexer(indexer, indexPos)
 		table.secondaryAnyIndexers = append(table.secondaryAnyIndexers, anyIndexer)
 		table.indexPositions[indexPos] = name
 		indexPos++
-	}
-
-	// Primary index must always be unique
-	if !primaryIndexer.isUnique() {
-		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
 	}
 
 	// Validate that indexes have unique ids.
@@ -413,7 +426,12 @@ func (t *genTable[Obj]) numDeletedObjects(txn ReadTxn) int {
 }
 
 func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {
-	obj, revision, _, ok = t.GetWatch(txn, q)
+	index := txn.root()[t.pos].indexes[t.indexPos(q.index)]
+	iobj, ok := index.getNoWatch(q.key)
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
 	return
 }
 
@@ -428,8 +446,8 @@ func (t *genTable[Obj]) GetWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision u
 }
 
 func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Revision] {
-	iter, _ := t.LowerBoundWatch(txn, q)
-	return iter
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
+	return objSeq[Obj](indexTxn.lowerBoundNoWatch(q.key))
 }
 
 func (t *genTable[Obj]) LowerBoundWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
@@ -439,8 +457,8 @@ func (t *genTable[Obj]) LowerBoundWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Ob
 }
 
 func (t *genTable[Obj]) Prefix(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Revision] {
-	iter, _ := t.PrefixWatch(txn, q)
-	return iter
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
+	return objSeq[Obj](indexTxn.prefixNoWatch(q.key))
 }
 
 func (t *genTable[Obj]) PrefixWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
@@ -450,8 +468,13 @@ func (t *genTable[Obj]) PrefixWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, R
 }
 
 func (t *genTable[Obj]) All(txn ReadTxn) iter.Seq2[Obj, Revision] {
-	iter, _ := t.AllWatch(txn)
-	return iter
+	indexTxn := txn.mustIndexReadTxn(t, PrimaryIndexPos)
+	iter := indexTxn.allNoWatch()
+	return func(yield func(Obj, Revision) bool) {
+		iter.All(func(_ []byte, obj object) bool {
+			return yield(obj.data.(Obj), obj.revision)
+		})
+	}
 }
 
 func (t *genTable[Obj]) AllWatch(txn ReadTxn) (iter.Seq2[Obj, Revision], <-chan struct{}) {
@@ -465,8 +488,8 @@ func (t *genTable[Obj]) AllWatch(txn ReadTxn) (iter.Seq2[Obj, Revision], <-chan 
 }
 
 func (t *genTable[Obj]) List(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Revision] {
-	iter, _ := t.ListWatch(txn, q)
-	return iter
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
+	return objSeq[Obj](indexTxn.listNoWatch(q.key))
 }
 
 func (t *genTable[Obj]) ListWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
@@ -476,13 +499,17 @@ func (t *genTable[Obj]) ListWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Rev
 }
 
 func (t *genTable[Obj]) Insert(txn WriteTxn, obj Obj) (oldObj Obj, hadOld bool, err error) {
-	oldObj, hadOld, _, err = t.InsertWatch(txn, obj)
+	var old object
+	old, hadOld, _, err = txn.unwrap().insert(t, Revision(0), obj, false)
+	if hadOld {
+		oldObj = old.data.(Obj)
+	}
 	return
 }
 
 func (t *genTable[Obj]) InsertWatch(txn WriteTxn, obj Obj) (oldObj Obj, hadOld bool, watch <-chan struct{}, err error) {
 	var old object
-	old, hadOld, watch, err = txn.unwrap().insert(t, Revision(0), obj)
+	old, hadOld, watch, err = txn.unwrap().insert(t, Revision(0), obj, true)
 	if hadOld {
 		oldObj = old.data.(Obj)
 	}
@@ -495,7 +522,7 @@ func (t *genTable[Obj]) Modify(txn WriteTxn, obj Obj, merge func(old, new Obj) O
 		return new
 	}
 	var old object
-	old, hadOld, _, err = txn.unwrap().modify(t, Revision(0), obj, mergeObjects)
+	old, hadOld, _, err = txn.unwrap().modify(t, Revision(0), obj, mergeObjects, false)
 	if hadOld {
 		oldObj = old.data.(Obj)
 	}
@@ -504,7 +531,7 @@ func (t *genTable[Obj]) Modify(txn WriteTxn, obj Obj, merge func(old, new Obj) O
 
 func (t *genTable[Obj]) CompareAndSwap(txn WriteTxn, rev Revision, obj Obj) (oldObj Obj, hadOld bool, err error) {
 	var old object
-	old, hadOld, _, err = txn.unwrap().insert(t, rev, obj)
+	old, hadOld, _, err = txn.unwrap().insert(t, rev, obj, false)
 	if hadOld {
 		oldObj = old.data.(Obj)
 	}

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -322,6 +322,12 @@ type Indexer[Obj any] interface {
 	newTableIndex() tableIndex
 }
 
+// secondaryOnlyIndexer marks index implementations that cannot be used as a
+// table's primary index.
+type secondaryOnlyIndexer interface {
+	secondaryOnly()
+}
+
 // TableWritable is a constraint for objects that implement tabular
 // pretty-printing. Used by the "db" script commands to render a table.
 type TableWritable interface {
@@ -410,11 +416,17 @@ type tableIndexIterator interface {
 type tableIndexReader interface {
 	len() int
 	get(key index.Key) (object, <-chan struct{}, bool)
+	getNoWatch(key index.Key) (object, bool)
 	prefix(key index.Key) (tableIndexIterator, <-chan struct{})
+	prefixNoWatch(key index.Key) tableIndexIterator
 	lowerBound(key index.Key) (tableIndexIterator, <-chan struct{})
+	lowerBoundNoWatch(key index.Key) tableIndexIterator
 	lowerBoundNext(key index.Key) (func() ([]byte, object, bool), <-chan struct{})
+	lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, bool)
 	list(key index.Key) (tableIndexIterator, <-chan struct{})
+	listNoWatch(key index.Key) tableIndexIterator
 	all() (tableIndexIterator, <-chan struct{})
+	allNoWatch() tableIndexIterator
 	rootWatch() <-chan struct{}
 	objectToKey(obj object) index.Key
 }
@@ -429,7 +441,9 @@ type tableIndexTxn interface {
 	tableIndex
 
 	insert(key index.Key, obj object) (old object, hadOld bool, watch <-chan struct{})
+	insertNoWatch(key index.Key, obj object) (old object, hadOld bool)
 	modify(key index.Key, obj object, mod func(old, new object) object) (old object, new object, hadOld bool, watch <-chan struct{})
+	modifyNoWatch(key index.Key, obj object, mod func(old, new object) object) (old object, new object, hadOld bool)
 	delete(key index.Key) (old object, hadOld bool)
 	reindex(primaryKey index.Key, old object, new object)
 }

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -112,11 +112,11 @@ func (txn *writeTxnState) mustIndexWriteTxn(meta TableMeta, indexPos int) tableI
 	return indexTxn
 }
 
-func (txn *writeTxnState) insert(meta TableMeta, guardRevision Revision, data any) (object, bool, <-chan struct{}, error) {
-	return txn.modify(meta, guardRevision, data, nil)
+func (txn *writeTxnState) insert(meta TableMeta, guardRevision Revision, data any, withWatch bool) (object, bool, <-chan struct{}, error) {
+	return txn.modify(meta, guardRevision, data, nil, withWatch)
 }
 
-func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData any, merge func(old, new object) object) (object, bool, <-chan struct{}, error) {
+func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData any, merge func(old, new object) object, withWatch bool) (object, bool, <-chan struct{}, error) {
 	if txn == nil {
 		return object{}, false, nil, ErrTransactionClosed
 	}
@@ -142,11 +142,19 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		watch     <-chan struct{}
 	)
 	if merge == nil {
-		oldObj, oldExists, watch = idIndexTxn.insert(idKey, obj)
+		if withWatch {
+			oldObj, oldExists, watch = idIndexTxn.insert(idKey, obj)
+		} else {
+			oldObj, oldExists = idIndexTxn.insertNoWatch(idKey, obj)
+		}
 	} else {
 		// Insert the object into the primary index. This returns the merged new
 		// object which we'll then insert into the secondary indexes.
-		oldObj, obj, oldExists, watch = idIndexTxn.modify(idKey, obj, merge)
+		if withWatch {
+			oldObj, obj, oldExists, watch = idIndexTxn.modify(idKey, obj, merge)
+		} else {
+			oldObj, obj, oldExists = idIndexTxn.modifyNoWatch(idKey, obj, merge)
+		}
 	}
 
 	// Sanity check: is the same object being inserted back and thus the
@@ -176,7 +184,7 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 			// Revert the change. We're assuming here that it's rarer for CompareAndSwap() to
 			// fail and thus we're optimizing to have only one lookup in the common case
 			// (versus doing a Get() and then Insert()).
-			idIndexTxn.insert(idKey, oldObj)
+			idIndexTxn.insertNoWatch(idKey, oldObj)
 			table.revision = oldRevision
 			return oldObj, true, watch, ErrRevisionNotEqual
 		}
@@ -188,12 +196,12 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		binary.BigEndian.PutUint64(txn.revKey[:], oldObj.revision)
 		revIndexTxn.delete(txn.revKey[:])
 	}
-	revIndexTxn.insert(index.Uint64(obj.revision), obj)
+	revIndexTxn.insertNoWatch(index.Uint64(obj.revision), obj)
 
 	// If it's new, possibly remove an older deleted object with the same
 	// primary key from the graveyard.
 	if !oldExists {
-		if old, _, existed := txn.mustIndexReadTxn(meta, GraveyardIndexPos).get(idKey); existed {
+		if old, existed := txn.mustIndexReadTxn(meta, GraveyardIndexPos).getNoWatch(idKey); existed {
 			txn.mustIndexWriteTxn(meta, GraveyardIndexPos).delete(idKey)
 			binary.BigEndian.PutUint64(txn.revKey[:], old.revision)
 			txn.mustIndexWriteTxn(meta, GraveyardRevisionIndexPos).delete(txn.revKey[:])
@@ -256,7 +264,7 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 	// revert the change.
 	if guardRevision > 0 {
 		if obj.revision != guardRevision {
-			idIndex.insert(idKey, obj)
+			idIndex.insertNoWatch(idKey, obj)
 			return obj, true, ErrRevisionNotEqual
 		}
 	}
@@ -277,10 +285,10 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 	if txn.hasDeleteTrackers(meta) {
 		graveyardIndex := txn.mustIndexWriteTxn(meta, GraveyardIndexPos)
 		obj.revision = revision
-		if _, existed, _ := graveyardIndex.insert(idKey, obj); existed {
+		if _, existed := graveyardIndex.insertNoWatch(idKey, obj); existed {
 			panic("BUG: Double deletion! Deleted object already existed in graveyard")
 		}
-		txn.mustIndexWriteTxn(meta, GraveyardRevisionIndexPos).insert(index.Uint64(revision), obj)
+		txn.mustIndexWriteTxn(meta, GraveyardRevisionIndexPos).insertNoWatch(index.Uint64(revision), obj)
 	}
 
 	return obj, true, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -361,7 +361,7 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.8.4
+# github.com/cilium/statedb v0.9.0
 ## explicit; go 1.25.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Release notes: https://github.com/cilium/statedb/releases/tag/v0.9.0

The major changes are performance improvements and extensions to the StatusSet type. The latter are needed for the ongoing Table[Node] work.

pkg/loadbalancer/benchmark before (best of 3):
```
  Memory statistics from N=10 iterations:
  Min: Allocated 446723kB in total, 1940361 objects / 103445kB still reachable (per service:  38 objs,  9148B alloc,  2118B in-use)
  Avg: Allocated 457889kB in total, 2573533 objects / 151007kB still reachable (per service:  51 objs,  9377B alloc,  3092B in-use)
  Max: Allocated 503133kB in total, 3672276 objects / 224735kB still reachable (per service:  73 objs, 10304B alloc,  4602B in-use)

  Insert statistics from N=10 iterations:
  Min: Reconciled 50000 objects in 617.183086ms (12.343µs  per service /  81018 services per second)
  Avg: Reconciled 50000 objects in 711.083155ms (14.221µs  per service /  70319 services per second)
  Max: Reconciled 50000 objects in 994.472746ms (19.889µs  per service /  50279 services per second)

  Delete statistics from N=10 iterations:
  Min: Reconciled 50000 objects in 329.117888ms (6.582µs   per service / 151930 services per second)
  Avg: Reconciled 50000 objects in 555.965705ms (11.119µs  per service /  89936 services per second)
  Max: Reconciled 50000 objects in 926.791799ms (18.535µs  per service /  53952 services per second)
```
After:
```
  Memory statistics from N=10 iterations:
  Min: Allocated 370479kB in total, 1949283 objects /  81855kB still reachable (per service:  38 objs,  7587B alloc,  1676B in-use)
  Avg: Allocated 381021kB in total, 2265657 objects / 104213kB still reachable (per service:  45 objs,  7803B alloc,  2134B in-use)
  Max: Allocated 425476kB in total, 3682494 objects / 197894kB still reachable (per service:  73 objs,  8713B alloc,  4052B in-use)

  Insert statistics from N=10 iterations:
  Min: Reconciled 50000 objects in 569.36416ms (11.387µs  per service /  87819 services per second)
  Avg: Reconciled 50000 objects in 636.496921ms (12.729µs  per service /  78561 services per second)
  Max: Reconciled 50000 objects in 1.012630461s (20.252µs  per service /  49378 services per second)

  Delete statistics from N=10 iterations:
  Min: Reconciled 50000 objects in 250.090453ms (5.001µs   per service / 199960 services per second)
  Avg: Reconciled 50000 objects in 268.922938ms (5.378µs   per service / 185943 services per second)
  Max: Reconciled 50000 objects in 320.020085ms (6.4µs     per service / 156250 services per second)
```
