### PR TITLE
node: Bridge SetPrefixClusterMutatorFn to Writer

### DIFF
--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -69,7 +69,7 @@ type NodeManager interface {
 
 	// SetPrefixClusterMutatorFn allows to inject a custom prefix cluster mutator.
 	// The mutator may then be applied to the PrefixCluster(s) using cmtypes.PrefixClusterFrom.
-	SetPrefixClusterMutatorFn(mutator func(*types.Node) []cmtypes.PrefixClusterOpts)
+	SetPrefixClusterMutatorFn(mutator node.PrefixClusterMutatorFn)
 }
 
 func newAllNodeManager(in struct {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -176,7 +176,7 @@ type manager struct {
 	meshNodeTableInit    func()
 
 	// custom mutator function to enrich prefixCluster(s) from node objects.
-	prefixClusterMutatorFn func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts
+	prefixClusterMutatorFn node.PrefixClusterMutatorFn
 
 	// wireguard configuration used when calling endpointEncryptionKey.
 	wgConfig types.Config
@@ -1300,6 +1300,9 @@ func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 
 // SetPrefixClusterMutatorFn allows to inject a custom prefix cluster mutator.
 // The mutator may then be applied to the PrefixCluster(s) using cmtypes.PrefixClusterFrom.
-func (m *manager) SetPrefixClusterMutatorFn(mutator func(*nodeTypes.Node) []cmtypes.PrefixClusterOpts) {
+func (m *manager) SetPrefixClusterMutatorFn(mutator node.PrefixClusterMutatorFn) {
 	m.prefixClusterMutatorFn = mutator
+	if m.writer != nil {
+		m.writer.SetPrefixClusterMutatorFn(mutator)
+	}
 }

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/node/types"
 )
@@ -146,13 +147,14 @@ var (
 	// because configured Cilium internal router addresses may legitimately be
 	// shared by every node. Writer resolves all other conflicts according to
 	// source priority.
-	NodeAddressIndex = statedb.Index[*Node, netip.Addr]{
+	NodeAddressIndex = statedb.Index[*Node, cmtypes.AddrCluster]{
 		Name: "address",
 		FromObject: func(obj *Node) index.KeySet {
 			keys := make([]index.Key, 0, len(obj.IPAddresses)+4)
 			appendAddr := func(addr netip.Addr) {
 				if addr.IsValid() {
-					keys = append(keys, index.NetIPAddr(addr.Unmap()))
+					addrCluster := cmtypes.AddrClusterFrom(addr.Unmap(), 0)
+					keys = append(keys, nodeAddressKey(addrCluster))
 				}
 			}
 			for _, address := range obj.IPAddresses {
@@ -166,8 +168,8 @@ var (
 			appendAddr(obj.IPv6IngressIP.Addr)
 			return index.NewKeySet(keys...)
 		},
-		FromKey:    index.NetIPAddr,
-		FromString: index.NetIPAddrString,
+		FromKey:    nodeAddressKey,
+		FromString: nodeAddressKeyString,
 		Unique:     false,
 	}
 	NodeByAddress = NodeAddressIndex.Query
@@ -189,6 +191,19 @@ var (
 	NodeByLocal    = NodeLocalIndex.Query
 	LocalNodeQuery = NodeByLocal(true)
 )
+
+func nodeAddressKey(addr cmtypes.AddrCluster) index.Key {
+	key := addr.As20()
+	return key[:]
+}
+
+func nodeAddressKeyString(s string) (index.Key, error) {
+	addr, err := cmtypes.ParseAddrCluster(s)
+	if err != nil {
+		return nil, err
+	}
+	return nodeAddressKey(addr), nil
+}
 
 func NewNodeTable(db *statedb.DB) (statedb.RWTable[*Node], error) {
 	return statedb.NewTable(

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -15,6 +15,7 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -27,6 +28,12 @@ type LocalNode = Node
 // +deepequal-gen=true
 type Node struct {
 	types.Node
+
+	// addressClusterID identifies the cluster address space used by
+	// cluster-scoped node addresses. It is derived when the node is written and
+	// is not part of the externally serialized node data.
+	// +deepequal-gen=false
+	addressClusterID uint32
 
 	// Local is non-nil if this is the local node. This carries additional
 	// information about the local node that is not shared outside.
@@ -151,21 +158,25 @@ var (
 		Name: "address",
 		FromObject: func(obj *Node) index.KeySet {
 			keys := make([]index.Key, 0, len(obj.IPAddresses)+4)
-			appendAddr := func(addr netip.Addr) {
+			appendAddr := func(addr netip.Addr, clusterID uint32) {
 				if addr.IsValid() {
-					addrCluster := cmtypes.AddrClusterFrom(addr.Unmap(), 0)
+					addrCluster := cmtypes.AddrClusterFrom(addr.Unmap(), clusterID)
 					keys = append(keys, nodeAddressKey(addrCluster))
 				}
 			}
 			for _, address := range obj.IPAddresses {
 				if addr, ok := netip.AddrFromSlice(address.IP); ok {
-					appendAddr(addr)
+					clusterID := uint32(0)
+					if address.Type == addressing.NodeCiliumInternalIP {
+						clusterID = obj.addressClusterID
+					}
+					appendAddr(addr, clusterID)
 				}
 			}
-			appendAddr(obj.IPv4HealthIP.Addr)
-			appendAddr(obj.IPv6HealthIP.Addr)
-			appendAddr(obj.IPv4IngressIP.Addr)
-			appendAddr(obj.IPv6IngressIP.Addr)
+			appendAddr(obj.IPv4HealthIP.Addr, obj.addressClusterID)
+			appendAddr(obj.IPv6HealthIP.Addr, obj.addressClusterID)
+			appendAddr(obj.IPv4IngressIP.Addr, obj.addressClusterID)
+			appendAddr(obj.IPv6IngressIP.Addr, obj.addressClusterID)
 			return index.NewKeySet(keys...)
 		},
 		FromKey:    nodeAddressKey,

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -4,6 +4,7 @@
 package node
 
 import (
+	"iter"
 	"net/netip"
 	"slices"
 	"strings"
@@ -77,6 +78,52 @@ func (n *Node) TableRow() []string {
 }
 
 var _ statedb.TableWritable = &Node{}
+
+// addressClusters returns the normalized, cluster-aware addresses associated
+// with the node. The optional predicate omits configured Cilium internal
+// router addresses that may intentionally be shared by every node.
+func (n *Node) addressClusters(
+	omitStaticLocalRouterIP func(string) bool,
+) iter.Seq[cmtypes.AddrCluster] {
+	return func(yield func(cmtypes.AddrCluster) bool) {
+		yieldAddr := func(addr netip.Addr, clusterID uint32) bool {
+			if !addr.IsValid() {
+				return true
+			}
+			return yield(cmtypes.AddrClusterFrom(addr.Unmap(), clusterID))
+		}
+
+		for _, address := range n.IPAddresses {
+			if address.Type == addressing.NodeCiliumInternalIP &&
+				omitStaticLocalRouterIP != nil &&
+				omitStaticLocalRouterIP(address.ToString()) {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(address.IP)
+			if !ok {
+				continue
+			}
+			clusterID := uint32(0)
+			if address.Type == addressing.NodeCiliumInternalIP {
+				clusterID = n.addressClusterID
+			}
+			if !yieldAddr(addr, clusterID) {
+				return
+			}
+		}
+
+		for _, addr := range []netip.Addr{
+			n.IPv4HealthIP.Addr,
+			n.IPv6HealthIP.Addr,
+			n.IPv4IngressIP.Addr,
+			n.IPv6IngressIP.Addr,
+		} {
+			if !yieldAddr(addr, n.addressClusterID) {
+				return
+			}
+		}
+	}
+}
 
 // LocalNodeInfo is the additional information about the local node that
 // is only used internally.
@@ -158,25 +205,9 @@ var (
 		Name: "address",
 		FromObject: func(obj *Node) index.KeySet {
 			keys := make([]index.Key, 0, len(obj.IPAddresses)+4)
-			appendAddr := func(addr netip.Addr, clusterID uint32) {
-				if addr.IsValid() {
-					addrCluster := cmtypes.AddrClusterFrom(addr.Unmap(), clusterID)
-					keys = append(keys, nodeAddressKey(addrCluster))
-				}
+			for addr := range obj.addressClusters(nil) {
+				keys = append(keys, nodeAddressKey(addr))
 			}
-			for _, address := range obj.IPAddresses {
-				if addr, ok := netip.AddrFromSlice(address.IP); ok {
-					clusterID := uint32(0)
-					if address.Type == addressing.NodeCiliumInternalIP {
-						clusterID = obj.addressClusterID
-					}
-					appendAddr(addr, clusterID)
-				}
-			}
-			appendAddr(obj.IPv4HealthIP.Addr, obj.addressClusterID)
-			appendAddr(obj.IPv6HealthIP.Addr, obj.addressClusterID)
-			appendAddr(obj.IPv4IngressIP.Addr, obj.addressClusterID)
-			appendAddr(obj.IPv6IngressIP.Addr, obj.addressClusterID)
 			return index.NewKeySet(keys...)
 		},
 		FromKey:    nodeAddressKey,

--- a/pkg/node/table_test.go
+++ b/pkg/node/table_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package node
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+func TestNodeAddressIndexClusterIdentity(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+
+	n := &Node{
+		Node: nodeTypes.Node{
+			Name:      "node-1",
+			ClusterID: 99,
+			IPAddresses: []nodeTypes.Address{
+				{
+					Type: addressing.NodeCiliumInternalIP,
+					IP:   net.ParseIP("10.0.0.1"),
+				},
+				{
+					Type: addressing.NodeInternalIP,
+					IP:   net.ParseIP("192.0.2.1"),
+				},
+			},
+			IPv4HealthIP:  iputil.AddrFrom(netip.MustParseAddr("10.0.0.2")),
+			IPv4IngressIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.3")),
+		},
+		addressClusterID: 42,
+	}
+	txn := db.WriteTxn(nodes)
+	_, _, err = nodes.Insert(txn, n)
+	require.NoError(t, err)
+	txn.Commit()
+
+	tests := []struct {
+		name      string
+		address   string
+		clusterID uint32
+		found     bool
+	}{
+		{"cilium address in cluster", "10.0.0.1", 42, true},
+		{"cilium address locally scoped", "10.0.0.1", 0, false},
+		{"cilium address from serialized cluster ID", "10.0.0.1", 99, false},
+		{"underlay address globally scoped", "192.0.2.1", 0, true},
+		{"underlay address in cluster", "192.0.2.1", 42, false},
+		{"health address in cluster", "10.0.0.2", 42, true},
+		{"ingress address in cluster", "10.0.0.3", 42, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address := cmtypes.AddrClusterFrom(
+				netip.MustParseAddr(tt.address),
+				tt.clusterID,
+			)
+			_, _, found := nodes.Get(db.ReadTxn(), NodeByAddress(address))
+			require.Equal(t, tt.found, found)
+		})
+	}
+}

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -255,7 +256,8 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 	// a single stronger owner rejects the update without deleting weaker ones.
 	conflicts := map[string]*Node{}
 	for _, addr := range w.conflictAddresses(n) {
-		for candidate := range w.nodes.List(txn, NodeByAddress(addr)) {
+		addrCluster := cmtypes.AddrClusterFrom(addr, 0)
+		for candidate := range w.nodes.List(txn, NodeByAddress(addrCluster)) {
 			if candidate.Fullname() == obj.Fullname() {
 				continue
 			}

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -17,7 +17,6 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -30,10 +29,15 @@ type Writer struct {
 	db    *statedb.DB
 	nodes statedb.RWTable[*Node]
 
-	isStaticLocalRouterIP func(string) bool
+	isStaticLocalRouterIP  func(string) bool
+	prefixClusterMutatorFn PrefixClusterMutatorFn
 
 	requiredReconcilers []string
 }
+
+// PrefixClusterMutatorFn derives cluster-aware addressing options from a
+// serialized node.
+type PrefixClusterMutatorFn = func(*nodeTypes.Node) []cmtypes.PrefixClusterOpts
 
 // NewWriter constructs a node table writer.
 func NewWriter(log *slog.Logger, db *statedb.DB, nodes statedb.RWTable[*Node]) *Writer {
@@ -59,6 +63,21 @@ func provideWriter(p writerParams) *Writer {
 
 // Table returns read-only access to the node table.
 func (w *Writer) Table() statedb.Table[*Node] { return w.nodes }
+
+// SetPrefixClusterMutatorFn installs the cluster-address qualification hook.
+// This hook must be set during Hive invoke time.
+func (w *Writer) SetPrefixClusterMutatorFn(mutator PrefixClusterMutatorFn) {
+	w.prefixClusterMutatorFn = mutator
+}
+
+func deriveAddressClusterID(mutator PrefixClusterMutatorFn, n *nodeTypes.Node) uint32 {
+	if mutator == nil {
+		return 0
+	}
+	// The mutator only enriches PrefixCluster metadata. The prefix itself is
+	// irrelevant when extracting the derived cluster ID.
+	return cmtypes.PrefixClusterFrom(netip.Prefix{}, mutator(n)...).ClusterID()
+}
 
 // RegisterInitializer registers a producer that must finish its initial node
 // listing before the table is considered initialized.
@@ -232,8 +251,9 @@ func (w *Writer) Refresh(ctx context.Context) error {
 func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 	reconcilers := w.getRequiredReconcilers(txn)
 	obj := &Node{
-		Node:     *n,
-		Statuses: reconciler.NewStatusSet().Pending(reconcilers...),
+		Node:             *n,
+		addressClusterID: deriveAddressClusterID(w.prefixClusterMutatorFn, n),
+		Statuses:         reconciler.NewStatusSet().Pending(reconcilers...),
 	}
 
 	old, _, found := w.nodes.Get(txn, NodeByName(obj.Fullname()))
@@ -246,7 +266,8 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 			)
 			return false
 		}
-		if old.Node.DeepEqual(&obj.Node) {
+		if old.Node.DeepEqual(&obj.Node) &&
+			old.addressClusterID == obj.addressClusterID {
 			return false
 		}
 	}
@@ -255,14 +276,16 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 	// operation atomic when an incoming node overlaps multiple existing nodes:
 	// a single stronger owner rejects the update without deleting weaker ones.
 	conflicts := map[string]*Node{}
-	for _, addr := range w.conflictAddresses(n) {
-		addrCluster := cmtypes.AddrClusterFrom(addr, 0)
+	for addrCluster := range obj.addressClusters(w.isStaticLocalRouterIP) {
 		for candidate := range w.nodes.List(txn, NodeByAddress(addrCluster)) {
 			if candidate.Fullname() == obj.Fullname() {
 				continue
 			}
+			if _, found := conflicts[candidate.Fullname()]; found {
+				continue
+			}
 			w.log.Warn("Node address conflicts with another node",
-				logfields.IPAddr, addr,
+				logfields.IPAddr, addrCluster,
 				logfields.Node, obj.Fullname(),
 				logfields.Source, obj.Source,
 				logfields.ConflictingResource, candidate.Fullname(),
@@ -301,40 +324,6 @@ func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
 		return false
 	}
 	return true
-}
-
-// conflictAddresses returns the normalized addresses whose ownership used to
-// gate NodeManager datapath updates. Configured Cilium internal router IPs are
-// omitted because they may intentionally be shared by every node. IPv4-mapped
-// IPv6 addresses are normalized to IPv4 so both representations conflict with
-// one another.
-func (w *Writer) conflictAddresses(n *nodeTypes.Node) []netip.Addr {
-	addrs := make([]netip.Addr, 0, len(n.IPAddresses)+4)
-	appendAddr := func(addr netip.Addr) {
-		if addr.IsValid() {
-			addrs = append(addrs, addr.Unmap())
-		}
-	}
-
-	for _, address := range n.IPAddresses {
-		// In delegated IPAM mode the local router IP is configured statically and is the same
-		// on all nodes. Exempt the conflict in those cases.
-		if address.Type == addressing.NodeCiliumInternalIP &&
-			w.isStaticLocalRouterIP != nil &&
-			w.isStaticLocalRouterIP(address.ToString()) {
-			continue
-		}
-		if addr, ok := netip.AddrFromSlice(address.IP); ok {
-			appendAddr(addr)
-		}
-	}
-	appendAddr(n.IPv4HealthIP.Addr)
-	appendAddr(n.IPv6HealthIP.Addr)
-	appendAddr(n.IPv4IngressIP.Addr)
-	appendAddr(n.IPv6IngressIP.Addr)
-
-	slices.SortFunc(addrs, netip.Addr.Compare)
-	return slices.Compact(addrs)
 }
 
 // Delete removes a remote node if this writer's source still owns it. It

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -480,7 +481,8 @@ func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
 		netip.MustParseAddr("fe80::"),
 	} {
 		var owners []string
-		for n := range nodes.List(db.ReadTxn(), NodeByAddress(address)) {
+		addrCluster := cmtypes.AddrClusterFrom(address, 0)
+		for n := range nodes.List(db.ReadTxn(), NodeByAddress(addrCluster)) {
 			owners = append(owners, n.Name)
 		}
 		require.ElementsMatch(t, []string{"local", "remote-1", "remote-2"}, owners)

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -432,6 +432,92 @@ func TestWriterAddressConflicts(t *testing.T) {
 	requireNoNode("mixed")
 }
 
+func TestWriterClusterAwareAddressConflicts(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	upsert := func(n *types.Node) bool {
+		txn := db.WriteTxn(nodes)
+		defer txn.Commit()
+		return w.Upsert(txn, n)
+	}
+	requireNode := func(name string) *Node {
+		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.True(t, found, name)
+		return n
+	}
+	requireNoNode := func(name string) {
+		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
+		require.False(t, found, name)
+	}
+	newNode := func(
+		name, cluster string,
+		addressType addressing.AddressType,
+		address string,
+	) *types.Node {
+		return &types.Node{
+			Name:      name,
+			Cluster:   cluster,
+			ClusterID: 99,
+			Source:    source.Kubernetes,
+			IPAddresses: []types.Address{{
+				Type: addressType,
+				IP:   net.ParseIP(address),
+			}},
+		}
+	}
+
+	// The hook is installed during Hive invoke time, before producers write to
+	// the table.
+	w.SetPrefixClusterMutatorFn(func(n *types.Node) []cmtypes.PrefixClusterOpts {
+		clusterIDs := map[string]uint32{"cluster-1": 1, "cluster-2": 2}
+		return []cmtypes.PrefixClusterOpts{cmtypes.WithClusterID(clusterIDs[n.Cluster])}
+	})
+
+	// The serialized ClusterID is deliberately unrelated to address-space
+	// qualification and must not affect the index.
+	require.True(t, upsert(newNode(
+		"node-1", "cluster-1", addressing.NodeCiliumInternalIP, "10.0.0.1",
+	)))
+	_, _, found := nodes.Get(
+		db.ReadTxn(),
+		NodeByAddress(cmtypes.AddrClusterFrom(netip.MustParseAddr("10.0.0.1"), 0)),
+	)
+	require.False(t, found)
+	_, _, found = nodes.Get(
+		db.ReadTxn(),
+		NodeByAddress(cmtypes.AddrClusterFrom(netip.MustParseAddr("10.0.0.1"), 1)),
+	)
+	require.True(t, found)
+
+	// Cluster-scoped Cilium internal addresses may overlap across clusters.
+	require.True(t, upsert(newNode(
+		"node-2", "cluster-2", addressing.NodeCiliumInternalIP, "10.0.0.1",
+	)))
+	requireNode("cluster-1/node-1")
+	requireNode("cluster-2/node-2")
+
+	// The same address in the same cluster still follows normal ownership rules.
+	require.True(t, upsert(newNode(
+		"latest", "cluster-1", addressing.NodeCiliumInternalIP, "10.0.0.1",
+	)))
+	requireNoNode("cluster-1/node-1")
+	requireNode("cluster-1/latest")
+	requireNode("cluster-2/node-2")
+
+	// Underlay addresses remain globally scoped and conflict across clusters.
+	require.True(t, upsert(newNode(
+		"underlay-1", "cluster-1", addressing.NodeInternalIP, "192.0.2.1",
+	)))
+	require.True(t, upsert(newNode(
+		"underlay-2", "cluster-2", addressing.NodeInternalIP, "192.0.2.1",
+	)))
+	requireNoNode("cluster-1/underlay-1")
+	requireNode("cluster-2/underlay-2")
+}
+
 func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
 	db := statedb.New()
 	nodes, err := NewNodeTable(db)


### PR DESCRIPTION
For semantically correct conflict checking the new node.Writer will also need to care about the PrefixClusterMutatorFn and compare addresses as PrefixCluster and not netip.Addr.

AIL:3