### PR TITLE
[v1.18] bpf: Fix agent crash when dumping events

### DIFF
--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -97,22 +97,8 @@ func (m *Map) initEventsBuffer(maxSize int, eventsTTL time.Duration) {
 		mapControllers.UpdateController(
 			fmt.Sprintf("bpf-event-buffer-gc-%s", m.name),
 			controller.ControllerParams{
-				Group: bpfEventBufferGCControllerGroup,
-				DoFunc: func(_ context.Context) error {
-					m.Logger.Debug(
-						"clearing bpf map events older than TTL",
-						logfields.TTL, b.eventTTL,
-					)
-					b.buffer.Compact(func(e any) bool {
-						event, ok := e.(*Event)
-						if !ok {
-							m.Logger.Error("Failed to compact the event buffer", logfields.Error, wrongObjTypeErr(e))
-							return false
-						}
-						return time.Since(event.Timestamp) < b.eventTTL
-					})
-					return nil
-				},
+				Group:       bpfEventBufferGCControllerGroup,
+				DoFunc:      b.garbageCollect,
 				RunInterval: b.eventTTL,
 			},
 		)
@@ -214,6 +200,23 @@ func (eb *eventsBuffer) dumpAndSubscribe(callback EventCallbackFunc, follow bool
 	defer eb.subsLock.Unlock()
 	eb.subscriptions = append(eb.subscriptions, h)
 	return h, nil
+}
+
+func (eb *eventsBuffer) garbageCollect(_ context.Context) error {
+	eb.logger.Debug(
+		"clearing bpf map events older than TTL",
+		logfields.TTL, eb.eventTTL,
+	)
+
+	eb.buffer.Compact(func(e any) bool {
+		event, ok := e.(*Event)
+		if !ok {
+			eb.logger.Error("Failed to compact the event buffer", logfields.Error, wrongObjTypeErr(e))
+			return false
+		}
+		return time.Since(event.Timestamp) < eb.eventTTL
+	})
+	return nil
 }
 
 // DumpAndSubscribe dumps existing buffer, if callback is not nil. Followed by creating a

--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -109,8 +109,11 @@ func (m *Map) initEventsBuffer(maxSize int, eventsTTL time.Duration) {
 // eventsBuffer stores a buffer of events for auditing and debugging
 // purposes.
 type eventsBuffer struct {
-	logger        *slog.Logger
-	buffer        *container.RingBuffer
+	logger *slog.Logger
+
+	mutex  lock.Mutex // protect 'buffer' only.
+	buffer *container.RingBuffer
+
 	eventTTL      time.Duration
 	subsLock      lock.RWMutex
 	subscriptions []*Handle
@@ -203,6 +206,9 @@ func (eb *eventsBuffer) dumpAndSubscribe(callback EventCallbackFunc, follow bool
 }
 
 func (eb *eventsBuffer) garbageCollect(_ context.Context) error {
+	eb.mutex.Lock()
+	defer eb.mutex.Unlock()
+
 	eb.logger.Debug(
 		"clearing bpf map events older than TTL",
 		logfields.TTL, eb.eventTTL,
@@ -289,6 +295,8 @@ func (eb *eventsBuffer) eventIsValid(e any) bool {
 type EventCallbackFunc func(*Event)
 
 func (eb *eventsBuffer) dumpWithCallback(callback EventCallbackFunc) {
+	eb.mutex.Lock()
+	defer eb.mutex.Unlock()
 	eb.buffer.IterateValid(eb.eventIsValid, func(e any) {
 		event, ok := e.(*Event)
 		if !ok {

--- a/pkg/bpf/events_test.go
+++ b/pkg/bpf/events_test.go
@@ -4,6 +4,7 @@
 package bpf
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -55,3 +56,64 @@ type IntTestKey uint32
 
 func (k IntTestKey) String() string { return fmt.Sprintf("key=%d", k) }
 func (k IntTestKey) New() MapKey    { return new(IntTestKey) }
+
+func TestEventsGC(t *testing.T) {
+	// Rather than setting a timeout, this testcase will avoid the time
+	// dependencies by using two blocking channels to *ensure* the garbage
+	// collection occurs in the critical section.
+	logger := hivetest.Logger(t)
+	m := Map{
+		Logger: logger,
+	}
+	m.initEventsBuffer(32, 0)
+	eb := m.events
+	dumpStarted := make(chan struct{})
+	doneChan := make(chan struct{})
+
+	// Add a bunch of keys. Garbage collection should clean these up.
+	keys := []int{}
+	for i := range 32 {
+		eb.add(&Event{cacheEntry: cacheEntry{Key: IntTestKey(i)}})
+	}
+
+	// Garbage collect the ringbuffer, but wait until the main test
+	// goroutine begins iterating the objects below before executing the
+	// garbage collection. This should make the failure highly reliable.
+	go func(dumpStarted, doneChan chan struct{}) {
+		<-dumpStarted
+		_ = eb.garbageCollect(context.Background())
+		close(doneChan)
+	}(dumpStarted, doneChan)
+
+	lastDump := false
+loop:
+	// Tight loop to touch the same internal data structures as the GC
+	// goroutine above to try to trigger a data race.
+	for {
+		if dumpStarted != nil {
+			close(dumpStarted)
+			dumpStarted = nil
+		}
+		keys = []int{}
+		eb.dumpAndSubscribe(func(e *Event) {
+			k := e.Key.(IntTestKey)
+			keys = append(keys, int(k))
+		}, false)
+		if lastDump {
+			break
+		}
+		select {
+		case <-doneChan:
+			// Do one last full dumpAndSubscribe to ensure the
+			// complete final (garbage-collected) map is dumped,
+			// so the contents comparison can pass below.
+			lastDump = true
+			continue loop
+		default:
+		}
+	}
+
+	// Ensure that garbage collection completed its cleanup successfully.
+	assert.Empty(t, keys)
+	assert.Equal(t, []int{}, keys)
+}


### PR DESCRIPTION
Backports #48273.

This backport needed custom fixes, because the following PR was missing on v1.18:
* https://github.com/cilium/cilium/pull/43390

Consequences are that this backport version follows the type assertion logic
used in v1.19 or earlier, and this version updates the subscribe functions
which use callbacks rather than updating the observable codepaths.

This was cherry-picked cleanly from https://github.com/cilium/cilium/pull/48379.

```upstream-prs
48273
```
