### PR TITLE
identity, clustermesh: use ClusterInfo for identity

### DIFF
--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -25,6 +25,8 @@ cilium-dbg preflight migrate-identity [flags]
       --bgp-router-id-allocation-ip-pool string     IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
       --bgp-router-id-allocation-mode string        BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
       --bgp-secrets-namespace string                Kubernetes namespace to get BGP control plane secrets from
+      --cluster-id uint32                           Unique identifier of the cluster
+      --cluster-name string                         Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
       --enable-bgp-control-plane                    Enable the BGP control plane
       --enable-bgp-control-plane-status-report      Enable the BGP control plane status reporting (default true)
       --enable-bgp-legacy-origin-attribute          Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
@@ -40,6 +42,7 @@ cilium-dbg preflight migrate-identity [flags]
       --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
       --kvstore string                              Key-value store type
       --kvstore-opt map                             Key-value store options e.g. etcd.address=127.0.0.1:4001
+      --max-connected-clusters uint32               Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
 ```
 
 ### Options inherited from parent commands

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -52,10 +52,19 @@ func migrateIdentityCmd() *cobra.Command {
 	hive := hive.New(
 		k8sClient.Cell,
 		cell.Config(bgpConfig.DefaultConfig),
-		cell.Invoke(func(lc cell.Lifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner, bgpCfg bgpConfig.BGPConfig) {
+		cell.Config(cmtypes.DefaultClusterInfo),
+		cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
+		cell.Invoke(cmtypes.ClusterInfo.Validate),
+		cell.Invoke(func(
+			lc cell.Lifecycle,
+			clientset k8sClient.Clientset,
+			shutdowner hive.Shutdowner,
+			bgpCfg bgpConfig.BGPConfig,
+			cinfo cmtypes.ClusterInfo,
+		) {
 			lc.Append(cell.Hook{
 				OnStart: func(ctx cell.HookContext) error {
-					return migrateIdentities(ctx, clientset, shutdowner, bgpCfg)
+					return migrateIdentities(ctx, clientset, shutdowner, bgpCfg, cinfo)
 				},
 			})
 		}),
@@ -90,7 +99,13 @@ func migrateIdentityCmd() *cobra.Command {
 //
 // NOTE: It is assumed that the migration is from k8s to k8s installations. The
 // key labels different when running in non-k8s mode.
-func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shutdowner hive.Shutdowner, bgpCfg bgpConfig.BGPConfig) error {
+func migrateIdentities(
+	ctx cell.HookContext,
+	clientset k8sClient.Clientset,
+	shutdowner hive.Shutdowner,
+	bgpCfg bgpConfig.BGPConfig,
+	cinfo cmtypes.ClusterInfo,
+) error {
 	defer shutdowner.Shutdown()
 
 	// This allows us to initialize a CRD allocator
@@ -100,7 +115,7 @@ func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shut
 	initCtx, initCancel := context.WithTimeout(ctx, opTimeout)
 	kvstoreBackend := initKVStore(ctx, initCtx)
 
-	crdBackend, crdAllocator := initK8s(initCtx, clientset, bgpCfg)
+	crdBackend, crdAllocator := initK8s(initCtx, clientset, bgpCfg, cinfo)
 	initCancel()
 
 	log.Info("Listing identities in kvstore")
@@ -208,7 +223,12 @@ func migrateIdentities(ctx cell.HookContext, clientset k8sClient.Clientset, shut
 
 // initK8s connects to k8s with a allocator.Backend and an initialized
 // allocator.Allocator, using the k8s config passed into the command.
-func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfig.BGPConfig) (crdBackend allocator.Backend, crdAllocator *allocator.Allocator) {
+func initK8s(
+	ctx context.Context,
+	clientset k8sClient.Clientset,
+	bgpCfg bgpConfig.BGPConfig,
+	cinfo cmtypes.ClusterInfo,
+) (crdBackend allocator.Backend, crdAllocator *allocator.Allocator) {
 	log.Info("Setting up kubernetes client")
 
 	// Update CRDs to ensure ciliumIdentity is present
@@ -227,11 +247,8 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfi
 
 	// Create a real allocator with CRD as the backend. This mimics the setup in
 	// pkg/allocator/cache
-	//
-	// FIXME: add options to handle clustermesh with this constructor parameter:
-	//    allocator.WithPrefixMask(idpool.ID(clusterID<<identity.ClusterIDShift)))
-	minID := idpool.ID(cmtypes.DefaultClusterInfo.MinimalAllocationIdentity())
-	maxID := idpool.ID(cmtypes.DefaultClusterInfo.MaximumAllocationIdentity())
+	minID := idpool.ID(cinfo.MinimalAllocationIdentity())
+	maxID := idpool.ID(cinfo.MaximumAllocationIdentity())
 	crdAllocator, err = allocator.NewAllocator(log, &cacheKey.GlobalIdentity{}, crdBackend, allocator.WithMax(maxID), allocator.WithMin(minID))
 	if err != nil {
 		logging.Fatal(log, "Unable to initialize Identity Allocator with CRD backend to allocate identities with already allocated IDs", logfields.Error, err)

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -51,10 +51,8 @@ func migrateIdentityCmd() *cobra.Command {
 
 	hive := hive.New(
 		k8sClient.Cell,
+		cmtypes.ClusterInfoCell,
 		cell.Config(bgpConfig.DefaultConfig),
-		cell.Config(cmtypes.DefaultClusterInfo),
-		cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
-		cell.Invoke(cmtypes.ClusterInfo.Validate),
 		cell.Invoke(func(
 			lc cell.Lifecycle,
 			clientset k8sClient.Clientset,

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -18,7 +18,6 @@ import (
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	cacheKey "github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -231,8 +230,8 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset, bgpCfg bgpConfi
 	//
 	// FIXME: add options to handle clustermesh with this constructor parameter:
 	//    allocator.WithPrefixMask(idpool.ID(clusterID<<identity.ClusterIDShift)))
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(cmtypes.DefaultClusterInfo.ID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))
+	minID := idpool.ID(cmtypes.DefaultClusterInfo.MinimalAllocationIdentity())
+	maxID := idpool.ID(cmtypes.DefaultClusterInfo.MaximumAllocationIdentity())
 	crdAllocator, err = allocator.NewAllocator(log, &cacheKey.GlobalIdentity{}, crdBackend, allocator.WithMax(maxID), allocator.WithMin(minID))
 	if err != nil {
 		logging.Fatal(log, "Unable to initialize Identity Allocator with CRD backend to allocate identities with already allocated IDs", logfields.Error, err)

--- a/clustermesh-apiserver/clustermesh/script_test.go
+++ b/clustermesh-apiserver/clustermesh/script_test.go
@@ -53,10 +53,9 @@ func TestScript(t *testing.T) {
 		storeFactory := store.NewFactory(log, store.MetricsProvider())
 
 		h := hive.New(
-			cell.Config(cmtypes.DefaultClusterInfo),
+			cmtypes.ClusterInfoCell,
 			cell.Config(cmtypes.DefaultServiceModeV2Config),
 			cell.Config(mcsapitypes.DefaultMCSAPIConfig),
-			cell.Invoke(cmtypes.ClusterInfo.Validate),
 			cell.Invoke(cmtypes.ServiceModeV2Config.Validate),
 
 			k8sClient.FakeClientCell(),

--- a/clustermesh-apiserver/common/cells.go
+++ b/clustermesh-apiserver/common/cells.go
@@ -24,8 +24,8 @@ var Cell = cell.Module(
 	"clustermesh-common",
 	"Common Cilium ClusterMesh modules",
 
+	cmtypes.ClusterInfoCell,
 	cell.Config(option.DefaultLegacyClusterMeshConfig),
-	cell.Config(cmtypes.DefaultClusterInfo),
 	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
 	cell.Config(cmtypes.DefaultServiceModeV2Config),
 	cell.Invoke(cmtypes.ServiceModeV2Config.Validate),

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -341,8 +341,8 @@ var (
 		policyDirectory.Cell,
 
 		// ClusterMesh is the Cilium's multicluster implementation.
-		cell.Config(cmtypes.DefaultClusterInfo),
-		cell.Config(cmtypes.DefaultPolicyConfig),
+		cmtypes.ClusterInfoCell,
+		cmtypes.PolicyConfigCell,
 		clustermesh.Cell,
 
 		// L2announcer resolves l2announcement policies, services, node labels and devices into a list of IPs+netdevs

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -136,10 +136,8 @@ var (
 	}
 
 	ControlPlaneCells = []cell.Cell{
-		cell.Config(cmtypes.DefaultClusterInfo),
-		cell.Config(cmtypes.DefaultPolicyConfig),
-		cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
-		cell.Invoke(cmtypes.ClusterInfo.Validate),
+		cmtypes.ClusterInfoCell,
+		cmtypes.PolicyConfigCell,
 
 		cell.Provide(func() *option.DaemonConfig {
 			return option.Config

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -39,7 +39,7 @@ func TestIdentitiesGC(t *testing.T) {
 	var authIdentityClient authIdentity.Provider
 
 	hive := hive.New(
-		cell.Config(cmtypes.DefaultClusterInfo),
+		cmtypes.ClusterInfoCell,
 		metrics.Metric(NewMetrics),
 
 		// provide a fake clientset
@@ -154,7 +154,7 @@ func TestIdentitiesGC_Disabled(t *testing.T) {
 	)
 
 	hive := hive.New(
-		cell.Config(cmtypes.DefaultClusterInfo),
+		cmtypes.ClusterInfoCell,
 		metrics.Metric(NewMetrics),
 
 		k8sFakeClient.FakeClientCell(),

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/allocator"
-	ciliumIdentity "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/idpool"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -23,8 +22,8 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
 	}
 
-	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity(igc.clusterInfo.ID))
-	maxID := idpool.ID(ciliumIdentity.GetMaximumAllocationIdentity(igc.clusterInfo.ID))
+	minID := idpool.ID(igc.clusterInfo.MinimalAllocationIdentity())
+	maxID := idpool.ID(igc.clusterInfo.MaximumAllocationIdentity())
 	igc.logger.InfoContext(ctx, "Garbage Collecting kvstore identities between range",
 		logfields.Min, minID,
 		logfields.Max, maxID,

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -15,7 +15,6 @@ import (
 
 	operator_k8s "github.com/cilium/cilium/operator/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/basicallocator"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -68,8 +67,8 @@ func newReconciler(
 ) (*reconciler, error) {
 	logger.InfoContext(ctx, "Creating CID controller Operator reconciler")
 
-	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(clusterInfo.ID))
-	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(clusterInfo.ID))
+	minIDValue := idpool.ID(clusterInfo.MinimalAllocationIdentity())
+	maxIDValue := idpool.ID(clusterInfo.MaximumAllocationIdentity())
 	idAllocator := basicallocator.NewBasicIDAllocator(minIDValue, maxIDValue)
 
 	nsStore, err := namespace.Store(ctx)

--- a/operator/pkg/kvstore/locksweeper/locksweeper.go
+++ b/operator/pkg/kvstore/locksweeper/locksweeper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -48,8 +47,8 @@ func runLockSweeper(p params) {
 		logging.Fatal(p.Logger, "Unable to initialize kvstore backend for stale locks collection", logfields.Error, err)
 	}
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(p.ClusterInfo.ID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(p.ClusterInfo.ID))
+	minID := idpool.ID(p.ClusterInfo.MinimalAllocationIdentity())
+	maxID := idpool.ID(p.ClusterInfo.MaximumAllocationIdentity())
 	a := allocator.NewAllocatorForGC(p.Logger, backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	keysToDelete := map[string]kvstore.Value{}

--- a/operator/pkg/kvstore/nodesgc/script_test.go
+++ b/operator/pkg/kvstore/nodesgc/script_test.go
@@ -52,7 +52,7 @@ func TestScript(t *testing.T) {
 
 	setup := func(t testing.TB, args []string) *script.Engine {
 		h := hive.New(
-			cell.Config(cmtypes.DefaultClusterInfo),
+			cmtypes.ClusterInfoCell,
 
 			cell.Provide(
 				func() store.Factory { return store.NewFactory(hivetest.Logger(t), store.MetricsProvider()) },

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -171,6 +171,7 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 	rc := &remoteCluster{
 		name:                     name,
 		clusterID:                cmtypes.ClusterIDUnset,
+		localClusterInfo:         cm.conf.ClusterInfo,
 		serviceModeV2:            cm.conf.ServiceModeV2,
 		status:                   status,
 		storeFactory:             cm.conf.StoreFactory,

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -42,6 +42,10 @@ type remoteCluster struct {
 	// clusterID is the clusterID advertized by the remote cluster
 	clusterID uint32
 
+	// localClusterInfo is the local cluster configuration, used for local
+	// interpretation of remote identity layout
+	localClusterInfo cmtypes.ClusterInfo
+
 	// mutex protects the following variables:
 	// - remoteIdentityCache
 	mutex lock.RWMutex
@@ -262,7 +266,7 @@ func (rc *remoteCluster) ipCacheWatcherOpts(config *cmtypes.CiliumClusterConfig)
 
 	if config != nil {
 		opts = append(opts, ipcache.WithCachedPrefix(config.Capabilities.Cached))
-		opts = append(opts, ipcache.WithIdentityValidator(config.ID))
+		opts = append(opts, ipcache.WithIdentityValidator(rc.localClusterInfo, config.ID))
 	}
 
 	if rc.ipCacheWatcherExtraOpts != nil {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -589,7 +590,7 @@ func TestIPCacheWatcherOpts(t *testing.T) {
 		{
 			name: "with extra opts",
 			extra: func(config *types.CiliumClusterConfig) []ipcache.IWOpt {
-				return []ipcache.IWOpt{ipcache.WithClusterID(10), ipcache.WithIdentityValidator(25)}
+				return []ipcache.IWOpt{ipcache.WithClusterID(10), ipcache.WithIdentityValidator(cmtypes.ClusterInfo{MaxConnectedClusters: 255}, 25)}
 			},
 			expected: 2,
 		},

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -97,8 +97,7 @@ func TestScript(t *testing.T) {
 			dial.ServiceResolverCell,
 			metrics.Cell,
 
-			cell.Config(cmtypes.DefaultClusterInfo),
-			cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax, cmtypes.ClusterInfo.Validate),
+			cmtypes.ClusterInfoCell,
 
 			cell.Provide(
 				tables.NewNodeAddressTable,

--- a/pkg/clustermesh/types/cell.go
+++ b/pkg/clustermesh/types/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+var (
+	// ClusterInfoCell provides and validates the configured information about the local cluster.
+	ClusterInfoCell = cell.Group(
+		cell.Config(DefaultClusterInfo),
+		cell.Invoke(ClusterInfo.InitClusterIDMax),
+		cell.Invoke(ClusterInfo.Validate),
+	)
+
+	// PolicyConfigCell provides information about the ClusterMesh and policies.
+	PolicyConfigCell = cell.Config(DefaultPolicyConfig)
+)

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -6,11 +6,13 @@ package types
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	identity "github.com/cilium/cilium/pkg/identity/numericidentity"
 )
 
 const (
@@ -46,6 +48,47 @@ func (c ClusterInfo) InitClusterIDMax() error {
 		return fmt.Errorf("--%s=%d is invalid; supported values are [%d, %d]", OptMaxConnectedClusters, c.MaxConnectedClusters, defaults.MaxConnectedClusters, ClusterIDExt511)
 	}
 	return nil
+}
+
+// GetClusterIDBits returns the number of bits that represent a cluster ID in a
+// numeric identity for this cluster configuration.
+func (c ClusterInfo) GetClusterIDBits() uint32 {
+	return uint32(math.Log2(float64(c.MaxConnectedClusters + 1)))
+}
+
+// GetClusterIDShift returns the number of bits to shift a cluster ID in a
+// numeric identity for this cluster configuration.
+func (c ClusterInfo) GetClusterIDShift() uint32 {
+	return identity.Bitlength - c.GetClusterIDBits()
+}
+
+// MinimalAllocationIdentity returns the minimal numeric identity not used for
+// reserved purposes for this cluster configuration.
+func (c ClusterInfo) MinimalAllocationIdentity() uint32 {
+	return c.MinimalAllocationIdentityFor(c.ID)
+}
+
+// MinimalAllocationIdentityFor returns the minimal numeric identity assigned
+// to the given cluster ID for this cluster configuration.
+func (c ClusterInfo) MinimalAllocationIdentityFor(clusterID uint32) uint32 {
+	if clusterID > 0 {
+		// For ClusterID > 0, the identity range just starts from cluster shift,
+		// no well-known-identities need to be reserved from the range.
+		return (1 << c.GetClusterIDShift()) * clusterID
+	}
+	return identity.MinimalIdentity
+}
+
+// MaximumAllocationIdentity returns the maximum numeric identity that should be
+// handed out by the identity allocator for this cluster configuration.
+func (c ClusterInfo) MaximumAllocationIdentity() uint32 {
+	return c.MaximumAllocationIdentityFor(c.ID)
+}
+
+// MaximumAllocationIdentityFor returns the maximum numeric identity assigned
+// to the given cluster ID for this cluster configuration.
+func (c ClusterInfo) MaximumAllocationIdentityFor(clusterID uint32) uint32 {
+	return (1<<c.GetClusterIDShift())*(clusterID+1) - 1
 }
 
 // ValidateClusterID ensures that the given clusterID is within the configured

--- a/pkg/clustermesh/types/types_test.go
+++ b/pkg/clustermesh/types/types_test.go
@@ -73,3 +73,124 @@ func TestClusterNameValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterInfoNumericIdentityLayout(t *testing.T) {
+	tests := []struct {
+		name                    string
+		cinfo                   ClusterInfo
+		expectedClusterIDBits   uint32
+		expectedClusterIDShift  uint32
+		expectedMinimalIdentity uint32
+		expectedMaximumIdentity uint32
+	}{
+		{
+			name: "cluster-id-0-max-255",
+			cinfo: ClusterInfo{
+				ID:                   0,
+				MaxConnectedClusters: 255,
+			},
+			expectedClusterIDBits:   8,
+			expectedClusterIDShift:  16,
+			expectedMinimalIdentity: 0x000100,
+			expectedMaximumIdentity: 0x00FFFF,
+		},
+		{
+			name: "cluster-id-1-max-255",
+			cinfo: ClusterInfo{
+				ID:                   1,
+				MaxConnectedClusters: 255,
+			},
+			expectedClusterIDBits:   8,
+			expectedClusterIDShift:  16,
+			expectedMinimalIdentity: 0x010000,
+			expectedMaximumIdentity: 0x01FFFF,
+		},
+		{
+			name: "cluster-id-255-max-255",
+			cinfo: ClusterInfo{
+				ID:                   255,
+				MaxConnectedClusters: 255,
+			},
+			expectedClusterIDBits:   8,
+			expectedClusterIDShift:  16,
+			expectedMinimalIdentity: 0xFF0000,
+			expectedMaximumIdentity: 0xFFFFFF,
+		},
+		{
+			name: "cluster-id-0-max-511",
+			cinfo: ClusterInfo{
+				ID:                   0,
+				MaxConnectedClusters: 511,
+			},
+			expectedClusterIDBits:   9,
+			expectedClusterIDShift:  15,
+			expectedMinimalIdentity: 0x000100,
+			expectedMaximumIdentity: 0x007FFF,
+		},
+		{
+			name: "cluster-id-1-max-511",
+			cinfo: ClusterInfo{
+				ID:                   1,
+				MaxConnectedClusters: 511,
+			},
+			expectedClusterIDBits:   9,
+			expectedClusterIDShift:  15,
+			expectedMinimalIdentity: 0x008000,
+			expectedMaximumIdentity: 0x00FFFF,
+		},
+		{
+			name: "cluster-id-511-max-511",
+			cinfo: ClusterInfo{
+				ID:                   511,
+				MaxConnectedClusters: 511,
+			},
+			expectedClusterIDBits:   9,
+			expectedClusterIDShift:  15,
+			expectedMinimalIdentity: 0xFF8000,
+			expectedMaximumIdentity: 0xFFFFFF,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedClusterIDBits, tt.cinfo.GetClusterIDBits())
+			assert.Equal(t, tt.expectedClusterIDShift, tt.cinfo.GetClusterIDShift())
+			assert.Equal(t, tt.expectedMinimalIdentity, tt.cinfo.MinimalAllocationIdentity())
+			assert.Equal(t, tt.expectedMaximumIdentity, tt.cinfo.MaximumAllocationIdentity())
+			assert.Equal(t, tt.expectedMinimalIdentity, tt.cinfo.MinimalAllocationIdentityFor(tt.cinfo.ID))
+			assert.Equal(t, tt.expectedMaximumIdentity, tt.cinfo.MaximumAllocationIdentityFor(tt.cinfo.ID))
+		})
+	}
+}
+
+func TestClusterInfoAllocationIdentityFor(t *testing.T) {
+	tests := []struct {
+		name                    string
+		cinfo                   ClusterInfo
+		clusterID               uint32
+		expectedMinimalIdentity uint32
+		expectedMaximumIdentity uint32
+	}{
+		{
+			name:                    "255-cluster-layout",
+			cinfo:                   ClusterInfo{ID: 42, MaxConnectedClusters: 255},
+			clusterID:               1,
+			expectedMinimalIdentity: 0x010000,
+			expectedMaximumIdentity: 0x01FFFF,
+		},
+		{
+			name:                    "511-cluster-layout",
+			cinfo:                   ClusterInfo{ID: 42, MaxConnectedClusters: 511},
+			clusterID:               1,
+			expectedMinimalIdentity: 0x008000,
+			expectedMaximumIdentity: 0x00FFFF,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMinimalIdentity, tt.cinfo.MinimalAllocationIdentityFor(tt.clusterID))
+			assert.Equal(t, tt.expectedMaximumIdentity, tt.cinfo.MaximumAllocationIdentityFor(tt.clusterID))
+		})
+	}
+}

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// ClusterID is the immutable identifier of the local cluster.
 	ClusterID uint32
 
+	// Number of bits of the identity reserved for the Cluster ID.
+	ClusterIDBits uint32
+
 	// NodeIPv4 is the primary IPv4 address of this node.
 	// Mutable at runtime.
 	// +deepequal-gen=false

--- a/pkg/datapath/config/node.go
+++ b/pkg/datapath/config/node.go
@@ -9,14 +9,13 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func NodeConfig(lnc *Config) Node {
 	node := *NewNode()
-	node.ClusterIDBits = identity.GetClusterIDBits()
+	node.ClusterIDBits = lnc.ClusterIDBits
 
 	node.CiliumHostIfIndex = lnc.CiliumHostIfIndex
 	node.CiliumHostMAC.Addr = lnc.CiliumHostMAC

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -18,6 +18,9 @@ func (in *Config) deepEqual(other *Config) bool {
 	if in.ClusterID != other.ClusterID {
 		return false
 	}
+	if in.ClusterIDBits != other.ClusterIDBits {
+		return false
+	}
 	if in.CiliumHostIfIndex != other.CiliumHostIfIndex {
 		return false
 	}

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/statedb"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/connector"
@@ -52,6 +53,7 @@ func newLocalNodeConfig(
 	daemon *option.DaemonConfig,
 	localNode node.LocalNode,
 	sysctlOps sysctl.Sysctl,
+	clusterInfo cmtypes.ClusterInfo,
 	tunnelCfg tunnel.Config,
 	txn statedb.ReadTxn,
 	directRoutingDevTbl tables.DirectRoutingDevice,
@@ -163,6 +165,7 @@ func newLocalNodeConfig(
 
 	return config.Config{
 		ClusterID:                    localNode.ClusterID,
+		ClusterIDBits:                clusterInfo.GetClusterIDBits(),
 		NodeIPv4:                     ip.AddrFromIP(localNode.GetNodeIP(false)),
 		NodeIPv6:                     ip.AddrFromIP(localNode.GetNodeIP(true)),
 		CiliumInternalIPv4:           ip.AddrFromIP(localNode.GetCiliumInternalIP(false)),

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
@@ -100,6 +101,7 @@ type orchestratorParams struct {
 	Config              Config
 	Log                 *slog.Logger
 	Loader              loader.Loader
+	ClusterInfo         cmtypes.ClusterInfo
 	TunnelConfig        tunnel.Config
 	OldMTU              mtu.MTU
 	MTU                 statedb.Table[mtu.RouteMTU]
@@ -240,6 +242,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 				option.Config,
 				localNode,
 				o.params.Sysctl,
+				o.params.ClusterInfo,
 				o.params.TunnelConfig,
 				o.params.DB.ReadTxn(),
 				o.params.DirectRoutingDevice,

--- a/pkg/egressgateway/script_test.go
+++ b/pkg/egressgateway/script_test.go
@@ -87,7 +87,7 @@ func TestPrivilegedScripts(t *testing.T) {
 				testCell,
 
 				cell.Config(metrics.RegistryConfig{}),
-				cell.Config(cmtypes.DefaultClusterInfo),
+				cmtypes.ClusterInfoCell,
 				cell.Provide(
 					metrics.NewRegistry,
 					// LocalNodeSynchronizer syncs via apiserver, after the node is initialized, generally

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -74,7 +74,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	logger := hivetest.Logger(tb)
 
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	s := &EndpointSuite{
 		orchestrator: &fakeendpoint.FakeOrchestrator{},
 		repo:         repo,
@@ -549,7 +549,7 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 		model := newTestEndpointModel(100, StateWaitingForIdentity)
 		logger := hivetest.Logger(t)
 		idmgr := identitymanager.NewIDManager(logger)
-		repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+		repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 		fetcher := testcompute.InstantiateCellForTesting(t, logger, "endpoint", "TestInitialNamedPortsIdentityLabel", repo, idmgr)
 		p := createEndpointParams(
 			t,
@@ -1658,7 +1658,7 @@ func TestComputeCIDRLabelsAfterRestore(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{"pods"}
 
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 
 	podIP := netip.MustParseAddr("10.244.1.7")

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -29,7 +29,7 @@ func TestPolicyLog(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
@@ -74,7 +74,7 @@ func TestPolicyLog(t *testing.T) {
 
 func TestPolicyLogAfterEndpointRestore(t *testing.T) {
 	logger := hivetest.Logger(t)
-	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 	model := newTestEndpointModel(12345, StateReady)
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -55,7 +55,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	logger := hivetest.Logger(t)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(hivetest.Logger(t))
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestIncrementalUpdatesDuringPolicyGeneration", repo, idManager)
 
 	addIdentity := func(labelKeys ...string) *identity.Identity {
@@ -221,7 +221,7 @@ func newPolicyTestFixture(t *testing.T) *policyTestFixture {
 	idcache := make(identity.IdentityMap)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", t.Name(), repo, idManager)
 
 	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -70,7 +70,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	}
 
 	s.do.idmgr = identitymanager.NewIDManager(logger)
-	s.do.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
+	s.do.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	s.do.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupRedirectSuite", s.do.repo, s.do.idmgr)
 

--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -209,7 +209,7 @@ func newUpdatePolicyMapsTestRepo(t *testing.T, withL7Rules bool) (*policy.Reposi
 	idmgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
-		cmtypes.DefaultClusterInfo.ID,
+		cmtypes.DefaultClusterInfo,
 		nil,
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -89,7 +89,7 @@ func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
 	logger := hivetest.Logger(tb)
 	s := &EndpointManagerSuite{}
 	s.idmgr = identitymanager.NewIDManager(logger)
-	s.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, s.idmgr, testpolicy.NewPolicyMetricsNoop())
+	s.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, s.idmgr, testpolicy.NewPolicyMetricsNoop())
 	s.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpointmanager", tb.Name(), s.repo, s.idmgr)
 	s.kvstoreSync = ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(tb, kvstore.DisabledBackendName))
 

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -673,7 +673,7 @@ func newStandaloneTestPolicyRepo(t *testing.T, logger *slog.Logger, secretManage
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
-		cmtypes.DefaultClusterInfo.ID,
+		cmtypes.DefaultClusterInfo,
 		idCache,
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, secretManager),

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -1453,7 +1453,7 @@ func TestCNPWildcardPortListenerRedirectToEnvoy(t *testing.T) {
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
-		cmtypes.DefaultClusterInfo.ID,
+		cmtypes.DefaultClusterInfo,
 		identity.IdentityMap{localIdentity.ID: localIdentity.LabelArray},
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),
@@ -2582,7 +2582,7 @@ func newTestEndpointPolicy(t *testing.T, ep *listenerProxyUpdaterMock) (*policy.
 	idMgr := identitymanager.NewIDManager(logger)
 	repo := policy.NewPolicyRepository(
 		logger,
-		cmtypes.DefaultClusterInfo.ID,
+		cmtypes.DefaultClusterInfo,
 		identity.IdentityMap{localIdentity.ID: localIdentity.LabelArray},
 		nil,
 		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -84,7 +84,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	s.repo = policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	s.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupDNSProxyTestSuite", s.repo, identitymanager.NewIDManager(logger))
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(tb)

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -123,7 +123,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 			ID:   uint16(i),
 			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", i/256, i%256)),
 			SecurityIdentity: &identity.Identity{
-				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))),
+				ID: identity.NumericIdentity(i % int(cmtypes.DefaultClusterInfo.MaximumAllocationIdentity())),
 			},
 			DNSZombies: &fqdn.DNSZombieMappings{
 				Mutex: lock.Mutex{},

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -86,7 +86,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		wg sync.WaitGroup
 	)
 
-	policyRepo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	policyRepo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	ipc := &mockipc.MockIPCache{}
 	nm := namemanager.New(namemanager.ManagerParams{
 		Config: namemanager.NameManagerConfig{

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -240,7 +240,7 @@ func TestNameManagerGCConsistency(t *testing.T) {
 		eps:    make(sets.Set[*endpoint.Endpoint]),
 	}
 	ep := &endpoint.Endpoint{ID: uint16(1), IPv4: netip.MustParseAddr("10.96.0.1"), SecurityIdentity: &identity.Identity{
-		ID: identity.NumericIdentity(int(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))),
+		ID: identity.NumericIdentity(int(cmtypes.DefaultClusterInfo.MaximumAllocationIdentity())),
 	},
 		DNSZombies: fqdn.NewDNSZombieMappings(logger, 10000, 10000),
 		DNSHistory: fqdn.NewDNSCache(1),

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -713,7 +713,7 @@ func TestClusterIDValidator(t *testing.T) {
 	)
 
 	var (
-		validator = clusterIDValidator(cid)
+		validator = clusterIDValidator(cmtypes.ClusterInfo{ID: cid, MaxConnectedClusters: 255}, cid)
 		key       = &cacheKey.GlobalIdentity{}
 	)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -221,8 +221,8 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 	m.logger.Info("Initializing identity allocator")
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(m.clusterInfo.ID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(m.clusterInfo.ID))
+	minID := idpool.ID(m.clusterInfo.MinimalAllocationIdentity())
+	maxID := idpool.ID(m.clusterInfo.MaximumAllocationIdentity())
 
 	m.logger.Info(
 		"Allocating identities between range",
@@ -309,7 +309,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 		allocOptions := []allocator.AllocatorOption{
 			allocator.WithMax(maxID), allocator.WithMin(minID),
 			allocator.WithEvents(events), allocator.WithSyncInterval(m.syncInterval),
-			allocator.WithPrefixMask(idpool.ID(m.clusterInfo.ID << identity.GetClusterIDShift())),
+			allocator.WithPrefixMask(idpool.ID(m.clusterInfo.ID << m.clusterInfo.GetClusterIDShift())),
 		}
 		if m.operatorIDManagement {
 			allocOptions = append(allocOptions, allocator.WithOperatorIDManagement())
@@ -942,7 +942,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, remo
 	remoteAlloc, err := allocator.NewAllocator(m.logger,
 		&key.GlobalIdentity{}, remoteAllocatorBackend,
 		allocator.WithEvents(m.IdentityAllocator.GetEvents()), allocator.WithoutGC(), allocator.WithoutAutostart(),
-		allocator.WithCacheValidator(clusterIDValidator(remoteID)),
+		allocator.WithCacheValidator(clusterIDValidator(m.clusterInfo, remoteID)),
 		allocator.WithCacheValidator(clusterNameValidator(remoteName)),
 	)
 	if err != nil {
@@ -1029,9 +1029,9 @@ func (m *CachingIdentityAllocator) LocalIdentityChanges() stream.Observable[Iden
 
 // clusterIDValidator returns a validator ensuring that the identity ID belongs
 // to the ClusterID range.
-func clusterIDValidator(clusterID uint32) allocator.CacheValidator {
-	min := idpool.ID(identity.GetMinimalAllocationIdentity(clusterID))
-	max := idpool.ID(identity.GetMaximumAllocationIdentity(clusterID))
+func clusterIDValidator(cinfo cmtypes.ClusterInfo, clusterID uint32) allocator.CacheValidator {
+	min := idpool.ID(cinfo.MinimalAllocationIdentityFor(clusterID))
+	max := idpool.ID(cinfo.MaximumAllocationIdentityFor(clusterID))
 
 	return func(_ allocator.AllocatorChangeKind, id idpool.ID, _ allocator.AllocatorKey) error {
 		if id < min || id > max {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -15,6 +15,7 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/identity/numericidentity"
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -39,11 +40,11 @@ const (
 
 	// IdentityScopeLocal is the tag in the numeric identity that identifies
 	// a numeric identity to have local (CIDR) scope.
-	IdentityScopeLocal = NumericIdentity(1 << 24)
+	IdentityScopeLocal = NumericIdentity(1 << numericidentity.Bitlength)
 
 	// IdentityScopeRemoteNode is the tag in the numeric identity that identifies
 	// an identity to be a remote in-cluster node.
-	IdentityScopeRemoteNode = NumericIdentity(2 << 24)
+	IdentityScopeRemoteNode = NumericIdentity(2 << numericidentity.Bitlength)
 
 	// MinAllocatorLocalIdentity represents the minimal numeric identity
 	// that the localIdentityCache allocator can allocate for a local (CIDR)
@@ -73,7 +74,7 @@ const (
 
 	// MinimalNumericIdentity represents the minimal numeric identity not
 	// used for reserved purposes.
-	MinimalNumericIdentity = NumericIdentity(256)
+	MinimalNumericIdentity = NumericIdentity(numericidentity.MinimalIdentity)
 
 	// UserReservedNumericIdentity represents the minimal numeric identity that
 	// can be used by users for reserved purposes.
@@ -85,13 +86,9 @@ const (
 )
 
 var (
-	// clusterIDInit ensures that clusterIDBits and clusterIDShift can only be
-	// set once, and only if we haven't used either value elsewhere already.
+	// clusterIDInit ensures that clusterIDShift can only be set once, and only if
+	// we haven't used the value elsewhere already.
 	clusterIDInit sync.Once
-
-	// clusterIDBits is the number of bits that represent a cluster ID in a
-	// numeric identity
-	clusterIDBits uint32
 
 	// clusterIDShift is the number of bits to shift a cluster ID in a numeric
 	// identity and is equal to the number of bits that represent a cluster-local identity.
@@ -349,37 +346,13 @@ func GetClusterIDShift() uint32 {
 	return clusterIDShift
 }
 
-// GetClusterIDBits returns the number of bits that represent a cluster ID in a numeric identity
-// A sync.Once is used to ensure we only initialize clusterIDBits once.
-func GetClusterIDBits() uint32 {
-	clusterIDInit.Do(initClusterIDShift)
-	return clusterIDBits
-}
-
 // initClusterIDShift sets variables that control the bit allocation of cluster
 // ID in a numeric identity.
 func initClusterIDShift() {
 	// ClusterIDLen is the number of bits that represent a cluster ID in a numeric identity
-	clusterIDBits = uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
+	clusterIDBits := uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
 	// ClusterIDShift is the number of bits to shift a cluster ID in a numeric identity
 	clusterIDShift = NumericIdentityBitlength - clusterIDBits
-}
-
-// GetMinimalNumericIdentity returns the minimal numeric identity not used for
-// reserved purposes.
-func GetMinimalAllocationIdentity(clusterID uint32) NumericIdentity {
-	if clusterID > 0 {
-		// For ClusterID > 0, the identity range just starts from cluster shift,
-		// no well-known-identities need to be reserved from the range.
-		return NumericIdentity((1 << GetClusterIDShift()) * clusterID)
-	}
-	return MinimalNumericIdentity
-}
-
-// GetMaximumAllocationIdentity returns the maximum numeric identity that
-// should be handed out by the identity allocator.
-func GetMaximumAllocationIdentity(clusterID uint32) NumericIdentity {
-	return NumericIdentity((1<<GetClusterIDShift())*(clusterID+1) - 1)
 }
 
 var (

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -10,7 +10,6 @@ import (
 	"net/netip"
 	"sort"
 	"strconv"
-	"sync"
 	"unsafe"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -83,16 +82,6 @@ const (
 	// InvalidIdentity is the identity assigned if the identity is invalid
 	// or not determined yet
 	InvalidIdentity = NumericIdentity(0)
-)
-
-var (
-	// clusterIDInit ensures that clusterIDShift can only be set once, and only if
-	// we haven't used the value elsewhere already.
-	clusterIDInit sync.Once
-
-	// clusterIDShift is the number of bits to shift a cluster ID in a numeric
-	// identity and is equal to the number of bits that represent a cluster-local identity.
-	clusterIDShift uint32
 )
 
 const (
@@ -338,23 +327,6 @@ func InitWellKnownIdentities(ciliumNS string, cinfo cmtypes.ClusterInfo) int {
 	return len(WellKnown)
 }
 
-// GetClusterIDShift returns the number of bits to shift a cluster ID in a numeric
-// identity and is equal to the number of bits that represent a cluster-local identity.
-// A sync.Once is used to ensure we only initialize clusterIDShift once.
-func GetClusterIDShift() uint32 {
-	clusterIDInit.Do(initClusterIDShift)
-	return clusterIDShift
-}
-
-// initClusterIDShift sets variables that control the bit allocation of cluster
-// ID in a numeric identity.
-func initClusterIDShift() {
-	// ClusterIDLen is the number of bits that represent a cluster ID in a numeric identity
-	clusterIDBits := uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
-	// ClusterIDShift is the number of bits to shift a cluster ID in a numeric identity
-	clusterIDShift = NumericIdentityBitlength - clusterIDBits
-}
-
 var (
 	reservedIdentities = map[string]NumericIdentity{
 		labels.IDNameHost:          ReservedIdentityHost,
@@ -450,10 +422,6 @@ func AddUserDefinedNumericIdentity(identity NumericIdentity, label string) error
 //	   24: LocalIdentityFlag: Indicates that the identity has a local scope
 type NumericIdentity uint32
 
-// NumericIdentityBitlength is the number of bits used on the wire for a
-// NumericIdentity
-const NumericIdentityBitlength = 24
-
 // MaxNumericIdentity is the maximum value of a NumericIdentity.
 const MaxNumericIdentity = math.MaxUint32
 
@@ -509,9 +477,10 @@ func (id NumericIdentity) IsReservedIdentity() bool {
 	return isReservedIdentity
 }
 
-// ClusterID returns the cluster ID associated with the identity
-func (id NumericIdentity) ClusterID() uint32 {
-	return (uint32(id) >> uint32(GetClusterIDShift())) & cmtypes.ClusterIDMax
+// ClusterID returns the cluster ID associated with the identity for the given
+// cluster configuration.
+func (id NumericIdentity) ClusterID(cinfo cmtypes.ClusterInfo) uint32 {
+	return (uint32(id) >> cinfo.GetClusterIDShift()) & cinfo.MaxConnectedClusters
 }
 
 // GetAllReservedIdentities returns a list of all reserved numeric identities

--- a/pkg/identity/numericidentity/constants.go
+++ b/pkg/identity/numericidentity/constants.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package numericidentity contains low-level constants shared by components
+// that need to reason about numeric identity wire layout without importing the
+// higher-level identity package.
+package numericidentity
+
+const (
+	// Bitlength is the number of bits used on the wire for a numeric identity.
+	Bitlength = 24
+
+	// MinimalIdentity is the first numeric identity value that is not reserved.
+	// Global identity allocation for cluster ID 0 starts at this value.
+	MinimalIdentity = 256
+)

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -4,10 +4,8 @@
 package identity
 
 import (
-	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -24,38 +22,32 @@ func TestLocalIdentity(t *testing.T) {
 }
 
 func TestClusterID(t *testing.T) {
-	tbl := []struct {
-		identity  uint32
+	tests := []struct {
+		name      string
+		identity  NumericIdentity
 		clusterID uint32
 	}{
 		{
-			identity:  0x000000,
+			name:      "zero",
+			identity:  NumericIdentity(0x000000),
 			clusterID: 0,
 		},
 		{
-			identity:  0x010000,
-			clusterID: 1,
-		},
-		{
-			identity:  0x2A0000,
+			name:      "regular value",
+			identity:  NumericIdentity(42 << 16),
 			clusterID: 42,
 		},
 		{
-			identity:  0xFF0000,
+			name:      "max value",
+			identity:  NumericIdentity(255 << 16),
 			clusterID: 255,
-		},
-		{ // make sure we support min/max configuration values
-			identity:  cmtypes.ClusterIDMin << 16,
-			clusterID: cmtypes.ClusterIDMin,
-		},
-		{
-			identity:  cmtypes.ClusterIDMax << 16,
-			clusterID: cmtypes.ClusterIDMax,
 		},
 	}
 
-	for _, item := range tbl {
-		require.Equal(t, item.clusterID, NumericIdentity(item.identity).ClusterID())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.clusterID, tt.identity.ClusterID())
+		})
 	}
 }
 
@@ -77,54 +69,5 @@ func TestAsUint32Slice(t *testing.T) {
 	require.Len(t, uint32Slice, len(nids))
 	for i, nid := range nids {
 		require.Equal(t, nid.Uint32(), uint32Slice[i])
-	}
-}
-
-func TestGetClusterIDShift(t *testing.T) {
-	resetClusterIDInit := func() { clusterIDInit = sync.Once{} }
-
-	tests := []struct {
-		name                   string
-		maxConnectedClusters   uint32
-		expectedClusterIDShift uint32
-		expectedClusterIDBits  uint32
-	}{
-		{
-			name:                   "clustermesh255",
-			maxConnectedClusters:   255,
-			expectedClusterIDShift: 16,
-			expectedClusterIDBits:  8,
-		},
-		{
-			name:                   "clustermesh511",
-			maxConnectedClusters:   511,
-			expectedClusterIDShift: 15,
-			expectedClusterIDBits:  9,
-		},
-	}
-
-	// cleanup state from any previous tests
-	resetClusterIDInit()
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Cleanup(resetClusterIDInit)
-			cinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tt.maxConnectedClusters}
-			cinfo.InitClusterIDMax()
-			assert.Equal(t, tt.expectedClusterIDShift, GetClusterIDShift())
-			assert.Equal(t, tt.expectedClusterIDBits, GetClusterIDBits())
-
-			// ensure we cannot change the clusterIDShift after it has been initialized
-			for _, tc := range tests {
-				if tc.name == tt.name {
-					// skip the current test case itself
-					continue
-				}
-				newCinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tc.maxConnectedClusters}
-				newCinfo.InitClusterIDMax()
-				assert.NotEqual(t, tc.expectedClusterIDShift, GetClusterIDShift())
-				assert.NotEqual(t, tc.expectedClusterIDBits, GetClusterIDBits())
-			}
-		})
 	}
 }

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -24,29 +24,45 @@ func TestLocalIdentity(t *testing.T) {
 func TestClusterID(t *testing.T) {
 	tests := []struct {
 		name      string
+		cinfo     cmtypes.ClusterInfo
 		identity  NumericIdentity
 		clusterID uint32
 	}{
 		{
-			name:      "zero",
+			name:      "255-cluster layout zero",
+			cinfo:     cmtypes.ClusterInfo{MaxConnectedClusters: 255},
 			identity:  NumericIdentity(0x000000),
 			clusterID: 0,
 		},
 		{
-			name:      "regular value",
+			name:      "255-cluster layout regular value",
+			cinfo:     cmtypes.ClusterInfo{MaxConnectedClusters: 255},
 			identity:  NumericIdentity(42 << 16),
 			clusterID: 42,
 		},
 		{
-			name:      "max value",
+			name:      "255-cluster layout max value",
+			cinfo:     cmtypes.ClusterInfo{MaxConnectedClusters: 255},
 			identity:  NumericIdentity(255 << 16),
 			clusterID: 255,
+		},
+		{
+			name:      "511-cluster layout regular value",
+			cinfo:     cmtypes.ClusterInfo{MaxConnectedClusters: 511},
+			identity:  NumericIdentity(42 << 15),
+			clusterID: 42,
+		},
+		{
+			name:      "511-cluster layout max value",
+			cinfo:     cmtypes.ClusterInfo{MaxConnectedClusters: 511},
+			identity:  NumericIdentity(511 << 15),
+			clusterID: 511,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.clusterID, tt.identity.ClusterID())
+			require.Equal(t, tt.clusterID, tt.identity.ClusterID(tt.cinfo))
 		})
 	}
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -289,10 +289,10 @@ func WithCachedPrefix(cached bool) IWOpt {
 
 // WithIdentityValidator registers a validation function to ensure that the
 // observed IPs are associated with an identity belonging to the expected range.
-func WithIdentityValidator(clusterID uint32) IWOpt {
+func WithIdentityValidator(cinfo cmtypes.ClusterInfo, clusterID uint32) IWOpt {
 	return func(opts *iwOpts) {
-		min := identity.GetMinimalAllocationIdentity(clusterID)
-		max := identity.GetMaximumAllocationIdentity(clusterID)
+		min := identity.NumericIdentity(cinfo.MinimalAllocationIdentityFor(clusterID))
+		max := identity.NumericIdentity(cinfo.MaximumAllocationIdentityFor(clusterID))
 
 		validator := func(pair *identity.IPIdentityPair) error {
 			switch {

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -68,7 +68,7 @@ func (fb *fakeBackend) ListAndWatch(ctx context.Context, prefix string, _ ...kvs
 	}
 
 	id := func(clusterID, localID uint32) identity.NumericIdentity {
-		return identity.NumericIdentity(clusterID<<identity.GetClusterIDShift() | localID)
+		return identity.NumericIdentity(clusterID<<cmtypes.DefaultClusterInfo.GetClusterIDShift() | localID)
 	}
 
 	fb.prefix = prefix

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
@@ -197,7 +198,7 @@ func TestIPIdentityWatcher(t *testing.T) {
 		require.Equal(t, NewEvent("delete", "10.0.0.1", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164", src), eventually(ipcache.events))
 		require.True(t, synced, "The on-sync callback should have been executed")
-	}, "cilium/state/ip/v1/default/", WithIdentityValidator(10)))
+	}, "cilium/state/ip/v1/default/", WithIdentityValidator(cmtypes.ClusterInfo{MaxConnectedClusters: 255}, 10)))
 }
 
 func TestIdentityValidator(t *testing.T) {
@@ -208,7 +209,7 @@ func TestIdentityValidator(t *testing.T) {
 	)
 
 	var opts iwOpts
-	WithIdentityValidator(cid)(&opts)
+	WithIdentityValidator(cmtypes.ClusterInfo{MaxConnectedClusters: 255}, cid)(&opts)
 
 	require.Len(t, opts.validators, 1, "The validator should have been configured")
 	validator := opts.validators[0]

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -140,7 +140,7 @@ func testNewPolicyRepository(t *testing.T, initialIDs []*identity.Identity) (ide
 	}
 	logger := hivetest.Logger(t)
 	idManager := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, idmap, nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, idmap, nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	idManager.Subscribe(testpolicy.SelectorCacheObserver{Cache: repo.GetSubjectSelectorCache()})
 	return idManager, repo

--- a/pkg/k8s/watchers/pod_test.go
+++ b/pkg/k8s/watchers/pod_test.go
@@ -548,7 +548,7 @@ func TestReplaceK8sPodV1ReconcilesEndpointLabels(t *testing.T) {
 	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, ""))
 	repo := policy.NewPolicyRepository(
 		logger,
-		cmtypes.DefaultClusterInfo.ID,
+		cmtypes.DefaultClusterInfo,
 		nil,
 		nil,
 		nil,

--- a/pkg/policy/aggregate.go
+++ b/pkg/policy/aggregate.go
@@ -33,14 +33,17 @@
 
 package policy
 
-import "github.com/cilium/cilium/pkg/identity"
+import (
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+)
 
 // aggregateFor returns the numeric identity that aggregates the
 // given nid. If the supplied `nid` is already a wildcard,
 // then it returns itself.
 //
 // THIS MUST!!! MATCH THE IMPLEMENTATION in bpf/lib/identity.h
-func aggregateFor(nid identity.NumericIdentity, localClusterID uint32) identity.NumericIdentity {
+func aggregateFor(nid identity.NumericIdentity, cinfo cmtypes.ClusterInfo) identity.NumericIdentity {
 	// all aggregates must aggregate to themselves
 	switch nid {
 	case identity.IdentityUnknown, identity.ReservedIdentityAggregateCluster, identity.ReservedIdentityAggregateClusterMesh, identity.ReservedIdentityAggregateWorld, identity.ReservedIdentityAggregateRemoteNode:
@@ -62,21 +65,20 @@ func aggregateFor(nid identity.NumericIdentity, localClusterID uint32) identity.
 
 	// NID is global scope and > 100.
 	// Determine if nid is in-cluster.
-	cid := nid.ClusterID()
-	if cid == localClusterID {
+	if nid.ClusterID(cinfo) == cinfo.ID {
 		return identity.ReservedIdentityAggregateCluster
 	}
 	return identity.ReservedIdentityAggregateClusterMesh
 }
 
 // aggregates returns true if child is a child of the wildcard.
-func aggregates(agg, child identity.NumericIdentity, localClusterID uint32) bool {
-	return agg != child && aggregateFor(child, localClusterID) == agg
+func aggregates(agg, child identity.NumericIdentity, cinfo cmtypes.ClusterInfo) bool {
+	return agg != child && aggregateFor(child, cinfo) == agg
 }
 
 // isAggregate returns true if th
-func isAggregate(nid identity.NumericIdentity, localClusterID uint32) bool {
-	return nid == aggregateFor(nid, localClusterID)
+func isAggregate(nid identity.NumericIdentity, cinfo cmtypes.ClusterInfo) bool {
+	return nid == aggregateFor(nid, cinfo)
 }
 
 // AllAggregates is the list of all identities that do not aggregate further.

--- a/pkg/policy/aggregate_test.go
+++ b/pkg/policy/aggregate_test.go
@@ -10,14 +10,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 )
 
 func TestAllAggregates(t *testing.T) {
 	// Validate that the aggregates evaluate to themselves:
+	cinfo := cmtypes.ClusterInfo{MaxConnectedClusters: defaults.MaxConnectedClusters}
 
 	for _, nid := range AllAggregates {
-		require.True(t, isAggregate(nid, 0))
+		require.True(t, isAggregate(nid, cinfo))
 	}
 
 	c := identity.ReservedIdentityAggregateCluster
@@ -35,14 +38,14 @@ func TestAllAggregates(t *testing.T) {
 		// duplicate of AllAggregates for efficiency.
 		switch nid {
 		case 0, c, m, n, w:
-			require.True(t, isAggregate(nid, 0))
+			require.True(t, isAggregate(nid, cinfo))
 		default:
-			require.False(t, isAggregate(nid, 0))
+			require.False(t, isAggregate(nid, cinfo))
 		}
 
 		if writeOutput {
 			expectedIn = append(expectedIn, nid)
-			expectedOut = append(expectedOut, aggregateFor(nid, 0))
+			expectedOut = append(expectedOut, aggregateFor(nid, cinfo))
 		}
 	}
 
@@ -95,6 +98,7 @@ func TestIsAggregate(t *testing.T) {
 	// save typing
 	w := identity.ReservedIdentityAggregateWorld
 	n := identity.ReservedIdentityAggregateRemoteNode
+	cinfo := cmtypes.ClusterInfo{MaxConnectedClusters: defaults.MaxConnectedClusters}
 
 	for i, tc := range []struct {
 		in, out identity.NumericIdentity
@@ -115,9 +119,10 @@ func TestIsAggregate(t *testing.T) {
 		{identity.IdentityScopeRemoteNode, n},
 		{identity.IdentityScopeRemoteNode + 100, n},
 	} {
-		require.Equal(t, tc.out, aggregateFor(tc.in, 0), "index %d ID %d", i, tc.in)
+		require.Equal(t, tc.out, aggregateFor(tc.in, cinfo), "index %d ID %d", i, tc.in)
 	}
 
+	cinfo.ID = 1
 	for i, tc := range []struct {
 		in, out identity.NumericIdentity
 	}{
@@ -137,6 +142,6 @@ func TestIsAggregate(t *testing.T) {
 		{identity.IdentityScopeRemoteNode, n},
 		{identity.IdentityScopeRemoteNode + 100, n},
 	} {
-		require.Equal(t, tc.out, aggregateFor(tc.in, 1), "cluster ID 1, index %d ID %d", i, tc.in)
+		require.Equal(t, tc.out, aggregateFor(tc.in, cinfo), "cluster ID 1, index %d ID %d", i, tc.in)
 	}
 }

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -87,7 +87,7 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	// cache of label selector -> identities for policy peers.
 	policyRepo := policy.NewPolicyRepository(
 		params.Logger,
-		params.ClusterInfo.ID,
+		params.ClusterInfo,
 		identity.ListReservedIdentities(), // Load SelectorCache with reserved identities
 		params.CertManager,
 		params.L7RulesTranslator,

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -100,7 +100,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	polComputer := testcompute.InstantiateCellForTesting(t, logger, "policy-cell", "TestAddReplaceRemoveRule", repo, idmgr)
 
 	pi := &Importer{

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -341,7 +341,7 @@ func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomput
 
 	logger := hivetest.Logger(t)
 	idmgr := identitymanager.NewIDManager(logger)
-	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 
 	var (
 		db       *statedb.DB

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -306,7 +306,7 @@ type policyDistillery struct {
 func newPolicyDistillery(t testing.TB, selectorCache *SelectorCache) *policyDistillery {
 	idMgr := identitymanager.NewIDManager(hivetest.Logger(t))
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo.ID, nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		Repository: NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo, nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idMgr:      idMgr,
 	}
 	ret.selectorCache = selectorCache

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -80,7 +80,7 @@ func newTestData(tb testing.TB, logger *slog.Logger) *testData {
 		identityManager:   idMgr,
 		sc:                testNewSelectorCache(tb, logger, nil),
 		subjectSc:         testNewSelectorCache(tb, logger, nil),
-		repo:              NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		repo:              NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idSet:             set.NewSet[identity.NumericIdentity](),
 		testPolicyContext: &testPolicyContextType{logger: logger},
 	}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -58,7 +58,7 @@ func TestEgressNamedPortToMapStateUnion(t *testing.T) {
 	epPolicy := &EndpointPolicy{
 		SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 		PolicyOwner:    owner,
-		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
+		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo),
 		selectors:      types.MockSelectorSnapshot(),
 	}
 	filter := &L4Filter{
@@ -114,7 +114,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
+			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -140,7 +140,7 @@ func TestEgressNamedPortWildcardOptimization(t *testing.T) {
 		epPolicy := &EndpointPolicy{
 			SelectorPolicy: &selectorPolicy{namedPortsGetter: testNamedPortsGetter{npm: namedPorts}},
 			PolicyOwner:    owner,
-			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
+			policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo),
 			selectors:      types.MockSelectorSnapshot(),
 		}
 
@@ -164,7 +164,7 @@ func TestNamedPortRulesDeleteByID(t *testing.T) {
 	logger := hivetest.Logger(t)
 	epPolicy := &EndpointPolicy{
 		PolicyOwner:    DummyOwner{logger: logger},
-		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo.ID),
+		policyMapState: newMapState(logger, nil, namedPortRules, cmtypes.DefaultClusterInfo),
 	}
 	require.NotNil(t, epPolicy.policyMapState.byId)
 
@@ -784,7 +784,7 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 // it is released, even after all current users have been removed.
 func TestHoldPreventsDetach(t *testing.T) {
 	logger := hivetest.Logger(t)
-	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	repo.revision.Store(1)
 
 	ep := testutils.NewTestEndpoint(t)
@@ -825,7 +825,7 @@ func TestHoldPreventsDetach(t *testing.T) {
 // a policy that is being replaced.
 func TestAddHoldRejectsDetached(t *testing.T) {
 	logger := hivetest.Logger(t)
-	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(logger, cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	repo.revision.Store(1)
 
 	ep := testutils.NewTestEndpoint(t)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -88,8 +88,8 @@ var (
 // greatly enhances the usefuleness of the Trie and improves lookup,
 // deletion, and insertion times.
 type mapState struct {
-	logger         *slog.Logger
-	localClusterID uint32
+	logger      *slog.Logger
+	clusterInfo cmtypes.ClusterInfo
 	// entries is the map containing the MapStateEntries
 	entries mapStateMap
 	// trie is a Trie that indexes policy Keys without their identity
@@ -197,7 +197,7 @@ func (ms *mapState) forKey(k Key, f func(Key, mapStateEntry) bool) bool {
 // forCoveredIDs calls 'f' for each covered non-aggregate ID in 'idSet' with port/proto from 'k'.
 func (ms *mapState) forCoveredIDs(agg identity.NumericIdentity, k Key, idSet IDSet, f func(Key, mapStateEntry) bool) bool {
 	for id := range idSet {
-		if aggregates(agg, id, ms.localClusterID) {
+		if aggregates(agg, id, ms.clusterInfo) {
 			k.Identity = id
 			if !ms.forKey(k, f) {
 				return false
@@ -222,7 +222,7 @@ func (ms *mapState) forID(k Key, idSet IDSet, f func(Key, mapStateEntry) bool) b
 //
 // All yielded keys will have either the specified ID or the aggregate ID.
 func (ms *mapState) CoveringBroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity, ms.localClusterID)
+	agg := aggregateFor(key.Identity, ms.clusterInfo)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -251,7 +251,7 @@ func (ms *mapState) CoveringBroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateE
 // The difference is when the aggregate key is supplied - this yields *all* keys
 // with shorter-or-equal prefix length.
 func (ms *mapState) BroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity, ms.localClusterID)
+	agg := aggregateFor(key.Identity, ms.clusterInfo)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -286,7 +286,7 @@ func (ms *mapState) BroaderOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
 // If a non-aggregate key is supplied, all keys yielded will have that identity.
 // If an aggregate key is supplied, all longer-prefix keys will be yielded.
 func (ms *mapState) CoveredNarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity, ms.localClusterID)
+	agg := aggregateFor(key.Identity, ms.clusterInfo)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.DescendantIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -320,7 +320,7 @@ func (ms *mapState) CoveredNarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateE
 //
 // If a aggregate key is supplied, this will yield all longer-prefix keys.
 func (ms *mapState) NarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
-	wc := aggregateFor(key.Identity, ms.localClusterID)
+	wc := aggregateFor(key.Identity, ms.clusterInfo)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.DescendantIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -383,7 +383,7 @@ func (ms *mapState) SubsetKeysWithSameID(key Key) iter.Seq2[Key, mapStateEntry] 
 // LPMAncestors iterates over broader or equal port/proto entries in the trie in LPM order,
 // with most specific match with the same ID as in 'key' being returned first.
 func (ms *mapState) LPMAncestors(key Key) iter.Seq2[Key, mapStateEntry] {
-	agg := aggregateFor(key.Identity, ms.localClusterID)
+	agg := aggregateFor(key.Identity, ms.clusterInfo)
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := ms.trie.AncestorLongestPrefixFirstIterator(key.PrefixLength(), key.LPMKey)
 		for ok, lpmKey, idSet := iter.Next(); ok; ok, lpmKey, idSet = iter.Next() {
@@ -419,7 +419,7 @@ func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 	}
 
 	// The aggregate identity to retrieve
-	agg := aggregateFor(key.Identity, ms.localClusterID)
+	agg := aggregateFor(key.Identity, ms.clusterInfo)
 
 	// two entries: aggregate and specific.
 	// Must retrieve both.
@@ -705,13 +705,9 @@ func NewMapStateEntry(e MapStateEntry) mapStateEntry {
 	}
 }
 
-func emptyMapState(logger *slog.Logger) mapState {
-	return newMapState(logger, nil, 0, cmtypes.DefaultClusterInfo.ID)
-}
-
 // newMapState returns a new mapState with capacities from the given old mapState (if non-nil),
 // according to the given policy features.
-func newMapState(logger *slog.Logger, old *mapState, features policyFeatures, localClusterID uint32) mapState {
+func newMapState(logger *slog.Logger, old *mapState, features policyFeatures, clusterInfo cmtypes.ClusterInfo) mapState {
 	var nEntries int
 
 	if old != nil {
@@ -719,10 +715,10 @@ func newMapState(logger *slog.Logger, old *mapState, features policyFeatures, lo
 	}
 
 	ms := mapState{
-		logger:         logger,
-		localClusterID: localClusterID,
-		entries:        make(mapStateMap, nEntries),
-		trie:           bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
+		logger:      logger,
+		clusterInfo: clusterInfo,
+		entries:     make(mapStateMap, nEntries),
+		trie:        bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
 	}
 
 	if features&(passRules|namedPortRules) != 0 {
@@ -1044,7 +1040,7 @@ func (ms *mapState) pruneCoveredNarrowerKey(k Key, v mapStateEntry, key Key, ent
 
 	// If k is a direct child of key, and k's entry is equivalent to key,
 	// then delete k as it is redundant.
-	deleteEntry = deleteEntry || (key.LPMKey == k.LPMKey && aggregates(key.Identity, k.Identity, ms.localClusterID) && v.equivalent(entry))
+	deleteEntry = deleteEntry || (key.LPMKey == k.LPMKey && aggregates(key.Identity, k.Identity, ms.clusterInfo) && v.equivalent(entry))
 
 	// Delete whole entry?
 	if deletePassMeta && deleteEntry {
@@ -1082,9 +1078,9 @@ func (sp *keySlice) addNewKeys(l34Keys, doneKeys *Keys) {
 
 // collectNarrowerPasses adds the narrower key 'k' (with identity from 'key' if narrower) to 'm' if
 // 'v' has a higher precedence pass.
-func (sp *keySlice) collectNarrowerPasses(tierMaxPrecedence types.Precedence, k Key, v mapStateEntry, key Key, doneKeys *Keys, localClusterID uint32) {
+func (sp *keySlice) collectNarrowerPasses(tierMaxPrecedence types.Precedence, k Key, v mapStateEntry, key Key, doneKeys *Keys, clusterInfo cmtypes.ClusterInfo) {
 	// k has narrower L4, but the narrower identity may be on 'key'
-	if k.Identity == aggregateFor(key.Identity, localClusterID) {
+	if k.Identity == aggregateFor(key.Identity, clusterInfo) {
 		k.Identity = key.Identity
 	}
 	if k != key {
@@ -1217,7 +1213,7 @@ func (ms *mapState) insertWithPasses(tierMaxPrecedence types.Precedence, key Key
 	var l34Keys, doneKeys Keys
 	var bailPrecedence types.Precedence
 	var keys keySlice
-	aggregateID := aggregateFor(key.Identity, ms.localClusterID)
+	aggregateID := aggregateFor(key.Identity, ms.clusterInfo)
 
 	// Find the covering pass and bail entries and pass if the found
 	// passPrecedence is higher than the bailPrecedence, else bail if found.
@@ -1283,7 +1279,7 @@ func (ms *mapState) insertWithPasses(tierMaxPrecedence types.Precedence, key Key
 		if !bail && isCoveringKey {
 			ms.pruneCoveredNarrowerKey(k, v, key, entry, entry.Precedence, changes)
 		}
-		keys.collectNarrowerPasses(tierMaxPrecedence, k, v, key, &doneKeys, ms.localClusterID)
+		keys.collectNarrowerPasses(tierMaxPrecedence, k, v, key, &doneKeys, ms.clusterInfo)
 	}
 
 	// Pass to a higher tier?
@@ -1489,7 +1485,7 @@ func (ms *mapState) insertWithChanges(tierMaxPrecedence types.Precedence, newKey
 // aggregateIsEquivalent returns true if an entry has an aggregate (wildcard)
 // on the same level. If so, inserting `newKey` can be skipped entirely.
 func (ms *mapState) aggregateIsEquivalent(newKey Key, newEntry mapStateEntry) bool {
-	agg := aggregateFor(newKey.Identity, ms.localClusterID)
+	agg := aggregateFor(newKey.Identity, ms.clusterInfo)
 	// if newKey is already aggregate, then we can bail.
 	if agg == newKey.Identity {
 		return false
@@ -1512,7 +1508,7 @@ func (ms *mapState) aggregateIsEquivalent(newKey Key, newEntry mapStateEntry) bo
 // of another entry appearing between the aggregated and specific entry.
 func (ms *mapState) pruneAggregated(newKey Key, newEntry mapStateEntry, changes ChangeState) {
 	// newKey must be capable of aggregating.
-	if !isAggregate(newKey.Identity, ms.localClusterID) {
+	if !isAggregate(newKey.Identity, ms.clusterInfo) {
 		return
 	}
 
@@ -1523,7 +1519,7 @@ func (ms *mapState) pruneAggregated(newKey Key, newEntry mapStateEntry, changes 
 	}
 
 	for id := range idSet {
-		if !aggregates(newKey.Identity, id, ms.localClusterID) {
+		if !aggregates(newKey.Identity, id, ms.clusterInfo) {
 			// skip if this ID is not aggregated by newKey
 			continue
 		}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"fmt"
 	"iter"
+	"log/slog"
 	"net/netip"
 	"slices"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -3434,6 +3437,10 @@ func TestMapState_passValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func emptyMapState(logger *slog.Logger) mapState {
+	return newMapState(logger, nil, 0, cmtypes.ClusterInfo{MaxConnectedClusters: defaults.MaxConnectedClusters})
 }
 
 func permutations(arr []int) [][]int {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
@@ -52,6 +53,7 @@ type PolicyRepository interface {
 
 	GetRevision() uint64
 	GetRulesList() *models.Policy
+	GetClusterInfo() cmtypes.ClusterInfo
 	GetSelectorCache() *SelectorCache
 	GetSubjectSelectorCache() *SelectorCache
 	Iterate(f func(rule *types.PolicyEntry))
@@ -68,8 +70,8 @@ type PolicyRepository interface {
 // Repository is a list of policy rules which in combination form the security
 // policy. A policy repository can be
 type Repository struct {
-	logger         *slog.Logger
-	localClusterID uint32
+	logger      *slog.Logger
+	clusterInfo cmtypes.ClusterInfo
 	// mutex protects the whole policy tree
 	mutex lock.RWMutex
 
@@ -112,6 +114,11 @@ func (p *Repository) GetSelectorCache() *SelectorCache {
 	return p.selectorCache
 }
 
+// GetClusterInfo returns the local cluster configuration used by the repository.
+func (p *Repository) GetClusterInfo() cmtypes.ClusterInfo {
+	return p.clusterInfo
+}
+
 // GetSubjectSelectorCache returns the selector cache used by the Repository for indexing policies
 func (p *Repository) GetSubjectSelectorCache() *SelectorCache {
 	return p.subjectSelectorCache
@@ -120,7 +127,7 @@ func (p *Repository) GetSubjectSelectorCache() *SelectorCache {
 // NewPolicyRepository creates a new policy repository.
 func NewPolicyRepository(
 	logger *slog.Logger,
-	localClusterID uint32,
+	clusterInfo cmtypes.ClusterInfo,
 	initialIDs identity.IdentityMap,
 	certManager certificatemanager.CertificateManager,
 	l7RulesTranslator envoypolicy.EnvoyL7RulesTranslator,
@@ -132,7 +139,7 @@ func NewPolicyRepository(
 	repo := &Repository{
 		logger:               logger,
 		rules:                make(map[ruleKey]*rule),
-		localClusterID:       localClusterID,
+		clusterInfo:          clusterInfo,
 		rulesByNamespace:     make(map[string]sets.Set[ruleKey]),
 		rulesByResource:      make(map[ipcachetypes.ResourceID]map[ruleKey]*rule),
 		selectorCache:        selectorCache,
@@ -341,7 +348,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	calculatedPolicy := &selectorPolicy{
 		Revision:             p.GetRevision(),
-		localClusterID:       p.localClusterID,
+		clusterInfo:          p.clusterInfo,
 		SelectorCache:        sc,
 		namedPortsGetter:     p.namedPortsGetter,
 		L4Policy:             NewL4Policy(p.GetRevision()),
@@ -718,7 +725,7 @@ func (p *Repository) Snapshot(logger *slog.Logger, cm certificatemanager.Certifi
 
 	out := NewPolicyRepository(
 		logger,
-		p.localClusterID,
+		p.clusterInfo,
 		ids,
 		cm,
 		rt,

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1334,7 +1334,7 @@ func TestDefaultAllow(t *testing.T) {
 func TestReplaceByResource(t *testing.T) {
 	// don't use the full testdata() here, since we want to watch
 	// selectorcache changes carefully
-	repo := NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo := NewPolicyRepository(hivetest.Logger(t), cmtypes.DefaultClusterInfo, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	sc := testNewSelectorCache(t, hivetest.Logger(t), nil)
 	assert.True(t, sc.selectors.Empty())
 	repo.subjectSelectorCache = sc

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -14,6 +14,7 @@ import (
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -189,7 +190,7 @@ type NamedPortsGetter interface {
 // particular Identity across all layers (L3, L4, and L7), with the policy
 // still determined in terms of EndpointSelectors.
 type selectorPolicy struct {
-	localClusterID uint32
+	clusterInfo cmtypes.ClusterInfo
 
 	// Revision is the revision of the policy repository used to generate
 	// this selectorPolicy.
@@ -341,8 +342,9 @@ type PolicyOwner interface {
 }
 
 // newSelectorPolicy returns an empty selectorPolicy stub.
-func newSelectorPolicy(selectorCache *SelectorCache) *selectorPolicy {
+func newSelectorPolicy(selectorCache *SelectorCache, clusterInfo cmtypes.ClusterInfo) *selectorPolicy {
 	return &selectorPolicy{
+		clusterInfo:   clusterInfo,
 		Revision:      0,
 		SelectorCache: selectorCache,
 		L4Policy:      NewL4Policy(0),
@@ -418,7 +420,7 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 		calculatedPolicy = &EndpointPolicy{
 			SelectorPolicy: p,
 			selectors:      selectors,
-			policyMapState: newMapState(logger, policyOwner.PreviousMapState(), features, p.localClusterID),
+			policyMapState: newMapState(logger, policyOwner.PreviousMapState(), features, p.clusterInfo),
 			policyMapChanges: MapChanges{
 				logger:   logger,
 				firstRev: selectors.Revision,
@@ -715,8 +717,8 @@ func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState
 // PolicyOwner is left as nil
 func NewEndpointPolicy(logger *slog.Logger, repo PolicyRepository) *EndpointPolicy {
 	return &EndpointPolicy{
-		SelectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
-		policyMapState: emptyMapState(logger),
+		SelectorPolicy: newSelectorPolicy(repo.GetSelectorCache(), repo.GetClusterInfo()),
+		policyMapState: newMapState(logger, nil, 0, repo.GetClusterInfo()),
 	}
 }
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
@@ -400,7 +401,7 @@ func TestGetEgressNamedPorts(t *testing.T) {
 		"http": pkgTypes.PortProto{Port: 9090, Proto: u8proto.TCP},
 	}))
 
-	sp := newSelectorPolicy(testNewSelectorCache(t, hivetest.Logger(t), nil))
+	sp := newSelectorPolicy(testNewSelectorCache(t, hivetest.Logger(t), nil), cmtypes.ClusterInfo{MaxConnectedClusters: 255})
 	sp.namedPortsGetter = testNamedPortsGetter{npm: namedPorts}
 
 	portsByNID := map[identity.NumericIdentity]uint16{}

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
-	"github.com/cilium/cilium/pkg/identity"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -507,8 +506,8 @@ func (d *statusCollector) getBPFMapStatus() *models.BPFMapStatus {
 
 func (d *statusCollector) getIdentityRange() *models.IdentityRange {
 	s := &models.IdentityRange{
-		MinIdentity: int64(identity.GetMinimalAllocationIdentity(d.statusParams.ClusterInfo.ID)),
-		MaxIdentity: int64(identity.GetMaximumAllocationIdentity(d.statusParams.ClusterInfo.ID)),
+		MinIdentity: int64(d.statusParams.ClusterInfo.MinimalAllocationIdentity()),
+		MaxIdentity: int64(d.statusParams.ClusterInfo.MaximumAllocationIdentity()),
 	}
 
 	return s


### PR DESCRIPTION
The PR:
1. moves numeric identity layout handling to ClusterInfo;
2. propagates it through all consumers;
3. removes the global shift state;

Please see description per-commit.

More context is in the comment: https://github.com/cilium/cilium/pull/43507#discussion_r2685359356