### PR TITLE
ipcache: Reconcile IPCache entries from the node table

### DIFF
--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -46,6 +46,8 @@ var Cell = cell.Module(
 	restoration.Cell,
 
 	cell.Invoke(
+		ipcache.RegisterNodeObserver,
+
 		// Register the watcher to the fence to ensure that we wait for ipcache
 		// synchronization from the kvstore (when enabled) before endpoint
 		// regeneration, to ensure that the ipcache map is ready at that point.

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -97,8 +97,8 @@ func newIPCache(params ipCacheParams) *ipcache.IPCache {
 		Logger:            params.Logger,
 		IdentityAllocator: params.CacheIdentityAllocator,
 		IdentityUpdater:   params.IdentityUpdater,
-		CacheStatus:       params.CacheStatus,
 	})
+	ipc.RegisterSync(params.CacheStatus)
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -538,7 +538,6 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 type MetadataBatchAPI interface {
 	UpsertMetadataBatch(updates ...MU) (revision uint64)
 	RemoveMetadataBatch(updates ...MU) (revision uint64)
-	WaitForRevision(ctx context.Context, rev uint64) error
 }
 
 var _ MetadataBatchAPI = &IPCache{}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -109,7 +108,6 @@ type Configuration struct {
 	// Accessors to other subsystems, provided by the daemon
 	cache.IdentityAllocator
 	ipcacheTypes.IdentityUpdater
-	synced.CacheStatus
 }
 
 // IPCache is a collection of mappings:
@@ -159,6 +157,9 @@ type IPCache struct {
 	// injectionStarted is a sync.Once so we can lazily start the prefix injection controller,
 	// but only once
 	injectionStarted sync.Once
+
+	syncsMu sync.Mutex
+	syncs   []<-chan struct{}
 }
 
 // CIDRSelectorAllocator defines the interface to trigger identity resolution for
@@ -194,6 +195,30 @@ func NewIPCache(c *Configuration) *IPCache {
 		Configuration:     c,
 	}
 	return ipc
+}
+
+// RegisterSync registers a channel that must close before IPCache metadata is
+// injected. Sync channels must be registered before metadata injection starts.
+func (ipc *IPCache) RegisterSync(ch <-chan struct{}) {
+	if ch == nil {
+		return
+	}
+	ipc.syncsMu.Lock()
+	ipc.syncs = append(ipc.syncs, ch)
+	ipc.syncsMu.Unlock()
+}
+
+func (ipc *IPCache) synchronized() bool {
+	ipc.syncsMu.Lock()
+	defer ipc.syncsMu.Unlock()
+	for _, ch := range ipc.syncs {
+		select {
+		case <-ch:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // Shutdown cleans up asynchronous routines associated with the IPCache.
@@ -536,6 +561,7 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 }
 
 type MetadataBatchAPI interface {
+	RegisterSync(ch <-chan struct{})
 	UpsertMetadataBatch(updates ...MU) (revision uint64)
 	RemoveMetadataBatch(updates ...MU) (revision uint64)
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -369,8 +370,8 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []cmtyp
 		return modifiedPrefixes, ErrLocalIdentityAllocatorUninitialized
 	}
 
-	if !ipc.Configuration.CacheStatus.Synchronized() {
-		return modifiedPrefixes, errors.New("k8s cache not fully synced")
+	if !ipc.synchronized() {
+		return modifiedPrefixes, errors.New("ipcache prerequisites not fully synced")
 	}
 
 	type ipcacheEntry struct {
@@ -996,14 +997,14 @@ var chunkSize = 512
 // handleLabelInjection dequeues the set of pending prefixes and processes
 // their metadata updates
 func (ipc *IPCache) handleLabelInjection(ctx context.Context) error {
-	if ipc.Configuration.CacheStatus != nil {
-		// wait for k8s caches to sync.
-		// this is duplicated from doInjectLabels(), but it keeps us from needlessly
-		// churning the queue while the agent initializes.
+	ipc.syncsMu.Lock()
+	syncs := slices.Clone(ipc.syncs)
+	ipc.syncsMu.Unlock()
+	for _, ch := range syncs {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ipc.Configuration.CacheStatus:
+		case <-ch:
 		}
 	}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache/types"
-	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8ssynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -678,19 +679,19 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 func TestAllMetadata(t *testing.T) {
 	s := setupIPCacheTestSuite(t)
 
-	tp1 := ipcachetypes.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.1")}
-	tp2 := ipcachetypes.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.2")}
+	tp1 := types.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.1")}
+	tp2 := types.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.2")}
 
-	ec1 := ipcachetypes.EncryptKey(1)
-	ec2 := ipcachetypes.EncryptKey(2)
+	ec1 := types.EncryptKey(1)
+	ec2 := types.EncryptKey(2)
 
-	ri1 := ipcachetypes.RequestedIdentity(1)
-	ri2 := ipcachetypes.RequestedIdentity(2)
+	ri1 := types.RequestedIdentity(1)
+	ri2 := types.RequestedIdentity(2)
 
-	epf1 := ipcachetypes.EndpointFlags{}
+	epf1 := types.EndpointFlags{}
 	epf1.SetRemoteCluster(true)
 
-	epf2 := ipcachetypes.EndpointFlags{}
+	epf2 := types.EndpointFlags{}
 	epf2.SetSkipTunnel(true)
 
 	steps := []struct {
@@ -852,7 +853,7 @@ func TestAllMetadata(t *testing.T) {
 			},
 		},
 		{
-			del:    ipcachetypes.AllMetadata{},
+			del:    types.AllMetadata{},
 			result: nil,
 		},
 	}
@@ -981,6 +982,44 @@ func TestHandleLabelInjection(t *testing.T) {
 	require.Contains(t, ipc.ipToIdentityCache, inClusterPrefix.String())
 	require.Contains(t, ipc.ipToIdentityCache, inClusterPrefix2.String())
 	require.NoError(t, err)
+}
+
+func TestHandleLabelInjectionWaitsForRegisteredSyncs(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ipc := s.IPIdentityCache
+	cacheStatus := make(k8ssynced.CacheStatus)
+	nodeObserverSynced := make(chan struct{})
+	ipc.RegisterSync(cacheStatus)
+	ipc.RegisterSync(nodeObserverSynced)
+	require.False(t, ipc.synchronized())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ipc.handleLabelInjection(t.Context())
+	}()
+
+	select {
+	case <-done:
+		require.FailNow(t, "metadata injection completed before cache synchronization")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(cacheStatus)
+	require.False(t, ipc.synchronized())
+	select {
+	case <-done:
+		require.FailNow(t, "metadata injection completed before node observer synchronization")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(nodeObserverSynced)
+	require.True(t, ipc.synchronized())
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "metadata injection did not complete after initial synchronization")
+	}
 }
 
 func TestMetadataRevision(t *testing.T) {

--- a/pkg/ipcache/node_observer.go
+++ b/pkg/ipcache/node_observer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -36,6 +37,7 @@ type nodeObserver struct {
 	db          *statedb.DB
 	nodes       statedb.Table[*node.Node]
 	ipcache     MetadataBatchAPI
+	synced      chan struct{}
 	config      *option.DaemonConfig
 	clusterInfo cmtypes.ClusterInfo
 	underlay    tunnel.UnderlayProtocol
@@ -57,11 +59,14 @@ func RegisterNodeObserver(
 	tunnelConfig tunnel.Config,
 	wgConfig wgTypes.Config,
 ) {
+	synced := make(chan struct{})
+	ipcache.RegisterSync(synced)
 	nodeTable := nodeWriter.Table()
 	observer := &nodeObserver{
 		db:          db,
 		nodes:       nodeTable,
 		ipcache:     ipcache,
+		synced:      synced,
 		config:      config,
 		clusterInfo: clusterInfo,
 		underlay:    tunnelConfig.UnderlayProtocol(),
@@ -72,6 +77,8 @@ func RegisterNodeObserver(
 }
 
 func (o *nodeObserver) run(ctx context.Context, health cell.Health) error {
+	const applyInterval = 100 * time.Millisecond
+
 	if _, err := node.WaitForLocalNodeInit(ctx, o.db, o.nodes); err != nil {
 		return nil
 	}
@@ -85,17 +92,26 @@ func (o *nodeObserver) run(ctx context.Context, health cell.Health) error {
 	wtxn.Commit()
 	defer changes.Close()
 
-	txn := o.db.ReadTxn()
 	for {
+		txn := o.db.ReadTxn()
 		seq, watch := changes.Next(txn)
 		o.apply(txn, seq)
 		health.OK("Node changes processed")
 
-		select {
-		case <-ctx.Done():
+		watches := statedb.NewWatchSet()
+		watches.Add(watch)
+		if o.synced != nil {
+			initialized, initWatch := o.nodes.Initialized(txn)
+			if initialized {
+				close(o.synced)
+				o.synced = nil
+			} else {
+				watches.Add(initWatch)
+			}
+		}
+
+		if _, err := watches.Wait(ctx, applyInterval); err != nil {
 			return nil
-		case <-watch:
-			txn = o.db.ReadTxn()
 		}
 	}
 }

--- a/pkg/ipcache/node_observer.go
+++ b/pkg/ipcache/node_observer.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"maps"
+	"net/netip"
+	"reflect"
+	"slices"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"go4.org/netipx"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/ip"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
+)
+
+type nodeObserver struct {
+	db          *statedb.DB
+	nodes       statedb.Table[*node.Node]
+	ipcache     MetadataBatchAPI
+	config      *option.DaemonConfig
+	clusterInfo cmtypes.ClusterInfo
+	underlay    tunnel.UnderlayProtocol
+	wgConfig    wgTypes.Config
+
+	lastApplied          map[nodeTypes.Identity]map[cmtypes.PrefixCluster]MU
+	optOutNodeEncryption bool
+}
+
+// RegisterNodeObserver registers the job that derives IPCache metadata from
+// the node table.
+func RegisterNodeObserver(
+	db *statedb.DB,
+	jobs job.Group,
+	nodeWriter *node.Writer,
+	ipcache MetadataBatchAPI,
+	config *option.DaemonConfig,
+	clusterInfo cmtypes.ClusterInfo,
+	tunnelConfig tunnel.Config,
+	wgConfig wgTypes.Config,
+) {
+	nodeTable := nodeWriter.Table()
+	observer := &nodeObserver{
+		db:          db,
+		nodes:       nodeTable,
+		ipcache:     ipcache,
+		config:      config,
+		clusterInfo: clusterInfo,
+		underlay:    tunnelConfig.UnderlayProtocol(),
+		wgConfig:    wgConfig,
+		lastApplied: map[nodeTypes.Identity]map[cmtypes.PrefixCluster]MU{},
+	}
+	jobs.Add(job.OneShot("node-ipcache", observer.run))
+}
+
+func (o *nodeObserver) run(ctx context.Context, health cell.Health) error {
+	if _, err := node.WaitForLocalNodeInit(ctx, o.db, o.nodes); err != nil {
+		return nil
+	}
+
+	wtxn := o.db.WriteTxn(o.nodes)
+	changes, err := o.nodes.Changes(wtxn)
+	if err != nil {
+		wtxn.Abort()
+		return fmt.Errorf("creating node change iterator: %w", err)
+	}
+	wtxn.Commit()
+	defer changes.Close()
+
+	txn := o.db.ReadTxn()
+	for {
+		seq, watch := changes.Next(txn)
+		o.apply(txn, seq)
+		health.OK("Node changes processed")
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+			txn = o.db.ReadTxn()
+		}
+	}
+}
+
+func (o *nodeObserver) apply(
+	txn statedb.ReadTxn,
+	changes iter.Seq2[statedb.Change[*node.Node], statedb.Revision],
+) {
+	affected := set.NewSet[nodeTypes.Identity]()
+	reapplyNodes := false
+	for change := range changes {
+		affected.Insert(change.Object.Identity())
+		if change.Deleted || change.Object.Local == nil {
+			continue
+		}
+		optOut := change.Object.Local.OptOutNodeEncryption
+		if o.optOutNodeEncryption != optOut {
+			o.optOutNodeEncryption = optOut
+			reapplyNodes = true
+		}
+	}
+
+	if reapplyNodes {
+		for n := range o.nodes.All(txn) {
+			if n.Local == nil {
+				affected.Insert(n.Identity())
+			}
+		}
+	}
+
+	var upserts, removals []MU
+	for identity := range affected.Members() {
+		old := o.lastApplied[identity]
+		n, _, found := o.nodes.Get(txn, node.NodeByName(identity.String()))
+		if !found {
+			removals = append(removals, metadataRemovals(old, nil)...)
+			delete(o.lastApplied, identity)
+			continue
+		}
+
+		desired := o.metadataForNode(n)
+		if reflect.DeepEqual(old, desired) {
+			continue
+		}
+		upserts = append(upserts, slices.Collect(maps.Values(desired))...)
+		removals = append(removals, metadataRemovals(old, desired)...)
+		o.lastApplied[identity] = desired
+	}
+	if len(upserts) > 0 {
+		o.ipcache.UpsertMetadataBatch(upserts...)
+	}
+	if len(removals) > 0 {
+		o.ipcache.RemoveMetadataBatch(removals...)
+	}
+}
+
+func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]MU {
+	metadata := map[cmtypes.PrefixCluster]MU{}
+	resource := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindNode,
+		n.Cluster,
+		n.Name,
+	)
+	add := func(prefix cmtypes.PrefixCluster, values ...IPMetadata) {
+		entry := metadata[prefix]
+		entry.Prefix = prefix
+		entry.Source = n.Source
+		entry.Resource = resource
+		entry.Metadata = append(entry.Metadata, values...)
+		metadata[prefix] = entry
+	}
+
+	var nodeIP netip.Addr
+	if value := n.GetNodeIP(o.underlay == tunnel.IPv6); value != nil {
+		nodeIP, _ = netipx.FromStdIP(value)
+	}
+	nodeLabels := o.nodeIdentityLabels(n)
+	encryptNodeIPs := o.nodeAddressHasEncryptKey()
+
+	for _, address := range n.IPAddresses {
+		prefix := ip.IPToNetPrefix(address.IP)
+		prefixCluster := cmtypes.NewLocalPrefixCluster(prefix)
+		if address.Type == addressing.NodeCiliumInternalIP {
+			prefixCluster = cmtypes.PrefixClusterFrom(prefix)
+		}
+
+		var tunnelIP netip.Addr
+		if o.nodeAddressHasTunnelIP(address) {
+			tunnelIP = nodeIP
+		}
+		var key uint8
+		if encryptNodeIPs {
+			key = n.EncryptionKey
+		}
+		endpointFlags := ipcacheTypes.EndpointFlags{}
+		if n.Cluster != o.clusterInfo.Name {
+			endpointFlags.SetRemoteCluster(true)
+		}
+		addressLabels := nodeLabels
+		if o.config.PolicyCIDRMatchesNodes() {
+			addressLabels = labels.NewFrom(nodeLabels)
+			addressLabels.MergeLabels(labels.GetCIDRLabels(prefix))
+		}
+		add(prefixCluster,
+			addressLabels,
+			ipcacheTypes.TunnelPeer{Addr: tunnelIP},
+			ipcacheTypes.EncryptKey(key),
+			endpointFlags,
+		)
+	}
+
+	if n.Local == nil {
+		for _, prefixes := range [][]netip.Prefix{
+			n.GetIPv4AllocCIDRs(),
+			n.GetIPv6AllocCIDRs(),
+		} {
+			for _, prefix := range prefixes {
+				if !prefix.IsValid() {
+					continue
+				}
+				prefixCluster := cmtypes.PrefixClusterFrom(prefix)
+				add(prefixCluster,
+					worldLabelForPrefix(prefix),
+					ipcacheTypes.TunnelPeer{Addr: nodeIP},
+					ipcacheTypes.EncryptKey(n.EncryptionKey),
+				)
+			}
+		}
+	}
+
+	for _, address := range []netip.Addr{n.IPv4HealthIP.Addr, n.IPv6HealthIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
+		if prefix.IsValid() {
+			add(cmtypes.PrefixClusterFrom(prefix),
+				labels.LabelHealth,
+				ipcacheTypes.TunnelPeer{Addr: nodeIP},
+				o.endpointEncryptionKey(n),
+			)
+		}
+	}
+
+	for _, address := range []netip.Addr{n.IPv4IngressIP.Addr, n.IPv6IngressIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
+		if prefix.IsValid() {
+			add(cmtypes.PrefixClusterFrom(prefix),
+				labels.LabelIngress,
+				ipcacheTypes.TunnelPeer{Addr: nodeIP},
+				o.endpointEncryptionKey(n),
+			)
+		}
+	}
+	return metadata
+}
+
+func (o *nodeObserver) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
+	return address.Type == addressing.NodeCiliumInternalIP ||
+		o.config.NodeEncryptionEnabled() || o.config.EnableHostFirewall
+}
+
+func (o *nodeObserver) nodeAddressHasEncryptKey() bool {
+	return o.config.NodeEncryptionEnabled() && !o.optOutNodeEncryption
+}
+
+func (o *nodeObserver) endpointEncryptionKey(n *node.Node) ipcacheTypes.EncryptKey {
+	if o.wgConfig.Enabled() {
+		return ipcacheTypes.EncryptKey(wgTypes.StaticEncryptKey)
+	}
+	return ipcacheTypes.EncryptKey(n.EncryptionKey)
+}
+
+func (o *nodeObserver) nodeIdentityLabels(n *node.Node) labels.Labels {
+	nodeLabels := labels.NewFrom(labels.LabelRemoteNode)
+	if n.Local != nil {
+		nodeLabels = labels.NewFrom(labels.LabelHost)
+		if o.config.PolicyCIDRMatchesNodes() {
+			for _, address := range n.IPAddresses {
+				addr, ok := netipx.FromStdIP(address.IP)
+				if ok && ((o.config.EnableIPv4 && addr.Is4()) ||
+					(o.config.EnableIPv6 && addr.Is6())) {
+					nodeLabels.MergeLabels(labels.GetCIDRLabels(
+						netip.PrefixFrom(addr, addr.BitLen()),
+					))
+				}
+			}
+		}
+	}
+
+	if o.config.PerNodeLabelsEnabled() {
+		filtered, _ := labelsfilter.FilterNodeLabels(
+			labels.Map2Labels(n.Labels, labels.LabelSourceNode),
+		)
+		nodeLabels.MergeLabels(filtered)
+		nodeLabels.MergeLabels(labels.Map2Labels(map[string]string{
+			k8sConst.PolicyLabelCluster: n.Cluster,
+		}, labels.LabelSourceK8s))
+	}
+	return nodeLabels
+}
+
+func worldLabelForPrefix(prefix netip.Prefix) labels.Labels {
+	lbls := make(labels.Labels, 1)
+	lbls.AddWorldLabel(prefix.Addr())
+	return lbls
+}
+
+func metadataRemovals(
+	old, desired map[cmtypes.PrefixCluster]MU,
+) []MU {
+	removals := make([]MU, 0, len(old))
+	for prefix, oldEntry := range old {
+		newEntry, found := desired[prefix]
+		if !found {
+			oldEntry.Metadata = []IPMetadata{ipcacheTypes.AllMetadata{}}
+			removals = append(removals, oldEntry)
+			continue
+		}
+
+		newKinds := set.NewSet[reflect.Type]()
+		for _, metadata := range newEntry.Metadata {
+			newKinds.Insert(reflect.TypeOf(metadata))
+		}
+		var removed []IPMetadata
+		for _, metadata := range oldEntry.Metadata {
+			if !newKinds.Has(reflect.TypeOf(metadata)) {
+				removed = append(removed, metadata)
+			}
+		}
+		if len(removed) > 0 {
+			oldEntry.Metadata = removed
+			removals = append(removals, oldEntry)
+		}
+	}
+	return removals
+}

--- a/pkg/ipcache/node_observer.go
+++ b/pkg/ipcache/node_observer.go
@@ -179,7 +179,7 @@ func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]M
 		prefix := ip.IPToNetPrefix(address.IP)
 		prefixCluster := cmtypes.NewLocalPrefixCluster(prefix)
 		if address.Type == addressing.NodeCiliumInternalIP {
-			prefixCluster = cmtypes.PrefixClusterFrom(prefix)
+			prefixCluster = nodePrefixCluster(n, prefix)
 		}
 
 		var tunnelIP netip.Addr
@@ -216,7 +216,7 @@ func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]M
 				if !prefix.IsValid() {
 					continue
 				}
-				prefixCluster := cmtypes.PrefixClusterFrom(prefix)
+				prefixCluster := nodePrefixCluster(n, prefix)
 				add(prefixCluster,
 					worldLabelForPrefix(prefix),
 					ipcacheTypes.TunnelPeer{Addr: nodeIP},
@@ -229,7 +229,7 @@ func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]M
 	for _, address := range []netip.Addr{n.IPv4HealthIP.Addr, n.IPv6HealthIP.Addr} {
 		prefix := netip.PrefixFrom(address, address.BitLen())
 		if prefix.IsValid() {
-			add(cmtypes.PrefixClusterFrom(prefix),
+			add(nodePrefixCluster(n, prefix),
 				labels.LabelHealth,
 				ipcacheTypes.TunnelPeer{Addr: nodeIP},
 				o.endpointEncryptionKey(n),
@@ -240,7 +240,7 @@ func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]M
 	for _, address := range []netip.Addr{n.IPv4IngressIP.Addr, n.IPv6IngressIP.Addr} {
 		prefix := netip.PrefixFrom(address, address.BitLen())
 		if prefix.IsValid() {
-			add(cmtypes.PrefixClusterFrom(prefix),
+			add(nodePrefixCluster(n, prefix),
 				labels.LabelIngress,
 				ipcacheTypes.TunnelPeer{Addr: nodeIP},
 				o.endpointEncryptionKey(n),
@@ -248,6 +248,10 @@ func (o *nodeObserver) metadataForNode(n *node.Node) map[cmtypes.PrefixCluster]M
 		}
 	}
 	return metadata
+}
+
+func nodePrefixCluster(n *node.Node, prefix netip.Prefix) cmtypes.PrefixCluster {
+	return cmtypes.NewPrefixCluster(prefix, n.AddressClusterID())
 }
 
 func (o *nodeObserver) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {

--- a/pkg/ipcache/node_observer_test.go
+++ b/pkg/ipcache/node_observer_test.go
@@ -189,6 +189,14 @@ func updatesByPrefix(updates []MU) map[netip.Prefix]MU {
 	return byPrefix
 }
 
+func updatesByPrefixCluster(updates []MU) map[cmtypes.PrefixCluster]MU {
+	byPrefix := make(map[cmtypes.PrefixCluster]MU, len(updates))
+	for _, update := range updates {
+		byPrefix[update.Prefix] = update
+	}
+	return byPrefix
+}
+
 func metadataValue[T any](t *testing.T, update MU) T {
 	t.Helper()
 	for _, metadata := range update.Metadata {
@@ -387,6 +395,86 @@ func TestNodeObserverCollapsesIntermediateChanges(t *testing.T) {
 	require.Len(t, metadata.upserts[0], 1)
 	require.Equal(t, netip.MustParsePrefix("10.0.0.2/32"),
 		metadata.upserts[0][0].Prefix.AsPrefix())
+}
+
+func TestNodeObserverClusterAwarePrefixes(t *testing.T) {
+	observer, metadata, db, nodes := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{},
+		fakewireguard.Config{},
+	)
+	writer := node.NewWriter(hivetest.Logger(t), db, nodes)
+	writer.SetPrefixClusterMutatorFn(func(n *nodeTypes.Node) []cmtypes.PrefixClusterOpts {
+		return []cmtypes.PrefixClusterOpts{cmtypes.WithClusterID(n.ClusterID)}
+	})
+
+	n := &nodeTypes.Node{
+		Name:      "node1",
+		Cluster:   "cluster1",
+		ClusterID: 10,
+		Source:    source.Kubernetes,
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("10.0.0.1")},
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("192.0.2.1")},
+		},
+		IPv4AllocCIDR: nodeTypes.PrefixFrom(
+			netip.MustParsePrefix("10.1.0.0/24"),
+		),
+		IPv4HealthIP:  ip.AddrFrom(netip.MustParseAddr("10.0.0.2")),
+		IPv4IngressIP: ip.AddrFrom(netip.MustParseAddr("10.0.0.3")),
+	}
+	txn := db.WriteTxn(nodes)
+	require.True(t, writer.Upsert(txn, n))
+	txn.Commit()
+	stored, _, found := nodes.Get(db.ReadTxn(), node.NodeByName(n.Identity().String()))
+	require.True(t, found)
+
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: stored}}))
+	require.Len(t, metadata.upserts, 1)
+	upserts := updatesByPrefixCluster(metadata.upserts[0])
+	for _, prefix := range []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.1/32"),
+		netip.MustParsePrefix("10.1.0.0/24"),
+		netip.MustParsePrefix("10.0.0.2/32"),
+		netip.MustParsePrefix("10.0.0.3/32"),
+	} {
+		require.Contains(t, upserts, cmtypes.PrefixClusterFrom(
+			prefix,
+			cmtypes.WithClusterID(10),
+		))
+	}
+	require.Contains(t, upserts, cmtypes.NewLocalPrefixCluster(
+		netip.MustParsePrefix("192.0.2.1/32"),
+	))
+
+	updated := n.DeepCopy()
+	updated.ClusterID = 20
+	txn = db.WriteTxn(nodes)
+	require.True(t, writer.Upsert(txn, updated))
+	txn.Commit()
+	stored, _, found = nodes.Get(db.ReadTxn(), node.NodeByName(updated.Identity().String()))
+	require.True(t, found)
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: stored}}))
+	require.Len(t, metadata.upserts, 2)
+	require.Len(t, metadata.removals, 1)
+
+	upserts = updatesByPrefixCluster(metadata.upserts[1])
+	removals := updatesByPrefixCluster(metadata.removals[0])
+	for _, prefix := range []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.1/32"),
+		netip.MustParsePrefix("10.1.0.0/24"),
+		netip.MustParsePrefix("10.0.0.2/32"),
+		netip.MustParsePrefix("10.0.0.3/32"),
+	} {
+		require.Contains(t, upserts, cmtypes.PrefixClusterFrom(
+			prefix,
+			cmtypes.WithClusterID(20),
+		))
+		require.Contains(t, removals, cmtypes.PrefixClusterFrom(
+			prefix,
+			cmtypes.WithClusterID(10),
+		))
+	}
 }
 
 func mapKeys(entries map[netip.Prefix]MU) []netip.Prefix {

--- a/pkg/ipcache/node_observer_test.go
+++ b/pkg/ipcache/node_observer_test.go
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"iter"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/ip"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
+)
+
+type metadataBatchMock struct {
+	upserts  [][]MU
+	removals [][]MU
+	notify   chan struct{}
+}
+
+func changeSeq(changes []statedb.Change[*node.Node]) iter.Seq2[statedb.Change[*node.Node], statedb.Revision] {
+	return func(yield func(statedb.Change[*node.Node], statedb.Revision) bool) {
+		for _, change := range changes {
+			if !yield(change, change.Revision) {
+				return
+			}
+		}
+	}
+}
+
+func (m *metadataBatchMock) UpsertMetadataBatch(updates ...MU) uint64 {
+	m.upserts = append(m.upserts, append([]MU(nil), updates...))
+	if m.notify != nil {
+		m.notify <- struct{}{}
+	}
+	return 0
+}
+
+func (m *metadataBatchMock) RemoveMetadataBatch(updates ...MU) uint64 {
+	m.removals = append(m.removals, append([]MU(nil), updates...))
+	if m.notify != nil {
+		m.notify <- struct{}{}
+	}
+	return 0
+}
+
+type testHealth struct{}
+
+func (testHealth) OK(string)                     {}
+func (testHealth) Stopped(string)                {}
+func (testHealth) Degraded(string, error)        {}
+func (h testHealth) NewScope(string) cell.Health { return h }
+func (testHealth) Close()                        {}
+
+func TestNodeObserverWaitsForLocalNodeInitialization(t *testing.T) {
+	db := statedb.New()
+	nodes, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+	metadata := &metadataBatchMock{notify: make(chan struct{}, 1)}
+	observer := &nodeObserver{
+		db:          db,
+		nodes:       nodes,
+		ipcache:     metadata,
+		config:      &option.DaemonConfig{},
+		clusterInfo: cmtypes.DefaultClusterInfo,
+		underlay:    tunnel.IPv4,
+		wgConfig:    fakewireguard.Config{},
+		lastApplied: map[nodeTypes.Identity]map[cmtypes.PrefixCluster]MU{},
+	}
+
+	txn := db.WriteTxn(nodes)
+	initDone := nodes.RegisterInitializer(txn, node.LocalNodeTableInitializerName)
+	_, _, err = nodes.Insert(txn, &node.Node{Node: nodeTypes.Node{
+		Name: "remote",
+		IPAddresses: []nodeTypes.Address{{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		}},
+	}})
+	require.NoError(t, err)
+	txn.Commit()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- observer.run(ctx, testHealth{}) }()
+
+	select {
+	case <-metadata.notify:
+		require.FailNow(t, "observer ran before local node initialization")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	txn = db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, &node.Node{
+		Node:  nodeTypes.Node{Name: "local", Source: source.Local},
+		Local: &node.LocalNodeInfo{},
+	})
+	require.NoError(t, err)
+	initDone(txn)
+	txn.Commit()
+
+	select {
+	case <-metadata.notify:
+	case <-time.After(time.Second):
+		require.FailNow(t, "observer did not process initial node snapshot")
+	}
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func newTestNodeObserver(
+	t *testing.T,
+	config *option.DaemonConfig,
+	wgConfig fakewireguard.Config,
+) (*nodeObserver, *metadataBatchMock, *statedb.DB, statedb.RWTable[*node.Node]) {
+	t.Helper()
+	db := statedb.New()
+	nodes, err := node.NewNodeTable(db)
+	require.NoError(t, err)
+	metadata := &metadataBatchMock{}
+	return &nodeObserver{
+		db:          db,
+		nodes:       nodes,
+		ipcache:     metadata,
+		config:      config,
+		clusterInfo: cmtypes.DefaultClusterInfo,
+		underlay:    tunnel.IPv4,
+		wgConfig:    wgConfig,
+		lastApplied: map[nodeTypes.Identity]map[cmtypes.PrefixCluster]MU{},
+	}, metadata, db, nodes
+}
+
+func applyNodeUpdate(
+	t *testing.T,
+	observer *nodeObserver,
+	db *statedb.DB,
+	nodes statedb.RWTable[*node.Node],
+	n *node.Node,
+) {
+	t.Helper()
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Insert(txn, n)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: n}}))
+}
+
+func applyNodeDelete(
+	t *testing.T,
+	observer *nodeObserver,
+	db *statedb.DB,
+	nodes statedb.RWTable[*node.Node],
+	n *node.Node,
+) {
+	t.Helper()
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Delete(txn, n)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{
+		Object:  n,
+		Deleted: true,
+	}}))
+}
+
+func updatesByPrefix(updates []MU) map[netip.Prefix]MU {
+	byPrefix := make(map[netip.Prefix]MU, len(updates))
+	for _, update := range updates {
+		byPrefix[update.Prefix.AsPrefix()] = update
+	}
+	return byPrefix
+}
+
+func metadataValue[T any](t *testing.T, update MU) T {
+	t.Helper()
+	for _, metadata := range update.Metadata {
+		if value, ok := metadata.(T); ok {
+			return value
+		}
+	}
+	var zero T
+	require.FailNow(t, "metadata type not found", "%T", zero)
+	return zero
+}
+
+func TestNodeObserverMetadataLifecycle(t *testing.T) {
+	observer, metadata, db, nodes := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{},
+		fakewireguard.Config{},
+	)
+	n := &node.Node{Node: nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "cluster1",
+		Source:  source.Kubernetes,
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.2")},
+			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
+		},
+		IPv4AllocCIDR: nodeTypes.PrefixFrom(
+			netip.MustParsePrefix("10.0.0.0/24"),
+		),
+		IPv4SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(
+			netip.MustParsePrefix("192.168.10.0/28"),
+		)},
+		IPv6AllocCIDR: nodeTypes.PrefixFrom(
+			netip.MustParsePrefix("f00d::/96"),
+		),
+		IPv6SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(
+			netip.MustParsePrefix("cafe::/96"),
+		)},
+		IPv4HealthIP:  ip.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		IPv6HealthIP:  ip.AddrFrom(netip.MustParseAddr("f00d::4")),
+		IPv4IngressIP: ip.AddrFrom(netip.MustParseAddr("10.0.0.5")),
+		IPv6IngressIP: ip.AddrFrom(netip.MustParseAddr("f00d::5")),
+		EncryptionKey: 42,
+	}}
+
+	applyNodeUpdate(t, observer, db, nodes, n)
+	require.Len(t, metadata.upserts, 1)
+	upserts := updatesByPrefix(metadata.upserts[0])
+	require.Len(t, upserts, 11)
+
+	nodeAddress := upserts[netip.MustParsePrefix("1.1.1.1/32")]
+	require.Equal(t, source.Kubernetes, nodeAddress.Source)
+	require.Equal(t,
+		ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "cluster1", "node1"),
+		nodeAddress.Resource,
+	)
+	require.True(t, labels.LabelRemoteNode.Equals(
+		metadataValue[labels.Labels](t, nodeAddress),
+	))
+	require.Equal(t, netip.MustParseAddr("10.0.0.2"),
+		metadataValue[ipcacheTypes.TunnelPeer](t, nodeAddress).Addr,
+	)
+	require.Equal(t, uint8(ipcacheTypes.FlagRemoteCluster),
+		metadataValue[ipcacheTypes.EndpointFlags](t, nodeAddress).Uint8(),
+	)
+
+	podCIDR := upserts[netip.MustParsePrefix("10.0.0.0/24")]
+	require.Equal(t, ipcacheTypes.EncryptKey(42),
+		metadataValue[ipcacheTypes.EncryptKey](t, podCIDR),
+	)
+	require.True(t, worldLabelForPrefix(podCIDR.Prefix.AsPrefix()).Equals(
+		metadataValue[labels.Labels](t, podCIDR),
+	))
+
+	health := upserts[netip.MustParsePrefix("10.0.0.4/32")]
+	require.True(t, labels.LabelHealth.Equals(
+		metadataValue[labels.Labels](t, health),
+	))
+	require.Equal(t, ipcacheTypes.EncryptKey(42),
+		metadataValue[ipcacheTypes.EncryptKey](t, health),
+	)
+	ingress := upserts[netip.MustParsePrefix("f00d::5/128")]
+	require.True(t, labels.LabelIngress.Equals(
+		metadataValue[labels.Labels](t, ingress),
+	))
+
+	// Status-only table writes do not change the derived metadata.
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: n}}))
+	require.Len(t, metadata.upserts, 1)
+
+	updated := n.DeepCopy()
+	updated.IPAddresses = updated.IPAddresses[:2]
+	updated.IPv4SecondaryAllocCIDRs = nil
+	updated.IPv6SecondaryAllocCIDRs = nil
+	applyNodeUpdate(t, observer, db, nodes, updated)
+	require.Len(t, metadata.removals, 1)
+	removed := updatesByPrefix(metadata.removals[0])
+	require.ElementsMatch(t, []netip.Prefix{
+		netip.MustParsePrefix("f00d::1/128"),
+		netip.MustParsePrefix("192.168.10.0/28"),
+		netip.MustParsePrefix("cafe::/96"),
+	}, mapKeys(removed))
+	for _, removal := range removed {
+		require.Equal(t, []IPMetadata{ipcacheTypes.AllMetadata{}}, removal.Metadata)
+	}
+
+	applyNodeDelete(t, observer, db, nodes, updated)
+	require.Len(t, metadata.removals, 2)
+	removed = updatesByPrefix(metadata.removals[1])
+	require.ElementsMatch(t, mapKeys(updatesByPrefix(metadata.upserts[1])), mapKeys(removed))
+	for _, removal := range removed {
+		require.Equal(t, []IPMetadata{ipcacheTypes.AllMetadata{}}, removal.Metadata)
+	}
+}
+
+func TestNodeObserverBatchesChanges(t *testing.T) {
+	observer, metadata, db, table := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{},
+		fakewireguard.Config{},
+	)
+	nodes := []*node.Node{
+		{Node: nodeTypes.Node{
+			Name:    "node1",
+			Cluster: "cluster1",
+			Source:  source.Kubernetes,
+			IPAddresses: []nodeTypes.Address{{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			}},
+		}},
+		{Node: nodeTypes.Node{
+			Name:    "node2",
+			Cluster: "cluster1",
+			Source:  source.Kubernetes,
+			IPAddresses: []nodeTypes.Address{{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.2"),
+			}},
+		}},
+	}
+	txn := db.WriteTxn(table)
+	for _, n := range nodes {
+		_, _, err := table.Insert(txn, n)
+		require.NoError(t, err)
+	}
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{
+		{Object: nodes[0]},
+		{Object: nodes[1]},
+	}))
+	require.Len(t, metadata.upserts, 1)
+	require.Len(t, metadata.upserts[0], 2)
+
+	txn = db.WriteTxn(table)
+	for _, n := range nodes {
+		_, _, err := table.Delete(txn, n)
+		require.NoError(t, err)
+	}
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{
+		{Object: nodes[0], Deleted: true},
+		{Object: nodes[1], Deleted: true},
+	}))
+	require.Len(t, metadata.removals, 1)
+	require.Len(t, metadata.removals[0], 2)
+}
+
+func TestNodeObserverCollapsesIntermediateChanges(t *testing.T) {
+	observer, metadata, db, table := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{},
+		fakewireguard.Config{},
+	)
+	old := &node.Node{Node: nodeTypes.Node{
+		Name: "node1",
+		IPAddresses: []nodeTypes.Address{{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.1"),
+		}},
+	}}
+	updated := old.DeepCopy()
+	updated.IPAddresses[0].IP = net.ParseIP("10.0.0.2")
+
+	txn := db.WriteTxn(table)
+	_, _, err := table.Insert(txn, updated)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{
+		{Object: old},
+		{Object: updated},
+	}))
+
+	require.Len(t, metadata.upserts, 1)
+	require.Len(t, metadata.upserts[0], 1)
+	require.Equal(t, netip.MustParsePrefix("10.0.0.2/32"),
+		metadata.upserts[0][0].Prefix.AsPrefix())
+}
+
+func mapKeys(entries map[netip.Prefix]MU) []netip.Prefix {
+	keys := make([]netip.Prefix, 0, len(entries))
+	for prefix := range entries {
+		keys = append(keys, prefix)
+	}
+	return keys
+}
+
+func TestMetadataRemovalsForRetainedPrefix(t *testing.T) {
+	prefix := cmtypes.PrefixClusterFrom(netip.MustParsePrefix("10.0.0.1/32"))
+	flags := ipcacheTypes.EndpointFlags{}
+	flags.SetRemoteCluster(true)
+	old := map[cmtypes.PrefixCluster]MU{
+		prefix: {
+			Prefix: prefix,
+			Metadata: []IPMetadata{
+				labels.LabelRemoteNode,
+				ipcacheTypes.TunnelPeer{},
+				ipcacheTypes.EncryptKey(0),
+				flags,
+			},
+		},
+	}
+	desired := map[cmtypes.PrefixCluster]MU{
+		prefix: {
+			Prefix: prefix,
+			Metadata: []IPMetadata{
+				labels.LabelHealth,
+				ipcacheTypes.TunnelPeer{},
+				ipcacheTypes.EncryptKey(0),
+			},
+		},
+	}
+
+	removals := metadataRemovals(old, desired)
+	require.Len(t, removals, 1)
+	require.Equal(t, []IPMetadata{flags}, removals[0].Metadata)
+}
+
+func TestNodeObserverNodeEncryption(t *testing.T) {
+	observer, _, db, nodes := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{EncryptNode: true},
+		fakewireguard.Config{},
+	)
+	local := &node.Node{
+		Node:  nodeTypes.Node{Name: "local", Source: source.Local},
+		Local: &node.LocalNodeInfo{OptOutNodeEncryption: true},
+	}
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Insert(txn, local)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: local}}))
+
+	remote := &node.Node{Node: nodeTypes.Node{
+		Name:          "remote",
+		Cluster:       cmtypes.DefaultClusterInfo.Name,
+		EncryptionKey: 42,
+		IPAddresses: []nodeTypes.Address{{
+			Type: addressing.NodeCiliumInternalIP,
+			IP:   net.ParseIP("10.0.0.2"),
+		}},
+		IPv4HealthIP: ip.AddrFrom(netip.MustParseAddr("10.0.0.3")),
+	}}
+	desired := observer.metadataForNode(remote)
+	require.Equal(t, ipcacheTypes.EncryptKey(0), metadataValue[ipcacheTypes.EncryptKey](
+		t,
+		desired[cmtypes.PrefixClusterFrom(netip.MustParsePrefix("10.0.0.2/32"))],
+	))
+	require.Equal(t, ipcacheTypes.EncryptKey(42), metadataValue[ipcacheTypes.EncryptKey](
+		t,
+		desired[cmtypes.PrefixClusterFrom(netip.MustParsePrefix("10.0.0.3/32"))],
+	))
+
+	local = local.DeepCopy()
+	local.Local.OptOutNodeEncryption = false
+	txn = db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, local)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{{Object: local}}))
+	desired = observer.metadataForNode(remote)
+	require.Equal(t, ipcacheTypes.EncryptKey(42), metadataValue[ipcacheTypes.EncryptKey](
+		t,
+		desired[cmtypes.PrefixClusterFrom(netip.MustParsePrefix("10.0.0.2/32"))],
+	))
+
+	observer.wgConfig = fakewireguard.Config{EnableWireguard: true}
+	desired = observer.metadataForNode(remote)
+	require.Equal(t, ipcacheTypes.EncryptKey(0xff), metadataValue[ipcacheTypes.EncryptKey](
+		t,
+		desired[cmtypes.PrefixClusterFrom(netip.MustParsePrefix("10.0.0.3/32"))],
+	))
+}
+
+func TestNodeObserverNodeIdentityLabels(t *testing.T) {
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(
+		hivetest.Logger(t),
+		nil,
+		nil,
+		"",
+	))
+	observer, _, _, _ := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{
+			EnableIPv4:               true,
+			EnableNodeSelectorLabels: true,
+			PolicyCIDRMatchMode:      []string{"nodes"},
+		},
+		fakewireguard.Config{},
+	)
+
+	local := &node.Node{
+		Node: nodeTypes.Node{
+			Name:    "local",
+			Cluster: "cluster1",
+			Labels:  map[string]string{"role": "worker"},
+			IPAddresses: []nodeTypes.Address{{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			}},
+		},
+		Local: &node.LocalNodeInfo{},
+	}
+	want := labels.NewFrom(labels.LabelHost)
+	want.MergeLabels(labels.Map2Labels(local.Labels, labels.LabelSourceNode))
+	want.MergeLabels(labels.Map2Labels(map[string]string{
+		"io.cilium.k8s.policy.cluster": "cluster1",
+	}, labels.LabelSourceK8s))
+	want.MergeLabels(labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.1/32")))
+	require.True(t, want.Equals(observer.nodeIdentityLabels(local)))
+
+	remote := local.DeepCopy()
+	remote.Name = "remote"
+	remote.Local = nil
+	want = labels.NewFrom(labels.LabelRemoteNode)
+	want.MergeLabels(labels.Map2Labels(remote.Labels, labels.LabelSourceNode))
+	want.MergeLabels(labels.Map2Labels(map[string]string{
+		"io.cilium.k8s.policy.cluster": "cluster1",
+	}, labels.LabelSourceK8s))
+	require.True(t, want.Equals(observer.nodeIdentityLabels(remote)))
+}
+
+func TestNodeObserverRecomputesRemoteNodesOnLocalEncryptionChange(t *testing.T) {
+	observer, metadata, db, nodes := newTestNodeObserver(
+		t,
+		&option.DaemonConfig{EncryptNode: true},
+		fakewireguard.Config{},
+	)
+	local := &node.Node{
+		Node:  nodeTypes.Node{Name: "local", Source: source.Local},
+		Local: &node.LocalNodeInfo{OptOutNodeEncryption: true},
+	}
+	remote := &node.Node{Node: nodeTypes.Node{
+		Name:          "remote",
+		EncryptionKey: 42,
+		IPAddresses: []nodeTypes.Address{{
+			Type: addressing.NodeCiliumInternalIP,
+			IP:   net.ParseIP("10.0.0.2"),
+		}},
+	}}
+	txn := db.WriteTxn(nodes)
+	_, _, err := nodes.Insert(txn, local)
+	require.NoError(t, err)
+	_, _, err = nodes.Insert(txn, remote)
+	require.NoError(t, err)
+	txn.Commit()
+	observer.apply(db.ReadTxn(), changeSeq([]statedb.Change[*node.Node]{
+		{Object: local},
+		{Object: remote},
+	}))
+
+	local = local.DeepCopy()
+	local.Local.OptOutNodeEncryption = false
+	applyNodeUpdate(t, observer, db, nodes, local)
+
+	require.Len(t, metadata.upserts, 2)
+	remoteAddress := updatesByPrefix(metadata.upserts[1])[netip.MustParsePrefix("10.0.0.2/32")]
+	require.Equal(t, ipcacheTypes.EncryptKey(42),
+		metadataValue[ipcacheTypes.EncryptKey](t, remoteAddress),
+	)
+}

