### PR TITLE
Fix nodeport egress tuple reuse for closed connections

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1259,6 +1259,17 @@ static __always_inline bool
 __ct_has_nodeport_egress_entry(const struct ct_entry *entry,
 			       __u16 *rev_nat_index, bool check_dsr)
 {
+	/* A fully-closed egress entry belongs to a terminated connection.
+	 * When the same CT_EGRESS tuple is reused by a new, non-service
+	 * flow(eg. a direct client-to-backend connection), driving reverse
+	 * NAT from the stale entry would incorrectly rewrite the new flow's
+	 * replies to the old service/hostPort frontend and break the
+	 * connection. Skip processing nodeport egress CT entry corresponding
+	 * to a closed connection.
+	 */
+	if (!ct_entry_alive(entry))
+		return false;
+
 	if (entry->node_port) {
 		if (rev_nat_index)
 			*rev_nat_index = entry->rev_nat_index;

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -207,6 +207,34 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		assert(monitor == TRACE_PAYLOAD_LEN);
 	});
 
+	TEST("ct_has_nodeport_egress_entry", {
+		struct ct_entry entry = {};
+		__u16 rev_nat_index = 0;
+
+		entry.node_port = 1;
+		entry.rev_nat_index = 42;
+
+		/* An alive NodePort entry drives reverse-NAT. */
+		assert(__ct_has_nodeport_egress_entry(&entry, &rev_nat_index, false));
+		assert(rev_nat_index == 42);
+
+		/* Once both directions have seen a closing packet, the connection
+		 * is fully closed. Its egress tuple can now be reused by an
+		 * unrelated flow, so it must no longer be treated as a NodePort
+		 * egress entry.
+		 */
+		rev_nat_index = 0;
+		entry.rx_closing = 1;
+		entry.tx_closing = 1;
+		assert(!__ct_has_nodeport_egress_entry(&entry, &rev_nat_index, false));
+		assert(rev_nat_index == 0);
+
+		/* Closing in only one direction doesn't terminate the connection. */
+		entry.tx_closing = 0;
+		assert(__ct_has_nodeport_egress_entry(&entry, &rev_nat_index, false));
+		assert(rev_nat_index == 42);
+	});
+
 	test_finish();
 }
 


### PR DESCRIPTION
See commit message for details. Issue [details/repro](https://github.com/cilium/cilium/issues/43769#issuecomment-5448039915)
Fixes https://github.com/cilium/cilium/issues/43769
