### PR TITLE
[v1.18] bpf: nodeport: remove Ingress HostFW Policy between RevSNAT and RevDNAT

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -206,7 +206,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
 		}
-	} else if (!ctx_skip_host_fw(ctx)) {
+	} else {
 		/* Verifier workaround: R5 invalid mem access 'scalar'. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
@@ -641,7 +641,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
 		}
-	} else if (!ctx_skip_host_fw(ctx)) {
+	} else {
 		/* Verifier workaround: R5 invalid mem access 'scalar'. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -641,7 +641,6 @@ struct encrypt_config {
 #define TC_INDEX_F_FROM_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
 #define TC_INDEX_F_UNUSED		8
-#define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
 #define CB_NAT_FLAGS_REVDNAT_ONLY	(1 << 0)
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1112,14 +1112,6 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 #if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
     (defined(ENABLE_EGRESS_GATEWAY_COMMON) && (defined(IS_BPF_XDP) || defined(IS_BPF_HOST)))
 
-# if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
-	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
-	if (IS_ERR(ret))
-		goto drop_err;
-
-	ctx_skip_host_fw_set(ctx);
-# endif
-
 	ret = invoke_traced_tailcall_if(__or(__and(is_defined(ENABLE_HOST_FIREWALL),
 						   is_defined(IS_BPF_HOST)),
 					     __and(is_defined(ENABLE_IPV6_FRAGMENTS),
@@ -2411,17 +2403,6 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 #if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
     (defined(ENABLE_EGRESS_GATEWAY_COMMON) &&						\
      (defined(IS_BPF_XDP) || defined(IS_BPF_HOST)))
-
-# if defined(ENABLE_HOST_FIREWALL) && defined(IS_BPF_HOST)
-	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
-	if (IS_ERR(ret))
-		goto drop_err;
-
-	/* We don't want to enforce host policies a second time,
-	 * on recircle / after RevDNAT.
-	 */
-	ctx_skip_host_fw_set(ctx);
-# endif
 
 	/* If we're not in full DSR mode, reply traffic from remote backends
 	 * might pass back through the LB node and requires revDNAT.

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -180,23 +180,6 @@ ctx_skip_nodeport(struct __sk_buff *ctx __maybe_unused)
 #endif
 }
 
-#ifdef ENABLE_HOST_FIREWALL
-static __always_inline void
-ctx_skip_host_fw_set(struct __sk_buff *ctx)
-{
-	ctx->tc_index |= TC_INDEX_F_SKIP_HOST_FIREWALL;
-}
-
-static __always_inline bool
-ctx_skip_host_fw(struct __sk_buff *ctx)
-{
-	volatile __u32 tc_index = ctx->tc_index;
-
-	ctx->tc_index &= ~TC_INDEX_F_SKIP_HOST_FIREWALL;
-	return tc_index & TC_INDEX_F_SKIP_HOST_FIREWALL;
-}
-#endif /* ENABLE_HOST_FIREWALL */
-
 static __always_inline __maybe_unused __u32 ctx_get_xfer(struct __sk_buff *ctx,
 							 __u32 off)
 {


### PR DESCRIPTION
 * [ ] https://github.com/cilium/cilium/pull/46232 (@julianwiedmann)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 46232
```
