### PR TITLE
ipcache: add special "remove-all-metadata" placeholder type

### DIFF
--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache/types"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -671,6 +672,203 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	ip, key = s.IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.101", ip.String())
 	assert.Equal(t, uint8(6), key)
+}
+
+// TestAllMetadata tests inserting and removing all kinds of metadata
+func TestAllMetadata(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	tp1 := ipcachetypes.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.1")}
+	tp2 := ipcachetypes.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.2")}
+
+	ec1 := ipcachetypes.EncryptKey(1)
+	ec2 := ipcachetypes.EncryptKey(2)
+
+	ri1 := ipcachetypes.RequestedIdentity(1)
+	ri2 := ipcachetypes.RequestedIdentity(2)
+
+	epf1 := ipcachetypes.EndpointFlags{}
+	epf1.SetRemoteCluster(true)
+
+	epf2 := ipcachetypes.EndpointFlags{}
+	epf2.SetSkipTunnel(true)
+
+	steps := []struct {
+		add    IPMetadata
+		del    IPMetadata
+		result *resourceInfo
+	}{
+		{
+			add: labels.LabelIngress,
+			result: &resourceInfo{
+				labels: labels.LabelIngress,
+			},
+		},
+		{
+			add: labels.LabelHealth,
+			result: &resourceInfo{
+				labels: labels.LabelHealth,
+			},
+		},
+		{
+			add: overrideIdentity(true),
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+			},
+		},
+		{
+			add: tp1,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp1,
+			},
+		}, {
+			add: tp2,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp2,
+			},
+		}, {
+			add: ec1,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp2,
+				encryptKey:       ec1,
+			},
+		}, {
+			add: ec2,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp2,
+				encryptKey:       ec2,
+			},
+		}, {
+			add: ri1,
+			result: &resourceInfo{
+				labels:            labels.LabelHealth,
+				identityOverride:  true,
+				tunnelPeer:        tp2,
+				encryptKey:        ec2,
+				requestedIdentity: ri1,
+			},
+		}, {
+			add: ri2,
+			result: &resourceInfo{
+				labels:            labels.LabelHealth,
+				identityOverride:  true,
+				tunnelPeer:        tp2,
+				encryptKey:        ec2,
+				requestedIdentity: ri2,
+			},
+		}, {
+			add: epf1,
+			result: &resourceInfo{
+				labels:            labels.LabelHealth,
+				identityOverride:  true,
+				tunnelPeer:        tp2,
+				encryptKey:        ec2,
+				endpointFlags:     epf1,
+				requestedIdentity: ri2,
+			},
+		}, {
+			add: epf2,
+			result: &resourceInfo{
+				labels:            labels.LabelHealth,
+				identityOverride:  true,
+				tunnelPeer:        tp2,
+				encryptKey:        ec2,
+				endpointFlags:     epf2,
+				requestedIdentity: ri2,
+			},
+		},
+		{
+			del: epf2,
+			result: &resourceInfo{
+				labels:            labels.LabelHealth,
+				identityOverride:  true,
+				tunnelPeer:        tp2,
+				encryptKey:        ec2,
+				requestedIdentity: ri2,
+			},
+		},
+		{
+			del: ri2,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp2,
+				encryptKey:       ec2,
+			},
+		},
+		{
+			del: ec2,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp2,
+			},
+		},
+		{
+			del: tp2,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+			},
+		},
+		{
+			del: overrideIdentity(false),
+			result: &resourceInfo{
+				labels: labels.LabelHealth,
+			},
+		},
+		{
+			del:    labels.LabelHealth,
+			result: nil,
+		},
+		{
+			add: labels.LabelHealth,
+			result: &resourceInfo{
+				labels: labels.LabelHealth,
+			},
+		},
+		{
+			add: overrideIdentity(true),
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+			},
+		},
+		{
+			add: tp1,
+			result: &resourceInfo{
+				labels:           labels.LabelHealth,
+				identityOverride: true,
+				tunnelPeer:       tp1,
+			},
+		},
+		{
+			del:    ipcachetypes.AllMetadata{},
+			result: nil,
+		},
+	}
+	for i, step := range steps {
+		if step.add != nil {
+			s.IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "test", step.add)
+		}
+		if step.del != nil {
+			s.IPIdentityCache.metadata.remove(inClusterPrefix, "test", step.del)
+		}
+		if step.result != nil {
+			step.result.source = source.CustomResource
+		}
+		require.Equal(t, step.result, s.IPIdentityCache.metadata.getLocked(inClusterPrefix), "step %d", i)
+	}
+
 }
 
 // TestRequestIdentity checks that the identity restoration mechanism works as expected:

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -131,6 +131,8 @@ func (m *resourceInfo) unmerge(logger *slog.Logger, info IPMetadata) {
 		m.requestedIdentity = ipcachetypes.RequestedIdentity(identity.IdentityUnknown)
 	case ipcachetypes.EndpointFlags:
 		m.endpointFlags = ipcachetypes.EndpointFlags{}
+	case ipcachetypes.AllMetadata:
+		*m = resourceInfo{}
 	default:
 		logger.Error(
 			"BUG: Invalid IPMetadata passed to ipinfo.unmerge()",

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -157,3 +157,7 @@ func (e EndpointFlags) Uint8() uint8 {
 	}
 	return flags
 }
+
+// AllMetadata is a placeholder metadata type for when all metadata
+// for a given ip + resource should be deleted.
+type AllMetadata struct{}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -958,7 +958,6 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		// See comment in NodeUpdated().
 		oldNodeIP, _ = netipx.FromStdIP(nIP)
 	}
