### PR TITLE
[v1.20] bpf: Reduce stack usage of send_trace_notify

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1858,7 +1858,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 	int ret, verdict, l4_off, zero = 0;
 	struct ct_buffer6 *ct_buffer;
 	struct trace_ctx trace;
-	union v6addr orig_sip;
+	union v6addr orig_sip __align_stack_8;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -202,24 +202,6 @@ struct debug_capture_msg {
 				     ##__VA_ARGS__);		\
 		})
 
-
-static __always_inline void cilium_dbg(const struct __ctx_buff *ctx, __u8 type,
-				       __u32 arg1, __u32 arg2)
-{
-	struct debug_msg msg = {
-		__notify_common_hdr(CILIUM_NOTIFY_DBG_MSG, type),
-		.arg1	= arg1,
-		.arg2	= arg2,
-	};
-#ifdef DEBUG_TAGGED
-	if (!load_ip_trace_id())
-		return;
-#endif
-	dbg_extension_hook(ctx, msg);
-	ctx_event_output(ctx, &cilium_events, BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
-}
-
 static __always_inline void cilium_dbg3(const struct __ctx_buff *ctx, __u8 type,
 					__u32 arg1, __u32 arg2, __u32 arg3)
 {
@@ -238,6 +220,12 @@ static __always_inline void cilium_dbg3(const struct __ctx_buff *ctx, __u8 type,
 			 &msg, sizeof(msg));
 }
 
+
+static __always_inline void
+cilium_dbg(const struct __ctx_buff *ctx, __u8 type, __u32 arg1, __u32 arg2)
+{
+	cilium_dbg3(ctx, type, arg1, arg2, 0);
+}
 
 static __always_inline void cilium_dbg_capture2(const struct __ctx_buff *ctx, __u8 type,
 						__u32 arg1, __u32 arg2)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -127,7 +127,7 @@ __declare_tail(CILIUM_CALL_IPV6_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 src_id = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
-	union v6addr saddr = {};
+	union v6addr saddr __align_stack_8 = {};
 	int ret;
 	__s8 ext_err = 0;
 	struct snat_v6_args *args = AUX(snat_v6_args);

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -207,10 +207,10 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 }
 
 static __always_inline void
-_send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
-		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
-		   enum trace_reason reason, __u32 monitor,
-		   __be16 proto, __u16 line, __u8 file)
+__send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
+		    __u32 src, __u32 dst, void *orig_addr, __u16 dst_id, __u32 ifindex,
+		    enum trace_reason reason, __u32 monitor,
+		    __be16 proto, __u16 line, __u8 file)
 {
 	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -251,11 +251,27 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ip_trace_id	= ip_trace_id,
 	};
 	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
+	if (orig_addr) {
+		if (proto == bpf_htons(ETH_P_IP))
+			memcpy(&msg.orig_ip4.be32, orig_addr, sizeof(__be32));
+		else
+			ipv6_addr_copy(&msg.orig_ip6, orig_addr);
+	}
 
 	trace_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
 			 &msg, sizeof(msg));
+}
+
+static __always_inline void
+_send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
+		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
+		   enum trace_reason reason, __u32 monitor,
+		   __be16 proto, __u16 line, __u8 file)
+{
+	return __send_trace_notify(ctx, obs_point, src, dst, NULL, dst_id, ifindex,
+				   reason, monitor, proto, line, file);
 }
 
 static __always_inline void
@@ -264,50 +280,9 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 ifindex, enum trace_reason reason, __u32 monitor,
 		    __u16 line, __u8 file)
 {
-	__u64 ip_trace_id = load_ip_trace_id();
-	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
-	struct trace_notify msg = {};
-	cls_flags_t flags = CLS_FLAG_NONE;
-
-	_update_trace_metrics(ctx, obs_point, reason, line, file);
-
-	if (!emit_trace_notify(obs_point, monitor))
-		return;
-
-	if (CONFIG(events_map_rate_limit) > 0) {
-		settings.bucket_size = CONFIG(events_map_burst_limit);
-		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
-		if (!ratelimit_check_and_take(&rkey, &settings))
-			return;
-	}
-
-	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP), obs_point);
-	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
-
-	msg = (typeof(msg)) {
-		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
-		.src_label	= src,
-		.dst_label	= dst,
-		.dst_id		= dst_id,
-		.reason		= reason,
-		.ifindex	= ifindex,
-		.flags		= flags,
-		.orig_ip4.be32	= orig_addr,
-		.ip_trace_id	= ip_trace_id,
-	};
-
-	trace_extension_hook(ctx, msg);
-	ctx_event_output(ctx, &cilium_events,
-			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+	return __send_trace_notify(ctx, obs_point, src, dst, &orig_addr, dst_id,
+				   ifindex, reason, monitor, bpf_htons(ETH_P_IP),
+				   line, file);
 }
 
 static __always_inline void
