### PR TITLE
cilium-cli: stop retrying the expected 403 in the TLS deny test

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -22,9 +22,8 @@ func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, t
 		WithCiliumPolicy(templates["clientEgressL7TLSPolicyYAML"]).   // L7 allow policy with TLS interception
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(tests.PodToWorldWithTLSIntercept(
+			// No --retry-all-errors: curl reports the last attempt, so retrying the expected 403 lets a later stall decide.
 			"--retry", "5",
-			"--retry-delay", "0",
-			"--retry-all-errors",
 		)).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultDropCurlHTTPError, check.ResultNone


### PR DESCRIPTION
client-egress-l7-tls-deny-without-headers expects curl to exit 22, the
CURLE_HTTP_RETURNED_ERROR behind the 403 the L7 TLS-intercept policy is
meant to produce. The scenario nevertheless passes --retry-all-errors, so
curl treats that 403 as a failure and re-issues the request, and because
curl reports the last attempt's exit code the verdict comes from attempt
six instead of attempt one.

https://github.com/cilium/cilium/actions/runs/33383707257/job/99490149168
shows it end to end, in a run carrying the curl instrumentation from #48241
that printed the stderr this was previously inferred from: five "curl: (22)
The requested URL returned error: 403" lines, the wanted verdict five times
over, then a sixth attempt ending "curl: (28) SSL connection timeout". The
policy was enforced on all six.

Keep plain --retry 5, since curl retries a timeout on its own, and drop
--retry-delay 0, since zero selects the default backoff rather than
disabling it. #47415 already made retryCondition.CurlOptions return nothing
when expectSuccess is false, and this site escaped that guard by passing
curl flags straight to the scenario; it is the only one pairing
--retry-all-errors with a non-zero expected exit, the three that remain
expecting exit 0 where retrying until success is the right verdict. An
unenforced policy still exits 0 and still fails, and a handshake error such
as exit 35 is now decided by the first attempt rather than the sixth.

This PR was prepared with AIL:3. I personally checked the instrumented
curl output in run 33383707257.
