### PR TITLE
docs: explain IPv6 cluster-pool "node CIDR size is too big" error

### DIFF
--- a/Documentation/network/concepts/ipam/cluster-pool.rst
+++ b/Documentation/network/concepts/ipam/cluster-pool.rst
@@ -79,3 +79,32 @@ You can solve it in two ways:
 
   - Explicitly set ``clusterPoolIPv4PodCIDRList`` to a non-conflicting CIDR
   - Use a different CIDR for your nodes
+
+Fix ``the node CIDR size is too big`` for IPv6
+==============================================
+
+When enabling IPv6 with cluster-pool IPAM, ``cilium-operator`` may fail to
+start with an error similar to:
+
+.. code-block:: shell-session
+
+    level=fatal msg="Unable to init cluster-pool allocator" error="unable to initialize IPv6 allocator New CIDR set failed; the node CIDR size is too big" subsys=cilium-operator-generic
+
+This happens because the per-node mask size (``clusterPoolIPv6MaskSize``,
+``/120`` by default) is only allowed to differ from the mask size of the pool
+CIDR (``clusterPoolIPv6PodCIDRList``) by up to 16 bits. For example, a
+``/64`` pool CIDR only supports a ``clusterPoolIPv6MaskSize`` of up to
+``/80`` (``80 - 64 = 16``); the default of ``/120`` exceeds that difference
+and triggers the error above.
+
+To fix this, either:
+
+  - Use a pool CIDR whose mask is at least ``clusterPoolIPv6MaskSize - 16``,
+    e.g. a ``/104`` or smaller range instead of ``/64``, for the default
+    ``/120`` per-node mask, or
+  - Lower ``clusterPoolIPv6MaskSize`` to be within 16 bits of your pool
+    CIDR's mask, e.g. ``--set ipam.operator.clusterPoolIPv6MaskSize=80`` for
+    a ``/64`` pool CIDR.
+
+This limit comes from the underlying CIDR allocator and mirrors a similar
+restriction in upstream Kubernetes.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
      (N/A — this is a documentation-only change, no code paths affected.)
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

`cilium-operator` can fail to start when cluster-pool IPAM is used with
IPv6 with the error "unable to initialize IPv6 allocator New CIDR set
failed; the node CIDR size is too big". This is caused by an undocumented
constraint: `clusterPoolIPv6MaskSize` cannot differ from the
`clusterPoolIPv6PodCIDRList` mask by more than 16 bits (see
`pkg/ipam/cidrset/cidr_set.go`).

Document the constraint and two ways to work around it in the
cluster-pool IPAM troubleshooting section.

This PR was prepared with AIL:3 (Claude Code). I personally read and
verified the 16-bit constraint against `pkg/ipam/cidrset/cidr_set.go` and
the default `clusterPoolIPv6MaskSize: 120` in
`install/kubernetes/cilium/values.yaml` before writing the documentation
text and this description.

Fixes: #20756

```release-note
docs: document the IPv6 cluster-pool CIDR/mask-size constraint that causes
"the node CIDR size is too big" errors
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request