@@ -316,51 +291,9 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		    __u32 monitor, __u16 line, __u8 file)
 {
-	__u64 ip_trace_id = load_ip_trace_id();
-	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
-	struct trace_notify msg = {};
-	cls_flags_t flags = CLS_FLAG_NONE;
-
-	_update_trace_metrics(ctx, obs_point, reason, line, file);
-
-	if (!emit_trace_notify(obs_point, monitor))
-		return;
-
-	if (CONFIG(events_map_rate_limit) > 0) {
-		settings.bucket_size = CONFIG(events_map_burst_limit);
-		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
-		if (!ratelimit_check_and_take(&rkey, &settings))
-			return;
-	}
-
-	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6), obs_point);
-	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
-
-	msg = (typeof(msg)) {
-		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
-		.src_label	= src,
-		.dst_label	= dst,
-		.dst_id		= dst_id,
-		.reason		= reason,
-		.ifindex	= ifindex,
-		.flags		= flags,
-		.ip_trace_id	= ip_trace_id,
-	};
-
-	ipv6_addr_copy(&msg.orig_ip6, orig_addr);
-
-	trace_extension_hook(ctx, msg);
-	ctx_event_output(ctx, &cilium_events,
-			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+	return __send_trace_notify(ctx, obs_point, src, dst, &orig_addr, dst_id,
+				   ifindex, reason, monitor, bpf_htons(ETH_P_IPV6),
+				   line, file);
 }
 #else
 static __always_inline void

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -206,62 +206,71 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 	return true;
 }
 
+struct trace_notify_vars {
+	__u64 cap_len;
+	cls_flags_t flags;
+	struct ratelimit_key key;
+	struct ratelimit_settings settings;
+	struct trace_notify msg;
+};
+
+DEFINE_AUX(struct trace_notify_vars, trace_notify_vars);
+
 static __always_inline void
 __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src, __u32 dst, const void *orig_addr, __u16 dst_id,
 		    __u32 ifindex, enum trace_reason reason, __u32 monitor,
 		    __be16 proto, __u16 line, __u8 file)
 {
-	__u64 ip_trace_id = load_ip_trace_id();
-	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
-	};
-	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
-	struct trace_notify msg = {};
-	cls_flags_t flags = CLS_FLAG_NONE;
+	struct trace_notify_vars *vars = AUX(trace_notify_vars);
+
+	memset(vars, 0, sizeof(*vars));
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
 
 	if (!emit_trace_notify(obs_point, monitor))
 		return;
 
+	vars->key.usage = RATELIMIT_USAGE_EVENTS_MAP;
+	vars->settings.topup_interval_ns = NSEC_PER_SEC;
 	if (CONFIG(events_map_rate_limit) > 0) {
-		settings.bucket_size = CONFIG(events_map_burst_limit);
-		settings.tokens_per_topup = CONFIG(events_map_rate_limit);
-		if (!ratelimit_check_and_take(&rkey, &settings))
+		vars->settings.bucket_size = CONFIG(events_map_burst_limit);
+		vars->settings.tokens_per_topup = CONFIG(events_map_rate_limit);
+		if (!ratelimit_check_and_take(&vars->key, &vars->settings))
 			return;
 	}
 
-	flags = ctx_classify(ctx, proto, obs_point);
-	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
-
-	msg = (typeof(msg)) {
+	vars->flags = ctx_classify(ctx, proto, obs_point);
+	vars->cap_len = compute_capture_len(ctx, monitor, vars->flags, obs_point);
+	vars->msg = (typeof(vars->msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
+		__notify_pktcap_hdr((__u32)ctx_full_len(ctx),
+				    (__u16)vars->cap_len,
+				    NOTIFY_TRACE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
 		.reason		= reason,
-		.flags		= flags,
+		.flags		= vars->flags,
 		.ifindex	= ifindex,
-		.ip_trace_id	= ip_trace_id,
+		.ip_trace_id	= load_ip_trace_id(),
 	};
-	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
-	if (orig_addr) {
-		if (proto == bpf_htons(ETH_P_IP))
-			memcpy(&msg.orig_ip4.be32, orig_addr, sizeof(__be32));
-		else
-			ipv6_addr_copy(&msg.orig_ip6, orig_addr);
-	}
 
-	trace_extension_hook(ctx, msg);
-	ctx_event_output(ctx, &cilium_events,
-			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+	{
+		struct trace_notify *msg = &vars->msg;
+
+		if (orig_addr) {
+			if (proto == bpf_htons(ETH_P_IP))
+				memcpy(&msg->orig_ip4.be32, orig_addr, sizeof(__be32));
+			else
+				ipv6_addr_copy(&msg->orig_ip6, orig_addr);
+		}
+
+		trace_extension_hook(ctx, *msg);
+		ctx_event_output(ctx, &cilium_events,
+				 (vars->cap_len << 32) | BPF_F_CURRENT_CPU,
+				 msg, sizeof(*msg));
+	}
 }
 
 static __always_inline void

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -208,8 +208,8 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 
 static __always_inline void
 __send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
-		    __u32 src, __u32 dst, void *orig_addr, __u16 dst_id, __u32 ifindex,
-		    enum trace_reason reason, __u32 monitor,
+		    __u32 src, __u32 dst, const void *orig_addr, __u16 dst_id,
+		    __u32 ifindex, enum trace_reason reason, __u32 monitor,
 		    __be16 proto, __u16 line, __u8 file)
 {
 	__u64 ip_trace_id = load_ip_trace_id();
@@ -291,7 +291,7 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		    __u32 monitor, __u16 line, __u8 file)
 {
-	return __send_trace_notify(ctx, obs_point, src, dst, &orig_addr, dst_id,
+	return __send_trace_notify(ctx, obs_point, src, dst, orig_addr, dst_id,
 				   ifindex, reason, monitor, bpf_htons(ETH_P_IPV6),
 				   line, file);
 }


### PR DESCRIPTION
Clean backport of
* [ ] #47879
* [ ] #47908
* [ ] #47911

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47879 47908 47911
```