### PR TITLE
endpoint/restore: skip cleanup for reserved internal endpoints

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -297,10 +297,11 @@ func (r *endpointRestorer) validateDatapathModeCompatibility(endpoints map[uint1
 // responsible for its workload, etc.
 //
 // Returns true to indicate that the endpoint is valid to restore, and an
-// optional error.
-func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error) {
+// optional error. In case the endpoint is invalid for restore, `cleanup`
+// indicates if the endpoint state should be purged by the caller.
+func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid, cleanup bool, err error) {
 	if ep.IsProperty(endpointtypes.PropertyFakeEndpoint) {
-		return true, nil
+		return true, false, nil
 	}
 
 	// On each restart, the health and ingress endpoints are supposed to be recreated.
@@ -318,12 +319,13 @@ func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, 
 				logfields.Path, epStateDir,
 			)
 		}
-		return false, nil
+		// Skip restore and cleanup for reserved endpoints.
+		return false, false, nil
 	}
 
 	if ep.K8sPodName != "" && ep.K8sNamespace != "" && r.clientset.IsEnabled() {
 		if err := r.getPodForEndpoint(ep); err != nil {
-			return false, err
+			return false, true, err
 		}
 
 		// Initialize the endpoint's event queue because the following call to
@@ -336,16 +338,16 @@ func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, 
 	}
 
 	if err := ep.ValidateConnectorPlumbing(r.checkLink); err != nil {
-		return false, err
+		return false, true, err
 	}
 
 	if !ep.DatapathConfiguration.ExternalIpam {
 		if err := r.allocateIPsLocked(ep); err != nil {
-			return false, fmt.Errorf("Failed to re-allocate IP of endpoint: %w", err)
+			return false, true, fmt.Errorf("Failed to re-allocate IP of endpoint: %w", err)
 		}
 	}
 
-	return true, nil
+	return true, false, nil
 }
 
 func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
@@ -466,7 +468,7 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 			scopedLog = scopedLog.With(logfields.CEPName, ep.GetK8sNamespaceAndCEPName())
 		}
 
-		restore, err := r.validateEndpoint(ep)
+		restore, cleanup, err := r.validateEndpoint(ep)
 		if err != nil {
 			// Disconnected EPs are not failures, clean them silently below
 			if !ep.IsDisconnecting() {
@@ -483,7 +485,9 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 			if err == nil {
 				skipped++
 			}
-			r.restoreState.toClean = append(r.restoreState.toClean, ep)
+			if cleanup {
+				r.restoreState.toClean = append(r.restoreState.toClean, ep)
+			}
 			continue
 		}
 


### PR DESCRIPTION
See commit message for details.

Additional fix on top of: https://github.com/cilium/cilium/pull/42150