### PR TITLE
bpf: remove always unused `snat_v{4,6}_rev_nat` `ext_err` parameter

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -182,8 +182,7 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPV4
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
 static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
-							__u32 src_sec_identity,
-							__s8 *ext_err)
+							__u32 src_sec_identity)
 {
 	int ret;
 	struct iphdr *ip4;
@@ -199,7 +198,7 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 	};
 	struct trace_ctx trace;
 
-	ret = snat_v4_rev_nat(ctx, &target, &trace, ext_err);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	if (ret != NAT_PUNT_TO_STACK && ret != DROP_NAT_NO_MAPPING) {
 		if (IS_ERR(ret))
 			return ret;
@@ -241,11 +240,10 @@ int tail_handle_inter_cluster_revsnat(struct __ctx_buff *ctx)
 {
 	int ret;
 	__u32 src_sec_identity = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
-	__s8 ext_err = 0;
 
-	ret = handle_inter_cluster_revsnat(ctx, src_sec_identity, &ext_err);
+	ret = handle_inter_cluster_revsnat(ctx, src_sec_identity);
 	if (IS_ERR(ret))
-		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
+		return send_drop_notify_error(ctx, src_sec_identity, ret,
 						  METRIC_INGRESS);
 	return ret;
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1313,20 +1313,6 @@ rewrite: __maybe_unused
 				       tuple.dport, to_dport, port_off,
 				       outer_csum_diff);
 }
-#else /* defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT) */
-static __always_inline __maybe_unused
-int snat_v4_nat(struct __ctx_buff *ctx __maybe_unused,
-		const struct ipv4_nat_target *target __maybe_unused)
-{
-	return CTX_ACT_OK;
-}
-
-static __always_inline __maybe_unused
-int snat_v4_rev_nat(struct __ctx_buff *ctx __maybe_unused,
-		    const struct ipv4_nat_target *target __maybe_unused)
-{
-	return CTX_ACT_OK;
-}
 #endif /* defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT) */
 
 struct ipv6_nat_entry {
@@ -2297,20 +2283,6 @@ rewrite: __maybe_unused
 				       ipfrag_has_l4_header(fraginfo), off,
 				       &tuple.daddr, &state->to_daddr, IPV6_DADDR_OFF,
 				       tuple.dport, to_dport, port_off);
-}
-#else /* defined(ENABLE_IPV6) && defined(ENABLE_NODEPORT) */
-static __always_inline __maybe_unused
-int snat_v6_nat(struct __ctx_buff *ctx __maybe_unused,
-		const struct ipv6_nat_target *target __maybe_unused)
-{
-	return CTX_ACT_OK;
-}
-
-static __always_inline __maybe_unused
-int snat_v6_rev_nat(struct __ctx_buff *ctx __maybe_unused,
-		    const struct ipv6_nat_target *target __maybe_unused)
-{
-	return CTX_ACT_OK;
 }
 #endif /* defined(ENABLE_IPV6) && defined(ENABLE_NODEPORT) */
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1203,7 +1203,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 
 static __always_inline __maybe_unused int
 snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
-		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
+		struct trace_ctx *trace)
 {
 	struct ipv4_nat_entry *state = NULL;
 	struct ipv4_ct_tuple tuple __align_stack_8 = {};
@@ -2186,7 +2186,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 
 static __always_inline __maybe_unused int
 snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
-		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
+		struct trace_ctx *trace)
 {
 	struct ipv6_nat_entry *state = NULL;
 	struct ipv6_ct_tuple tuple = {};

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1162,10 +1162,10 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	int ret;
 
-	ret = snat_v6_rev_nat(ctx, &target, &trace, &ext_err);
+	ret = snat_v6_rev_nat(ctx, &target, &trace);
 	if (CONFIG(nodeport_port_max_nat_ext) && ret == NAT_PUNT_TO_STACK) {
 		swap_nat_port_range_ipv6(&target);
-		ret = snat_v6_rev_nat(ctx, &target, &trace, &ext_err);
+		ret = snat_v6_rev_nat(ctx, &target, &trace);
 	}
 	if (IS_ERR(ret)) {
 		if (ret == NAT_PUNT_TO_STACK ||
@@ -2409,10 +2409,10 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	int ret;
 
-	ret = snat_v4_rev_nat(ctx, &target, &trace, &ext_err);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	if (CONFIG(nodeport_port_max_nat_ext) && ret == NAT_PUNT_TO_STACK) {
 		swap_nat_port_range_ipv4(&target);
-		ret = snat_v4_rev_nat(ctx, &target, &trace, &ext_err);
+		ret = snat_v4_rev_nat(ctx, &target, &trace);
 	}
 	if (IS_ERR(ret)) {
 		if (ret == NAT_PUNT_TO_STACK ||

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -228,7 +228,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	assert(ret == 0);
 
 	__be16 proto;
@@ -348,7 +348,7 @@ int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	assert(ret == 0);
 
 	__be16 proto;
@@ -466,7 +466,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	assert(ret == 0);
 
 	__be16 proto;
@@ -579,7 +579,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	assert(ret == 0);
 
 	__be16 proto;
@@ -681,7 +681,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	assert(ret == DROP_CSUM_L4);
 
 	/* nothing really change with udp/tcp */

--- a/bpf/tests/icmp_error_revnat.c
+++ b/bpf/tests/icmp_error_revnat.c
@@ -114,7 +114,7 @@ int nat4_icmp_error_tcp_snat_revnat_setup(struct __ctx_buff *ctx)
 	 * 2. Reverse NAT the embedded IP src: pod -> endpoint
 	 * 3. Restore the embedded TCP sport: NODEPORT_PORT_MIN_NAT -> 3030
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace);
 	if (ret != 0)
 		return TEST_ERROR;
 


### PR DESCRIPTION
See commits for details.

AIL: 0