### PR TITLE
lib/auxvars.h: Let `AUX()` zero value.

### DIFF
--- a/bpf/lib/auxvars.h
+++ b/bpf/lib/auxvars.h
@@ -13,7 +13,7 @@ volatile const __section(".rodata.aux") __u64 _aux_cpu_mask;
 volatile const __section(".rodata.aux") __u64 _aux_stride_shift;
 
 /*
- * The AUX macro is used to access per-CPU auxiliary variables. It calculates
+ * The AUX[_REUSE] macros are used to access per-CPU auxiliary variables. It calculates
  * the address of the variable for the current CPU by adding an offset based on
  * the CPU ID and a stride shift value.
  *
@@ -21,6 +21,19 @@ volatile const __section(".rodata.aux") __u64 _aux_stride_shift;
  * switch back to the previous implementation to avoid the memory overhead.
  * (see https://github.com/cilium/cilium/issues/48301)
  */
-#define AUX(name) \
+
+/* AUX_REUSE() returns a pointer to an auxvar of the given name, without zeroing it out.
+ * Use this for transferring data between functions or tail calls.
+ */
+#define AUX_REUSE(name) \
 	((__typeof__(__aux_##name) *)((void *)&__aux_##name + \
 	 ((get_smp_processor_id() & _aux_cpu_mask) << _aux_stride_shift)))
+
+/* AUX() returns a pointer to an auxvar of the given name, and zeroes it out.
+ * Use this for additional non-stack scratch space.
+ */
+#define AUX(name) ({ \
+	__typeof__(__aux_##name) *ptr = AUX_REUSE(name); \
+	__bpf_memzero(ptr, sizeof(*ptr)); \
+	ptr; \
+})

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1086,8 +1086,6 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 	union tcp_flags seen_flags = { .value = 0 };
 	int err;
 
-	memset(entry, 0, sizeof(*entry));
-
 	if (ct_state)
 		ct_create_fill_entry(entry, ct_state, dir);
 
@@ -1101,7 +1099,6 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 		/* Create an ICMPv6 entry to relate errors */
 		struct ipv6_ct_tuple *icmp_tuple = AUX(ct_create6_tuple);
 