-	oldNodeLabels := m.nodeIdentityLabels(oldNode)
 
 	// Delete the old node IP addresses if they have changed in this node.
 	for _, address := range oldNode.IPAddresses {
@@ -974,26 +973,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			oldPrefixCluster = cmtypes.NewLocalPrefixCluster(prefix)
 		}
 
-		var oldTunnelIP netip.Addr
-		if m.nodeAddressHasTunnelIP(address) {
-			oldTunnelIP = oldNodeIP
-		}
+		m.ipcache.RemoveMetadata(oldPrefixCluster, resource, ipcacheTypes.AllMetadata{})
 
-		var oldKey uint8
-		if m.nodeAddressHasEncryptKey() {
-			oldKey = oldNode.EncryptionKey
-		}
-
-		oldEndpointFlags := ipcacheTypes.EndpointFlags{}
-		if oldNode.Cluster != m.clusterInfo.Name {
-			oldEndpointFlags.SetRemoteCluster(true)
-		}
-
-		m.ipcache.RemoveMetadata(oldPrefixCluster, resource,
-			oldNodeLabels,
-			ipcacheTypes.TunnelPeer{Addr: oldTunnelIP},
-			ipcacheTypes.EncryptKey(oldKey),
-			oldEndpointFlags)
 	}
 
 	// Remove old pod CIDR fallback entries from IPCache
@@ -1028,8 +1009,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 
 		m.ipcache.RemoveMetadata(prefixCluster, resource,
 			labels.LabelHealth,
-			ipcacheTypes.TunnelPeer{Addr: oldNodeIP},
-			m.endpointEncryptionKey(&oldNode))
+			ipcacheTypes.AllMetadata{})
 	}
 
 	// Delete the old ingress IP addresses if they have changed in this node.
@@ -1043,8 +1023,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 
 		m.ipcache.RemoveMetadata(prefixCluster, resource,
 			labels.LabelIngress,
-			ipcacheTypes.TunnelPeer{Addr: oldNodeIP},
-			m.endpointEncryptionKey(&oldNode))
+			ipcacheTypes.AllMetadata{})
 	}
 }
 


### PR DESCRIPTION
To remove all metadata for a prefix, it is necessary to supply all kinds of metadata that may have been provided. This is a bit unnecessary when a given resource is known to be going away.

So, add a placeholder type to indicate that all metadata for a given resource + ip can be deleted. This means that providers no longer have to reconstruct the full metadata set.

Then, change the node manager to utilize this.