### PR TITLE
.github: Add /default ariane workflows to /test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -2,6 +2,7 @@ allowed-teams:
   - organization-members
 
 triggers:
+  # These workflows should be duplicated between /default and /test triggers.
   /default:
     workflows:
     - tests-smoke-conformance.yaml
@@ -12,6 +13,8 @@ triggers:
   # This trigger needs to be kept in sync with ariane-scheduled.yaml workflow
   /test\s*:
     workflows:
+    - lint-ariane-config.yaml
+    - lint-images-base.yaml
     - conformance-aws-cni.yaml
     - conformance-clustermesh.yaml
     - conformance-delegated-ipam.yaml
@@ -33,8 +36,11 @@ triggers:
     - conformance-race.yaml
     - conformance-runtime.yaml
     - integration-test.yaml
+    - tests-cifuzz.yaml
     - tests-clustermesh-upgrade.yaml
     - tests-datapath-verifier.yaml
+    - tests-smoke-conformance.yaml
+    - tests-smoke-ipv6.yaml
     - hubble-cli-integration-test.yaml
     - k8s-kind-network-e2e.yaml
     - k8s-kind-network-policies-e2e.yaml


### PR DESCRIPTION
When external contributors submit pull requests, we don't trigger the
`/default` workflows for their PRs automatically. This is because they run
in a potentially sensitive context, so a reviewer needs to assess the
safety of the pull request first before triggering the testsuite. This
is a bit of a pain because all reviewers need to know about this nuance
and then trigger the `/default` tests on behalf of the contributor in
addition to the `/test` command.

Fix it by adding the workflows also to the `/test` command.

Fixes: 29c832727dad ("ci: handle pull_request workflows by ariane")
Fixes: https://github.com/cilium/cilium/issues/47901
