### PR TITLE
cilium-cni: make log rotation size and backups configurable

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -61,6 +61,12 @@ const (
 	// defaultLogMaxBackups is to make sure that we have an upper bound on disk space used by
 	// CNI file logging (e.g. < 7 * 100 MB).
 	defaultLogMaxBackups = 7
+	// defaultLogMaxSize is the default maximum size in MB of a single CNI log file
+	// before it gets rotated. It is kept small relative to the lumberjack default
+	// (100 MB) so that the worst-case disk usage of retained logs (MaxBackups * MaxSize
+	// plus the active file) stays well below the size of the /run tmpfs (10% of RAM,
+	// e.g. ~795 MB on an 8 GB node) that /var/run resolves to on most distros.
+	defaultLogMaxSize = 10
 )
 
 var (
@@ -461,12 +467,21 @@ func (cmd *Cmd) setupLogging(n *types.NetConf) error {
 	}
 
 	if len(n.LogFile) != 0 {
+		maxBackups := n.LogMaxBackups
+		if maxBackups == 0 {
+			maxBackups = defaultLogMaxBackups
+		}
+		maxSize := n.LogMaxSize
+		if maxSize == 0 {
+			maxSize = defaultLogMaxSize
+		}
 		logging.AddHandlers(hooks.NewFileRotationLogHook(
 			// slogloggercheck: the logger has been initialized with default settings
 			logging.GetSlogLevel(logging.DefaultSlogLogger),
 			n.LogFile,
 			hooks.EnableCompression(),
-			hooks.WithMaxBackups(defaultLogMaxBackups),
+			hooks.WithMaxBackups(maxBackups),
+			hooks.WithMaxSize(maxSize),
 		))
 	}
 

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -31,6 +31,8 @@ type NetConf struct {
 	EnableDebug    bool                   `json:"enable-debug"`
 	LogFormat      string                 `json:"log-format"`
 	LogFile        string                 `json:"log-file"`
+	LogMaxBackups  int                    `json:"log-max-backups,omitempty"`
+	LogMaxSize     int                    `json:"log-max-size,omitempty"`
 	ChainingMode   string                 `json:"chaining-mode"`
 }
 

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -65,6 +65,29 @@ func TestReadCNIConf(t *testing.T) {
 	testConfRead(t, confFile2, &netConf2)
 }
 
+func TestReadCNIConfLogRotation(t *testing.T) {
+	confFile := `
+{
+  "name": "cilium",
+  "type": "cilium-cni",
+  "log-file": "/var/run/cilium/cilium-cni.log",
+  "log-max-backups": 3,
+  "log-max-size": 25
+}
+`
+
+	netConf := NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "cilium",
+			Type: "cilium-cni",
+		},
+		LogFile:       "/var/run/cilium/cilium-cni.log",
+		LogMaxBackups: 3,
+		LogMaxSize:    25,
+	}
+	testConfRead(t, confFile, &netConf)
+}
+
 func TestReadCNIConfENIWithPlugins(t *testing.T) {
 	confFile1 := `
 {


### PR DESCRIPTION
The default CNI file logging writes to `/var/run/cilium/cilium-cni.log`, which on most distros resolves to `/run`, a tmpfs sized at 10% of RAM (e.g. ~795 MB on an 8 GB node). The rotation policy is hardcoded in `setupLogging`:

- `MaxBackups = 7` (`defaultLogMaxBackups`)
- `MaxSize = 100 MB` (lumberjack's default from `pkg/logging/hooks/file_rotation.go`, never overridden)
- `Compress = true` (`hooks.EnableCompression()`)

The worst-case retained set is therefore 7 × 100 MB backups + up to 100 MB active file ≈ 800 MB — larger than the `/run` tmpfs on nodes with ≤ 8 GB RAM. When `/run` reaches 100%, containerd can no longer create pod sandboxes:

```
FailedCreatePodSandBox: failed to create containerd task: ... write /run/containerd/runc/k8s.io. state-: no space left on device
```

Meanwhile every standard node health signal still reports healthy (`Ready=True`, `DiskPressure=False`), because kubelet eviction/GC only watches nodefs/imagefs, not `/run`.

### Fix

1. **Make the values configurable** via the CNI network configuration: add `log-max-size` and `log-max-backups` fields to the cilium-cni `NetConf` (mirroring the existing `log-file` / `log-format` fields) and honor them in `setupLogging`.
2. **Lower the default max file size to 10 MB** so that the out-of-the-box configuration caps the retained set at 7 × 10 MB + 10 MB ≈ 80 MB, comfortably below a 795 MB tmpfs. The default now comes from cilium-cni itself instead of silently inheriting lumberjack's 100 MB default.

Existing configurations that override `log-max-backups` keep their behavior.

### Tests

Added `TestReadCNIConfLogRotation` in `plugins/cilium-cni/types/types_test.go` verifying that `log-max-backups` / `log-max-size` are parsed from the CNI config into `NetConf`.

Fixes: #48279

```release-note
Make the cilium-cni log rotation size and backup count configurable via the CNI config (log-max-size, log-max-backups) and cap the default max log file size at 10 MB so the retained logs cannot fill the /run tmpfs on small nodes.
```

This PR was prepared with AIL:3. I personally reviewed and verified the change compiles (GOOS=linux) and the new unit test passes.
