### PR TITLE
loadbalancer: keep terminating backends selected under topology-aware routing

### DIFF
--- a/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
@@ -27,8 +27,9 @@ db/cmp frontends frontends-both.table
 # Transform endpointslice2 to a terminating endpoint that has no hints, as
 # the real EndpointSlice controller would produce for a non-Ready Pod.
 # Pre-fix this would have fallen back to all backends (missingHints=true);
-# post-fix the safeguard ignores the terminating backend and only the
-# Ready zone-local endpoint is selected.
+# post-fix the safeguard ignores the terminating backend. The terminating
+# backend itself stays selected so that it remains in the datapath maps and
+# its established connections can drain.
 cp endpointslice2.yaml endpointslice2-terminating.yaml
 sed 'ready: true' 'ready: false' endpointslice2-terminating.yaml
 sed 'terminating: false' 'terminating: true' endpointslice2-terminating.yaml
@@ -81,7 +82,7 @@ Address               Type        ServiceName   PortName   Status  Backends
 
 -- frontends-only-eps1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
 
 -- frontends-both-terminating.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -478,6 +478,12 @@ func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *load
 	return !be.Unhealthy && be.UnhealthyUpdatedAt != nil
 }
 
+// backendTerminating reports whether the backend is in a terminating state.
+func backendTerminating(be *loadbalancer.Backend) bool {
+	return be.State == loadbalancer.BackendStateTerminating ||
+		be.State == loadbalancer.BackendStateTerminatingNotServing
+}
+
 func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadbalancer.Backend, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {
 	onlyLocal := false
 	isLocalProxyDelegation := func(loadbalancer.L3n4Addr) bool { return true }
@@ -517,14 +523,19 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 		if candidatesFound {
 			return func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
 				for be, rev := range bes {
-					if be.NodeName != w.nodeName {
-						continue
-					}
 					if !matchesFrontend(be, fe) {
 						continue
 					}
-					if !w.topologyPreferenceCandidate(svc, be) {
-						continue
+					// Keep terminating backends selected regardless of the
+					// same-node preference so that their established
+					// connections can drain.
+					if !backendTerminating(be) {
+						if be.NodeName != w.nodeName {
+							continue
+						}
+						if !w.topologyPreferenceCandidate(svc, be) {
+							continue
+						}
 					}
 					if !yield(be, rev) {
 						return
@@ -598,7 +609,12 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 			if checkZoneHints {
 				if be.Zone == nil ||
 					!slices.Contains(be.Zone.ForZones, *thisZone) {
-					continue
+					// A terminating backend has no zone hints. Keep it
+					// selected so that it stays in the datapath maps and
+					// its established connections can drain.
+					if !backendTerminating(be) {
+						continue
+					}
 				}
 			}
 			if !yield(be, rev) {

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -1003,11 +1003,19 @@ func TestWriter_SelectBackends_PreferCloseIgnoresNonActiveForMissingHints(t *tes
 
 	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
 
-	// Topology safeguard must remain engaged: only the zone-a Active backend
-	// should be selected. Terminating backends are filtered from primary traffic
-	// because their (possibly empty / nil) ForZones cannot match the local zone.
-	require.Len(t, selected, 1)
-	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
+	// Topology safeguard must remain engaged: among the Active backends only
+	// the zone-a one is selected (zone-b is filtered). Terminating backends
+	// are retained in the selection regardless of hints so that they stay in
+	// the datapath maps and their established connections can drain.
+	require.Len(t, selected, 3)
+	addresses := make([]string, 0, len(selected))
+	for _, be := range selected {
+		addresses = append(addresses, be.Address.String())
+	}
+	assert.Contains(t, addresses, activeLocalAddr.String())
+	assert.Contains(t, addresses, terminatingAddr.String())
+	assert.Contains(t, addresses, terminatingNoZoneAddr.String())
+	assert.NotContains(t, addresses, activeRemoteAddr.String())
 }
 
 // TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating verifies that
@@ -1130,8 +1138,15 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresNonActiveBackends(t *testing
 
 	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
 
-	// Only the active local backend should be selected.
-	// All other non-active local backends must be filtered out.
-	require.Len(t, selected, 1)
-	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
+	// The active local backend is selected for new connections. 
+	// The terminating backend is retained in the selection so that it stays in
+	// the datapath maps and its established connections can drain; its state
+	// excludes it from new-connection selection.
+	require.Len(t, selected, 2)
+	addresses := make([]string, 0, len(selected))
+	for _, be := range selected {
+		addresses = append(addresses, be.Address.String())
+	}
+	assert.Contains(t, addresses, activeLocalAddr.String())
+	assert.Contains(t, addresses, terminatingLocalAddr.String())
 }


### PR DESCRIPTION
### description
Fixes: #48348 — Backend evicted before pod termination when using trafficDistribution

Since #45947, terminating backends have been skipped to keep topology-aware
routing engaged, but that skip gets the terminating backend evicted during its pod's grace period.
The early eviction resets the existing connections on the terminating pod.

This patch still keep terminating pods out of topology-aware routing decisions, 
but guards the terminating backend from eviction.

This PR was prepared with AIL:2.

### test
- updated `pkg/loadbalancer/writer` unit tests for the PreferClose / PreferSameNode selection semantics and the topology-aware-terminating script test expectation
- `go test ./pkg/loadbalancer/...` and the loadbalancer script tests pass
- build image with this patch and verified on a multi-zone cluster with the reproducer from #48348 

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request


```release-note
Fix an issue where terminating backends were evicted from BPF maps when trafficDistribution was enabled.
```