### PR TITLE
node: Node table reconciler registration

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -61,14 +61,16 @@ type LocalNodeStoreParams struct {
 	Jobs        job.Group
 	ClusterInfo cmtypes.ClusterInfo
 	Nodes       statedb.RWTable[*LocalNode]
+	NodeWriter  *Writer
 }
 
 // LocalNodeStore is the canonical owner for the local node object and provides
 // a reactive API for observing and updating the state.
 type LocalNodeStore struct {
-	db    *statedb.DB
-	nodes statedb.RWTable[*LocalNode]
-	sync  LocalNodeSynchronizer
+	db     *statedb.DB
+	nodes  statedb.RWTable[*LocalNode]
+	sync   LocalNodeSynchronizer
+	writer *Writer
 }
 
 // NewNodeTableAndLocalNodeStore constructs [LocalNodeStore] and the node table.
@@ -100,7 +102,7 @@ func NewNodeTableAndLocalNodeStore(params LocalNodeStoreParams) (
 		})
 	wtxn.Commit()
 
-	s := &LocalNodeStore{params.DB, nodeTable, params.Sync}
+	s := &LocalNodeStore{params.DB, nodeTable, params.Sync, params.NodeWriter}
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
@@ -111,6 +113,7 @@ func NewNodeTableAndLocalNodeStore(params LocalNodeStoreParams) (
 
 			n = n.DeepCopy()
 			err := params.Sync.InitLocalNode(ctx, n)
+			n.Statuses = n.Statuses.Pending(s.writer.getRequiredReconcilers(wtxn)...)
 			nodeTable.Insert(wtxn, n)
 			initDone(wtxn)
 			wtxn.Commit()
@@ -234,7 +237,7 @@ func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 		// No changes.
 		return
 	}
