### PR TITLE
bpf: use `eth_{load,store}_*` helpers instead of open-coding

### DIFF
--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -48,8 +48,8 @@ static __always_inline bool eth_is_supported_ethertype(__be16 proto)
 	return proto >= bpf_htons(ETH_P_802_3_MIN);
 }
 
-static __always_inline int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac,
-					  int off)
+static __always_inline int eth_load_saddr(const struct __ctx_buff *ctx,
+					  __u8 *mac, int off)
 {
 	return ctx_load_bytes(ctx, off + ETH_ALEN, mac, ETH_ALEN);
 }
@@ -79,8 +79,8 @@ static __always_inline int eth_store_saddr(struct __ctx_buff *ctx,
 #endif
 }
 
-static __always_inline int eth_load_daddr(struct __ctx_buff *ctx, __u8 *mac,
-					  int off)
+static __always_inline int eth_load_daddr(const struct __ctx_buff *ctx,
+					  __u8 *mac, int off)
 {
 	return ctx_load_bytes(ctx, off, mac, ETH_ALEN);
 }

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -365,7 +365,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 	if (ipv6_addr_equals(&target, &service_loopback)) {
 		union macaddr source_mac;
 
-		if (ctx_load_bytes(ctx, ETH_ALEN, source_mac.addr, ETH_ALEN) < 0)
+		if (eth_load_saddr(ctx, source_mac.addr, 0) < 0)
 			return DROP_INVALID;
 		return icmp6_send_ndisc_adv(ctx, nh_off, &source_mac, false);
 	}

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -220,8 +220,7 @@ srv6_decapsulation(struct __ctx_buff *ctx, __u8 *nexthdr)
 parse_outer_ipv4: __maybe_unused;
 		if (ctx_change_proto(ctx, new_proto, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (ctx_store_bytes(ctx, offsetof(struct ethhdr, h_proto),
-				    &new_proto, sizeof(new_proto), 0) < 0)
+		if (eth_store_proto(ctx, new_proto, 0) < 0)
 			return DROP_WRITE_ERROR;
 		/* ctx_change_proto above shrinks the packet from IPv6 header
 		 * length to IPv4 header length. It removes that space from the
@@ -269,8 +268,7 @@ srv6_handling4(struct __ctx_buff *ctx, union v6addr *src_sid,
 	 */
 	new_payload_len = bpf_ntohs(ip4->tot_len) - (__u16)(ip4->ihl << 2) + sizeof(struct iphdr);
 
-	if (ctx_store_bytes(ctx, offsetof(struct ethhdr, h_proto),
-			    &outer_proto, sizeof(outer_proto), 0) < 0)
+	if (eth_store_proto(ctx, outer_proto, 0) < 0)
 		return DROP_WRITE_ERROR;
 
 #ifdef ENABLE_SRV6_SRH_ENCAP


### PR DESCRIPTION
See commits for details.

AIL: 0