### PR TITLE
policy: work around CiliumCIDRGroup zero-length prefix

### DIFF
--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -64,6 +64,22 @@ func (p *policyWatcher) cidrsAndLabelsForCIDRGroup(name string) (sets.Set[netip.
 				)
 				continue
 			}
+			// workaround for GH-39688: identity 2 (world) doesn't have any CIDR labels,
+			// so we can't select zero-length (0.0.0.0/0) prefixes directly. Split it in to
+			// two /1 prefixes
+			if pfx.Bits() == 0 {
+				if pfx.Addr().Is4() {
+					newCIDRs.Insert(
+						netip.MustParsePrefix("0.0.0.0/1"),
+						netip.MustParsePrefix("128.0.0.0/1"),
+					)
+				} else {
+					newCIDRs.Insert(
+						netip.MustParsePrefix("::/1"),
+						netip.MustParsePrefix("8000::/1"),
+					)
+				}
+			}
 			newCIDRs.Insert(pfx)
 		}
 	}


### PR DESCRIPTION
When a CiliumCIDRGroup selects the zero-length prefix (i.e. 0.0.0.0/0), it inserts a label selector for the special label "cidr:0.0.0.0/0". Unfortunately, due to known issue #39688, this doesn't actually work. This is because the `reserved:world` identity doesn't actually have the full world CIDR on it. So, the `cidr:0.0.0.0/0` selector selects no identities.

This workaround splits all zero-length prefixes in to two /1 prefixes, keeping the same effect and avoiding the unfortunate world bug.

```release-note
Fixes an issue where CiliumCIDRGroups with zero-length cidrs (i.e. 0.0.0.0/0) inadvertently selected no traffic.
```
