### PR TITLE
cleanup: Replace deprecated strings.Title with x/text/cases

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,6 +86,9 @@ linters:
             - '!**/resiliency/**'
     forbidigo:
       forbid:
+        - pattern: ^strings\.Title$
+          pkg: ^strings$
+          msg: "strings.Title is deprecated, use golang.org/x/text/cases instead."
         # List based on https://github.com/vishvananda/netlink/pull/1018
         - pattern: ^netlink\.(Handle\.)?(AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList|NeighProxyList|NeighListExecute|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFiltered|RouteListFilteredIter|RouteSubscribeWithOptions|RuleList|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|SocketXDPGetInfo|SocketDiagXDP|VDPAGetDevList|VDPAGetDevConfigList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
           pkg: ^github.com/vishvananda/netlink$

--- a/hubble/cmd/common/template/usage.go
+++ b/hubble/cmd/common/template/usage.go
@@ -4,7 +4,8 @@
 package template
 
 import (
-	"strings"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -18,7 +19,8 @@ var (
 )
 
 func init() {
-	cobra.AddTemplateFunc("title", strings.Title)
+	caser := cases.Title(language.English, cases.NoLower)
+	cobra.AddTemplateFunc("title", caser.String)
 	cobra.AddTemplateFunc("getFlagSets", getFlagSets)
 }
 

--- a/hubble/cmd/list/node.go
+++ b/hubble/cmd/list/node.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strings"
+
 	"text/tabwriter"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -25,6 +28,8 @@ import (
 )
 
 const notAvailable = "N/A"
+
+var titleCaser = cases.Title(language.English, cases.NoLower)
 
 func newNodeCommand(vp *viper.Viper) *cobra.Command {
 	listCmd := &cobra.Command{
@@ -110,7 +115,7 @@ func nodeTableOutput(buf io.Writer, nodes []*observerpb.Node) error {
 		if v := n.GetVersion(); v != "" {
 			version = v
 		}
-		fmt.Fprint(tw, n.GetName(), "\t", strings.Title(nodeStateToString(n.GetState())), "\t", age, "\t", flowsPerSec, "\t", flowsRatio)
+		fmt.Fprint(tw, n.GetName(), "\t", titleCaser.String(nodeStateToString(n.GetState())), "\t", age, "\t", flowsPerSec, "\t", flowsRatio)
 		if listOpts.output == "wide" {
 			tls := notAvailable
 			if t := n.GetTls(); t != nil {

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -10,6 +10,9 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/go-openapi/strfmt"
 	versionapi "k8s.io/apimachinery/pkg/version"
 
@@ -40,6 +43,8 @@ import (
 type StatusCollector interface {
 	GetStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse
 }
+
+var titleCaser = cases.Title(language.English, cases.NoLower)
 
 type statusCollector struct {
 	statusCollectMutex lock.RWMutex
@@ -329,7 +334,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		}
 		if d.statusParams.LBConfig.LBMode == loadbalancer.LBModeHybrid {
 			//nolint:staticcheck
-			features.NodePort.Mode = strings.Title(d.statusParams.LBConfig.LBMode)
+			features.NodePort.Mode = titleCaser.String(d.statusParams.LBConfig.LBMode)
 		}
 		features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmRandom
 		if d.statusParams.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
@@ -342,7 +347,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		if d.statusParams.DaemonConfig.NodePortAcceleration == option.NodePortAccelerationGeneric {
 			features.NodePort.Acceleration = models.KubeProxyReplacementFeaturesNodePortAccelerationGeneric
 		} else {
-			features.NodePort.Acceleration = strings.Title(d.statusParams.DaemonConfig.NodePortAcceleration)
+			features.NodePort.Acceleration = titleCaser.String(d.statusParams.DaemonConfig.NodePortAcceleration)
 		}
 		features.NodePort.PortMin = int64(d.statusParams.LBConfig.NodePortMin)
 		features.NodePort.PortMax = int64(d.statusParams.LBConfig.NodePortMax)


### PR DESCRIPTION
Ref: #32274

### Description
As part of the ongoing cleanup of deprecated Go functions (as requested in the issue tracking), this PR replaces all occurrences of `strings.Title` (deprecated in Go 1.18 due to Unicode punctuation handling issues) with `cases.Title` from `golang.org/x/text/cases`. 

The replacements were implemented across:
- `hubble/cmd/common/template/usage.go`
- `hubble/cmd/list/node.go`
- `pkg/status/status_collector.go`

Furthermore, to prevent regressions and enforce this standard going forward, a `forbidigo` rule was added to `.golangci.yaml` to strictly block any future usage of `strings.Title` in the codebase.

### Testing / Validation
- Validated through local compilation.
- `golangci-lint` config updated and verified to ensure the new `forbidigo` rule successfully flags the deprecated function.