### PR TITLE
bpf: misc cleanups

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1113,7 +1113,7 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 
 				if (ctx_adjust_hroom(ctx, -(int)sizeof(*ip6),
 						     BPF_ADJ_ROOM_MAC,
-						     ctx_adjust_hroom_flags())) {
+						     BPF_F_ADJ_ROOM_NO_CSUM_RESET)) {
 					ret = DROP_INVALID;
 					goto drop_err_ingress;
 				}
@@ -1200,7 +1200,7 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 
 				if (ctx_adjust_hroom(ctx, -(int)sizeof(*ip4),
 						     BPF_ADJ_ROOM_MAC,
-						     ctx_adjust_hroom_flags())) {
+						     BPF_F_ADJ_ROOM_NO_CSUM_RESET)) {
 					ret = DROP_INVALID;
 					goto drop_err_ingress;
 				}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -370,11 +370,6 @@ struct lb4_reverse_nat {
 	__be16 port;
 } __packed;
 
-static __always_inline __u64 ctx_adjust_hroom_flags(void)
-{
-	return BPF_F_ADJ_ROOM_NO_CSUM_RESET;
-}
-
 struct lpm_v4_key {
 	struct bpf_lpm_trie_key lpm;
 	__u8 addr[4];

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -14,6 +14,12 @@
 #include "overloadable.h"
 #ifdef ENABLE_IPV4
 
+static __always_inline int icmp_load_type(struct __ctx_buff *ctx, int l4_off, __u8 *type)
+{
+	return ctx_load_bytes(ctx, l4_off + offsetof(struct icmphdr, type),
+			      type, sizeof(*type));
+}
+
 #define ICMP_PACKET_MAX_SAMPLE_SIZE 8
 
 static __always_inline

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -68,7 +68,7 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	 */
 
 	ret = ctx_adjust_hroom(ctx, sizeof(*ip4) + sizeof(*icmphdr),
-			       BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags());
+			       BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET);
 	if (ret < 0)
 		return DROP_INVALID;
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -641,7 +641,7 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	 */
 
 	ret = ctx_adjust_hroom(ctx, sizeof(*ip6) + sizeof(*icmphdr),
-			       BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags());
+			       BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET);
 	if (ret < 0)
 		return DROP_INVALID;
 

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -37,6 +37,13 @@ static __always_inline bool tcp_is_syn(union tcp_flags flags)
 }
 
 static __always_inline int
+udp_load_csum(const struct __ctx_buff *ctx, int l4_off, __be16 *csum)
+{
+	return ctx_load_bytes(ctx, l4_off + offsetof(struct udphdr, check),
+			      csum, field_sizeof(struct udphdr, check));
+}
+
+static __always_inline int
 l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
 {
 	return ctx_store_bytes(ctx, l4_off + port_off, &port, sizeof(port), 0);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -851,8 +851,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
-				   &tuple.sport, sizeof(tuple.sport)) < 0)
+		if (l4_load_port(ctx, inner_l4_off + port_off, &tuple.sport) < 0)
 			return DROP_INVALID;
 		break;
 	default:
@@ -1100,8 +1099,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
-				   &tuple.dport, sizeof(tuple.dport)) < 0)
+		if (l4_load_port(ctx, inner_l4_off + port_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 		break;
 	default:
@@ -1861,8 +1859,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
-				   &tuple.sport, sizeof(tuple.sport)) < 0)
+		if (l4_load_port(ctx, inner_l4_off + port_off, &tuple.sport) < 0)
 			return DROP_INVALID;
 		break;
 	default:
@@ -2084,8 +2081,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		port_off = offsetof(struct icmp6hdr,
 				    icmp6_dataun.u_echo.identifier);
 
