### PR TITLE
gha/scale-clustermesh: explicitly set authentication mode

### DIFF
--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -355,6 +355,7 @@ jobs:
           # * Increase the KVStoreMesh QPS to match the ones of the cmapisrv-mock,
           #   as not a problem considering the limited number of watchers.
           # * Store etcd data directly in memory, for improved performance.
+          # * Set authentication mode to legacy, for simplicity.
           cilium upgrade --reuse-values \
             --chart-directory=untrusted/install/kubernetes/cilium \
             --set clustermesh.useAPIServer=true \
@@ -365,6 +366,7 @@ jobs:
             --set clustermesh.apiserver.tolerations[0].key=node-role.kubernetes.io/control-plane \
             --set clustermesh.apiserver.tolerations[0].operator=Exists \
             --set clustermesh.apiserver.metrics.serviceMonitor.enabled=true \
+            --set clustermesh.apiserver.tls.authMode=legacy \
             --values values-clustermesh-config.yaml
 
           cilium status --wait --interactive=false


### PR DESCRIPTION
e6ebc6d3d764 ("clustermesh: set authMode to cluster by default") enabled the `cluster` authentication mode by default. However, this change broke the clustermesh scale test, as the mapisrv-mock does not configure the extra users required in `cluster` mode. Hence, let's explicitly set the `legacy` authentication mode there, for simplicity.

AIL: 0