### PR TITLE
ci: stop asking a PHP app for the AKS runner IP

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -34,9 +34,8 @@ runs:
       id: get-runner-ip
       uses: ./.github/actions/get-runner-ip
       with:
-        source: https://whatismyip.azurewebsites.net/json/
-        parsing: json
-        json-key: ip
+        source: https://checkip.amazonaws.com
+        parsing: text
 
     - name: Create AKS cluster
       shell: bash


### PR DESCRIPTION
Every cloud's cluster setup begins by asking one hard-coded web service for the
runner's own egress address, which then goes into the API server's authorized
ranges, and one non-2xx answer is terminal. For AKS that service was
whatismyip.azurewebsites.net, which is not a Microsoft endpoint: it answers with
Microsoft-IIS/10.0, PHP/5.6.40 and an ARRAffinity cookie on the shared
azurewebsites.net default hostname, so a community PHP 5.6 app on one App
Service worker. A leg that absorbed its cold start got an HTTP 500 in under a
second and died twenty seconds in, every later step reported as skipped:
https://github.com/cilium/cilium/actions/runs/33321237856/job/99283550676

Point AKS at checkip.amazonaws.com, which the EKS setup and the EKS delete
workflow already use, so the runner address no longer depends on a stranger's
shared-tenant PHP app. It answers with the bare address as text, so this call
site no longer needs the json parsing mode or its key.

This PR was prepared with AIL:2. I personally checked the response headers
of both endpoints.
