### PR TITLE
docs: Avoid indexing documentation fragments

### DIFF
--- a/Documentation/.readthedocs.yaml
+++ b/Documentation/.readthedocs.yaml
@@ -21,3 +21,23 @@ sphinx:
 python:
   install:
   - requirements: Documentation/requirements.txt
+
+search:
+   ignore:
+     - '*.inc'
+     - 'alpha.rst'
+     - 'beta.rst'
+     - 'installation/cli-download.rst'
+     - 'installation/cli-status.rst'
+     - 'installation/cni-chaining-limitations.rst'
+     - 'installation/k8s-install-download-release.rst'
+     - 'installation/k8s-install-validate.rst'
+     - 'installation/next-steps.rst'
+     - 'installation/requirements-*.rst'
+     - 'network/kubernetes/compatibility-table.rst'
+     - 'network/servicemesh/gateway-api/demo-app.rst'
+     - 'network/servicemesh/gateway-api/tls-cert.rst'
+     - 'network/servicemesh/installation.rst'
+     - 'network/servicemesh/warning.rst'
+     - 'security/gsg_requirements.rst'
+     - 'security/gsg_sw_demo.rst'


### PR DESCRIPTION
When you do a search for certain terms like 'upgrade', some fragment
pages are indexed with broken links. It looks like the cause is that RTD
docsearch doesn't index based on the pages that are viewable to the
user, but most likely instead directly based on filepaths in the
repository. Hopefully if we configure these settings, the irrelevant
search results will be filtered out.

Specification reference:
https://github.com/readthedocs/readthedocs.org/blob/2026.08.26/readthedocs/rtd_tests/fixtures/spec/v2/schema.json#L561

Reported-by: @HadrienPatte
