### PR TITLE
workflows: Stop using kind-action

### DIFF
--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -271,14 +271,16 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          cluster_name: "kind"
-          config: kind-config-delegated-ipam.yaml # created by earlier step
-          wait: 0
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config kind-config-delegated-ipam.yaml --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@7ca7fc53c20275f5c10ef5f3557076691fd1d720 # v0.19.7

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -249,13 +249,16 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.kind_config }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.kind_config }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -205,13 +205,16 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.kind_config }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.kind_config }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -89,13 +89,16 @@ jobs:
           auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.KIND_CONFIG }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -120,13 +120,16 @@ jobs:
         id: external_network
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.kind_config }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.kind_config }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Add external targets to kind cluster
         uses: ./.github/actions/kind-external-targets

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -280,13 +280,16 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ./.github/kind-config-multi-pool.yaml
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config .github/kind-config-multi-pool.yaml --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -146,15 +146,17 @@ jobs:
           make -C hubble
           ./hubble/hubble version
 
-      # Setup the cluster
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0 -C hubble
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.KIND_CONFIG }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -143,13 +143,16 @@ jobs:
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.KIND_CONFIG }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -115,13 +115,16 @@ jobs:
           test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.KIND_CONFIG }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -117,13 +117,16 @@ jobs:
           sudo systemctl restart docker
 
       - name: Create kind cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_K8S_IMAGE }}
-          kubectl_version: ${{ env.KIND_K8S_VERSION }}
-          config: ${{ env.KIND_CONFIG }}
-          wait: 0 # The control-plane never becomes ready, since no CNI is present
+        run: |
+          export IMAGE=${{ env.KIND_K8S_IMAGE }}
+
+          # These commands are passed to stdin of ssh as a here-document. Env
+          # vars used here are substituted by bash from GitHub's env. However,
+          # in order to include them into the enviroment of kind.sh called
+          # below, they also need to be set inside the ssh session.
+          export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
+
+          kind create cluster --config ${{ env.KIND_CONFIG }} --image ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
         if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}


### PR DESCRIPTION
Let's consolidate ways to setup the Kind clusters in CI, to avoid running into https://github.com/cilium/cilium/issues/23283 again and again.