### PR TITLE
ztunnel: support PKCS#1 CA private keys

### DIFF
--- a/pkg/ztunnel/ca/ca_server.go
+++ b/pkg/ztunnel/ca/ca_server.go
@@ -139,34 +139,38 @@ func (s *Server) init() error {
 	}
 
 	block, _ = pem.Decode(buf)
-	if block.Type != "PRIVATE KEY" {
-		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key", caKeyPath)
+
+	s.caKey, err = parseCAPrivateKey(block)
+	if err != nil {
+		return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
 	}
 
+	return nil
+}
+
+// parseCAPrivateKey parses a PEM block containing an RSA private key,
+// supporting both PKCS#8 ("PRIVATE KEY") and PKCS#1 ("RSA PRIVATE KEY")
+// encodings.
+func parseCAPrivateKey(block *pem.Block) (*rsa.PrivateKey, error) {
 	switch block.Type {
 	case "PRIVATE KEY":
 		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
-			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
+			return nil, err
 		}
 
 		// only support RSA keys for now.
-		var ok bool
-		if s.caKey, ok = key.(*rsa.PrivateKey); !ok {
-			return fmt.Errorf("CA private key file %s is not a valid RSA private key", caKeyPath)
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("not a valid RSA private key")
 		}
+		return rsaKey, nil
 	case "RSA PRIVATE KEY":
 		// this block type parses directly to an RSA private key.
-		s.caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
-		}
-
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
 	default:
-		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key, got %q", caKeyPath, block.Type)
+		return nil, fmt.Errorf("not a valid PEM encoded RSA private key, got %q", block.Type)
 	}
-
-	return nil
 }
 
 // createCertificate will generate a certificate given a CSR and return the

--- a/pkg/ztunnel/ca/ca_server_test.go
+++ b/pkg/ztunnel/ca/ca_server_test.go
@@ -22,6 +22,48 @@ import (
 	"github.com/cilium/cilium/pkg/ztunnel/pb"
 )
 
+// TestParseCAPrivateKey covers the two PEM encodings ztunnel's CA private key
+// is expected to support: PKCS#8 ("PRIVATE KEY") and PKCS#1 ("RSA PRIVATE
+// KEY"). See https://github.com/cilium/cilium/issues/48274.
+func TestParseCAPrivateKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	pkcs8DER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal PKCS#8 key: %v", err)
+	}
+	pkcs1DER := x509.MarshalPKCS1PrivateKey(key)
+
+	tests := []struct {
+		name  string
+		block *pem.Block
+	}{
+		{
+			name:  "PKCS#8 PRIVATE KEY",
+			block: &pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8DER},
+		},
+		{
+			name:  "PKCS#1 RSA PRIVATE KEY",
+			block: &pem.Block{Type: "RSA PRIVATE KEY", Bytes: pkcs1DER},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parseCAPrivateKey(tt.block)
+			if err != nil {
+				t.Fatalf("failed to parse CA private key: %v", err)
+			}
+			if !parsed.Equal(key) {
+				t.Fatalf("parsed key does not match the generated key")
+			}
+		})
+	}
+}
+
 // fakeEndpointManager wraps the shared panic-by-default mock and supplies the
 // single method exercised by the CA server test.
 type fakeEndpointManager struct {


### PR DESCRIPTION
ztunnel rejected PKCS#1 RSA private keys because it only accepted `PRIVATE KEY` PEM blocks before parsing.

This change allows both PKCS#8 and PKCS#1 RSA private keys.

Fixes: #48274

```release-note
ztunnel: Accept PKCS#1 RSA private keys for the CA.
```

This PR was prepared with AIL:3. AI was used to assist with the implementation and tests. I reviewed and tested the resulting changes.