### PR TITLE
Fixes #47918: Implement label prefix filter config v2 with regex support

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -21,11 +22,15 @@ var (
 	validLabelPrefixesMU   lock.RWMutex
 	validLabelPrefixes     *labelPrefixCfg // Label prefixes used to filter from all labels
 	validNodeLabelPrefixes *labelPrefixCfg
+
+	// validCfgVersions contains all the config versions currently supported
+	validCfgVersions = []int{LPCfgFileVersion, LPCfgFileVersionRegex}
 )
 
 const (
 	// LPCfgFileVersion represents the version of a Label Prefix Configuration File
-	LPCfgFileVersion = 1
+	LPCfgFileVersion      = 1 // literal prefix matching
+	LPCfgFileVersionRegex = 2 // prefixes are regexps, as with --labels
 
 	// reservedLabelsPattern is the prefix pattern for all reserved labels
 	reservedLabelsPattern = labels.LabelSourceReserved + ":.*"
@@ -277,7 +282,7 @@ func readLabelPrefixCfgFrom(fileName string) (*labelPrefixCfg, error) {
 	if err != nil {
 		return nil, err
 	}
-	if lpc.Version != LPCfgFileVersion {
+	if !slices.Contains(validCfgVersions, lpc.Version) {
 		return nil, fmt.Errorf("unsupported version %d", lpc.Version)
 	}
 	for _, lp := range lpc.LabelPrefixes {
@@ -287,6 +292,17 @@ func readLabelPrefixCfgFrom(fileName string) (*labelPrefixCfg, error) {
 		if lp.Source == "" {
 			return nil, fmt.Errorf("invalid label prefix file: source was empty")
 		}
+
+		// If using version 2 of the config we enable regex matching
+		// This follows the same approach as with --label-prefix-filter
+		if lpc.Version == LPCfgFileVersionRegex {
+			r, err := regexp.Compile(lp.Prefix)
+			if err != nil {
+				return nil, fmt.Errorf("invalid label prefix file: unable to compile regexp %q: %w", lp.Prefix, err)
+			}
+			lp.expr = r
+		}
+
 		if !lp.Ignore {
 			lpc.whitelist = true
 		}

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -4,6 +4,8 @@
 package labelsfilter
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -250,4 +252,169 @@ func TestFilterLabelsByRegex(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func writeLabelPrefixCfg(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "labels.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestReadLabelPrefixCfgFromVersion1(t *testing.T) {
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 1,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "id."}
+		]
+	}`,
+	)
+
+	cfg, err := readLabelPrefixCfgFrom(path)
+	require.NoError(t, err)
+	require.Equal(t, LPCfgFileVersion, cfg.Version)
+	require.Len(t, cfg.LabelPrefixes, 2)
+	// No regular expression is compiled for version 1, so matching falls back
+	// to literal prefix matching.
+	for _, lp := range cfg.LabelPrefixes {
+		require.Nil(t, lp.expr)
+	}
+	// An inclusive (non-ignore) prefix flips the whitelist flag.
+	require.True(t, cfg.whitelist)
+}
+
+func TestReadLabelPrefixCfgFromVersion1SkipsRegexCompile(t *testing.T) {
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 1,
+		"valid-prefixes": [
+			{"source": "k8s", "prefix": "id.[("}
+		]
+	}`,
+	)
+
+	cfg, err := readLabelPrefixCfgFrom(path)
+	// Shouldn't error as not attempting to parse the invalid regex
+	require.NoError(t, err)
+	require.Nil(t, cfg.LabelPrefixes[0].expr)
+}
+
+func TestReadLabelPrefixCfgFromVersion2(t *testing.T) {
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 2,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "id\\..*"},
+			{"source": "k8s", "prefix": "ignore\\..*", "invert": true}
+		]
+	}`,
+	)
+
+	cfg, err := readLabelPrefixCfgFrom(path)
+	require.NoError(t, err)
+	require.Equal(t, LPCfgFileVersionRegex, cfg.Version)
+	require.Len(t, cfg.LabelPrefixes, 3)
+	// A regular expression is compiled for every prefix in version 2.
+	for _, lp := range cfg.LabelPrefixes {
+		require.NotNil(t, lp.expr)
+	}
+	require.True(t, cfg.whitelist)
+}
+
+func TestReadLabelPrefixCfgFromUnsupportedVersion(t *testing.T) {
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 3,
+		"valid-prefixes": [
+			{"source": "k8s", "prefix": "id."}
+		]
+	}`,
+	)
+
+	_, err := readLabelPrefixCfgFrom(path)
+	require.ErrorContains(t, err, "unsupported version 3")
+}
+
+func TestReadLabelPrefixCfgFromVersion2InvalidRegex(t *testing.T) {
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 2,
+		"valid-prefixes": [
+			{"source": "k8s", "prefix": "id.[("}
+		]
+	}`,
+	)
+
+	_, err := readLabelPrefixCfgFrom(path)
+	require.ErrorContains(t, err, "unable to compile regexp")
+}
+
+func TestFilterLabelsFromRegexConfigFile(t *testing.T) {
+	logger := hivetest.Logger(t)
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 2,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "id\\.[a-z]+$"}
+		]
+	}`,
+	)
+
+	err := ParseLabelPrefixCfg(logger, nil, nil, path)
+	require.NoError(t, err)
+
+	allLabels := labels.Labels{
+		"id.lizards":     labels.NewLabel("id.lizards", "web", labels.LabelSourceK8s),
+		"id.lizards.k8s": labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
+		"other":          labels.NewLabel("other", "foo", labels.LabelSourceK8s),
+		"host":           labels.NewLabel("host", "", labels.LabelSourceReserved),
+	}
+
+	filtered, info := validLabelPrefixes.filterLabels(allLabels)
+
+	// id.lizards matches the anchored regexp and host matches the reserved
+	// wildcard, so both become identity labels.
+	require.Contains(t, filtered, "id.lizards")
+	require.Contains(t, filtered, "host")
+	// id.lizards.k8s does not match the "$" anchored regexp, and "other" does
+	// not match any inclusive prefix, so both are treated as information only.
+	require.NotContains(t, filtered, "id.lizards.k8s")
+	require.NotContains(t, filtered, "other")
+	require.Contains(t, info, "id.lizards.k8s")
+	require.Contains(t, info, "other")
+}
+
+func TestFilterLabelsFromLiteralConfigFile(t *testing.T) {
+	logger := hivetest.Logger(t)
+	path := writeLabelPrefixCfg(
+		t, `{
+		"version": 1,
+		"valid-prefixes": [
+			{"source": "reserved", "prefix": ".*"},
+			{"source": "k8s", "prefix": "id\\.[a-z]+$"}
+		]
+	}`,
+	)
+
+	err := ParseLabelPrefixCfg(logger, nil, nil, path)
+	require.NoError(t, err)
+
+	allLabels := labels.Labels{
+		"id.lizards": labels.NewLabel("id.lizards", "web", labels.LabelSourceK8s),
+		"host":       labels.NewLabel("host", "", labels.LabelSourceReserved),
+	}
+
+	filtered, info := validLabelPrefixes.filterLabels(allLabels)
+
+	// With version 1 the prefixes are matched literally, so neither the
+	// regexp-looking prefix "id\.[a-z]+$" nor the literal ".*" prefix match any
+	// of the labels; every label is treated as information only.
+	require.NotContains(t, filtered, "id.lizards")
+	require.NotContains(t, filtered, "host")
+	require.Contains(t, info, "id.lizards")
+	require.Contains(t, info, "host")
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

Implements a version `2` of the label prefix file config which supports regex prefix matching in-line with that available via `--label-prefix-filter`. This is backwards compatible as existing configs using `version: 1` will continue to operate as they always have.

Fixes: #47918

```release-note
Introduces a new version `2` for the config used with `--label-prefix-file` that supports RegEx prefix matching.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
