### PR TITLE
ci: disable TCP/UDPRouteWeightedRouting gateway-api conformance tests

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -199,9 +199,9 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
-          SKIPPED_TESTS=""
+          SKIPPED_TESTS="TCPRouteWeightedRouting,UDPRouteWeightedRouting"
           if [ "${{ matrix.conformance-profile }}" == "true" ]; then
-            SKIPPED_TESTS="MeshConsumerRoute,HTTPRouteListenerPortMatching"
+            SKIPPED_TESTS=",MeshConsumerRoute,HTTPRouteListenerPortMatching"
           fi
 
           # The conformance-profile jobs consume SKIPPED_TESTS through the


### PR DESCRIPTION
Disables flaking TCP/UDPRouteWeightedRouting gateway-api conformance tests.

See: https://github.com/cilium/cilium/issues/48355