### PR TITLE
renovate: Allow cilium-envoy v1.38.x for v1.19 and v1.18

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -928,24 +928,8 @@
       "allowedVersions": "/^v1\\.37\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.20",
-      ]
-    },
-    {
-      // cilium-envoy is referenced in both images/cilium/Dockerfile and
-      // install/kubernetes/Makefile.values. Without explicit grouping,
-      // Renovate creates separate PRs for each manager. The groupSlug ensures
-      // both updates use the same branch name and get combined into a single
-      // PR.
-      "groupName": "cilium-envoy",
-      "groupSlug": "cilium-envoy",
-      "matchDepNames": [
-        "quay.io/cilium/cilium-envoy"
-      ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
-      "allowedVersions": "/^v1\\.36\\.([0-9]+)-([0-9]+)-.*$/",
-      "matchBaseBranches": [
         "v1.19",
-        "v1.18",
+        "v1.18"
       ]
     },
     {


### PR DESCRIPTION
This is as part of regular maintenance as envoy 1.37 will be EOL in coming October.
