### PR TITLE
gateway-api: escape backreferences in URLRewrite ReplaceFullPath

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -409,7 +409,7 @@ func pathPrefixMutation(rewrite *model.HTTPURLRewriteFilter, httpRoute *model.HT
 				Pattern: &envoy_type_matcher_v3.RegexMatcher{
 					Regex: `^/(.*)`,
 				},
-				Substitution: strings.TrimSuffix(rewrite.Path.Prefix, "/") + `/\1`,
+				Substitution: strings.ReplaceAll(strings.TrimSuffix(rewrite.Path.Prefix, "/"), `\`, `\\`) + `/\1`,
 			}
 		} else {
 			route.Route.PrefixRewrite = rewrite.Path.Prefix
@@ -427,7 +427,7 @@ func pathFullReplaceMutation(rewrite *model.HTTPURLRewriteFilter) routeActionMut
 			Pattern: &envoy_type_matcher_v3.RegexMatcher{
 				Regex: "^/.*$",
 			},
-			Substitution: rewrite.Path.Exact,
+			Substitution: strings.ReplaceAll(rewrite.Path.Exact, `\`, `\\`),
 		}
 		return route
 	}

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -573,6 +573,136 @@ func Test_pathPrefixMutation(t *testing.T) {
 	})
 }
 
+func Test_pathFullReplaceMutation(t *testing.T) {
+	t.Run("no full path replace", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		res := pathFullReplaceMutation(nil)(route)
+		require.Equal(t, route, res)
+
+		res = pathFullReplaceMutation(&model.HTTPURLRewriteFilter{})(route)
+		require.Equal(t, route, res)
+
+		res = pathFullReplaceMutation(&model.HTTPURLRewriteFilter{Path: &model.StringMatch{}})(route)
+		require.Equal(t, route, res)
+	})
+
+	t.Run("with simple full path replace", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: "/new-path",
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: "/new-path",
+		}, res.Route.RegexRewrite)
+	})
+
+	t.Run("with full path replace containing backreferences", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: `/foo/\1`,
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: `/foo/\\1`,
+		}, res.Route.RegexRewrite)
+	})
+
+	t.Run("with full path replace containing whole match backreference 0", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: `/prefix/\0/suffix`,
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: `/prefix/\\0/suffix`,
+		}, res.Route.RegexRewrite)
+	})
+
+	t.Run("with full path replace containing trailing backslash", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: `/foo\`,
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: `/foo\\`,
+		}, res.Route.RegexRewrite)
+	})
+
+	t.Run("with full path replace containing consecutive backslashes", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: `/foo\\bar`,
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: `/foo\\\\bar`,
+		}, res.Route.RegexRewrite)
+	})
+
+	t.Run("with full path replace containing multiple backslashes", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Exact: `\1\2\3\g\k`,
+			},
+		}
+
+		res := pathFullReplaceMutation(rewrite)(route)
+		require.Equal(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+			Pattern: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^/.*$",
+			},
+			Substitution: `\\1\\2\\3\\g\\k`,
+		}, res.Route.RegexRewrite)
+	})
+}
+
 func Test_requestMirrorMutation(t *testing.T) {
 	t.Run("no mirror", func(t *testing.T) {
 		route := &envoy_config_route_v3.Route_Route{


### PR DESCRIPTION
When translating a Gateway API HTTPRoute URLRewrite filter with ReplaceFullPath, the exact path was previously passed unescaped to Envoy's RegexMatchAndSubstitute rule.

Because Envoy uses Google RE2 for regex substitution and the matching pattern contains no capturing groups, unescaped backslashes and capture group references (e.g. \1) in user-defined paths cause RE2 to fail internally at runtime. Envoy safely catches this failure, aborts the rewrite filter without crashing, and falls back to proxying downstream requests with the original, unmodified path.

Escape literal backslashes during translation so that Envoy evaluates them as literal characters. Also add defense-in-depth escaping for ReplacePrefixMatch and unit tests covering edge cases.

```release-note
Fix an issue where Gateway API URLRewrite ReplaceFullPath filters containing unescaped backreferences were silently bypassed by Envoy out of safety.
```

Fixes: 3cf560f9fd78 ("gateway-api: add support for URL rewrite")

This PR was prepared with AIL:3.