### PR TITLE
Fix: Prevent BPF verifier failures from misaligned CT tuple copies

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2008,7 +2008,7 @@ __declare_tail(CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY)
 static __always_inline
 int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -366,7 +366,7 @@ snat_v4_nat_handle_mapping(const struct __ctx_buff *ctx,
 	*state = __snat_lookup(map, tuple);
 
 	if (needs_ct) {
-		struct ipv4_ct_tuple tuple_snat;
+		struct ipv4_ct_tuple tuple_snat __align_stack_8;
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1645,7 +1645,7 @@ snat_v6_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
 	}
 
 	if (*state && (*state)->common.needs_ct) {
-		struct ipv6_ct_tuple tuple_revsnat;
+		struct ipv6_ct_tuple tuple_revsnat __align_stack_8;
 		int ret;
 
 		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
@@ -2203,7 +2203,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct ipv6_nat_entry *state = NULL;
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;


### PR DESCRIPTION
This is a follow-up to commit 9bb7aa0481f3 ("bpf: Force-align IPv4 CT tuples used by revSNAT memcpy()").

Cilium's constant-size `__bpf_memcpy()` implementation uses 8-byte accesses.

When a copied tuple is allocated on the BPF stack, its alignment must therefore be explicitly guaranteed with `__align_stack_8`. Otherwise, compiler stack placement may result in misaligned 8-byte accesses and cause the BPF verifier to reject the program.


<!-- Description of change -->


```release-note
Fix: Prevent BPF verifier failures from misaligned CT tuple copies
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
