### PR TITLE
bpf: Fix agent crash when dumping map events

### DIFF
--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -101,17 +101,8 @@ func newEventsBuffer(logger *slog.Logger, name string, bufSize int, ttl time.Dur
 		mapControllers.UpdateController(
 			fmt.Sprintf("bpf-event-buffer-gc-%s", name),
 			controller.ControllerParams{
-				Group: bpfEventBufferGCControllerGroup,
-				DoFunc: func(_ context.Context) error {
-					logger.Debug(
-						"clearing bpf map events older than TTL",
-						logfields.TTL, b.eventTTL,
-					)
-					b.buffer.Compact(func(event Event) bool {
-						return time.Since(event.Timestamp) < b.eventTTL
-					})
-					return nil
-				},
+				Group:       bpfEventBufferGCControllerGroup,
+				DoFunc:      b.garbageCollect,
 				RunInterval: b.eventTTL,
 			},
 		)
@@ -133,6 +124,17 @@ type eventsBuffer struct {
 	observe stream.Observable[Event]
 	next    func(Event)
 	done    func(error)
+}
+
+func (eb *eventsBuffer) garbageCollect(_ context.Context) error {
+	eb.logger.Debug(
+		"clearing bpf map events older than TTL",
+		logfields.TTL, eb.eventTTL,
+	)
+	eb.buffer.Compact(func(event Event) bool {
+		return time.Since(event.Timestamp) < eb.eventTTL
+	})
+	return nil
 }
 
 func (eb *eventsBuffer) dumpAndSubscribe(ctx context.Context, callback EventCallbackFunc, follow bool) {

--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 
@@ -94,7 +95,9 @@ func newEventsBuffer(logger *slog.Logger, name string, bufSize int, ttl time.Dur
 	}
 	b.observe, b.next, b.done = stream.Multicast[Event]()
 	b.observe.Observe(context.Background(), func(e Event) {
+		b.mutex.Lock()
 		b.buffer.Add(e)
+		b.mutex.Unlock()
 	}, func(err error) {})
 	if b.eventTTL > 0 {
 		logger.Debug("starting bpf map event buffer GC controller")
@@ -117,7 +120,9 @@ func (m *Map) initEventsBuffer(maxSize int, eventsTTL time.Duration) {
 // eventsBuffer stores a buffer of events for auditing and debugging
 // purposes.
 type eventsBuffer struct {
-	logger   *slog.Logger
+	logger *slog.Logger
+
+	mutex    lock.Mutex
 	buffer   *container.RingBuffer[Event]
 	eventTTL time.Duration
 
@@ -127,6 +132,9 @@ type eventsBuffer struct {
 }
 
 func (eb *eventsBuffer) garbageCollect(_ context.Context) error {
+	eb.mutex.Lock()
+	defer eb.mutex.Unlock()
+
 	eb.logger.Debug(
 		"clearing bpf map events older than TTL",
 		logfields.TTL, eb.eventTTL,
@@ -176,6 +184,8 @@ func (eb *eventsBuffer) eventIsValid(e Event) bool {
 type EventCallbackFunc func(Event)
 
 func (eb *eventsBuffer) dumpWithCallback(callback EventCallbackFunc) {
+	eb.mutex.Lock()
+	defer eb.mutex.Unlock()
 	eb.buffer.IterateValid(eb.eventIsValid, func(event Event) {
 		callback(event)
 	})

--- a/pkg/bpf/events_test.go
+++ b/pkg/bpf/events_test.go
@@ -4,6 +4,7 @@
 package bpf
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -36,3 +37,59 @@ type IntTestKey uint32
 
 func (k IntTestKey) String() string { return fmt.Sprintf("key=%d", k) }
 func (k IntTestKey) New() MapKey    { return new(IntTestKey) }
+
+func TestEventsGC(t *testing.T) {
+	// Rather than setting a timeout, this testcase will avoid the time
+	// dependencies by using two blocking channels to *ensure* the garbage
+	// collection occurs in the critical section.
+	eb := newEventsBuffer(hivetest.Logger(t), "test", 32, 0)
+	dumpStarted := make(chan struct{})
+	doneChan := make(chan struct{})
+
+	// Add a bunch of keys. Garbage collection should clean these up.
+	keys := []int{}
+	for i := range 32 {
+		eb.add(&Event{cacheEntry: cacheEntry{Key: IntTestKey(i)}})
+	}
+
+	// Garbage collect the ringbuffer, but wait until the main test
+	// goroutine begins iterating the objects below before executing the
+	// garbage collection. This should make the failure highly reliable.
+	go func(dumpStarted, doneChan chan struct{}) {
+		<-dumpStarted
+		_ = eb.garbageCollect(context.Background())
+		close(doneChan)
+	}(dumpStarted, doneChan)
+
+	lastDump := false
+loop:
+	// Tight loop to touch the same internal data structures as the GC
+	// goroutine above to try to trigger a data race.
+	for {
+		if dumpStarted != nil {
+			close(dumpStarted)
+			dumpStarted = nil
+		}
+		keys = []int{}
+		eb.dumpAndSubscribe(t.Context(), func(e Event) {
+			k := e.Key.(IntTestKey)
+			keys = append(keys, int(k))
+		}, false)
+		if lastDump {
+			break
+		}
+		select {
+		case <-doneChan:
+			// Do one last full dumpAndSubscribe to ensure the
+			// complete final (garbage-collected) map is dumped,
+			// so the contents comparison can pass below.
+			lastDump = true
+			continue loop
+		default:
+		}
+	}
+
+	// Ensure that garbage collection completed its cleanup successfully.
+	assert.Empty(t, keys)
+	assert.Equal(t, []int{}, keys)
+}


### PR DESCRIPTION
The underlying ringbuffer here is not thread-safe, so access into the
buffer needs to be single-threaded. Prior to this fix, the event monitor
and garbage collection codepaths could each execute at the same time
because there was no mutex protecting them. The dump path attempted to
protect these paths through acquiring a _read lock_ from the parent map,
but this was insufficient to prevent GC goroutines from interacting with
the underlying ringbuffer data concurrently.

The included test would fail prior to the fix:

    $ go test ./pkg/bpf/
    --- FAIL: TestEventsGC (0.00s)
    panic: runtime error: integer divide by zero [recovered, repanicked]

    goroutine 42 [running]:
    testing.tRunner.func1.2({0x17451c0, 0x2a19720})
            /home/joenats/sdk/go1.26.4/src/testing/testing.go:1974 +0x232
    testing.tRunner.func1()
            /home/joenats/sdk/go1.26.4/src/testing/testing.go:1977 +0x349
    panic({0x17451c0?, 0x2a19720?})
            /home/joenats/sdk/go1.26.4/src/runtime/panic.go:860 +0x13a
    github.com/cilium/cilium/pkg/container.(*RingBuffer[...]).mapIndex(...)
            /var/git/cilium/pkg/container/ring_buffer.go:83
    github.com/cilium/cilium/pkg/container.(*RingBuffer[...]).IterateValid(0x10, 0x27791e915df0?, 0x27791e915de0)
            /var/git/cilium/pkg/container/ring_buffer.go:76 +0x27f
    github.com/cilium/cilium/pkg/bpf.(*eventsBuffer).dumpWithCallback(0x27791e915e38?, 0x428005?)
            /var/git/cilium/pkg/bpf/events.go:179 +0x4a
    github.com/cilium/cilium/pkg/bpf.(*eventsBuffer).dumpAndSubscribe(0x27791ed908c0, {0x1b10920, 0x27791ed8e8c0}, 0x27791ed82da0, 0x0)
            /var/git/cilium/pkg/bpf/events.go:141 +0x33
    github.com/cilium/cilium/pkg/bpf.TestEventsGC(0x27791edc4b48)
            /var/git/cilium/pkg/bpf/events_test.go:64 +0x29c
    testing.tRunner(0x27791edc4b48, 0x1ae8168)
            /home/joenats/sdk/go1.26.4/src/testing/testing.go:2036 +0xea
    created by testing.(*T).Run in goroutine 1
            /home/joenats/sdk/go1.26.4/src/testing/testing.go:2101 +0x4c5
    FAIL    github.com/cilium/cilium/pkg/bpf        0.018s
    FAIL

Adding a new lock here seemed like the simpler option than attempting to
reuse the parent map's RWMutex, so I went with this option.

Thanks to @mikiiier for identifying and reporting this bug.

Fixes: https://github.com/cilium/cilium/pull/21235