-		memset(icmp_tuple, 0, sizeof(*icmp_tuple));
 		*icmp_tuple = (struct ipv6_ct_tuple) {
 			.nexthdr = IPPROTO_ICMPV6,
 			.sport = 0,
@@ -1150,8 +1147,6 @@ static __always_inline int ct_create4(const void *map_main,
 	union tcp_flags seen_flags = { .value = 0 };
 	int err;
 
-	memset(entry, 0, sizeof(*entry));
-
 	if (ct_state)
 		ct_create_fill_entry(entry, ct_state, dir);
 
@@ -1165,7 +1160,6 @@ static __always_inline int ct_create4(const void *map_main,
 		/* Create an ICMP entry to relate errors */
 		struct ipv4_ct_tuple *icmp_tuple = AUX(ct_create4_tuple);
 
-		memset(icmp_tuple, 0, sizeof(*icmp_tuple));
 		*icmp_tuple = (struct ipv4_ct_tuple) {
 			.daddr = tuple->daddr,
 			.saddr = tuple->saddr,

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -173,7 +173,7 @@ DEFINE_AUX(struct ipv6_hdrlen_arg, ipv6_hdrlen_arg);
 __noinline __weak
 int ipv6_hdrlen_with_fraginfo_weak(const struct __ctx_buff *ctx)
 {
-	struct ipv6_hdrlen_arg *arg = AUX(ipv6_hdrlen_arg);
+	struct ipv6_hdrlen_arg *arg = AUX_REUSE(ipv6_hdrlen_arg);
 
 	return ipv6_hdrlen_offset(ctx, ETH_HLEN, &arg->nexthdr, &arg->fraginfo);
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -782,7 +782,7 @@ DEFINE_AUX(struct snat_v4_args, snat_v4_args);
 __noinline __weak int
 snat_v4_needs_masquerade(struct __ctx_buff *ctx, fraginfo_t fraginfo, int l4_off)
 {
-	struct snat_v4_args *args = AUX(snat_v4_args);
+	struct snat_v4_args *args = AUX_REUSE(snat_v4_args);
 	void *data, *data_end;
 	struct iphdr *ip4;
 
@@ -1383,7 +1383,6 @@ static __always_inline int snat_v6_new_mapping(const struct __ctx_buff *ctx,
 	int ret;
 	__u16 port;
 
-	memset(rstate, 0, sizeof(*rstate));
 	memset(ostate, 0, sizeof(*ostate));
 
 	rstate->to_daddr = otuple->saddr;
@@ -1503,7 +1502,6 @@ snat_v6_nat_handle_mapping(const struct __ctx_buff *ctx,
 			if (!lookup_result) {
 				struct ipv6_nat_entry *rstate = AUX(snat_v6_nhm_nat_entry);
 
-				memset(rstate, 0, sizeof(*rstate));
 				rstate->to_daddr = tuple->saddr;
 				rstate->to_dport = tuple->sport;
 				rstate->common.needs_ct = needs_ct;
@@ -1530,7 +1528,7 @@ snat_v6_nat_handle_mapping(const struct __ctx_buff *ctx,
 			__snat_delete(&cilium_snat_v6_external, rtuple);
 	}
 
-	*state = AUX(snat_v6_nhm_nat_entry);
+	*state = AUX_REUSE(snat_v6_nhm_nat_entry);
 	return snat_v6_new_mapping(ctx, tuple, *state, target, needs_ct, ext_err);
 }
 
@@ -1794,7 +1792,7 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 fraginfo_t fraginfo __maybe_unused,
 			 int l4_off __maybe_unused)
 {
-	struct snat_v6_args *args = AUX(snat_v6_args);
+	struct snat_v6_args *args = AUX_REUSE(snat_v6_args);
 
 	return __snat_v6_needs_masquerade(ctx, &args->tuple, fraginfo, l4_off, &args->target);
 }
@@ -1917,7 +1915,7 @@ __noinline __weak int
 snat_v6_nat(struct __ctx_buff *ctx, fraginfo_t fraginfo, int off, __s8 *ext_err)
 {
 	struct ipv6_nat_entry *state = NULL;
-	struct snat_v6_args *args = AUX(snat_v6_args);
+	struct snat_v6_args *args = AUX_REUSE(snat_v6_args);
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u16 port_off = 0;

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -138,7 +138,6 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	struct snat_v6_args *args = AUX(snat_v6_args);
 
-	memset(args, 0, sizeof(*args));
 	args->trace = (struct trace_ctx){
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
@@ -347,7 +346,6 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	fraginfo = ipfrag_encode_ipv4(ip4);
 
 	args = AUX(snat_v4_args);
-	memset(args, 0, sizeof(*args));
 	select_nat_port_range_ipv4(&args->target);
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
 	args->target.cluster_id = cluster_id,

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -220,8 +220,6 @@ __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 {
 	struct trace_notify_vars *vars = AUX(trace_notify_vars);
 
-	memset(vars, 0, sizeof(*vars));
-
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
 
 	if (!emit_trace_notify(obs_point, monitor))


### PR DESCRIPTION
Auxvars have two main use cases at the moment, the first is to act as a storage for large variables we do not want to put on the stack. The second is to transfer data to a global function or tail call.

Since auxvars are global values, their values persist. For the first use case this can be a foot gun. A normal stack variable is always zero initialized, something we often implicitly rely on without even knowing it. To make this less error prone, we now zero initialize auxvars when using `AUX()`.

For the second use case, we introduce a new macro `AUX_REUSE()` which does not zero initialize the auxvar, and can be used to transfer data between functions or tail calls.

This commit also removes any superfluous `memset()` calls that were added to deal with this in the past.
