### PR TITLE
envoy: wait for policy restoration instead of publishing without it

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -85,7 +85,7 @@ type xdsServerParams struct {
 // runnableXDSServer extends XDSServer with the lifecycle method used internally by the cell.
 type runnableXDSServer interface {
 	XDSServer
-	run(ctx context.Context) error
+	run(ctx context.Context, health cell.Health) error
 }
 
 func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
@@ -144,8 +144,8 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 		return xdsServer, nil
 	}
 
-	params.JobGroup.Add(job.OneShot("xds-server", func(ctx context.Context, _ cell.Health) error {
-		return xdsServer.run(ctx)
+	params.JobGroup.Add(job.OneShot("xds-server", func(ctx context.Context, health cell.Health) error {
+		return xdsServer.run(ctx, health)
 	}, job.WithShutdown()))
 
 	if !option.Config.ExternalEnvoyProxy {

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/cilium/hive/cell"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_cluster "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -31,7 +32,7 @@ var ErrNotImplemented = errors.New("not implemented")
 // runXDSGRPCServer runs a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener. Returns on error or when [ctx]
 // is cancelled.
-func (s *xdsServer) runXDSGRPCServer(ctx context.Context, config map[string]*xds.ResourceTypeConfiguration) error {
+func (s *xdsServer) runXDSGRPCServer(ctx context.Context, health cell.Health, config map[string]*xds.ResourceTypeConfiguration) error {
 	listener, err := s.newSocketListener()
 	if err != nil {
 		return fmt.Errorf("failed to create socket listener: %w", err)
@@ -58,7 +59,7 @@ func (s *xdsServer) runXDSGRPCServer(ctx context.Context, config map[string]*xds
 
 	s.stopFunc = grpcServer.Stop
 
-	if err := awaitEndpointPolicyRestoration(ctx, s.logger, s.restorerPromise,
+	if err := awaitEndpointPolicyRestoration(ctx, health, s.logger, s.restorerPromise,
 		s.config.policyRestoreTimeout); err != nil {
 		s.logger.Debug("Envoy: xDS server stopped before started serving")
 		return err

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -56,26 +56,14 @@ func (s *xdsServer) runXDSGRPCServer(ctx context.Context, config map[string]*xds
 
 	reflection.Register(grpcServer)
 
-	restoreCtx, cancel := context.WithTimeout(ctx, s.config.policyRestoreTimeout)
-	defer cancel()
 	s.stopFunc = grpcServer.Stop
 
+	if err := awaitEndpointPolicyRestoration(ctx, s.logger, s.restorerPromise,
+		s.config.policyRestoreTimeout); err != nil {
+		s.logger.Debug("Envoy: xDS server stopped before started serving")
+		return err
+	}
 	if s.restorerPromise != nil {
-		s.logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
-		restorer, err := s.restorerPromise.Await(restoreCtx)
-		if err == nil && restorer != nil {
-			s.logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
-			err = restorer.WaitForInitialPolicy(restoreCtx)
-		}
-		if errors.Is(err, context.Canceled) {
-			s.logger.Debug("Envoy: xDS server stopped before started serving")
-			return err
-		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			s.logger.Warn("Envoy: Endpoint policy restoration took longer than configured restore timeout, starting serving resources to Envoy",
-				logfields.Duration, s.config.policyRestoreTimeout,
-			)
-		}
 		// Tell xdsServer it's time to start waiting for acknowledgements
 		xdsServer.RestoreCompleted()
 	}
@@ -84,7 +72,7 @@ func (s *xdsServer) runXDSGRPCServer(ctx context.Context, config map[string]*xds
 		logfields.Address, listener.Addr(),
 	)
 
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
 		<-ctx.Done()

--- a/pkg/envoy/grpcnew.go
+++ b/pkg/envoy/grpcnew.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/cilium/hive/cell"
 	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/sotw/v3"
 	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
@@ -23,7 +24,7 @@ import (
 
 // startAdsGRPCServer runs a gRPC server to serve ADS APIs. Returns on error or
 // when ctx is cancelled.
-func (s *adsServer) startAdsGRPCServer(ctx context.Context) error {
+func (s *adsServer) startAdsGRPCServer(ctx context.Context, health cell.Health) error {
 	listener, err := s.newSocketListener()
 	if err != nil {
 		return fmt.Errorf("failed to create socket listener: %w", err)
@@ -46,7 +47,7 @@ func (s *adsServer) startAdsGRPCServer(ctx context.Context) error {
 
 	s.stopFunc = grpcServer.Stop
 
-	if err := awaitEndpointPolicyRestoration(ctx, s.logger, s.restorerPromise,
+	if err := awaitEndpointPolicyRestoration(ctx, health, s.logger, s.restorerPromise,
 		s.config.policyRestoreTimeout); err != nil {
 		s.logger.Debug("Envoy: xDS server stopped before started serving")
 		return err

--- a/pkg/envoy/grpcnew.go
+++ b/pkg/envoy/grpcnew.go
@@ -44,33 +44,19 @@ func (s *adsServer) startAdsGRPCServer(ctx context.Context) error {
 
 	reflection.Register(grpcServer)
 
-	restoreCtx, cancel := context.WithTimeout(ctx, s.config.policyRestoreTimeout)
-	defer cancel()
 	s.stopFunc = grpcServer.Stop
 
-	if s.restorerPromise != nil {
-		s.logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
-		restorer, err := s.restorerPromise.Await(restoreCtx)
-		if err == nil && restorer != nil {
-			s.logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
-			err = restorer.WaitForInitialPolicy(restoreCtx)
-		}
-		if errors.Is(err, context.Canceled) {
-			s.logger.Debug("Envoy: xDS server stopped before started serving")
-			return err
-		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			s.logger.Warn("Envoy: Endpoint policy restoration took longer than configured restore timeout, starting serving resources to Envoy",
-				logfields.Duration, s.config.policyRestoreTimeout,
-			)
-		}
+	if err := awaitEndpointPolicyRestoration(ctx, s.logger, s.restorerPromise,
+		s.config.policyRestoreTimeout); err != nil {
+		s.logger.Debug("Envoy: xDS server stopped before started serving")
+		return err
 	}
 
 	s.logger.Info("Envoy: Starting xDS gRPC server listening",
 		logfields.Address, listener.Addr(),
 	)
 
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
 		<-ctx.Done()

--- a/pkg/envoy/grpcnew_test.go
+++ b/pkg/envoy/grpcnew_test.go
@@ -25,7 +25,7 @@ func TestADSGRPCServerStopsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- server.run(ctx)
+		done <- server.run(ctx, testHealth())
 	}()
 
 	require.Eventually(t, func() bool {

--- a/pkg/envoy/restore_wait.go
+++ b/pkg/envoy/restore_wait.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/cilium/hive/cell"
+
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/promise"
@@ -15,35 +17,87 @@ import (
 )
 
 // awaitEndpointPolicyRestoration waits for the endpoint restorer, and then for
-// the restored endpoints to have computed their initial policy, bounded by
-// timeout. It returns an error only when the caller should stop, that is when
-// its context was cancelled.
-func awaitEndpointPolicyRestoration(ctx context.Context, logger *slog.Logger,
-	restorerPromise promise.Promise[endpointstate.Restorer], timeout time.Duration,
+// the restored endpoints to have computed their initial policy, so that the
+// first resources served to Envoy are a complete state of the world.
+//
+// Serving early is not a lesser evil. At that point the cilium-http listeners do
+// not exist yet, because endpoint regeneration creates them when it builds the
+// proxy redirect, and no endpoint has a network policy. A cilium-envoy that
+// survived the agent restart is still serving traffic with the configuration it
+// already has, and it applies whatever it is sent as authoritative, so an early
+// snapshot makes it drop the listeners and every policy it was using.
+//
+// reportInterval therefore bounds how often this reports that it is still
+// waiting, not how long it is prepared to wait. It returns an error only when
+// the caller should stop, that is when its context was cancelled.
+func awaitEndpointPolicyRestoration(ctx context.Context, health cell.Health, logger *slog.Logger,
+	restorerPromise promise.Promise[endpointstate.Restorer], reportInterval time.Duration,
 ) error {
 	if restorerPromise == nil {
 		return nil
 	}
 
-	restoreCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
 
-	restorer, err := restorerPromise.Await(restoreCtx)
-	if err == nil && restorer != nil {
-		logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
-		err = restorer.WaitForInitialPolicy(restoreCtx)
-	}
-
-	if errors.Is(err, context.Canceled) {
+	restorer, err := awaitWithReports(ctx, health, logger, reportInterval,
+		func(ctx context.Context) (endpointstate.Restorer, error) {
+			return restorerPromise.Await(ctx)
+		})
+	if err != nil {
 		return err
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		logger.Warn("Envoy: Endpoint policy restoration took longer than configured restore timeout, starting serving resources to Envoy",
-			logfields.Duration, timeout,
-		)
+	if restorer == nil {
+		return nil
 	}
 
-	return nil
+	logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
+
+	_, err = awaitWithReports(ctx, health, logger, reportInterval,
+		func(ctx context.Context) (struct{}, error) {
+			return struct{}{}, restorer.WaitForInitialPolicy(ctx)
+		})
+	return err
+}
+
+// awaitWithReports calls await with a deadline of reportInterval, and on expiry
+// reports that it is still waiting and calls it again. It only returns when
+// await succeeds or ctx is done.
+func awaitWithReports[T any](ctx context.Context, health cell.Health, logger *slog.Logger,
+	reportInterval time.Duration, await func(context.Context) (T, error),
+) (T, error) {
+	var zero T
+
+	for waited := time.Duration(0); ; waited += reportInterval {
+		attemptCtx, cancel := context.WithTimeout(ctx, reportInterval)
+		started := time.Now()
+		res, err := await(attemptCtx)
+		cancel()
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			if err != nil {
+				return zero, err
+			}
+			return res, nil
+		}
+
+		// The parent context being done is reported as DeadlineExceeded by the
+		// child, so distinguish the two before deciding to keep waiting.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return zero, ctxErr
+		}
+
+		// An implementation that reports the deadline without having waited for
+		// it would otherwise spin here.
+		if remaining := reportInterval - time.Since(started); remaining > 0 {
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(remaining):
+			}
+		}
+
+		reason := "Envoy: Endpoint policy restoration has not completed yet, still waiting before serving resources to Envoy"
+		logger.Warn(reason, logfields.Duration, waited+reportInterval)
+		health.Degraded(reason, err)
+	}
 }

--- a/pkg/envoy/restore_wait.go
+++ b/pkg/envoy/restore_wait.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// awaitEndpointPolicyRestoration waits for the endpoint restorer, and then for
+// the restored endpoints to have computed their initial policy, bounded by
+// timeout. It returns an error only when the caller should stop, that is when
+// its context was cancelled.
+func awaitEndpointPolicyRestoration(ctx context.Context, logger *slog.Logger,
+	restorerPromise promise.Promise[endpointstate.Restorer], timeout time.Duration,
+) error {
+	if restorerPromise == nil {
+		return nil
+	}
+
+	restoreCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
+
+	restorer, err := restorerPromise.Await(restoreCtx)
+	if err == nil && restorer != nil {
+		logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
+		err = restorer.WaitForInitialPolicy(restoreCtx)
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		logger.Warn("Envoy: Endpoint policy restoration took longer than configured restore timeout, starting serving resources to Envoy",
+			logfields.Duration, timeout,
+		)
+	}
+
+	return nil
+}

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -291,7 +291,7 @@ func TestEnvoyAds(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -422,7 +422,7 @@ func TestEnvoyAdsResourcesHandling(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -528,7 +528,7 @@ func TestEnvoyAdsNetworkPoliciesHandling(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -821,7 +821,7 @@ func TestEnvoyDelta(t *testing.T) {
 	xdsServer.l7RulesTranslator = envoypolicy.NewEnvoyL7RulesTranslator(logger, secretManager)
 
 	go func() {
-		err = xdsServer.run(ctx)
+		err = xdsServer.run(ctx, testHealth())
 		require.NoError(t, err)
 	}()
 
@@ -978,7 +978,7 @@ func TestEnvoy(t *testing.T) {
 	xdsServer.l7RulesTranslator = envoypolicy.NewEnvoyL7RulesTranslator(logger, secretManager)
 
 	go func() {
-		err = xdsServer.run(ctx)
+		err = xdsServer.run(ctx, testHealth())
 		require.NoError(t, err)
 	}()
 
@@ -1129,7 +1129,7 @@ func TestEnvoyNACK(t *testing.T) {
 	xdsServer.l7RulesTranslator = envoypolicy.NewEnvoyL7RulesTranslator(logger, secretManager)
 
 	go func() {
-		err = xdsServer.run(ctx)
+		err = xdsServer.run(ctx, testHealth())
 		require.NoError(t, err)
 	}()
 
@@ -1223,7 +1223,7 @@ func TestEnvoyAdsNACKRevert(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -1345,7 +1345,7 @@ func TestEnvoyAdsMultipleVersionsSentBeforeAckReceived(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -1443,7 +1443,7 @@ func TestEnvoyAdsMultipleVersionsSentBeforeNackReceived(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
@@ -1546,7 +1546,7 @@ func TestEnvoyAdsLocalityClusterEndpointsACK(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.run(t.Context())
+		err = xdsServer.run(t.Context(), testHealth())
 		require.NoError(t, err)
 	}()
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/cilium/hive/cell"
 	envoy_config_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -203,8 +204,8 @@ func newXDSServer(logger *slog.Logger, restorerPromise promise.Promise[endpoints
 	return xdsServer
 }
 
-func (s *xdsServer) run(ctx context.Context) error {
-	return s.runXDSGRPCServer(ctx, s.resourceConfig)
+func (s *xdsServer) run(ctx context.Context, health cell.Health) error {
+	return s.runXDSGRPCServer(ctx, health, s.resourceConfig)
 }
 
 func (s *xdsServer) initializeXdsConfigs() {

--- a/pkg/envoy/xds_server_ads.go
+++ b/pkg/envoy/xds_server_ads.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/cilium/hive/cell"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -117,8 +118,8 @@ func newADSServer(logger *slog.Logger, ipCache IPCacheEventSource, localEndpoint
 	return newADSServerWithCache(xdsnew.NewCache(logger, config.envoyXDSMode.IsStrictADS()), logger, ipCache, localEndpointStore, config, secretManager, restorerPromise)
 }
 
-func (s *adsServer) run(ctx context.Context) error {
-	return s.startAdsGRPCServer(ctx)
+func (s *adsServer) run(ctx context.Context, health cell.Health) error {
+	return s.startAdsGRPCServer(ctx, health)
 }
 
 func (s *adsServer) newSocketListener() (*net.UnixListener, error) {

--- a/pkg/envoy/xds_server_ads_test.go
+++ b/pkg/envoy/xds_server_ads_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/hive/cell"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"google.golang.org/protobuf/proto"
 
@@ -1032,6 +1033,9 @@ func (m *testableEndpointUpdater) GetListenerProxyPort(string) uint16 { return 0
 // mockRestorer implements endpointstate.Restorer for testing.
 type mockRestorer struct {
 	waitErr error
+	// block makes WaitForInitialPolicy wait for the context instead of
+	// returning immediately, as the real restorer does.
+	block bool
 }
 
 func (m *mockRestorer) WaitForEndpointRestore(ctx context.Context) error {
@@ -1043,6 +1047,10 @@ func (m *mockRestorer) WaitForEndpointRestoreWithoutRegeneration(ctx context.Con
 }
 
 func (m *mockRestorer) WaitForInitialPolicy(ctx context.Context) error {
+	if m.block {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 	return m.waitErr
 }
 
@@ -1060,7 +1068,7 @@ func TestStartAdsGRPCServerWithRestorerSuccess(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.startAdsGRPCServer(ctx)
+		errCh <- server.startAdsGRPCServer(ctx, testHealth())
 	}()
 
 	// Resolve the promise with a restorer that succeeds.
@@ -1077,34 +1085,45 @@ func TestStartAdsGRPCServerWithRestorerSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestStartAdsGRPCServerWithRestorerDeadlineExceeded(t *testing.T) {
+func TestStartAdsGRPCServerWaitsForRestorationPastTheReportInterval(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	config := xdsServerConfig{
 		envoySocketDir:       t.TempDir(),
-		policyRestoreTimeout: 5 * time.Second,
+		policyRestoreTimeout: 50 * time.Millisecond,
 	}
 
 	resolver, restorerPromise := promise.New[endpointstate.Restorer]()
 	server := newADSServer(logger, nil, nil, config, nil, restorerPromise)
 
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	health, simpleHealth := cell.NewSimpleHealth()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.startAdsGRPCServer(ctx)
+		errCh <- server.startAdsGRPCServer(ctx, health)
 	}()
 
-	// Resolve with a restorer that returns DeadlineExceeded.
-	resolver.Resolve(&mockRestorer{waitErr: context.DeadlineExceeded})
+	// Restoration never completes, so the server must keep waiting rather than
+	// serve a state of the world with no listeners and no policies.
+	resolver.Resolve(&mockRestorer{block: true})
 
-	// Server should still start serving despite the deadline exceeded.
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case err := <-errCh:
+		t.Fatalf("server returned while restoration was incomplete: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
 
-	require.NotNil(t, server.stopFunc, "stopFunc should be set even after deadline exceeded")
-	server.stopFunc()
+	// And it reports that it is waiting rather than doing so silently.
+	require.Eventually(t, func() bool {
+		return simpleHealth.Level == cell.StatusDegraded
+	}, time.Second, 20*time.Millisecond, "expected a degraded report while waiting")
+
+	cancel()
 
 	err := <-errCh
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestStartAdsGRPCServerWithRestorerCanceled(t *testing.T) {
@@ -1121,7 +1140,7 @@ func TestStartAdsGRPCServerWithRestorerCanceled(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.startAdsGRPCServer(ctx)
+		errCh <- server.startAdsGRPCServer(ctx, testHealth())
 	}()
 
 	// Resolve with a restorer that returns context.Canceled.
@@ -1144,7 +1163,7 @@ func TestStartAdsGRPCServerWithNilRestorerPromise(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.startAdsGRPCServer(ctx)
+		errCh <- server.startAdsGRPCServer(ctx, testHealth())
 	}()
 
 	// With nil restorerPromise, server should start immediately.
@@ -1171,7 +1190,7 @@ func TestStartAdsGRPCServerContextCanceledBeforeResolve(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- server.startAdsGRPCServer(ctx)
+		errCh <- server.startAdsGRPCServer(ctx, testHealth())
 	}()
 
 	// Cancel context before resolving the promise — simulates shutdown during startup.
@@ -1180,4 +1199,10 @@ func TestStartAdsGRPCServerContextCanceledBeforeResolve(t *testing.T) {
 
 	err := <-errCh
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// testHealth returns a throwaway health handle for the xDS server under test.
+func testHealth() cell.Health {
+	h, _ := cell.NewSimpleHealth()
+	return h
 }


### PR DESCRIPTION
The xDS server waited for the restored endpoints to compute their initial
policy under a deadline of --envoy-policy-restore-timeout, and on expiry served
anyway. At that point the cilium-http listeners do not exist yet and no endpoint
has a network policy, so a cilium-envoy that survived the agent restart applies
that as authoritative and drops the configuration it was using.

On https://github.com/cilium/cilium/actions/runs/32952837790/job/98128204123 the
node that crossed the deadline published ten listeners with neither cilium-http
listener among them and a network policy response with no resources at all, then
re-added its policies one endpoint at a time over 18 seconds while conn-disrupt
clients were answered with a 503.

The first commit moves the wait, which both server implementations duplicated,
into one function with no behaviour change. The second makes it keep waiting and
report the job degraded once per interval instead of publishing.

```release-note
Fix cilium-agent publishing an xDS state of the world without the L7 proxy listeners or any network policy when endpoint policy restoration takes longer than --envoy-policy-restore-timeout, which made a running Envoy drop the configuration it was using.
```

This PR was prepared with AIL:3.
