### PR TITLE
clustermesh: fix race condition that can resurrect a stopped connection

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -298,6 +298,14 @@ func (rc *remoteCluster) watchdog(
 	ctx context.Context, backend kvstore.BackendOperations,
 	clusterLock *clusterLock, configChanged <-chan struct{},
 ) {
+	restart := func() {
+		// Let's manually trigger the controller, instead of directly calling
+		// restartRemoteConnection, to prevent the risk of a race condition if
+		// the watchdog triggers at the same time of the cluster removal, which
+		// would otherwise resurrect an already stopped connection.
+		rc.controllers.TriggerController(rc.remoteConnectionControllerName)
+	}
+
 	handleErr := func(err error) {
 		rc.logger.Warn("Error observed on etcd connection, reconnecting etcd", logfields.Error, err)
 		rc.mutex.Lock()
@@ -308,7 +316,7 @@ func (rc *remoteCluster) watchdog(
 		rc.metricReadinessStatus.Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 		rc.mutex.Unlock()
 
-		rc.restartRemoteConnection()
+		restart()
 	}
 
 	select {
@@ -323,7 +331,7 @@ func (rc *remoteCluster) watchdog(
 	case <-configChanged:
 		rc.logger.Info("Remote cluster configuration changed, reconnecting")
 		// Let's bypass handleErr as it's not an actual error
-		rc.restartRemoteConnection()
+		restart()
 	case <-ctx.Done():
 		return
 	}
@@ -449,8 +457,7 @@ func (rc *remoteCluster) status() *models.RemoteCluster {
 	rc.mutex.RLock()
 	defer rc.mutex.RUnlock()
 
-	// This can happen when the controller in restartRemoteConnection is waiting
-	// for the first connection to succeed.
+	// This can happen when the first connection has not succeeded yet.
 	var backendStatus = "Waiting for initial connection to be established"
 	if rc.backend != nil {
 		backendStatus = rc.backend.Status().Msg

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -252,24 +252,41 @@ func (c *controller) SetParams(params ControllerParams) {
 		params.RunInterval = maxInterval
 	}
 
+	old := c.params
+	c.params = params
+	c.updateContextLocked(old.Context, params.Context, old.CancelDoFuncOnUpdate)
+}
+
+// MaybeResetContext cancels the controller context if [CancelDoFuncOnUpdate] is
+// set, and replaces it with a new background context. It is a no-op otherwise.
+//
+// Manager's mutex must be held; controller.mutex must not be held
+func (c *controller) MaybeResetContext() {
+	c.paramMutex.Lock()
+	defer c.paramMutex.Unlock()
+
+	c.updateContextLocked(c.params.Context, nil, c.params.CancelDoFuncOnUpdate)
+}
+
+func (c *controller) updateContextLocked(curr, next context.Context, shouldCancel bool) {
 	// Save current context on update if not canceling
-	ctx := c.params.Context
+	ctx := curr
+
 	// Check if the current context needs to be cancelled
-	if c.params.CancelDoFuncOnUpdate && c.cancelDoFunc != nil {
+	if shouldCancel && c.cancelDoFunc != nil {
 		c.cancelDoFunc()
-		c.params.Context = nil
+		ctx = nil
 	}
 
 	// (re)set the context as the previous might have been cancelled
-	if c.params.Context == nil {
-		if params.Context == nil {
+	if ctx == nil {
+		if next == nil {
 			ctx, c.cancelDoFunc = context.WithCancel(context.Background())
 		} else {
-			ctx, c.cancelDoFunc = context.WithCancel(params.Context)
+			ctx, c.cancelDoFunc = context.WithCancel(next)
 		}
 	}
 
-	c.params = params
 	c.params.Context = ctx
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -393,4 +394,57 @@ func TestControllerUpdateDuringJitter(t *testing.T) {
 
 	// Cleanup
 	require.NoError(t, mngr.RemoveControllerAndWait("test-jitter"))
+}
+
+func TestTriggerControllerContext(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			mgr  = NewManager()
+			cnt  [2]uint
+			stop = make(chan struct{})
+
+			do = func(idx int) ControllerFunc {
+				return func(ctx context.Context) error {
+					cnt[idx]++
+					select {
+					case <-ctx.Done():
+					case <-stop:
+					}
+					return nil
+				}
+			}
+		)
+
+		mgr.CreateController("with-cancel", ControllerParams{
+			DoFunc:               do(0),
+			CancelDoFuncOnUpdate: true,
+		})
+
+		mgr.CreateController("without-cancel", ControllerParams{
+			DoFunc: do(1),
+		})
+
+		t.Cleanup(func() {
+			require.NoError(t, mgr.RemoveControllerAndWait("with-cancel"), "mgr.RemoveControllerAndWait")
+			require.NoError(t, mgr.RemoveControllerAndWait("without-cancel"), "mgr.RemoveControllerAndWait")
+		})
+
+		synctest.Wait()
+		require.EqualValues(t, 1, cnt[0], "Both controllers should have been triggered once")
+		require.EqualValues(t, 1, cnt[1], "Both controllers should have been triggered once")
+
+		mgr.TriggerController("with-cancel")
+		mgr.TriggerController("without-cancel")
+
+		synctest.Wait()
+		require.EqualValues(t, 2, cnt[0], "The controller with CancelDoFuncOnUpdate should have been triggered twice")
+		require.EqualValues(t, 1, cnt[1], "The controller without CancelDoFuncOnUpdate should not have been retriggered")
+
+		close(stop)
+		stop = nil
+
+		synctest.Wait()
+		require.EqualValues(t, 2, cnt[0], "The controller with CancelDoFuncOnUpdate should not have been automatically retriggered")
+		require.EqualValues(t, 2, cnt[1], "The controller without CancelDoFuncOnUpdate should have been retriggered by the queued trigger")
+	})
 }

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -267,10 +267,15 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 
 // TriggerController triggers the controller with the specified name.
 func (m *Manager) TriggerController(name string) {
-	ctrl := m.lookup(name)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	ctrl := m.lookupLocked(name)
 	if ctrl == nil {
 		return
 	}
+
+	ctrl.MaybeResetContext()
 
 	select {
 	case ctrl.trigger <- struct{}{}:


### PR DESCRIPTION
Currently, the clustermesh logic handling the connection to remote
clusters is affected by a (arguably extremely rare) race condition
that can cause the connection to a removed cluster to be incorrectly
resurrected. Specifically, this can happen if a watchdog error fires
at the same time that [remoteCluster.onStop] is called, and the
controller is first removed, and then immediately created back by
[remoteCluster.restartRemoteConnection].

Let's get this fixed by leveraging [TriggerController] in case of
watchdog errors, which is a no-op if the controller has already been
deleted. More in general, we should refactor this whole logic to not
leverage the controller construct anymore, as it is becoming extremely
difficult to reason about, and prone to subtle issues. However, that's
a larger refactoring for another time, as also not suitable for backport.

AIL: 0

<!-- Description of change -->

```release-note
Cluster Mesh: fix extremely rare race condition that may cause a removed remote cluster to not be correctly disconnected 
```