-		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
-				   &tuple.dport, sizeof(tuple.dport)) < 0)
+		if (l4_load_port(ctx, inner_l4_off + port_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 		break;
 	default:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -21,6 +21,7 @@
 #include "drop_reasons.h"
 #include "egress_gateway.h"
 #include "eps.h"
+#include "icmp.h"
 #include "icmp6.h"
 #include "nat_46x64.h"
 #include "signal.h"
@@ -838,7 +839,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
+		if (icmp_load_type(ctx, inner_l4_off, &type) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -1086,7 +1087,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 		port_off = TCP_SPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
+		if (icmp_load_type(ctx, inner_l4_off, &type) < 0)
 			return DROP_INVALID;
 
 		switch (type) {

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -872,8 +872,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	if (tuple.nexthdr == IPPROTO_UDP) {
 		__be16 l4_csum_be = 0;
 
-		if (ctx_load_bytes(ctx, inner_l4_off + offsetof(struct udphdr, check),
-				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
+		if (udp_load_csum(ctx, inner_l4_off, &l4_csum_be) < 0)
 			return DROP_INVALID;
 		if (l4_csum_be == 0)
 			is_inner_l4_csum_enabled = false;
@@ -1120,8 +1119,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	if (tuple.nexthdr == IPPROTO_UDP) {
 		__be16 l4_csum_be = 0;
 
-		if (ctx_load_bytes(ctx, inner_l4_off + offsetof(struct udphdr, check),
-				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
+		if (udp_load_csum(ctx, inner_l4_off, &l4_csum_be) < 0)
 			return DROP_INVALID;
 		if (l4_csum_be == 0)
 			is_inner_l4_csum_enabled = false;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -421,7 +421,7 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 	rss_gen_src6(&saddr, (union v6addr *)&ip6->saddr, l4_hint);
 
 	if (ctx_adjust_hroom(ctx, sizeof(*ip6), BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()))
+			     BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 	if (ctx_store_bytes(ctx, l3_off + offsetof(struct ipv6hdr, payload_len),
 			    &tp_new.payload_len, 4, 0) < 0)
@@ -473,7 +473,7 @@ static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 	opt.port = svc_port;
 
 	if (ctx_adjust_hroom(ctx, sizeof(opt), BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()))
+			     BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip6), &opt,
 			    sizeof(opt), 0) < 0)
@@ -1751,7 +1751,7 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 	}
 
 	if (ctx_adjust_hroom(ctx, sizeof(*ip4), BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()))
+			     BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 	sum = csum_diff(&tp_old, 16, &tp_new, 16, 0);
 	if (ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, tot_len),
@@ -1818,7 +1818,7 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	sum = csum_diff(NULL, 0, &opt, sizeof(opt), sum);
 
 	if (ctx_adjust_hroom(ctx, sizeof(opt), BPF_ADJ_ROOM_NET,
-			     ctx_adjust_hroom_flags()))
+			     BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 
 	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip4),

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -172,7 +172,7 @@ ctx_set_encap_info4(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	/* Add space in front (50 bytes + options) */
 	outer_len = sizeof(*eth) + sizeof(*ip4) + sizeof(*udp) + tunnel_hdr_len + opt_len;
 
-	if (ctx_adjust_hroom(ctx, outer_len, BPF_ADJ_ROOM_NET, ctx_adjust_hroom_flags()))
+	if (ctx_adjust_hroom(ctx, outer_len, BPF_ADJ_ROOM_NET, BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 
 	/* validate access to outer headers: */
@@ -253,7 +253,7 @@ ctx_set_tunnel_opt(struct xdp_md *ctx, void *opt, __u32 opt_len)
 	struct genevehdr geneve;
 
 	/* add free space after GENEVE header: */
-	if (ctx_adjust_hroom(ctx, opt_len, BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags()) < 0)
+	if (ctx_adjust_hroom(ctx, opt_len, BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET) < 0)
 		return DROP_INVALID;
 
 	/* write the options */

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -241,7 +241,7 @@ parse_outer_ipv6: __maybe_unused;
 
 	/* Remove the outer IPv6 header. */
 	if (ctx_adjust_hroom(ctx, -shrink, BPF_ADJ_ROOM_MAC,
-			     ctx_adjust_hroom_flags()))
+			     BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 	return 0;
 }


### PR DESCRIPTION
Trivial cleanup for `ctx_adjust_hroom_flags()`, along with a bunch of `ctx_load_bytes()` cleanups.
