### PR TITLE
test/k8s: wait for the L7 visibility policy to be realized

### DIFF
--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -52,13 +52,17 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 
 		addVisibilityPolicy := func(ns string) {
 			By("Applying L7 visibility policy")
-			res := kubectl.Apply(helpers.ApplyOptions{FilePath: visibilityPolicyPath, Namespace: ns})
-			res.ExpectSuccess("could not create L7 visibility policy")
+			// Wait for the realized revision so the L7 redirect is live before we curl.
+			_, err := kubectl.CiliumPolicyAction(ns, visibilityPolicyPath,
+				helpers.KubectlApply, helpers.HelperTimeout)
+			Expect(err).To(BeNil(), "could not create L7 visibility policy")
 		}
 
 		removeVisibilityPolicy := func(ns string) {
 			By("Removing L7 visibility policy")
-			kubectl.DeleteInNamespace(ns, visibilityPolicyPath)
+			_, err := kubectl.CiliumPolicyAction(ns, visibilityPolicyPath,
+				helpers.KubectlDelete, helpers.HelperTimeout)
+			Expect(err).To(BeNil(), "could not delete L7 visibility policy")
 		}
 
 		getFlowsFromRelay := func(args string) []*observerpb.GetFlowsResponse {


### PR DESCRIPTION
The two L7 Hubble specs apply the L7 visibility policy and curl app1
roughly 200ms later. addVisibilityPolicy does a bare kubectl apply and
returns, so nothing waits for the revision to be realized on the endpoints
that gain the ingress HTTP redirect, and the curl races their regeneration.

When it loses, one handshake straddles the moment the redirect goes live.
The SYN reaches the pod, which SYN-ACKs, and the ACK is then traced
to-proxy, because ipv4_policy() re-derives the proxy port for every
forward-direction packet, established ones included. That bare mid-stream
ACK lands on the cilium-http-ingress listen socket, which holds no
request-sock for the tuple, so the host stack RSTs it and curl exits 7, as
the f10-agent-hubble-bandwidth leg did in
https://github.com/cilium/cilium/actions/runs/33264616706/job/99132593286.

The barrier used to exist: while visibility was driven by pod annotations
the helper polled the endpoint's proxy-statistics until the redirect showed
up, and the switch to a visibility policy dropped it. Use
CiliumPolicyAction for both helpers, as the FQDN spec in the same file
already does. The delete needs converting too, since both specs defer
removeVisibilityPolicy right before addVisibilityPolicy, and a
fire-and-forget delete leaves a revision bump in flight that satisfies the
next spec's wait in place of the apply.

This PR was prepared with AIL:3. I personally reviewed the code.