-	ln.Statuses = orig.Statuses.Pending()
+	ln.Statuses = orig.Statuses.Pending(s.writer.getRequiredReconcilers(txn)...)
 
 	if orig.Fullname() != ln.Fullname() {
 		// Name or cluster has changed, delete first to remove it from the name index.
@@ -261,7 +264,7 @@ func NewTestLocalNodeStore(mockNode LocalNode) *LocalNodeStore {
 	txn := db.WriteTxn(tbl)
 	tbl.Insert(txn, &mockNode)
 	txn.Commit()
-	return &LocalNodeStore{db, tbl, nil}
+	return &LocalNodeStore{db, tbl, nil, nil}
 }
 
 // LocalNodeStoreTestCell is a convenience for tests that provides a no-op

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -119,6 +119,8 @@ func TestLocalNodeStore(t *testing.T) {
 }
 
 func TestLocalNodeStoreUpdateMarksStatusesPending(t *testing.T) {
+	const requiredReconciler = "required"
+
 	var (
 		store *LocalNodeStore
 		db    *statedb.DB
@@ -129,8 +131,14 @@ func TestLocalNodeStoreUpdateMarksStatusesPending(t *testing.T) {
 		cell.Provide(func() cmtypes.ClusterInfo {
 			return cmtypes.ClusterInfo{Name: "test"}
 		}),
-		cell.Invoke(func(s *LocalNodeStore, d *statedb.DB, ns statedb.Table[*Node]) {
+		cell.Invoke(func(
+			s *LocalNodeStore,
+			d *statedb.DB,
+			ns statedb.Table[*Node],
+			writer *Writer,
+		) {
 			store, db, nodes = s, d, ns
+			writer.RegisterReconciler(requiredReconciler)
 		}),
 	)
 
@@ -150,6 +158,10 @@ func TestLocalNodeStoreUpdateMarksStatusesPending(t *testing.T) {
 	require.True(t, found)
 	local = local.DeepCopy()
 	local.Statuses = local.Statuses.Set("test", reconciler.StatusDone())
+	local.Statuses = local.Statuses.Set(
+		requiredReconciler,
+		reconciler.StatusDone(),
+	)
 	_, _, err := rwNodes.Insert(txn, local)
 	require.NoError(t, err)
 	txn.Commit()
@@ -158,11 +170,19 @@ func TestLocalNodeStoreUpdateMarksStatusesPending(t *testing.T) {
 	local, _, found = nodes.Get(db.ReadTxn(), LocalNodeQuery)
 	require.True(t, found)
 	require.Equal(t, reconciler.StatusKindDone, local.Statuses.Get("test").Kind)
+	require.Equal(t,
+		reconciler.StatusKindDone,
+		local.Statuses.Get(requiredReconciler).Kind,
+	)
 
 	store.Update(func(n *LocalNode) { n.ClusterID++ })
 	local, _, found = nodes.Get(db.ReadTxn(), LocalNodeQuery)
 	require.True(t, found)
 	require.Equal(t, reconciler.StatusKindPending, local.Statuses.Get("test").Kind)
+	require.Equal(t,
+		reconciler.StatusKindPending,
+		local.Statuses.Get(requiredReconciler).Kind,
+	)
 }
 
 func TestWaitForLocalNodeInit(t *testing.T) {

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -28,6 +28,8 @@ type Writer struct {
 	nodes statedb.RWTable[*Node]
 
 	isStaticLocalRouterIP func(string) bool
+
+	requiredReconcilers []string
 }
 
 // NewWriter constructs a node table writer.
@@ -61,15 +63,95 @@ func (w *Writer) RegisterInitializer(txn statedb.WriteTxn, name string) func(sta
 	return w.nodes.RegisterInitializer(txn, name)
 }
 
+// RegisterReconciler adds the named reconciler to the list of required
+// reconcilers and marks existing nodes pending for it. This list is passed to
+// [reconciler.StatusSet.Pending] when nodes are created or updated.
+// Panics if the reconciler has already been registered.
+func (w *Writer) RegisterReconciler(name string) {
+	txn := w.db.WriteTxn(w.nodes)
+	defer txn.Abort()
+
+	i, found := slices.BinarySearch(w.requiredReconcilers, name)
+	if found {
+		panic(fmt.Sprintf("Reconciler %q already registered", name))
+	}
+	requiredReconcilers := slices.Insert(
+		slices.Clone(w.requiredReconcilers),
+		i,
+		name,
+	)
+
+	// RegisterReconciler may be called from a start hook after node producers
+	// have populated the table. Materialize the new pending status so observers
+	// cannot mistake another reconciler completing for full reconciliation.
+	for n := range w.nodes.All(txn) {
+		updated := *n
+		updated.Statuses = updated.Statuses.Set(name, reconciler.StatusPending())
+		if _, _, err := w.nodes.Insert(txn, &updated); err != nil {
+			w.log.Error("Failed to register node reconciler status",
+				logfields.Error, err,
+				logfields.Name, name,
+			)
+			return
+		}
+	}
+	w.requiredReconcilers = requiredReconcilers
+	txn.Commit()
+}
+
+// UnregisterReconciler removes the reconciler from the list of required
+// reconcilers and removes its status from every node. The reconciler must be
+// stopped before it is unregistered so it cannot write its status back.
+func (w *Writer) UnregisterReconciler(name string) {
+	txn := w.db.WriteTxn(w.nodes)
+	defer txn.Abort()
+
+	i, found := slices.BinarySearch(w.requiredReconcilers, name)
+	if !found {
+		return
+	}
+	requiredReconcilers := slices.Delete(
+		slices.Clone(w.requiredReconcilers),
+		i,
+		i+1,
+	)
+
+	// Remove the reconciler from the nodes so it will no longer be waited for.
+	for n := range w.nodes.All(txn) {
+		updated := *n
+		updated.Statuses = updated.Statuses.Delete(name)
+		if _, _, err := w.nodes.Insert(txn, &updated); err != nil {
+			w.log.Error("Failed to unregister node reconciler",
+				logfields.Error, err,
+				logfields.Name, name,
+			)
+			return
+		}
+	}
+
+	w.requiredReconcilers = requiredReconcilers
+	txn.Commit()
+}
+
+// getRequiredReconcilers must only be called while holding a write transaction
+// for the node table. The transaction serializes access to the registry.
+func (w *Writer) getRequiredReconcilers(_ statedb.WriteTxn) []string {
+	if w == nil {
+		return nil
+	}
+	return slices.Clone(w.requiredReconcilers)
+}
+
 // Refresh marks every node pending and waits for all currently known node
 // reconcilers to successfully process them.
 func (w *Writer) Refresh(ctx context.Context) error {
 	txn := w.db.WriteTxn(w.nodes)
 	targets := []string{}
+	reconcilers := w.getRequiredReconcilers(txn)
 	for n := range w.nodes.All(txn) {
 		targets = append(targets, n.Fullname())
 		updated := *n
-		updated.Statuses = updated.Statuses.Pending()
+		updated.Statuses = updated.Statuses.Pending(reconcilers...)
 		if _, _, err := w.nodes.Insert(txn, &updated); err != nil {
 			txn.Abort()
 			return fmt.Errorf("marking node %s pending: %w", updated.Fullname(), err)
@@ -114,7 +196,11 @@ func (w *Writer) Refresh(ctx context.Context) error {
 // objects are not retained, so their producer must upsert them again if the
 // winning object is later deleted.
 func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
-	obj := &Node{Node: *n}
+	reconcilers := w.getRequiredReconcilers(txn)
+	obj := &Node{
+		Node:     *n,
+		Statuses: reconciler.NewStatusSet().Pending(reconcilers...),
+	}
 
 	old, _, found := w.nodes.Get(txn, NodeByName(obj.Fullname()))
 	if found {
@@ -168,7 +254,7 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 	}
 
 	if found {
-		obj.Statuses = old.Statuses.Pending()
+		obj.Statuses = old.Statuses.Pending(reconcilers...)
 	}
 
 	if _, _, err := w.nodes.Insert(txn, obj); err != nil {

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/netip"
 	"slices"
 
@@ -19,6 +20,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Writer provides source-aware write access to the node table.
@@ -142,14 +144,72 @@ func (w *Writer) getRequiredReconcilers(_ statedb.WriteTxn) []string {
 	return slices.Clone(w.requiredReconcilers)
 }
 
+// WaitUntilReconciled waits until all nodes present in txn have been
+// reconciled. When requireDone is false, both done and error statuses are
+// considered finished. When it is true, every status must be done.
+func (w *Writer) WaitUntilReconciled(
+	ctx context.Context,
+	txn statedb.ReadTxn,
+	requireDone bool,
+) error {
+	const settleTime = 10 * time.Millisecond
+
+	targets := map[string]statedb.Revision{}
+	for n := range w.nodes.All(txn) {
+		targets[n.Fullname()] = 0
+	}
+
+	ws := statedb.NewWatchSet()
+	for {
+		// Iteration is faster than individual lookups and we assume that the set
+		// of nodes in [targets] is mostly the same as what we see in later
+		// transactions.
+		allNodes, watch := w.nodes.AllWatch(txn)
+		rev := w.nodes.Revision(txn)
+
+		for node := range allNodes {
+			if _, found := targets[node.Fullname()]; found {
+				finished := true
+				for _, status := range node.Statuses.All() {
+					if status.Kind != reconciler.StatusKindDone &&
+						(requireDone || status.Kind != reconciler.StatusKindError) {
+						finished = false
+						break
+					}
+				}
+				if finished {
+					delete(targets, node.Fullname())
+				} else {
+					targets[node.Fullname()] = rev
+				}
+			}
+		}
+
+		// Remove targets that have disappeared
+		maps.DeleteFunc(targets, func(_ string, targetRev statedb.Revision) bool {
+			return targetRev != rev
+		})
+
+		if len(targets) == 0 {
+			break
+		}
+
+		ws.Add(watch)
+		if _, err := ws.Wait(ctx, settleTime); err != nil {
+			return err
+		}
+		txn = w.db.ReadTxn()
+	}
+	return nil
+}
+
 // Refresh marks every node pending and waits for all currently known node
-// reconcilers to successfully process them.
+// reconcilers have attempted to process them (status is either Done or Error).
+// The error is [ctx.Err()] if context is cancelled.
 func (w *Writer) Refresh(ctx context.Context) error {
 	txn := w.db.WriteTxn(w.nodes)
-	targets := []string{}
 	reconcilers := w.getRequiredReconcilers(txn)
 	for n := range w.nodes.All(txn) {
-		targets = append(targets, n.Fullname())
 		updated := *n
 		updated.Statuses = updated.Statuses.Pending(reconcilers...)
 		if _, _, err := w.nodes.Insert(txn, &updated); err != nil {
@@ -157,37 +217,10 @@ func (w *Writer) Refresh(ctx context.Context) error {
 			return fmt.Errorf("marking node %s pending: %w", updated.Fullname(), err)
 		}
 	}
-	txn.Commit()
+	rtxn := txn.Commit()
 
-	rtxn := w.db.ReadTxn()
-	for _, fullname := range targets {
-		for {
-			n, _, watch, found := w.nodes.GetWatch(rtxn, NodeByName(fullname))
-			if !found {
-				break
-			}
-
-			finished := true
-			for _, status := range n.Statuses.All() {
-				if status.Kind != reconciler.StatusKindDone &&
-					status.Kind != reconciler.StatusKindError {
-					finished = false
-					break
-				}
-			}
-			if finished {
-				break
-			}
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-watch:
-				rtxn = w.db.ReadTxn()
-			}
-		}
-	}
-	return nil
+	// Wait until refresh of all nodes has been attempted.
+	return w.WaitUntilReconciled(ctx, rtxn, false)
 }
 
 // Upsert takes ownership of n and inserts or updates it if its source is

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/netip"
 	"slices"
@@ -204,6 +205,110 @@ func requiredReconcilers(
 	txn := db.WriteTxn(nodes)
 	defer txn.Abort()
 	return w.getRequiredReconcilers(txn)
+}
+
+func TestWriterWaitUntilReconciled(t *testing.T) {
+	newWriter := func(t *testing.T) (*statedb.DB, statedb.RWTable[*Node], *Writer) {
+		t.Helper()
+		db := statedb.New()
+		nodes, err := NewNodeTable(db)
+		require.NoError(t, err)
+		return db, nodes, NewWriter(hivetest.Logger(t), db, nodes)
+	}
+	upsert := func(
+		t *testing.T,
+		db *statedb.DB,
+		nodes statedb.RWTable[*Node],
+		w *Writer,
+		name string,
+	) {
+		t.Helper()
+		txn := db.WriteTxn(nodes)
+		require.True(t, w.Upsert(txn, &types.Node{
+			Name:   name,
+			Source: source.Kubernetes,
+		}))
+		txn.Commit()
+	}
+	setStatus := func(
+		t *testing.T,
+		db *statedb.DB,
+		nodes statedb.RWTable[*Node],
+		nodeName, reconcilerName string,
+		status reconciler.Status,
+	) {
+		t.Helper()
+		txn := db.WriteTxn(nodes)
+		n, _, found := nodes.Get(txn, NodeByName(nodeName))
+		require.True(t, found)
+		updated := *n
+		updated.Statuses = updated.Statuses.Set(reconcilerName, status)
+		_, _, err := nodes.Insert(txn, &updated)
+		require.NoError(t, err)
+		txn.Commit()
+	}
+	waitUntilReconciled := func(
+		t *testing.T,
+		w *Writer,
+		txn statedb.ReadTxn,
+		requireDone bool,
+	) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		require.NoError(t, w.WaitUntilReconciled(ctx, txn, requireDone))
+	}
+
+	t.Run("all statuses must finish", func(t *testing.T) {
+		db, nodes, w := newWriter(t)
+		w.RegisterReconciler("ipset")
+		w.RegisterReconciler("wireguard")
+		upsert(t, db, nodes, w, "node-1")
+		setStatus(t, db, nodes, "node-1", "ipset", reconciler.StatusDone())
+
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		err := w.WaitUntilReconciled(ctx, db.ReadTxn(), false)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+		setStatus(t, db, nodes, "node-1", "wireguard", reconciler.StatusError(errors.New("failed")))
+		waitUntilReconciled(t, w, db.ReadTxn(), false)
+
+		ctx, cancel = context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		err = w.WaitUntilReconciled(ctx, db.ReadTxn(), true)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+		setStatus(t, db, nodes, "node-1", "wireguard", reconciler.StatusDone())
+		waitUntilReconciled(t, w, db.ReadTxn(), true)
+	})
+
+	t.Run("deleted target is finished", func(t *testing.T) {
+		db, nodes, w := newWriter(t)
+		w.RegisterReconciler("wireguard")
+		upsert(t, db, nodes, w, "node-1")
+		txn := db.ReadTxn()
+
+		wtxn := db.WriteTxn(nodes)
+		n, _, found := nodes.Get(wtxn, NodeByName("node-1"))
+		require.True(t, found)
+		_, _, err := nodes.Delete(wtxn, n)
+		require.NoError(t, err)
+		wtxn.Commit()
+
+		waitUntilReconciled(t, w, txn, false)
+	})
+
+	t.Run("new nodes are not included", func(t *testing.T) {
+		db, nodes, w := newWriter(t)
+		w.RegisterReconciler("wireguard")
+		upsert(t, db, nodes, w, "initial")
+		setStatus(t, db, nodes, "initial", "wireguard", reconciler.StatusDone())
+		txn := db.ReadTxn()
+
+		upsert(t, db, nodes, w, "later")
+		waitUntilReconciled(t, w, txn, true)
+	})
 }
 
 func TestSourceWriterDoesNotOverwriteLocalNode(t *testing.T) {

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -83,6 +83,129 @@ func TestSourceWriter(t *testing.T) {
 	require.False(t, found)
 }
 
+func TestWriterReconcilerRegistration(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	upsert := func(n *types.Node) bool {
+		txn := db.WriteTxn(nodes)
+		defer txn.Commit()
+		return w.Upsert(txn, n)
+	}
+	get := func(name string) *Node {
+		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.True(t, found)
+		return n
+	}
+
+	// Registration also adds a pending status to nodes that already exist.
+	require.True(t, upsert(&types.Node{
+		Name:   "existing",
+		Source: source.Kubernetes,
+	}))
+	require.Empty(t, get("existing").Statuses.All())
+	existing := get("existing").DeepCopy()
+	existing.Statuses = existing.Statuses.Set("already-done", reconciler.StatusDone())
+	txn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, existing)
+	require.NoError(t, err)
+	txn.Commit()
+
+	w.RegisterReconciler("wireguard")
+	existing = get("existing")
+	require.Equal(t,
+		reconciler.StatusKindPending,
+		existing.Statuses.Get("wireguard").Kind,
+	)
+	require.Contains(t, existing.Statuses.All(), "wireguard")
+	require.Equal(t,
+		reconciler.StatusKindDone,
+		existing.Statuses.Get("already-done").Kind,
+	)
+	require.Equal(t, []string{"wireguard"}, requiredReconcilers(db, nodes, w))
+
+	// Required reconcilers are materialized on newly inserted nodes. Seeing one
+	// completed status therefore cannot hide another required pending status.
+	w.RegisterReconciler("ipset")
+	require.Equal(t,
+		[]string{"ipset", "wireguard"},
+		requiredReconcilers(db, nodes, w),
+	)
+	require.True(t, upsert(&types.Node{
+		Name:   "new",
+		Source: source.Kubernetes,
+	}))
+
+	// Duplicate registration panics
+	require.Panics(t,
+		func() {
+			w.RegisterReconciler("ipset")
+		})
+
+	newNode := get("new").DeepCopy()
+	require.Len(t, newNode.Statuses.All(), 2)
+	newNode.Statuses = newNode.Statuses.Set("ipset", reconciler.StatusDone())
+	txn = db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, newNode)
+	require.NoError(t, err)
+	txn.Commit()
+
+	newNode = get("new")
+	require.Equal(t,
+		reconciler.StatusKindDone,
+		newNode.Statuses.Get("ipset").Kind,
+	)
+	require.Equal(t,
+		reconciler.StatusKindPending,
+		newNode.Statuses.Get("wireguard").Kind,
+	)
+
+	w.UnregisterReconciler("wireguard")
+	require.Equal(t, []string{"ipset"}, requiredReconcilers(db, nodes, w))
+	existing = get("existing")
+	newNode = get("new")
+	require.NotContains(t, existing.Statuses.All(), "wireguard")
+	require.NotContains(t, newNode.Statuses.All(), "wireguard")
+	require.Equal(t,
+		reconciler.StatusKindDone,
+		existing.Statuses.Get("already-done").Kind,
+	)
+	require.Equal(t,
+		reconciler.StatusKindDone,
+		newNode.Statuses.Get("ipset").Kind,
+	)
+
+	// Duplicate unregistration does not rewrite the nodes.
+	revision := nodes.Revision(db.ReadTxn())
+	w.UnregisterReconciler("wireguard")
+	require.Equal(t, revision, nodes.Revision(db.ReadTxn()))
+
+	// Re-registering materializes a fresh pending status on all nodes.
+	w.RegisterReconciler("wireguard")
+	require.Contains(t, get("existing").Statuses.All(), "wireguard")
+	require.Contains(t, get("new").Statuses.All(), "wireguard")
+	require.Equal(t,
+		reconciler.StatusKindPending,
+		get("existing").Statuses.Get("wireguard").Kind,
+	)
+	require.Equal(t,
+		reconciler.StatusKindPending,
+		get("new").Statuses.Get("wireguard").Kind,
+	)
+}
+
+func requiredReconcilers(
+	db *statedb.DB,
+	nodes statedb.RWTable[*Node],
+	w *Writer,
+) []string {
+	txn := db.WriteTxn(nodes)
+	defer txn.Abort()
+	return w.getRequiredReconcilers(txn)
+}
+
 func TestSourceWriterDoesNotOverwriteLocalNode(t *testing.T) {
 	db := statedb.New()
 	nodes, err := NewNodeTable(db)

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -81,6 +81,7 @@ type Agent struct {
 	db                *statedb.DB
 	mtuTable          statedb.Table[mtu.RouteMTU]
 	nodes             statedb.Table[*node.Node]
+	nodeWriter        *node.Writer
 	nodesReconciler   reconciler.Reconciler[*node.Node]
 	localNode         *node.LocalNodeStore
 	nodeDiscovery     *nodediscovery.NodeDiscovery
@@ -111,7 +112,7 @@ type params struct {
 	Config            Config
 	DB                *statedb.DB
 	MTUTable          statedb.Table[mtu.RouteMTU]
-	Nodes             statedb.Table[*node.Node]
+	NodeWriter        *node.Writer
 	JobGroup          job.Group
 	ReconcilerParams  reconciler.Params
 	Sysctl            sysctl.Sysctl
@@ -130,7 +131,8 @@ func newAgent(p params) *Agent {
 		config:            p.Config,
 		db:                p.DB,
 		mtuTable:          p.MTUTable,
-		nodes:             p.Nodes,
+		nodeWriter:        p.NodeWriter,
+		nodes:             p.NodeWriter.Table(),
 		jobGroup:          p.JobGroup,
 		reconcilerParams:  p.ReconcilerParams,
 		sysctl:            p.Sysctl,
@@ -182,6 +184,7 @@ func (a *Agent) Start(cell.HookContext) error {
 		a.ipCache.AddListener(a)
 	}
 
+	a.nodeWriter.RegisterReconciler(wireGuardNodeReconcilerName)
 	a.nodesReconciler, err = reconciler.Register(
 		a.reconcilerParams,
 		a.nodes.(statedb.RWTable[*node.Node]),
@@ -198,6 +201,7 @@ func (a *Agent) Start(cell.HookContext) error {
 		reconciler.WithoutPruning(),
 	)
 	if err != nil {
+		a.nodeWriter.UnregisterReconciler(wireGuardNodeReconcilerName)
 		return fmt.Errorf("registering WireGuard node reconciler: %w", err)
 	}
 	a.jobGroup.Add(
@@ -224,6 +228,8 @@ func (a *Agent) Stop(cell.HookContext) error {
 
 	// Set [wgClient] to nil to prevent further use.
 	a.wgClient = nil
+
+	a.nodeWriter.UnregisterReconciler(wireGuardNodeReconcilerName)
 
 	return err
 }


### PR DESCRIPTION
The `Table[Node]` supports a dynamic set of StateDB reconcilers via the `reconciler.StatusSet`. In order to reliable detect whether all reconcilers acting on the node table have completed we the `StatusSet` to carry the names of the reconcilers at all times. Without this an empty "Pending" `reconciler.StatusSet` would be considered "Done" as soon as a single reconciler has updated its status.

Add `Writer.RegisterReconciler` and `Writer.UnregisterReconciler` to manage the set of reconciler names that is always included when creating the pending set. Add `Writer.WaitUntilReconciled` to have a common utility for waiting for reconciliation to finish.

Finally change wireguard (currently the only node table reconciler) register its node table reconciler name.

AIL:1 (testing and reviewing)