--- a/pkg/ipcache/node_observer_test.go
+++ b/pkg/ipcache/node_observer_test.go
@@ -33,7 +33,12 @@ import (
 type metadataBatchMock struct {
 	upserts  [][]MU
 	removals [][]MU
+	syncs    []<-chan struct{}
 	notify   chan struct{}
+}
+
+func (m *metadataBatchMock) RegisterSync(ch <-chan struct{}) {
+	m.syncs = append(m.syncs, ch)
 }
 
 func changeSeq(changes []statedb.Change[*node.Node]) iter.Seq2[statedb.Change[*node.Node], statedb.Revision] {
@@ -75,10 +80,12 @@ func TestNodeObserverWaitsForLocalNodeInitialization(t *testing.T) {
 	nodes, err := node.NewNodeTable(db)
 	require.NoError(t, err)
 	metadata := &metadataBatchMock{notify: make(chan struct{}, 1)}
+	synced := make(chan struct{})
 	observer := &nodeObserver{
 		db:          db,
 		nodes:       nodes,
 		ipcache:     metadata,
+		synced:      synced,
 		config:      &option.DaemonConfig{},
 		clusterInfo: cmtypes.DefaultClusterInfo,
 		underlay:    tunnel.IPv4,
@@ -88,6 +95,7 @@ func TestNodeObserverWaitsForLocalNodeInitialization(t *testing.T) {
 
 	txn := db.WriteTxn(nodes)
 	initDone := nodes.RegisterInitializer(txn, node.LocalNodeTableInitializerName)
+	tableInitDone := nodes.RegisterInitializer(txn, "test")
 	_, _, err = nodes.Insert(txn, &node.Node{Node: nodeTypes.Node{
 		Name: "remote",
 		IPAddresses: []nodeTypes.Address{{
@@ -121,6 +129,20 @@ func TestNodeObserverWaitsForLocalNodeInitialization(t *testing.T) {
 	case <-metadata.notify:
 	case <-time.After(time.Second):
 		require.FailNow(t, "observer did not process initial node snapshot")
+	}
+	select {
+	case <-synced:
+		require.FailNow(t, "observer reported synchronization before table initialization")
+	default:
+	}
+
+	txn = db.WriteTxn(nodes)
+	tableInitDone(txn)
+	txn.Commit()
+	select {
+	case <-synced:
+	case <-time.After(time.Second):
+		require.FailNow(t, "observer did not report synchronization after table initialization")
 	}
 	cancel()
 	require.NoError(t, <-done)

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -10,15 +10,10 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
-	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Cell provides the NodeManager, which manages information about Cilium nodes
@@ -75,32 +70,23 @@ type NodeManager interface {
 func newAllNodeManager(in struct {
 	cell.In
 	Logger                       *slog.Logger
-	ClusterInfo                  cmtypes.ClusterInfo
-	TunnelConf                   tunnel.Config
 	Lifecycle                    cell.Lifecycle
-	IPCache                      *ipcache.IPCache
 	NodeMetrics                  *nodeMetrics
 	Health                       cell.Health
 	JobGroup                     job.Group
 	DB                           *statedb.DB
 	Devices                      statedb.Table[*tables.Device]
-	WGConfig                     wgTypes.Config
 	Writer                       *node.Writer
 	ClusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc
 },
 ) (NodeManager, error) {
 	mngr, err := New(
 		in.Logger,
-		option.Config,
-		in.ClusterInfo,
-		in.TunnelConf,
-		in.IPCache,
 		in.NodeMetrics,
 		in.Health,
 		in.JobGroup,
 		in.DB,
 		in.Devices,
-		in.WGConfig,
 		in.Writer,
 		in.ClusterSizeDependantInterval,
 	)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -7,40 +7,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"log/slog"
-	"net"
-	"net/netip"
-	"slices"
 	"sync"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
-	"go4.org/netipx"
 	"golang.org/x/time/rate"
 
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/ip"
-	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
-	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 const (
@@ -65,15 +49,6 @@ type nodeEntry struct {
 	// Manager.mutex must *always* be acquired first.
 	mutex lock.Mutex
 	node  nodeTypes.Node
-}
-
-// IPCache is the set of interactions the node manager performs with the ipcache
-type IPCache interface {
-	GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source
-	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
-	RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
-	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
-	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
 }
 
 var _ Notifier = (*manager)(nil)
@@ -118,18 +93,6 @@ type manager struct {
 	// metrics to track information about the node manager
 	metrics *nodeMetrics
 
-	// conf is the configuration of the caller passed in via NewManager.
-	// This field is immutable after NewManager()
-	conf *option.DaemonConfig
-	// clusterInfo is the local cluster information passed in via NewManager.
-	// This field is immutable after NewManager()
-	clusterInfo cmtypes.ClusterInfo
-
-	underlay tunnel.UnderlayProtocol
-
-	// ipcache is the set operations performed against the ipcache
-	ipcache IPCache
-
 	// controllerManager manages the controllers that are launched within the
 	// Manager.
 	controllerManager *controller.Manager
@@ -150,12 +113,6 @@ type manager struct {
 	// sources initialized. The node table is initialized after both complete.
 	clusterNodeTableInit func()
 	meshNodeTableInit    func()
-
-	// custom mutator function to enrich prefixCluster(s) from node objects.
-	prefixClusterMutatorFn node.PrefixClusterMutatorFn
-
-	// wireguard configuration used when calling endpointEncryptionKey.
-	wgConfig types.Config
 }
 
 // Subscribe subscribes the given node handler to node events.
@@ -242,16 +199,11 @@ func NewNodeMetrics() *nodeMetrics {
 // New returns a new node manager
 func New(
 	logger *slog.Logger,
-	c *option.DaemonConfig,
-	clusterInfo cmtypes.ClusterInfo,
-	tunnelConf tunnel.Config,
-	ipCache IPCache,
 	nodeMetrics *nodeMetrics,
 	health cell.Health,
 	jobGroup job.Group,
 	db *statedb.DB,
 	devices statedb.Table[*tables.Device],
-	wgCfg types.Config,
 	writer *node.Writer,
 	clusterSizeDependantInterval node.ClusterSizeDependantIntervalFunc,
 ) (*manager, error) {
@@ -259,20 +211,14 @@ func New(
 		logger:                       logger,
 		nodes:                        map[nodeTypes.Identity]*nodeEntry{},
 		writer:                       writer,
-		conf:                         c,
-		clusterInfo:                  clusterInfo,
-		underlay:                     tunnelConf.UnderlayProtocol(),
 		controllerManager:            controller.NewManager(),
 		nodeHandlers:                 map[node.Handler]struct{}{},
-		ipcache:                      ipCache,
 		metrics:                      nodeMetrics,
 		health:                       health,
 		jobGroup:                     jobGroup,
 		clusterSizeDependantInterval: clusterSizeDependantInterval,
 		db:                           db,
 		devices:                      devices,
-		prefixClusterMutatorFn:       func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
-		wgConfig:                     wgCfg,
 	}
 
 	if writer != nil {
@@ -398,93 +344,6 @@ func (m *manager) singleBackgroundLoop(ctx context.Context, expectedLoopTime tim
 	return errs
 }
 
-func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
-	// If the host firewall is enabled, all traffic to remote nodes must go
-	// through the tunnel to preserve the source identity as part of the
-	// encapsulation. In encryption case we also want to use vxlan device
-	// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
-	return address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() ||
-		m.conf.EnableHostFirewall
-}
-
-func (m *manager) nodeAddressHasEncryptKey() bool {
-	optOut := false
-	if m.writer != nil && m.db != nil {
-		if localNode, _, found := m.writer.Table().Get(m.db.ReadTxn(), node.LocalNodeQuery); found {
-			optOut = localNode.Local.OptOutNodeEncryption
-		}
-	}
-
-	// If we are doing encryption, but not node based encryption, then do not
-	// add a key to the nodeIPs so that we avoid a trip through stack and attempting
-	// to encrypt something we know does not have an encryption policy installed
-	// in the datapath. By setting key=0 and tunnelIP this will result in traffic
-	// being sent unencrypted over overlay device.
-	return m.conf.NodeEncryptionEnabled() &&
-		// Also ignore any remote node's key if the local node opted to not perform
-		// node-to-node encryption
-		!optOut
-}
-
-// endpointEncryptionKey returns the encryption key index to use for the health
-// and ingress endpoints of a node. This is needed for WireGuard where the
-// node's EncryptionKey and the endpoint's EncryptionKey are not the same if
-// a node has opted out of node-to-node encryption by zeroing n.EncryptionKey.
-// With WireGuard, we always want to encrypt pod-to-pod traffic, thus we return
-// a static non-zero encrypt key here.
-// With IPSec (or no encryption), the node's encryption key index and the
-// encryption key of the endpoint on that node are the same.
-func (m *manager) endpointEncryptionKey(n *nodeTypes.Node) ipcacheTypes.EncryptKey {
-	if m.wgConfig.Enabled() {
-		return ipcacheTypes.EncryptKey(types.StaticEncryptKey)
-	}
-
-	return ipcacheTypes.EncryptKey(n.EncryptionKey)
-}
-
-func (m *manager) nodeIdentityLabels(n nodeTypes.Node) labels.Labels {
-	nodeLabels := labels.NewFrom(labels.LabelRemoteNode)
-	if n.IsLocal() {
-		nodeLabels = labels.NewFrom(labels.LabelHost)
-		if m.conf.PolicyCIDRMatchesNodes() {
-			for _, address := range n.IPAddresses {
-				addr, ok := netipx.FromStdIP(address.IP)
-				if ok {
-					bitLen := addr.BitLen()
-					if m.conf.EnableIPv4 && bitLen == net.IPv4len*8 ||
-						m.conf.EnableIPv6 && bitLen == net.IPv6len*8 {
-						prefix, err := addr.Prefix(bitLen)
-						if err == nil {
-							cidrLabels := labels.GetCIDRLabels(prefix)
-							nodeLabels.MergeLabels(cidrLabels)
-						}
-					}
-				}
-			}
-		}
-	}
-
-	if option.Config.PerNodeLabelsEnabled() {
-		lbls := labels.Map2Labels(n.Labels, labels.LabelSourceNode)
-		filteredLbls, _ := labelsfilter.FilterNodeLabels(lbls)
-		nodeLabels.MergeLabels(filteredLbls)
-		nodeLabels.MergeLabels(labels.Map2Labels(map[string]string{
-			k8sConst.PolicyLabelCluster: n.Cluster,
-		}, labels.LabelSourceK8s))
-	}
-
-	return nodeLabels
-}
-
-// worldLabelForPrefix returns the labels which will resolve to
-// reserved:world identity given the provided prefix and the
-// current cluster configuration in terms of dual-stack.
-func worldLabelForPrefix(prefix netip.Prefix) labels.Labels {
-	lbls := make(labels.Labels, 1)
-	lbls.AddWorldLabel(prefix.Addr())
-	return lbls
-}
-
 // NodeUpdated is called after the information of a node has been updated. The
 // node in the manager is added or updated if the source is allowed to update
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
@@ -504,150 +363,12 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	}
 
 	nodeIdentifier := n.Identity()
-	dpUpdate := true
-	var nodeIP netip.Addr
-	if nIP := n.GetNodeIP(m.underlay == tunnel.IPv6); nIP != nil {
-		// GH-24829: Support IPv6-only nodes.
-
-		// Skip returning the error here because at this level, we assume that
-		// the IP is valid as long as it's coming from nodeTypes.Node. This
-		// object is created either from the node discovery (K8s) or from an
-		// event from the kvstore.
-		nodeIP, _ = netipx.FromStdIP(nIP)
-	}
-
-	resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-	nodeLabels := m.nodeIdentityLabels(n)
-
-	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix
-
-	for _, address := range n.IPAddresses {
-		prefix := ip.IPToNetPrefix(address.IP)
-		var prefixCluster cmtypes.PrefixCluster
-		if address.Type == addressing.NodeCiliumInternalIP {
-			prefixCluster = cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
-		} else {
-			prefixCluster = cmtypes.NewLocalPrefixCluster(prefix)
-		}
-
-		var tunnelIP netip.Addr
-		if m.nodeAddressHasTunnelIP(address) {
-			tunnelIP = nodeIP
-		}
-
-		var key uint8
-		if m.nodeAddressHasEncryptKey() {
-			key = n.EncryptionKey
-		}
-
-		endpointFlags := ipcacheTypes.EndpointFlags{}
-		if n.Cluster != m.clusterInfo.Name {
-			endpointFlags.SetRemoteCluster(true)
-		}
-
-		// We expect the node manager to have a source of either Kubernetes,
-		// CustomResource, or KVStore. Prioritize the KVStore source over the
-		// rest as it is the strongest source, i.e. only trigger datapath
-		// updates if the information we receive takes priority.
-		//
-		// There are two exceptions to the rules above:
-		// * kube-apiserver entries - in that case,
-		//   we still want to inform subscribers about changes in auxiliary
-		//   data such as for example the health endpoint.
-		// * CiliumInternal IP addresses that match configured local router IP.
-		//   In that case, we still want to inform subscribers about a new node
-		//   even when IP addresses may seem repeated across the nodes.
-		existing := m.ipcache.GetMetadataSourceByPrefix(prefixCluster)
-		overwrite := source.AllowOverwrite(existing, n.Source)
-		if !overwrite && existing != source.KubeAPIServer &&
-			!(address.Type == addressing.NodeCiliumInternalIP && m.conf.IsLocalRouterIP(address.ToString())) {
-			dpUpdate = false
-		}
-
-		lbls := nodeLabels
-		// Add the CIDR labels for this node, if we allow selecting nodes by CIDR
-		if m.conf.PolicyCIDRMatchesNodes() {
-			lbls = labels.NewFrom(nodeLabels)
-			lbls.MergeLabels(labels.GetCIDRLabels(prefixCluster.AsPrefix()))
-		}
-
-		// Always associate the prefix with metadata, even though this may not
-		// end up in an ipcache entry.
-		m.ipcache.UpsertMetadata(prefixCluster, n.Source, resource,
-			lbls,
-			ipcacheTypes.TunnelPeer{Addr: tunnelIP},
-			ipcacheTypes.EncryptKey(key),
-			endpointFlags)
-		nodeIPsAdded = append(nodeIPsAdded, prefixCluster.AsPrefix())
-	}
-
-	// Add the remote node's Pod CIDRs as fallback entries into IPCache with
-	// the nodeIP as the tunnel endpoint (no tunnel endpoint fallback is needed
-	// for the local node).
-	if !n.IsLocal() {
-		ipv4PodCIDRs := n.GetIPv4AllocCIDRs()
-		ipv6PodCIDRs := n.GetIPv6AllocCIDRs()
-
-		mu := make([]ipcache.MU, 0, len(ipv4PodCIDRs)+len(ipv6PodCIDRs))
-		for entry := range m.podCIDREntries(n.Source, resource, m.cidrsToPrefixesCluster(&n, ipv4PodCIDRs...), nodeIP, n.EncryptionKey) {
-			mu = append(mu, entry)
-			podCIDRsAdded = append(podCIDRsAdded, entry.Prefix.AsPrefix())
-		}
-		for entry := range m.podCIDREntries(n.Source, resource, m.cidrsToPrefixesCluster(&n, ipv6PodCIDRs...), nodeIP, n.EncryptionKey) {
-			mu = append(mu, entry)
-			podCIDRsAdded = append(podCIDRsAdded, entry.Prefix.AsPrefix())
-		}
-		m.ipcache.UpsertMetadataBatch(mu...)
-	}
-
-	for _, address := range []netip.Addr{n.IPv4HealthIP.Addr, n.IPv6HealthIP.Addr} {
-		prefix := netip.PrefixFrom(address, address.BitLen())
-		if !prefix.IsValid() {
-			continue
-		}
-
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
-
-		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(prefixCluster), n.Source) {
-			dpUpdate = false
-		}
-
-		m.ipcache.UpsertMetadata(prefixCluster, n.Source, resource,
-			labels.LabelHealth,
-			ipcacheTypes.TunnelPeer{Addr: nodeIP},
-			m.endpointEncryptionKey(&n))
-		healthIPsAdded = append(healthIPsAdded, prefixCluster.AsPrefix())
-	}
-
-	for _, address := range []netip.Addr{n.IPv4IngressIP.Addr, n.IPv6IngressIP.Addr} {
-		prefix := netip.PrefixFrom(address, address.BitLen())
-		if !prefix.IsValid() {
-			continue
-		}
-
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
-
-		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(prefixCluster), n.Source) {
-			dpUpdate = false
-		}
-
-		m.ipcache.UpsertMetadata(prefixCluster, n.Source, resource,
-			labels.LabelIngress,
-			ipcacheTypes.TunnelPeer{Addr: nodeIP},
-			m.endpointEncryptionKey(&n))
-		ingressIPsAdded = append(ingressIPsAdded, prefixCluster.AsPrefix())
-	}
-
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentifier]
 	if oldNodeExists {
 		m.metrics.EventsReceived.WithLabelValues("update", string(n.Source)).Inc()
 
 		if !source.AllowOverwrite(entry.node.Source, n.Source) {
-			// Done; skip node-handler updates and label injection
-			// triggers below. Includes case where the local host
-			// was discovered locally and then is subsequently
-			// updated by the k8s watcher.
 			m.mutex.Unlock()
 			return
 		}
@@ -657,37 +378,26 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		oldNode := entry.node
 		entry.node = n
 		m.upsertToNodeTable(&entry.node)
-		if dpUpdate {
-			var errs error
-			m.Iter(func(nh node.Handler) {
-				if err := nh.NodeUpdate(oldNode, entry.node); err != nil {
-					m.logger.Error(
-						"Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.",
-						logfields.Error, err,
-						logfields.Handler, nh.Name(),
-						logfields.Node, entry.node.Name,
-					)
-					errs = errors.Join(errs, err)
-				}
-			})
 
-			hr := m.health.NewScope("nodes-update")
-			if errs != nil {
-				hr.Degraded("Failed to update nodes", errs)
-			} else {
-				hr.OK("Node updates successful")
+		var errs error
+		m.Iter(func(nh node.Handler) {
+			if err := nh.NodeUpdate(oldNode, entry.node); err != nil {
+				m.logger.Error(
+					"Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.",
+					logfields.Error, err,
+					logfields.Handler, nh.Name(),
+					logfields.Node, entry.node.Name,
+				)
+				errs = errors.Join(errs, err)
 			}
+		})
+
+		hr := m.health.NewScope("nodes-update")
+		if errs != nil {
+			hr.Degraded("Failed to update nodes", errs)
+		} else {
+			hr.OK("Node updates successful")
 		}
-
-		m.removeNodeFromIPCache(
-			oldNode,
-			resource,
-			nodeIPsAdded,
-			healthIPsAdded,
-			ingressIPsAdded,
-			podCIDRsAdded,
-		)
-
 		entry.mutex.Unlock()
 	} else {
 		m.metrics.EventsReceived.WithLabelValues("add", string(n.Source)).Inc()
@@ -698,30 +408,28 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.nodes[nodeIdentifier] = entry
 		m.upsertToNodeTable(&entry.node)
 		m.mutex.Unlock()
+
 		var errs error
-		if dpUpdate {
-			m.Iter(func(nh node.Handler) {
-				if err := nh.NodeAdd(entry.node); err != nil {
-					m.logger.Error(
-						"Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.",
-						logfields.Error, err,
-						logfields.Handler, nh.Name(),
-						logfields.Node, entry.node.Name,
-					)
-					errs = errors.Join(errs, err)
-				}
-			})
-		}
+		m.Iter(func(nh node.Handler) {
+			if err := nh.NodeAdd(entry.node); err != nil {
+				m.logger.Error(
+					"Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.",
+					logfields.Error, err,
+					logfields.Handler, nh.Name(),
+					logfields.Node, entry.node.Name,
+				)
+				errs = errors.Join(errs, err)
+			}
+		})
 		entry.mutex.Unlock()
+
 		hr := m.health.NewScope("nodes-add")
 		if errs != nil {
 			hr.Degraded("Failed to add nodes", errs)
 		} else {
 			hr.OK("Node adds successful")
 		}
-
 	}
-
 }
 
 func (m *manager) upsertToNodeTable(n *nodeTypes.Node) {
@@ -740,123 +448,6 @@ func (m *manager) deleteFromNodeTable(src source.Source, nodeID nodeTypes.Identi
 	txn := m.db.WriteTxn(m.writer.Table())
 	m.writer.Delete(txn, src, nodeID)
 	txn.Commit()
-}
-
-func (m *manager) cidrsToPrefixesCluster(n *nodeTypes.Node, prefixes ...netip.Prefix) iter.Seq[cmtypes.PrefixCluster] {
-	return func(yield func(cmtypes.PrefixCluster) bool) {
-		for _, prefix := range prefixes {
-			if !yield(cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(n)...)) {
-				return
-			}
-		}
-	}
-}
-
-func (m *manager) podCIDREntries(source source.Source, resource ipcacheTypes.ResourceID, prefixes iter.Seq[cmtypes.PrefixCluster], tunnelIP netip.Addr, encryptKey uint8) iter.Seq[ipcache.MU] {
-	return func(yield func(ipcache.MU) bool) {
-		for prefix := range prefixes {
-			if !prefix.IsValid() {
-				continue
-			}
-
-			metadata := []ipcache.IPMetadata{
-				worldLabelForPrefix(prefix.AsPrefix()),
-				ipcacheTypes.TunnelPeer{Addr: tunnelIP},
-				ipcacheTypes.EncryptKey(encryptKey),
-			}
-
-			if !yield(ipcache.MU{
-				Prefix:   prefix,
-				Source:   source,
-				Resource: resource,
-				Metadata: metadata,
-			}) {
-				return
-			}
-		}
-	}
-}
-
-// removeNodeFromIPCache removes all addresses associated with oldNode from the IPCache,
-// unless they are present in the nodeIPsAdded, healthIPsAdded, ingressIPsAdded lists.
-// Removes all pod CIDRs associated with the oldNode from IPCache, unless they are present
-// in podCIDRsAdded.
-// The removal logic in this function should mirror the upsert logic in nodeAddressHasTunnelIP.
-func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcacheTypes.ResourceID,
-	nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix,
-) {
-	var oldNodeIP netip.Addr
-	if nIP := oldNode.GetNodeIP(false); nIP != nil {
-		// See comment in NodeUpdated().
-		oldNodeIP, _ = netipx.FromStdIP(nIP)
-	}
-
-	// Delete the old node IP addresses if they have changed in this node.
-	for _, address := range oldNode.IPAddresses {
-		prefix := ip.IPToNetPrefix(address.IP)
-		if slices.Contains(nodeIPsAdded, prefix) {
-			continue
-		}
-
-		var oldPrefixCluster cmtypes.PrefixCluster
-		if address.Type == addressing.NodeCiliumInternalIP {
-			oldPrefixCluster = cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
-		} else {
-			oldPrefixCluster = cmtypes.NewLocalPrefixCluster(prefix)
-		}
-
-		m.ipcache.RemoveMetadata(oldPrefixCluster, resource, ipcacheTypes.AllMetadata{})
-
-	}
-
-	// Remove old pod CIDR fallback entries from IPCache
-	if !oldNode.IsLocal() {
-		oldIPv4PodCIDRs := oldNode.GetIPv4AllocCIDRs()
-		oldIPv6PodCIDRs := oldNode.GetIPv6AllocCIDRs()
-
-		mu := make([]ipcache.MU, 0, len(oldIPv4PodCIDRs)+len(oldIPv6PodCIDRs))
-		for entry := range m.podCIDREntries(oldNode.Source, resource, m.cidrsToPrefixesCluster(&oldNode, oldIPv4PodCIDRs...), oldNodeIP, oldNode.EncryptionKey) {
-			if slices.Contains(podCIDRsAdded, entry.Prefix.AsPrefix()) {
-				continue
-			}
-			mu = append(mu, entry)
-		}
-		for entry := range m.podCIDREntries(oldNode.Source, resource, m.cidrsToPrefixesCluster(&oldNode, oldIPv6PodCIDRs...), oldNodeIP, oldNode.EncryptionKey) {
-			if slices.Contains(podCIDRsAdded, entry.Prefix.AsPrefix()) {
-				continue
-			}
-			mu = append(mu, entry)
-		}
-		m.ipcache.RemoveMetadataBatch(mu...)
-	}
-
-	// Delete the old health IP addresses if they have changed in this node.
-	for _, address := range []netip.Addr{oldNode.IPv4HealthIP.Addr, oldNode.IPv6HealthIP.Addr} {
-		prefix := netip.PrefixFrom(address, address.BitLen())
-		if !prefix.IsValid() || slices.Contains(healthIPsAdded, prefix) {
-			continue
-		}
-
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
-
-		m.ipcache.RemoveMetadata(prefixCluster, resource,
-			labels.LabelHealth,
-			ipcacheTypes.AllMetadata{})
-	}
-
-	// Delete the old ingress IP addresses if they have changed in this node.
-	for _, address := range []netip.Addr{oldNode.IPv4IngressIP.Addr, oldNode.IPv6IngressIP.Addr} {
-		prefix := netip.PrefixFrom(address, address.BitLen())
-		if !prefix.IsValid() || slices.Contains(ingressIPsAdded, prefix) {
-			continue
-		}
-
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
-
-		m.ipcache.RemoveMetadata(prefixCluster, resource,
-			labels.LabelIngress,
-			ipcacheTypes.AllMetadata{})
-	}
 }
 
 // NodeDeleted is called after a node has been deleted. It removes the node
@@ -911,8 +502,6 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 		return
 	}
 
-	resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-	m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil)
 	m.metrics.NumNodes.Dec()
 
 	entry.mutex.Lock()
@@ -991,7 +580,6 @@ func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 // SetPrefixClusterMutatorFn allows to inject a custom prefix cluster mutator.
 // The mutator may then be applied to the PrefixCluster(s) using cmtypes.PrefixClusterFrom.
 func (m *manager) SetPrefixClusterMutatorFn(mutator node.PrefixClusterMutatorFn) {
-	m.prefixClusterMutatorFn = mutator
 	if m.writer != nil {
 		m.writer.SetPrefixClusterMutatorFn(mutator)
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
-	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -21,106 +20,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
-	"github.com/cilium/cilium/pkg/identity"
 	iputil "github.com/cilium/cilium/pkg/ip"
-	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	fakenode "github.com/cilium/cilium/pkg/node/fake"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
-	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
-
-type nodeEvent struct {
-	event    string
-	prefix   netip.Prefix
-	metadata ipcache.IPMetadata
-}
 
 func testClusterSizeDependantInterval(interval time.Duration) time.Duration {
 	return interval
-}
-
-type ipcacheMock struct {
-	events chan nodeEvent
-}
-
-func newIPcacheMock() *ipcacheMock {
-	return &ipcacheMock{
-		events: make(chan nodeEvent, 1024),
-	}
-}
-
-func AddrOrPrefixToIP(ip string) (netip.Prefix, error) {
-	prefix, err := netip.ParsePrefix(ip)
-	if err != nil {
-		addr, err := netip.ParseAddr(ip)
-		if err != nil {
-			return netip.Prefix{}, err
-		}
-		return addr.Prefix(prefix.Bits())
-	}
-
-	return prefix, err
-}
-
-func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity, aux ...ipcache.IPMetadata) (bool, error) {
-	addr, err := AddrOrPrefixToIP(ip)
-	if err != nil {
-		i.events <- nodeEvent{fmt.Sprintf("upsert failed: %s", err), addr, aux}
-		return false, err
-	}
-	i.events <- nodeEvent{"upsert", addr, aux}
-	return false, nil
-}
-
-func (i *ipcacheMock) Delete(ip string, source source.Source, aux ...ipcache.IPMetadata) bool {
-	addr, err := AddrOrPrefixToIP(ip)
-	if err != nil {
-		i.events <- nodeEvent{fmt.Sprintf("delete failed: %s", err), addr, aux}
-		return false
-	}
-	i.events <- nodeEvent{"delete", addr, aux}
-	return false
-}
-
-func (i *ipcacheMock) GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source {
-	return source.Unspec
-}
-
-func (i *ipcacheMock) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
-	i.Upsert(prefix.String(), nil, 0, nil, ipcache.Identity{}, aux...)
-}
-
-func (i *ipcacheMock) RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
-	i.Delete(prefix.String(), source.CustomResource, aux...)
-}
-
-func (i *ipcacheMock) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, update := range updates {
-		i.UpsertMetadata(update.Prefix, update.Source, update.Resource, update.Metadata)
-	}
-	return 0
-}
-
-func (i *ipcacheMock) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, update := range updates {
-		i.RemoveMetadata(update.Prefix, update.Resource, update.Metadata)
-	}
-	return 0
 }
 
 type signalNodeHandler struct {
@@ -194,9 +107,8 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(logger, NewNodeMetrics(), h, nil, nil, nil, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -268,109 +180,6 @@ func TestNodeLifecycle(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNodeLabels(t *testing.T) {
-	logger := hivetest.Logger(t)
-
-	dp := newSignalNodeHandler()
-	ipcacheMock := newIPcacheMock()
-	h, _ := cell.NewSimpleHealth()
-
-	nodeLabels := map[string]string{
-		"test-label":  "test-value",
-		"other-label": "other-value",
-	}
-	nodeTypes.SetName("localNode")
-	nLocal := nodeTypes.Node{
-		Name:    "localNode",
-		Cluster: "default",
-		Labels:  nodeLabels,
-		Source:  source.Local,
-	}
-	nRemote := nodeTypes.Node{
-		Name:    "remoteNode",
-		Cluster: "default",
-		Labels:  nodeLabels,
-		Source:  source.Unspec,
-	}
-
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
-	mngr.Subscribe(dp)
-	require.NoError(t, err)
-	mngr.NodeUpdated(nRemote)
-
-	tests := []struct {
-		name               string
-		node               nodeTypes.Node
-		nodeSelectorLabels bool
-		nodeLabelPrefixes  []string
-		setupWanted        func() labels.Labels
-	}{{
-		name:               "Local node with node selector labels enabled",
-		node:               nLocal,
-		nodeSelectorLabels: true,
-		setupWanted: func() labels.Labels {
-			want := labels.NewFrom(labels.LabelHost)
-			want.MergeLabels(labels.Map2Labels(nodeLabels, labels.LabelSourceNode))
-			want.MergeLabels(labels.Map2Labels(map[string]string{
-				"io.cilium.k8s.policy.cluster": "default",
-			}, labels.LabelSourceK8s))
-			return want
-		},
-	}, {
-		name:               "Local node with node selector labels disabled",
-		node:               nLocal,
-		nodeSelectorLabels: false,
-		setupWanted: func() labels.Labels {
-			return labels.NewFrom(labels.LabelHost)
-		},
-	}, {
-		name:               "Remote node with node selector labels enabled",
-		node:               nRemote,
-		nodeSelectorLabels: true,
-		setupWanted: func() labels.Labels {
-			want := labels.NewFrom(labels.LabelRemoteNode)
-			want.MergeLabels(labels.Map2Labels(nodeLabels, labels.LabelSourceNode))
-			want.MergeLabels(labels.Map2Labels(map[string]string{
-				"io.cilium.k8s.policy.cluster": "default",
-			}, labels.LabelSourceK8s))
-			return want
-		},
-	}, {
-		name:               "Remote node with node selector labels disabled",
-		node:               nRemote,
-		nodeSelectorLabels: false,
-		setupWanted: func() labels.Labels {
-			return labels.NewFrom(labels.LabelRemoteNode)
-		},
-	}, {
-		name:               "Remote node with node selector labels enabled and filtered labels",
-		node:               nRemote,
-		nodeSelectorLabels: true,
-		nodeLabelPrefixes:  []string{"node:test-label"},
-		setupWanted: func() labels.Labels {
-			want := labels.NewFrom(labels.LabelRemoteNode)
-			want.MergeLabels(labels.Map2Labels(map[string]string{
-				"test-label": "test-value",
-			}, labels.LabelSourceNode))
-			want.MergeLabels(labels.Map2Labels(map[string]string{
-				"io.cilium.k8s.policy.cluster": "default",
-			}, labels.LabelSourceK8s))
-			return want
-		},
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, labelsfilter.ParseLabelPrefixCfg(logger, nil, tt.nodeLabelPrefixes, ""))
-			option.Config.EnableNodeSelectorLabels = tt.nodeSelectorLabels
-			option.Config.ClusterName = cmtypes.DefaultClusterInfo.Name
-			got := mngr.nodeIdentityLabels(tt.node)
-			want := tt.setupWanted()
-			assert.True(t, want.Equals(got), "Mismatched labels: want=%v got=%v", want, got)
-		})
-	}
-}
-
 func TestMultipleSources(t *testing.T) {
 	logger := hivetest.Logger(t)
 
@@ -378,9 +187,8 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(logger, NewNodeMetrics(), h, nil, nil, nil, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -460,11 +268,10 @@ func TestMultipleSources(t *testing.T) {
 }
 
 func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
-	ipcacheMock := newIPcacheMock()
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(b)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(logger, NewNodeMetrics(), h, nil, nil, nil, nil, testClusterSizeDependantInterval)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -484,10 +291,9 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
-	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(logger, NewNodeMetrics(), h, nil, nil, nil, nil, testClusterSizeDependantInterval)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -530,350 +336,14 @@ func TestBackgroundSync(t *testing.T) {
 	allNodeValidateCallsReceived.Wait()
 }
 
-func expectIPCacheUpdate(
-	t *testing.T, ipcacheMock *ipcacheMock,
-	eventType string, prefix netip.Prefix, metadata ...ipcache.IPMetadata,
-) {
-	t.Helper()
-
-	select {
-	case ev := <-ipcacheMock.events:
-		require.Equal(t, eventType, ev.event)
-		require.Equal(t, prefix, ev.prefix)
-		if len(metadata) > 0 {
-			// unpack outer metadata slice
-			require.IsType(t, []ipcache.IPMetadata{}, ev.metadata)
-			md := ev.metadata.([]ipcache.IPMetadata)
-
-			require.ElementsMatch(t, metadata, md)
-		}
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache upsert for %s", prefix)
-	}
-}
-
-func TestIpcache(t *testing.T) {
-	ipcacheMock := newIPcacheMock()
-	dp := newSignalNodeHandler()
-	h, _ := cell.NewSimpleHealth()
-	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
-	require.NoError(t, err)
-	mngr.Subscribe(dp)
-	defer mngr.Stop(context.TODO())
-
-	n1 := nodeTypes.Node{
-		Name:    "node1",
-		Cluster: "c1",
-		IPAddresses: []nodeTypes.Address{
-			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
-			{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.2")},
-			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
-		},
-
-		IPv4AllocCIDR:           nodeTypes.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
-		IPv4SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(netip.MustParsePrefix("192.168.10.0/28"))},
-		IPv6AllocCIDR:           nodeTypes.PrefixFrom(netip.MustParsePrefix("f00d::/96")),
-		IPv6SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(netip.MustParsePrefix("cafe::/96"))},
-	}
-	mngr.NodeUpdated(n1)
-
-	// node IP addresses
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
-
-	// node IPv4 allocation CIDRs
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("10.0.0.0/24"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("192.168.10.0/28"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-
-	// node IPv6 allocation CIDRs
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("f00d::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("cafe::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-
-	// Update node by removing ExternalIPs and secondary PodCIDRs
-	n1 = *n1.DeepCopy()
-	n1.IPAddresses = slices.DeleteFunc(n1.IPAddresses, func(address nodeTypes.Address) bool {
-		return address.IP.Equal(net.ParseIP("f00d::1"))
-	})
-	n1.IPv4SecondaryAllocCIDRs = nil
-	n1.IPv6SecondaryAllocCIDRs = nil
-	mngr.NodeUpdated(n1)
-
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("10.0.0.0/24"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("f00d::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.MustParsePrefix("192.168.10.0/28"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "delete", netip.MustParsePrefix("cafe::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-
-	mngr.NodeDeleted(n1)
-
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
-	expectIPCacheUpdate(
-		t, ipcacheMock, "delete", netip.MustParsePrefix("10.0.0.0/24"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.MustParsePrefix("f00d::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(0),
-		},
-	)
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-}
-
-func TestIpcacheHealthIP(t *testing.T) {
-	ipcacheMock := newIPcacheMock()
-	dp := newSignalNodeHandler()
-	h, _ := cell.NewSimpleHealth()
-	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
-	require.NoError(t, err)
-	mngr.Subscribe(dp)
-	defer mngr.Stop(context.TODO())
-
-	n1 := nodeTypes.Node{
-		Name:    "node1",
-		Cluster: "c1",
-		IPAddresses: []nodeTypes.Address{
-			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1").To4()},
-		},
-		IPv4HealthIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
-		IPv6HealthIP: iputil.AddrFrom(netip.MustParseAddr("f00d::4")),
-	}
-	mngr.NodeUpdated(n1)
-
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.4"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("f00d::4"), 128))
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-
-	mngr.NodeDeleted(n1)
-
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("10.0.0.4"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("f00d::4"), 128))
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-}
-
-func TestNodeEncryption(t *testing.T) {
-	logger := hivetest.Logger(t)
-
-	ipcacheMock := newIPcacheMock()
-	dp := newSignalNodeHandler()
-	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{
-		EncryptNode: true,
-	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
-	require.NoError(t, err)
-	mngr.Subscribe(dp)
-	defer mngr.Stop(context.TODO())
-
-	n1 := nodeTypes.Node{
-		Name:    "node1",
-		Cluster: "c1",
-		IPAddresses: []nodeTypes.Address{
-			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
-			{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.2")},
-			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
-		},
-		IPv4AllocCIDR:           nodeTypes.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
-		IPv4SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(netip.MustParsePrefix("192.168.10.0/28"))},
-		IPv6AllocCIDR:           nodeTypes.PrefixFrom(netip.MustParsePrefix("f00d::/96")),
-		IPv6SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(netip.MustParsePrefix("cafe::/96"))},
-		EncryptionKey:           42,
-	}
-	mngr.NodeUpdated(n1)
-
-	// node IP addresses
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
-
-	// node IPv4 allocation CIDRs
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("10.0.0.0/24"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("192.168.10.0/28"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-
-	// node IPv6 allocation CIDRs
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("f00d::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "upsert", netip.MustParsePrefix("cafe::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-
-	mngr.NodeDeleted(n1)
-
-	// node IP addresses
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
-
-	// node IPv4 allocation CIDRs
-	expectIPCacheUpdate(
-		t, ipcacheMock, "delete", netip.MustParsePrefix("10.0.0.0/24"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.MustParsePrefix("192.168.10.0/28"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-
-	// node IPv6 allocation CIDRs
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.MustParsePrefix("f00d::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-	expectIPCacheUpdate(
-		t, ipcacheMock, "delete", netip.MustParsePrefix("cafe::/96"),
-		[]ipcache.IPMetadata{
-			worldLabelForPrefix(netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)),
-			ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("10.0.0.2")},
-			ipcacheTypes.EncryptKey(42),
-		},
-	)
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("unexected ipcache interaction %+v", event)
-	default:
-	}
-}
-
 func TestNode(t *testing.T) {
-	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(logger, NewNodeMetrics(), h, nil, nil, nil, nil, testClusterSizeDependantInterval)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -908,11 +378,6 @@ func TestNode(t *testing.T) {
 		t.Errorf("timeout while waiting for NodeAdd() event for node1")
 	}
 
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("192.0.2.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("2001:DB8::1"), 128))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("192.0.2.2"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("2001:DB8::2"), 128))
-
 	n1V2 := n1.DeepCopy()
 	n1V2.IPAddresses = []nodeTypes.Address{
 		{
@@ -938,21 +403,6 @@ func TestNode(t *testing.T) {
 		t.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
 	case <-time.After(3 * time.Second):
 		t.Errorf("timeout while waiting for NodeUpdate() event for node2")
-	}
-
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("192.0.2.10"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("2001:DB8::1"), 128))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("192.0.2.20"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "upsert", netip.PrefixFrom(netip.MustParseAddr("2001:DB8::20"), 128))
-
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("192.0.2.1"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("192.0.2.2"), 32))
-	expectIPCacheUpdate(t, ipcacheMock, "delete", netip.PrefixFrom(netip.MustParseAddr("2001:DB8::2"), 128))
-
-	select {
-	case event := <-ipcacheMock.events:
-		t.Errorf("Received unexpected event %+v", event)
-	case <-time.After(1 * time.Second):
 	}
 
 	nodes := mngr.GetNodes()
@@ -993,17 +443,9 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		lifecycle.Append(m)
 	}
 
-	ipcacheMock := newIPcacheMock()
-	config := &option.DaemonConfig{
-		StateDir: t.TempDir(),
-	}
 	hive := hive.New(
 		cell.Provide(func() testParams {
 			return testParams{
-				Config:      config,
-				TunnelConf:  tunnel.Config{},
-				WgConf:      fakewireguard.Config{},
-				IPCache:     ipcacheMock,
 				NodeMetrics: NewNodeMetrics(),
 			}
 		}),
@@ -1015,7 +457,6 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 			return func(interval time.Duration) time.Duration { return interval }
 		}),
 		cell.Module("node_manager", "Node Manager", cell.Provide(New)),
-		cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.DefaultClusterInfo }),
 		cell.Invoke(fn),
 	)
 	l := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
@@ -1102,40 +543,26 @@ func (mh *mockHealth) Close() {}
 
 type testParams struct {
 	cell.Out
-	Config      *option.DaemonConfig
-	TunnelConf  tunnel.Config
-	WgConf      wgTypes.Config
-	IPCache     IPCache
 	NodeMetrics *nodeMetrics
-}
-
-type mockUpdater struct{}
-
-func (m *mockUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
-	out := make(chan struct{})
-	close(out)
-	return out
 }
 
 func TestNodeWithSameInternalIP(t *testing.T) {
 	logger := hivetest.Logger(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	allocator := testidentity.NewMockIdentityAllocator(nil)
-	ipcache := ipcache.NewIPCache(&ipcache.Configuration{
-		Context:           ctx,
-		Logger:            hivetest.Logger(t),
-		IdentityAllocator: allocator,
-		IdentityUpdater:   &mockUpdater{},
-	})
-	defer cancel()
 	dp := newSignalNodeHandler()
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{
-		LocalRouterIPv4: "169.254.4.6",
-	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcache, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, nil, testClusterSizeDependantInterval)
+	mngr, err := New(
+		logger,
+		NewNodeMetrics(),
+		h,
+		nil,
+		nil,
+		nil,
+		nil,
+		testClusterSizeDependantInterval,
+	)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1212,20 +639,14 @@ func TestNodeTableMirroring(t *testing.T) {
 	require.NoError(t, err)
 	writer := node.NewWriter(logger, db, nodeTable)
 
-	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(
 		logger,
-		&option.DaemonConfig{},
-		cmtypes.ClusterInfo{Name: "c1"},
-		tunnel.Config{},
-		ipcacheMock,
 		NewNodeMetrics(),
 		h,
 		nil,
 		db,
 		nil,
-		fakewireguard.Config{},
 		writer,
 		testClusterSizeDependantInterval,
 	)
@@ -1360,16 +781,11 @@ func TestNodeTableInitializersCompleteInEitherOrder(t *testing.T) {
 			health, _ := cell.NewSimpleHealth()
 			mngr, err := New(
 				hivetest.Logger(t),
-				&option.DaemonConfig{},
-				cmtypes.ClusterInfo{Name: "c1"},
-				tunnel.Config{},
-				newIPcacheMock(),
 				NewNodeMetrics(),
 				health,
 				nil,
 				db,
 				nil,
-				fakewireguard.Config{},
 				writer,
 				testClusterSizeDependantInterval,
 			)

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -54,6 +54,10 @@ func (n *Node) DeepCopy() *Node {
 	return &n2
 }
 
+// AddressClusterID returns the cluster address space assigned to cluster-scoped
+// addresses when the node was written to the table.
+func (n *Node) AddressClusterID() uint32 { return n.addressClusterID }
+
 // TableHeader implements statedb.TableWritable.
 func (n *Node) TableHeader() []string {
 	return []string{


### PR DESCRIPTION
Add a node table reconciler to IPCache to reconcile IPCache entries for nodes and remove the corresponding calls from NodeManager.
