### PR TITLE
bpf: misc. cleanup

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1761,7 +1761,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	if (tip == CONFIG(endpoint_ipv4).be32)
 		return CTX_ACT_OK;
 
-	ret = arp_respond(ctx, &mac, tip, &smac, sip, 0);
+	ret = arp_respond(ctx, &mac, tip, &smac, sip);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -807,7 +807,7 @@ pass_to_stack: __maybe_unused
 #ifndef ENABLE_ROUTING
 	/* See IPv4 path for comments. */
 	if (from_l7lb && ctx_get_ifindex(ctx) != CONFIG(cilium_host_ifindex))
-		return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		return redirect_self(ctx);
 #endif /* !ENABLE_ROUTING */
 
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, dst_sec_identity,
@@ -1379,7 +1379,7 @@ pass_to_stack: __maybe_unused
 	 * checked via tail call from bpf_host.
 	 */
 	if (from_l7lb && ctx_get_ifindex(ctx) != CONFIG(cilium_host_ifindex))
-		return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		return redirect_self(ctx);
 #endif /* !ENABLE_ROUTING */
 
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV4, dst_sec_identity,

--- a/bpf/bpf_sock_term.c
+++ b/bpf/bpf_sock_term.c
@@ -86,7 +86,7 @@ int sock_udp_destroy_v4(struct bpf_iter__udp *ctx)
 }
 
 static __always_inline
-int sock_tcp_destroy_v4(struct bpf_iter__tcp *ctx __maybe_unused)
+int sock_tcp_destroy_v4(struct bpf_iter__tcp *ctx)
 {
 	void *sk = ctx->tcp_sk;
 	__sock_cookie cookie;
@@ -126,7 +126,7 @@ int sock_udp_destroy_v6(struct bpf_iter__udp *ctx)
 }
 
 static __always_inline
-int sock_tcp_destroy_v6(struct bpf_iter__tcp *ctx __maybe_unused)
+int sock_tcp_destroy_v6(struct bpf_iter__tcp *ctx)
 {
 	void *sk = ctx->tcp_sk;
 	__sock_cookie cookie;

--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -72,7 +72,7 @@ arp_validate(const struct __ctx_buff *ctx, union macaddr *mac,
 
 static __always_inline int
 arp_respond(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
-	    union macaddr *dmac, __be32 tip, int direction)
+	    union macaddr *dmac, __be32 tip)
 {
 	int ret = arp_prepare_response(ctx, smac, sip, dmac, tip);
 
@@ -81,5 +81,5 @@ arp_respond(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
 
 	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
 			   ctx_get_ifindex(ctx));
-	return ctx_redirect(ctx, ctx_get_ifindex(ctx), direction);
+	return redirect_self(ctx);
 }

--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -37,12 +37,6 @@ get_cluster_id_upper_mask()
 }
 
 static __always_inline __maybe_unused __u32
-get_mark_magic_cluster_id_mask()
-{
-	return CLUSTER_ID_LOWER_MASK | get_cluster_id_upper_mask();
-}
-
-static __always_inline __maybe_unused __u32
 ctx_get_cluster_id_mark(const struct __ctx_buff *ctx __maybe_unused)
 {
 /* ctx->mark not available in XDP. */

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -14,7 +14,8 @@
 #include "overloadable.h"
 #ifdef ENABLE_IPV4
 
-static __always_inline int icmp_load_type(struct __ctx_buff *ctx, int l4_off, __u8 *type)
+static __always_inline int icmp_load_type(const struct __ctx_buff *ctx, int l4_off,
+					  __u8 *type)
 {
 	return ctx_load_bytes(ctx, l4_off + offsetof(struct icmphdr, type),
 			      type, sizeof(*type));

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -36,7 +36,8 @@
 #define ACTION_UNKNOWN_ICMP6_NS DROP_UNKNOWN_TARGET
 #endif
 
-static __always_inline int icmp6_load_type(struct __ctx_buff *ctx, int l4_off, __u8 *type)
+static __always_inline int icmp6_load_type(const struct __ctx_buff *ctx, int l4_off,
+					   __u8 *type)
 {
 	return ctx_load_bytes(ctx, l4_off + ICMP6_TYPE_OFFSET, type, sizeof(*type));
 }

--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -80,7 +80,7 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 		if (!stats)
 			return CTX_ACT_OK;
 
-		ret = arp_respond(ctx, &mac, key.ip4.be32, &smac, sip, 0);
+		ret = arp_respond(ctx, &mac, key.ip4.be32, &smac, sip);
 	} else {
 #ifdef ENABLE_IPV6
 		struct l2_responder_v6_key key6;

--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -19,7 +19,7 @@ struct {
 } cilium_nodeport_neigh6 __section_maps_btf;
 
 #if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV6)
-static __always_inline int neigh_record_ip6(struct __ctx_buff *ctx)
+static __always_inline int neigh_record_ip6(const struct __ctx_buff *ctx)
 {
 	union macaddr smac = {}, *mac;
 	void *data, *data_end;
@@ -64,7 +64,7 @@ struct {
 } cilium_nodeport_neigh4 __section_maps_btf;
 
 #if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV4)
-static __always_inline int neigh_record_ip4(struct __ctx_buff *ctx)
+static __always_inline int neigh_record_ip4(const struct __ctx_buff *ctx)
 {
 	union macaddr smac = {}, *mac;
 	void *data, *data_end;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -400,11 +400,9 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 	if (ctx_store_bytes(ctx, l3_off + offsetof(struct ipv6hdr, payload_len),
 			    &tp_new.payload_len, 4, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (ctx_store_bytes(ctx, l3_off + offsetof(struct ipv6hdr, daddr),
-			    backend_addr, sizeof(ip6->daddr), 0) < 0)
+	if (ipv6_store_daddr(ctx, backend_addr->addr, l3_off) < 0)
 		return DROP_WRITE_ERROR;
-	if (ctx_store_bytes(ctx, l3_off + offsetof(struct ipv6hdr, saddr),
-			    &saddr, sizeof(ip6->saddr), 0) < 0)
+	if (ipv6_store_saddr(ctx, saddr.addr, l3_off) < 0)
 		return DROP_WRITE_ERROR;
 	return 0;
 #  else /* __ctx_is == __ctx_xdp */

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -145,11 +145,9 @@ srv6_encapsulation(struct __ctx_buff *ctx, int growth, __u16 new_payload_len,
 		return DROP_INVALID;
 	if (ctx_store_bytes(ctx, ETH_HLEN, &new_ip6, len, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct ipv6hdr, saddr),
-			    saddr, sizeof(union v6addr), 0) < 0)
+	if (ipv6_store_saddr(ctx, saddr->addr, ETH_HLEN) < 0)
 		return DROP_WRITE_ERROR;
-	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct ipv6hdr, daddr),
-			    sid, sizeof(struct in6_addr), 0) < 0)
+	if (ipv6_store_daddr(ctx, (const __u8 *)sid, ETH_HLEN) < 0)
 		return DROP_WRITE_ERROR;
 
 #ifdef ENABLE_SRV6_SRH_ENCAP

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -361,7 +361,6 @@ int tail_srv6_encap(struct __ctx_buff *ctx)
 {
 	struct in6_addr dst_sid;
 	int ret = 0;
-	int __maybe_unused ext_err = 0;
 
 	srv6_load_meta_sid(ctx, &dst_sid);
 	ret = srv6_handling(ctx, &dst_sid);


### PR DESCRIPTION
Various cleanups in `bpf/` to use existing helper functions instead of open-coding them and removing unused variables, parameters and functions. See commit messages for details.