### PR TITLE
gha: move GCP auth pin past the STS token exchange retry fix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,7 +86,14 @@
     // 'google/oss-fuzz' is ignored from the updates because it's currently
     // unversioned and it would be receiving an update every time the upstream
     // repository would receive a new commit.
-    "google/oss-fuzz"
+    "google/oss-fuzz",
+    // 'google-github-actions/auth' is deliberately pinned a few commits ahead
+    // of the newest tag, to a commit that carries the STS token exchange retry
+    // fix (google-github-actions/auth#532). 'pinDigests' plus the
+    // 'auto-merge-trusted-deps' membership below would otherwise re-pin the
+    // digest back to v3.0.0 and silently revert it. Drop this entry once
+    // upstream tags a release above v3.0.0 containing that fix.
+    "google-github-actions/auth"
   ],
   "pinDigests": true,
   // We don't want to separate major and minor upgrades in separate PRs since

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Set up gcloud credentials
         id: 'auth'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PR_SA }}
@@ -377,7 +377,7 @@ jobs:
 
       - name: Set up gcloud credentials
         id: 'auth'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PR_SA }}

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -171,7 +171,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -250,7 +250,7 @@ jobs:
           go-version: 1.26.6
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Set up gcloud credentials
         id: 'auth'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-cleanup-kops.yaml
+++ b/.github/workflows/scale-cleanup-kops.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -210,7 +210,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -177,7 +177,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -137,7 +137,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -306,7 +306,7 @@ jobs:
           go-version: 1.26.6
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -113,7 +113,7 @@ jobs:
         uses: cilium/scale-tests-action/install-kops@529d919e01deb35642ba5c6ecdcbf2e2311cd3de # main
 
       - name: Setup gcloud credentials
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: google-github-actions/auth@12060449e87204eca501a11f2f7f1483024afff0 # v3.0.0 + google-github-actions/auth#532
         with:
           workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PERF_SA }}


### PR DESCRIPTION
Every GCP-touching workflow dies outright when one TCP connection is
lost in the "Set up gcloud credentials" step. google-github-actions/auth
writes the credentials file locally, then makes a single Workload
Identity token exchange against sts.googleapis.com as a misconfiguration
pre-flight whose auth_token output no cilium workflow reads. That POST
has no fault tolerance: the action asks @actions/http-client for
allowRetries with maxRetries 3, but the client grants retries only to
OPTIONS, GET, DELETE and HEAD, and even then only on a 502, 503 or 504
response, never on a socket error. A reset therefore ends authentication
on the first attempt, before any cluster is created. In
https://github.com/cilium/cilium/actions/runs/33262413149/job/99126603998
the KPR+IPsec leg died 61 ms after writing the credentials file, with
every step from cluster creation to the connectivity test reported as
skipped.

Upstream fixed this in google-github-actions/auth#532, merged on
2026-07-29, but cut no release: v3 and v3.0.0 both still resolve to the
commit three before it, so the tag-following auto-merge-trusted-deps
group can never reach the fix. Move the pin at all eleven call sites
onto 12060449e872, whose dist bundle carries the rebuilt fix and whose
only other delta over v3.0.0 is two README edits and a checkout bump in
the action's own CI. A misconfigured provider or an unbound service
account still fails on the first attempt.

Renovate needs the ignoreDeps entry because pinDigests plus that group
membership would otherwise re-pin down to the newest tag and silently
revert this. It goes away once upstream tags a release above v3.0.0.

This PR was prepared with AIL:3. I personally checked the upstream
dist bundles at both pins.
