### PR TITLE
fqdn: hold zombie names in a set

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
-	ciliumslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -840,9 +839,9 @@ func (c *DNSCache) UnmarshalJSON(raw []byte) error {
 //     to evict IPs with less DNS churn on them.
 //   - Zombies with the lowest count of DNS names in them are evicted first
 type DNSZombieMapping struct {
-	// Names is the list of names that had DNS lookups with this IP. These may
-	// derive from unrelated DNS lookups. The list is maintained de-duplicated.
-	Names []string `json:"names,omitempty"`
+	// Names is the set of names that had DNS lookups with this IP. These may
+	// derive from unrelated DNS lookups.
+	Names nameSet `json:"names,omitempty"`
 
 	// IP is an address that is pending for delete but may be in-use by a
 	// connection.
@@ -870,11 +869,57 @@ type DNSZombieMapping struct {
 	revisionAddedAt uint64 `json:"-"`
 }
 
+// nameSet is the set of DNS names a zombie holds.
+//
+// It is a defined type rather than sets.Set[string] used directly so that the
+// JSON encoding can live on the field itself. The endpoint header file is a
+// stable format and has to keep names as an array; a plain map-typed field
+// would encode as an object instead.
+type nameSet sets.Set[string]
+
+// newNameSet returns a nameSet holding names, de-duplicated.
+func newNameSet(names ...string) nameSet {
+	return nameSet(sets.New(names...))
+}
+
+// Insert adds names to the set, allocating it if needed. The receiver is a
+// pointer because a zombie restored from JSON that had no names has a nil set:
+// "names" is omitempty, so the field decoder never runs and never allocates.
+func (n *nameSet) Insert(names ...string) {
+	if *n == nil {
+		*n = newNameSet()
+	}
+	sets.Set[string](*n).Insert(names...)
+}
+
+func (n nameSet) Delete(names ...string) { sets.Set[string](n).Delete(names...) }
+
+// Sorted returns the names as a sorted slice. A set has no iteration order, so
+// sort wherever the order is observable, and identical state then produces
+// identical output.
+func (n nameSet) Sorted() []string { return sets.List(sets.Set[string](n)) }
+
+// MarshalJSON encodes the set as a sorted array. The receiver is a value, so
+// encoding/json finds it however the enclosing zombie is passed -- by pointer,
+// by value, or as a map element.
+func (n nameSet) MarshalJSON() ([]byte, error) { return json.Marshal(n.Sorted()) }
+
+// UnmarshalJSON decodes the array form back into a set. Restored names are not
+// trusted to be unique; loading them into a set de-duplicates them.
+func (n *nameSet) UnmarshalJSON(raw []byte) error {
+	var names []string
+	if err := json.Unmarshal(raw, &names); err != nil {
+		return err
+	}
+	*n = newNameSet(names...)
+	return nil
+}
+
 // DeepCopy returns a copy of zombie that does not share any internal pointers
 // or fields
 func (zombie *DNSZombieMapping) DeepCopy() *DNSZombieMapping {
 	return &DNSZombieMapping{
-		Names:           slices.Clone(zombie.Names),
+		Names:           maps.Clone(zombie.Names),
 		IP:              zombie.IP,
 		DeletePendingAt: zombie.DeletePendingAt,
 		AliveAt:         zombie.AliveAt,
@@ -923,7 +968,7 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, 
 	zombie, updatedExisting := zombies.deletes[addr]
 	if !updatedExisting {
 		zombie = &DNSZombieMapping{
-			Names:           ciliumslices.Unique(qname),
+			Names:           make(nameSet, len(qname)),
 			IP:              addr,
 			AliveAt:         zombies.lastCTGCUpdate,
 			DeletePendingAt: expiryTime,
@@ -931,7 +976,6 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, 
 		}
 		zombies.deletes[addr] = zombie
 	} else {
-		zombie.Names = ciliumslices.Unique(append(zombie.Names, qname...))
 		// Keep the latest expiry time
 		if expiryTime.After(zombie.DeletePendingAt) {
 			zombie.DeletePendingAt = expiryTime
@@ -941,6 +985,7 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, 
 			zombie.AliveAt = zombies.lastCTGCUpdate
 		}
 	}
+	zombie.Names.Insert(qname...)
 	return updatedExisting
 }
 
@@ -976,7 +1021,7 @@ func (zombies *DNSZombieMappings) getAliveNames() map[string][]*DNSZombieMapping
 
 	for _, z := range zombies.deletes {
 		if zombies.isConnectionAlive(z) {
-			for _, name := range z.Names {
+			for name := range z.Names {
 				if _, ok := aliveNames[name]; !ok {
 					aliveNames[name] = make([]*DNSZombieMapping, 0, 5)
 				}
@@ -988,7 +1033,7 @@ func (zombies *DNSZombieMappings) getAliveNames() map[string][]*DNSZombieMapping
 	// Add all of the "dead" IPs for live names into the result
 	for _, z := range zombies.deletes {
 		if !zombies.isConnectionAlive(z) {
-			for _, name := range z.Names {
+			for name := range z.Names {
 				if _, ok := aliveNames[name]; ok {
 					aliveNames[name] = append(aliveNames[name], z)
 				}
@@ -1012,7 +1057,7 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 		}
 	}
 
-	for _, name := range zombie.Names {
+	for name := range zombie.Names {
 		if z, ok := aliveNames[name]; ok {
 			alive = true
 			if zombies.perHostLimit == 0 {
@@ -1214,17 +1259,15 @@ func (zombies *DNSZombieMappings) ForceExpire(expireLookupsBefore time.Time, nam
 			continue
 		}
 
-		// A zombie has multiple names, collect the ones that should remain (i.e.
-		// do not match nameMatch)
-		var newNames []string
-		for _, name := range zombie.Names {
+		// A zombie has multiple names, drop the ones matching nameMatch and
+		// keep the rest. Deleting during a map range is safe.
+		for name := range zombie.Names {
 			if nameMatch != nil && !nameMatch.MatchString(name) {
-				newNames = append(newNames, name)
-			} else {
-				namesAffected = append(namesAffected, name)
+				continue
 			}
+			namesAffected = append(namesAffected, name)
+			zombie.Names.Delete(name)
 		}
-		zombie.Names = newNames
 
 		// Delete the zombie outright if no names remain
 		if len(zombie.Names) == 0 {
@@ -1258,7 +1301,7 @@ func (zombies *DNSZombieMappings) ForceExpireByNameIP(expireLookupsBefore time.T
 
 		// Remove the specified name (if extant) and, if it was
 		// the last one, delete the entry entirely
-		zombie.Names = slices.DeleteFunc(zombie.Names, func(s string) bool { return s == name })
+		zombie.Names.Delete(name)
 		if len(zombie.Names) == 0 {
 			delete(zombies.deletes, ip)
 		}

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -605,12 +605,12 @@ func assertZombiesContain(t *testing.T, zombies []*DNSZombieMapping, expected ma
 		names, exists := expected[zombie.IP.String()]
 		require.Truef(t, exists, "Unexpected zombie %s in zombies", zombie.IP.String())
 
-		slices.Sort(zombie.Names)
+		got := zombie.Names.Sorted()
 		slices.Sort(names)
 
-		require.Len(t, zombie.Names, len(names))
-		for i := range zombie.Names {
-			require.Equal(t, names[i], zombie.Names[i], "Unexpected name in zombie names list")
+		require.Len(t, got, len(names))
+		for i := range got {
+			require.Equal(t, names[i], got[i], "Unexpected name in zombie names list")
 		}
 	}
 }
@@ -1261,7 +1261,7 @@ func TestPerHostLimitBehaviourForS3(t *testing.T) {
 func (z *DNSZombieMapping) String() string {
 	return fmt.Sprintf(
 		"DNSZombieMapping{AliveAt: %s, DeletePendingAt: %s, Names: %v}",
-		z.AliveAt, z.DeletePendingAt, z.Names,
+		z.AliveAt, z.DeletePendingAt, z.Names.Sorted(),
 	)
 }
 
@@ -1331,7 +1331,7 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 		{
 			"single",
 			args{zombies: []*DNSZombieMapping{{
-				Names:           []string{"test.com"},
+				Names:           newNameSet("test.com"),
 				AliveAt:         moments[0],
 				DeletePendingAt: moments[1],
 			}}},
@@ -1364,12 +1364,12 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 			"swapped equal times, tiebreaker",
 			args{zombies: []*DNSZombieMapping{
 				{
-					Names:           []string{"test.com", "test2.com"},
+					Names:           newNameSet("test.com", "test2.com"),
 					AliveAt:         moments[0],
 					DeletePendingAt: moments[1],
 				},
 				{
-					Names:           []string{"test.com"},
+					Names:           newNameSet("test.com"),
 					AliveAt:         moments[0],
 					DeletePendingAt: moments[1],
 				},
@@ -1388,7 +1388,7 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 				m := DNSZombieMapping{
 					AliveAt:         mi,
 					DeletePendingAt: mj,
-					Names:           names[:k],
+					Names:           newNameSet(names[:k]...),
 				}
 				allMappings = append(allMappings, &m)
 			}
@@ -1423,4 +1423,130 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 			validateZombieSort(t, tt.args.zombies)
 		})
 	}
+}
+
+// DNSZombieMapping is written to the endpoint header file, which is a stable
+// format: an agent of a different version has to read back what this one wrote.
+// Names is a set in memory but must stay an array on the wire, so the tests
+// below pin the actual bytes rather than round-tripping through this same code.
+
+// zombieForWire returns a zombie with fixed timestamps and unsorted names, so
+// encoding it exercises ordering rather than an already-canonical case.
+func zombieForWire() DNSZombieMapping {
+	return DNSZombieMapping{
+		IP:              netip.MustParseAddr("10.0.0.1"),
+		AliveAt:         time.Unix(1, 0).UTC(),
+		DeletePendingAt: time.Unix(2, 0).UTC(),
+		Names:           newNameSet("zeta.example.com", "alpha.example.com"),
+	}
+}
+
+const zombieWireJSON = `{"names":["alpha.example.com","zeta.example.com"],` +
+	`"ip":"10.0.0.1","alive-at":"1970-01-01T00:00:01Z",` +
+	`"delete-pending-at":"1970-01-01T00:00:02Z"}`
+
+// The whole field rests on nameSet.MarshalJSON being reached: encoding/json
+// only finds a pointer method on an addressable value, so with a pointer
+// receiver a zombie arriving as a plain value -- a map element, say -- would
+// serialize with no names at all and no error. Cover every form callers can
+// hand it, and pin the bytes once.
+func TestZombieNamesSerialize(t *testing.T) {
+	zombie := zombieForWire()
+
+	t.Run("wire format", func(t *testing.T) {
+		encoded, err := json.Marshal(&zombie)
+		require.NoError(t, err)
+		require.JSONEq(t, zombieWireJSON, string(encoded),
+			"names must be a sorted array, not a map")
+	})
+
+	for name, encode := range map[string]func() ([]byte, error){
+		"pointer":       func() ([]byte, error) { return json.Marshal(&zombie) },
+		"value":         func() ([]byte, error) { return json.Marshal(zombie) },
+		"map element":   func() ([]byte, error) { return json.Marshal(map[string]DNSZombieMapping{"k": zombie}) },
+		"slice element": func() ([]byte, error) { return json.Marshal([]DNSZombieMapping{zombie}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := encode()
+			require.NoError(t, err)
+			require.Contains(t, string(encoded), `"names":["alpha.example.com","zeta.example.com"]`,
+				"%s must serialize names, not drop them silently", name)
+		})
+	}
+
+	// An agent running the previous release reads Names as a plain []string.
+	// Decoding what this revision writes with that shape catches the set
+	// leaking onto the wire as an object.
+	t.Run("previous release can decode", func(t *testing.T) {
+		zombies := NewDNSZombieMappings(hivetest.Logger(t), defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
+		zombies.Upsert(time.Unix(2, 0).UTC(), zombie.IP, "zeta.example.com", "alpha.example.com")
+
+		raw, err := json.Marshal(zombies)
+		require.NoError(t, err)
+
+		var legacy struct {
+			Deletes map[netip.Addr]struct {
+				Names           []string  `json:"names,omitempty"`
+				IP              string    `json:"ip,omitempty"`
+				DeletePendingAt time.Time `json:"delete-pending-at,omitempty"`
+			} `json:"deletes,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &legacy))
+
+		got := legacy.Deletes[zombie.IP]
+		require.Equal(t, []string{"alpha.example.com", "zeta.example.com"}, got.Names)
+		require.Equal(t, "10.0.0.1", got.IP)
+		require.Equal(t, time.Unix(2, 0).UTC(), got.DeletePendingAt.UTC())
+	})
+}
+
+// Names written by an older agent are not de-duplicated, so a restored array
+// may repeat a name. Loading it into a set has to collapse those.
+func TestZombieNamesDeserialize(t *testing.T) {
+	t.Run("from array", func(t *testing.T) {
+		raw := `{"names":["zeta.example.com","alpha.example.com","alpha.example.com"],` +
+			`"ip":"10.0.0.1","alive-at":"1970-01-01T00:00:01Z",` +
+			`"delete-pending-at":"1970-01-01T00:00:02Z"}`
+
+		var zombie DNSZombieMapping
+		require.NoError(t, json.Unmarshal([]byte(raw), &zombie))
+
+		require.Equal(t, []string{"alpha.example.com", "zeta.example.com"}, zombie.Names.Sorted(),
+			"restored names must be de-duplicated")
+		require.Equal(t, netip.MustParseAddr("10.0.0.1"), zombie.IP)
+		require.Equal(t, time.Unix(1, 0).UTC(), zombie.AliveAt.UTC())
+		require.Equal(t, time.Unix(2, 0).UTC(), zombie.DeletePendingAt.UTC())
+	})
+
+	// A zombie holding no names omits "names" entirely, so the field decoder
+	// never runs and never allocates the set. Upserting into that restored
+	// zombie must not panic on a nil map.
+	t.Run("without names", func(t *testing.T) {
+		ip := netip.MustParseAddr("10.0.0.3")
+
+		src := NewDNSZombieMappings(hivetest.Logger(t), defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
+		src.Upsert(time.Unix(4, 0).UTC(), ip)
+		raw, err := json.Marshal(src)
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), `"names"`, "a nameless zombie must omit the field")
+
+		restored := NewDNSZombieMappings(hivetest.Logger(t), defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
+		require.NoError(t, json.Unmarshal(raw, restored))
+
+		require.NotPanics(t, func() {
+			restored.Upsert(time.Unix(5, 0).UTC(), ip, "late.example.com")
+		}, "Upsert into a restored nameless zombie must not panic")
+		require.Equal(t, []string{"late.example.com"}, restored.deletes[ip].Names.Sorted())
+	})
+}
+
+// DeepCopy must not share the names map, or GC callers would mutate live state.
+func TestZombieDeepCopyDoesNotShareNames(t *testing.T) {
+	zombie := zombieForWire()
+
+	cp := zombie.DeepCopy()
+	cp.Names.Insert("new.example.com")
+
+	require.Equal(t, []string{"alpha.example.com", "zeta.example.com"}, zombie.Names.Sorted(),
+		"mutating the copy must not affect the original")
 }

--- a/pkg/fqdn/namemanager/api.go
+++ b/pkg/fqdn/namemanager/api.go
@@ -127,7 +127,7 @@ func (n *manager) dnsHistoryModel(endpointID string, prefixMatcher fqdn.PrefixMa
 		}
 
 		for _, delete := range ep.DNSZombies.DumpAlive(prefixMatcher) {
-			for _, name := range delete.Names {
+			for name := range delete.Names {
 				if !nameMatcher(name) {
 					continue
 				}
@@ -186,8 +186,8 @@ func (n *manager) deleteDNSLookups(expireLookupsBefore time.Time, matchPatternSt
 		zombies, dead := ep.DNSZombies.GC()
 		lookupTime := time.Now()
 		for _, zombie := range zombies {
-			namesToRegen.Insert(zombie.Names...)
-			for _, name := range zombie.Names {
+			for name := range zombie.Names {
+				namesToRegen.Insert(name)
 				activeConnections.Update(lookupTime, name, []netip.Addr{zombie.IP}, 0)
 			}
 		}

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -89,7 +89,7 @@ func (n *manager) doGC(ctx context.Context) error {
 		//
 		lookupTime := time.Now()
 		for _, zombie := range alive {
-			for _, name := range zombie.Names {
+			for name := range zombie.Names {
 				namesToClean.Insert(name)
 				activeConnections.Update(lookupTime, name, []netip.Addr{zombie.IP}, activeConnectionsTTL)
 			}
@@ -99,7 +99,9 @@ func (n *manager) doGC(ctx context.Context) error {
 		// Entries here have been evicted from the DNS cache (via .GC due to
 		// TTL expiration or overlimit) and are no longer active connections.
 		for _, zombie := range dead {
-			namesToClean.Insert(zombie.Names...)
+			for name := range zombie.Names {
+				namesToClean.Insert(name)
+			}
 		}
 
 		// Sync endpoint's persisted state if the DNS state changed during this GC run.
@@ -206,7 +208,7 @@ func (n *manager) RestorationNotify(possibleEndpoints map[uint16]*endpoint.Endpo
 			lookupTime := time.Now()
 			alive, _ := possibleEP.DNSZombies.GC()
 			for _, zombie := range alive {
-				for _, name := range zombie.Names {
+				for name := range zombie.Names {
 					n.cache.Update(lookupTime, name, []netip.Addr{zombie.IP}, int(2*DNSGCJobInterval.Seconds()))
 				}
 			}


### PR DESCRIPTION
`DNSZombieMapping.Names` is a slice kept unique by re-running `slices.Unique` over the whole slice on every `Upsert`. It takes O(n^2) below 192 elements, and above that allocates a fresh map sized to the entire slice on every call. `DNSCache.GC` calls `Upsert` once per expired entry, so accumulating N names onto a single IP costs O(N^2).
This is reachable whenever many distinct FQDNs resolve to the same IP and that IP is held open by a connection: the zombie is never reaped, so its name list only grows. #48359 

Hold `Names` as a set instead, so the membership test `Upsert` has to make is O(1).

## Benchmarks
- `UpsertDistinctNames` adds N different names, one `Upsert` per name. This is what `DNSCache.GC` does when many expired names share an IP. It measures the cost of building up the whole name list.
- `UpsertExistingName` builds the N names first, then times one `Upsert` of a name that is already there. It measures only the check for whether a name is already present.
- `ForceExpireByNameIP` looks for one name that the zombie does not hold. This runs on the DNS response path, once per response, from `NotifyOnDNSMsg`.

Before:
```
> go test ./pkg/fqdn/ -run '^$' -bench BenchmarkZombie -benchmem
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn
cpu: AMD Ryzen AI 7 PRO 350 w/ Radeon 860M
BenchmarkZombieUpsertDistinctNames/names=500-16        200     5943681 ns/op     4712159 B/op     1440 allocs/op
BenchmarkZombieUpsertDistinctNames/names=2000-16        18    68727532 ns/op    89017031 B/op    10667 allocs/op
BenchmarkZombieUpsertDistinctNames/names=8000-16         1  1207600097 ns/op  1455460984 B/op   123624 allocs/op
BenchmarkZombieUpsertExistingName/names=500-16       52324       21400 ns/op       27320 B/op        4 allocs/op
BenchmarkZombieUpsertExistingName/names=2000-16      15432       78272 ns/op      109236 B/op       10 allocs/op
BenchmarkZombieUpsertExistingName/names=8000-16       3794      341778 ns/op      436928 B/op       34 allocs/op
BenchmarkZombieForceExpireByNameIP/names=500-16    1703840         707.3 ns/op         0 B/op        0 allocs/op
BenchmarkZombieForceExpireByNameIP/names=2000-16    449528        2841 ns/op           0 B/op        0 allocs/op
BenchmarkZombieForceExpireByNameIP/names=8000-16    100774       10925 ns/op           0 B/op        0 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn       10.867s
```

After:
```
> go test ./pkg/fqdn/ -run '^$' -bench BenchmarkZombie -benchmem
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/fqdn
cpu: AMD Ryzen AI 7 PRO 350 w/ Radeon 860M
BenchmarkZombieUpsertDistinctNames/names=500-16      20227       58410 ns/op       54937 B/op       21 allocs/op
BenchmarkZombieUpsertDistinctNames/names=2000-16      5384      284883 ns/op      218762 B/op       35 allocs/op
BenchmarkZombieUpsertDistinctNames/names=8000-16       970     1319583 ns/op      874015 B/op       85 allocs/op
BenchmarkZombieUpsertExistingName/names=500-16    27474918          43.46 ns/op        0 B/op        0 allocs/op
BenchmarkZombieUpsertExistingName/names=2000-16   20154454          57.84 ns/op        0 B/op        0 allocs/op
BenchmarkZombieUpsertExistingName/names=8000-16   27493027          45.41 ns/op        0 B/op        0 allocs/op
BenchmarkZombieForceExpireByNameIP/names=500-16   23781009          47.21 ns/op        0 B/op        0 allocs/op
BenchmarkZombieForceExpireByNameIP/names=2000-16  25672296          54.21 ns/op        0 B/op        0 allocs/op
BenchmarkZombieForceExpireByNameIP/names=8000-16  21098392          51.21 ns/op        0 B/op        0 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/fqdn       11.224s
```

Building the list was quadratic and is now linear. Each time N grows 4x, the old cost grew 11.6x then 17.6x, the new cost grows 4.9x then 4.6x. At 8,000 names one pass drops from 1.21s to 1.32ms, and from 1.45GB to 874KB allocated.
The second benchmark shows why. Checking one name used to get slower as the list grew, from 21.4us at 500 names to 342us at 8,000, because it rescanned the whole list. It is now flat at roughly 43-58ns with no allocations, however many names the IP holds.
The third is the same scan on a different path. `ForceExpireByNameIP` used `slices.DeleteFunc`, which walks the whole list to remove one name, and it runs once per DNS response. It grew 15.4x from 500 to 8,000 names, tracking the 16x growth in N, and is now flat at roughly 47-54ns: 213x faster at 8,000 names.

```release-note
fqdn: hold zombie names in a set
```
AIL: 3; Bottleneck was found by me, test cases and code was iterated with the help of AI a few times after review.
