### PR TITLE
translation: merge HTTPS and TLS passthrough chains on shared port (fixes #48269)

### DIFF
--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -469,21 +469,35 @@ func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.
 		allResources = append(allResources, res)
 	}
 
-	// one Listener per HTTPS port
+	// one Listener per HTTPS port, merging any same-port TLS passthrough
+	// filter chains into the same Listener so the listener name stays
+	// unique. A port can carry both an HTTPS (Terminate) and a TLS
+	// passthrough listener; emitting two Listeners named "listener-<port>"
+	// would produce a duplicate Envoy Listener name and cause the whole
+	// CiliumEnvoyConfig to be rejected (see GH-48269).
 	for _, port := range m.HTTPSPortsSorted() {
 		lName := listenerNameForPort(port)
+
+		var filterChains []*envoy_config_listener.FilterChain
 
 		httpsFC, err := i.httpsFilterChainsForPort(lName, port, m)
 		if err != nil {
 			return nil, err
 		}
-		if len(httpsFC) == 0 {
+		filterChains = append(filterChains, httpsFC...)
+
+		if needsPerPortTLS {
+			tlsFC := tlsPassthroughFilterChainsForPort(port, m)
+			filterChains = append(filterChains, tlsFC...)
+		}
+
+		if len(filterChains) == 0 {
 			continue
 		}
 
 		httpsListener := &envoy_config_listener.Listener{
 			Name:         lName,
-			FilterChains: httpsFC,
+			FilterChains: filterChains,
 			ListenerFilters: []*envoy_config_listener.ListenerFilter{
 				{
 					Name: tlsInspectorType,
@@ -503,9 +517,17 @@ func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.
 		allResources = append(allResources, res)
 	}
 
-	// One Listener per TLS passthrough port.
+	// One Listener per TLS passthrough port that is not already covered by
+	// an HTTPS listener on the same port (those were merged above).
 	if needsPerPortTLS {
+		httpsPorts := make(map[uint32]struct{}, len(m.HTTPSPortsSorted()))
+		for _, p := range m.HTTPSPortsSorted() {
+			httpsPorts[p] = struct{}{}
+		}
 		for _, port := range m.TLSPassthroughPorts() {
+			if _, isHTTPSPort := httpsPorts[port]; isHTTPSPort {
+				continue
+			}
 			lName := listenerNameForPort(port)
 
 			tlsFC := tlsPassthroughFilterChainsForPort(port, m)

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -937,3 +937,125 @@ func TestDesiredEnvoyListenerSingleHTTPS(t *testing.T) {
 	hcm1 := decodeHCM(l.FilterChains[1])
 	require.Equal(t, "listener-secure", hcm1.GetRds().GetRouteConfigName())
 }
+
+// TestDesiredEnvoyListenerHTTPSAndTLSPassthroughSamePort checks that a port
+// carrying both an HTTPS (Terminate) listener and a TLS passthrough listener
+// emits a single Envoy Listener whose filter chains are merged, instead of two
+// listeners named "listener-<port>" (GH-48269).
+func TestDesiredEnvoyListenerHTTPSAndTLSPassthroughSamePort(t *testing.T) {
+	i := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	// Two distinct TLS passthrough ports force NeedsPerPortTLSPassthroughListeners()
+	// (and therefore the per-port translation path); the HTTPS + passthrough pair
+	// on port 443 is what previously produced a duplicate "listener-443".
+	m := &model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				Port:     443,
+				Hostname: "c.example.com",
+				TLS: []model.TLSSecret{
+					{Name: "c-tls", Namespace: "default"},
+				},
+			},
+		},
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Port: 8443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"a.example.com"},
+						Backends: []model.Backend{
+							{Name: "tls-backend-8443", Namespace: "default", Port: &model.BackendPort{Port: 9443}},
+						},
+					},
+				},
+			},
+			{
+				Port: 8883,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"b.example.com"},
+						Backends: []model.Backend{
+							{Name: "tls-backend-8883", Namespace: "default", Port: &model.BackendPort{Port: 9443}},
+						},
+					},
+				},
+			},
+			{
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"d.example.com"},
+						Backends: []model.Backend{
+							{Name: "tls-backend-443", Namespace: "default", Port: &model.BackendPort{Port: 9443}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	res, err := i.desiredEnvoyListener(m)
+	require.NoError(t, err)
+
+	// listener-443 (merged HTTPS + TLS passthrough), listener-8443, listener-8883.
+	require.Len(t, res, 3)
+
+	decodeListener := func(r ciliumv2.XDSResource) *envoy_config_listener.Listener {
+		l := &envoy_config_listener.Listener{}
+		require.NoError(t, proto.Unmarshal(r.Value, l))
+		return l
+	}
+	decodeHCM := func(fc *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_hcm_v3.HttpConnectionManager {
+		require.Len(t, fc.Filters, 1)
+		hcm := &envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{}
+		require.NoError(t, proto.Unmarshal(fc.Filters[0].GetTypedConfig().GetValue(), hcm))
+		return hcm
+	}
+	getTCPProxy := func(t *testing.T, fc *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+		require.Len(t, fc.Filters, 1)
+		tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{}
+		require.NoError(t, proto.Unmarshal(fc.Filters[0].GetTypedConfig().GetValue(), tcpProxy))
+		return tcpProxy
+	}
+
+	// The 443 listener must carry both the HTTPS filter chain (ServerNames
+	// c.example.com) and the TLS passthrough filter chain (d.example.com),
+	// and must appear exactly once.
+	var l443 *envoy_config_listener.Listener
+	names := map[string]int{}
+	for _, r := range res {
+		l := decodeListener(r)
+		names[l.Name]++
+		if l.Name == "listener-443" {
+			l443 = l
+		}
+	}
+	for name, count := range names {
+		require.Equal(t, 1, count, "listener %q must appear exactly once", name)
+	}
+
+	require.NotNil(t, l443, "listener-443 should exist")
+	require.Len(t, l443.FilterChains, 2, "listener-443: HTTPS + TLS passthrough filter chains merged")
+
+	httpsSNIs := []string{}
+	tlsSNIs := []string{}
+	for _, fc := range l443.FilterChains {
+		switch fc.Filters[0].GetName() {
+		case httpConnectionManagerType:
+			hcm := decodeHCM(fc)
+			require.Equal(t, "listener-443", hcm.GetRds().GetRouteConfigName())
+			httpsSNIs = append(httpsSNIs, fc.FilterChainMatch.GetServerNames()...)
+		case tcpProxyType:
+			tp := getTCPProxy(t, fc)
+			require.Equal(t, "default:tls-backend-443:9443", tp.GetCluster())
+			tlsSNIs = append(tlsSNIs, fc.FilterChainMatch.GetServerNames()...)
+		}
+	}
+	require.Equal(t, []string{"c.example.com"}, httpsSNIs)
+	require.Equal(t, []string{"d.example.com"}, tlsSNIs)
+}


### PR DESCRIPTION
### Summary

When a Gateway has more than one distinct TLS passthrough port, `NeedsPerPortListeners()` routes translation through `desiredEnvoyListenerPerPort`. That path emitted:

- one Envoy Listener per HTTPS port, and
- (when `needsPerPortTLS`) one Listener per TLS passthrough port,

both named after the port (`listener-<port>`). A port that carries **both** an HTTPS (Terminate) listener and a TLS passthrough listener therefore produced two Listeners with the same name, and the whole `CiliumEnvoyConfig` was rejected with:

```
error="duplicate Listener name \"gateway/.../listener-443\""
```

which takes **every** listener on that Gateway down (all previously-working HTTPS hosts stop serving), while Gateway API status keeps reporting `Accepted=True, Programmed=True`.

### Fix

Merge the filter chains of both protocols that share a port into a single Listener so the listener name stays unique:

- the HTTPS loop now appends any same-port TLS passthrough filter chains (when per-port TLS is active);
- the TLS passthrough loop skips ports already emitted by the HTTPS loop.

This matches the `https-tls-shared-port` scenario in the compatibility matrix (same-port HTTPS + passthrough with disjoint hostnames works via combined filter chains).

### Tests

Added `TestDesiredEnvoyListenerHTTPSAndTLSPassthroughSamePort`: two distinct passthrough ports (forcing the per-port path) plus an HTTPS + passthrough pair sharing port 443. Asserts `listener-443` appears exactly once and carries both the HTTPS filter chain (`c.example.com`) and the TLS passthrough chain (`d.example.com`). Existing per-port tests (`TestDesiredEnvoyListenerPerPort`, `TestDesiredEnvoyListenerCatchAllHTTPSWithMultiPortTLSPassthrough`) are unaffected.

Fixes: #48269

```release-note
Fix Gateway API translation emitting a duplicate Envoy listener name when an HTTPS and a TLS passthrough listener share the same port, which previously caused the whole CiliumEnvoyConfig to be rejected.
```

This PR was prepared with AI assistance (AIL:3). The root cause, fix, and test were personally reviewed for correctness.