### PR TITLE
Prepare cloud endpoint rules for reconciliation

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -367,13 +367,15 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			limiter := rate.NewLimiter(30*time.Second, 1)
 
 			for {
-				// Refresh the device MTU on every run so reconciliation applies the latest value.
-				if err := routingInfo.WithOptions(
-					linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
-				); err != nil {
-					health.Degraded("Failed to refresh egress route MTU", err)
-					limiter.Wait(ctx)
-					continue
+				// The ENI device configurator owns ENI MTU; other modes still rely on RoutingInfo.
+				if r.daemonConfig.IPAM != ipamOption.IPAMENI {
+					if err := routingInfo.WithOptions(
+						linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+					); err != nil {
+						health.Degraded("Failed to refresh egress route MTU", err)
+						limiter.Wait(ctx)
+						continue
+					}
 				}
 				watchSet, err := routingInfo.ReconcileGatewayRoutes(
 					r.db.ReadTxn(),
@@ -771,8 +773,12 @@ func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*lin
 func (r *infraIPAllocator) newRoutingInfo(result *ipam.AllocationResult, masquerade bool) (*linuxrouting.RoutingInfo, error) {
 	options := []linuxrouting.RoutingInfoOption{
 		linuxrouting.WithCIDRsAndMasquerade(result.CIDRs, masquerade),
-		linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
-		linuxrouting.WithLinkState(true),
+	}
+	if r.daemonConfig.IPAM != ipamOption.IPAMENI {
+		options = append(options,
+			linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+			linuxrouting.WithLinkState(true),
+		)
 	}
 	if r.daemonConfig.IPAM == ipamOption.IPAMAzure {
 		options = append(options, linuxrouting.WithCompatEgressPriority())

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -336,9 +336,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		r.daemonConfig.IPAM == ipamOption.IPAMAlibabaCloud ||
 		r.daemonConfig.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
-		routingInfo, err = linuxrouting.NewRoutingInfo(r.logger, result.GatewayIP.String(), result.CIDRs,
-			result.PrimaryMAC, result.InterfaceNumber, r.daemonConfig.IPAM,
-			masq)
+		routingInfo, err = r.newRoutingInfo(result, masq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create router info: %w", err)
 		}
@@ -355,7 +353,6 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 
 		if err = routingInfo.Configure(
 			result.IP,
-			r.mtuManager.GetDeviceMTU(),
 			true,
 		); err != nil {
 			return nil, fmt.Errorf("failed to configure router IP rules and routes: %w", err)
@@ -370,8 +367,15 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			limiter := rate.NewLimiter(30*time.Second, 1)
 
 			for {
+				// Refresh the device MTU on every run so reconciliation applies the latest value.
+				if err := routingInfo.WithOptions(
+					linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+				); err != nil {
+					health.Degraded("Failed to refresh egress route MTU", err)
+					limiter.Wait(ctx)
+					continue
+				}
 				watchSet, err := routingInfo.ReconcileGatewayRoutes(
-					r.mtuManager.GetDeviceMTU(),
 					r.db.ReadTxn(),
 					r.routes,
 				)
@@ -554,7 +558,6 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 
 				if err := ingressRouting.Configure(
 					result.IP,
-					r.mtuManager.GetDeviceMTU(),
 					false,
 				); err != nil {
 					r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)
@@ -621,11 +624,7 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 					)
 				}
 
-				if err := ingressRouting.Configure(
-					result.IP,
-					r.mtuManager.GetDeviceMTU(),
-					false,
-				); err != nil {
+				if err := ingressRouting.Configure(result.IP, false); err != nil {
 					r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)
 				}
 			}
@@ -762,27 +761,29 @@ func (r *infraIPAllocator) allocateRouterIPs(ctx context.Context, restoredRouter
 }
 
 func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*linuxrouting.RoutingInfo, error) {
+	masquerade := r.daemonConfig.EnableIPv6Masquerade
 	if result.IP.Is4() {
-		return linuxrouting.NewRoutingInfo(
-			r.logger,
-			result.GatewayIP.String(),
-			result.CIDRs,
-			result.PrimaryMAC,
-			result.InterfaceNumber,
-			r.daemonConfig.IPAM,
-			r.daemonConfig.EnableIPv4Masquerade,
-		)
-	} else {
-		return linuxrouting.NewRoutingInfo(
-			r.logger,
-			result.GatewayIP.String(),
-			result.CIDRs,
-			result.PrimaryMAC,
-			result.InterfaceNumber,
-			r.daemonConfig.IPAM,
-			r.daemonConfig.EnableIPv6Masquerade,
-		)
+		masquerade = r.daemonConfig.EnableIPv4Masquerade
 	}
+	return r.newRoutingInfo(result, masquerade)
+}
+
+func (r *infraIPAllocator) newRoutingInfo(result *ipam.AllocationResult, masquerade bool) (*linuxrouting.RoutingInfo, error) {
+	options := []linuxrouting.RoutingInfoOption{
+		linuxrouting.WithCIDRsAndMasquerade(result.CIDRs, masquerade),
+		linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+		linuxrouting.WithLinkState(true),
+	}
+	if r.daemonConfig.IPAM == ipamOption.IPAMAzure {
+		options = append(options, linuxrouting.WithCompatEgressPriority())
+	}
+
+	return linuxrouting.NewRoutingInfo(
+		result.GatewayIP.String(),
+		result.PrimaryMAC,
+		result.InterfaceNumber,
+		options...,
+	)
 }
 
 // removeOldCiliumHostIPs calls removeOldRouterState() for both IPv4 and IPv6

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -351,11 +351,11 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			}
 		}
 
-		if err = routingInfo.Configure(
+		if err = routingInfo.ReconcileEndpointRules(
 			result.IP,
 			true,
 		); err != nil {
-			return nil, fmt.Errorf("failed to configure router IP rules and routes: %w", err)
+			return nil, fmt.Errorf("failed to reconcile router IP rules and routes: %w", err)
 		}
 
 		node.SetRouterInfo(routingInfo)

--- a/pkg/aws/agent/device.go
+++ b/pkg/aws/agent/device.go
@@ -272,6 +272,7 @@ func waitForNetlinkDevices(logger *slog.Logger, configByMac configMap) (linkByMa
 	return linkByMac, errors.New("timed out waiting for ENIs to be attached")
 }
 
+// configureENINetlinkDevice owns the MTU and up-state of ENI links.
 func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sysctl.Sysctl) error {
 	if err := netlink.LinkSetMTU(link, cfg.mtu); err != nil {
 		return fmt.Errorf("failed to change MTU of link %s to %d: %w", link.Attrs().Name, cfg.mtu, err)

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -400,11 +400,13 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
-		if spec.From != nil && (r.Src == nil || r.Src.String() != spec.From.String()) {
+		// Match selectors exactly. A nil selector represents all addresses;
+		// it is not a wildcard that may match a scoped rule.
+		if !ruleSelectorEqual(r.Src, spec.From) {
 			continue
 		}
 
-		if spec.To != nil && (r.Dst == nil || r.Dst.String() != spec.To.String()) {
+		if !ruleSelectorEqual(r.Dst, spec.To) {
 			continue
 		}
 
@@ -425,6 +427,16 @@ func lookupRule(spec Rule, family int) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func ruleSelectorEqual(a, b *net.IPNet) bool {
+	if a == nil || b == nil {
+		// IPNet.String returns "<nil>" for both a nil selector and some
+		// malformed non-nil selectors. Keep absence distinct because a nil
+		// selector specifically represents all addresses.
+		return a == nil && b == nil
+	}
+	return a.String() == b.String()
 }
 
 // ListRules will list IP routing rules on Linux, filtered by `filter`. When

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -23,6 +23,21 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 }
 
+func TestRuleSelectorEqual(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("10.0.0.0/8")
+	require.NoError(t, err)
+	_, otherCIDR, err := net.ParseCIDR("192.0.2.0/24")
+	require.NoError(t, err)
+	malformedSelector := &net.IPNet{}
+
+	require.True(t, ruleSelectorEqual(nil, nil))
+	require.True(t, ruleSelectorEqual(cidr, cidr))
+	require.False(t, ruleSelectorEqual(nil, cidr))
+	require.False(t, ruleSelectorEqual(cidr, nil))
+	require.False(t, ruleSelectorEqual(malformedSelector, nil))
+	require.False(t, ruleSelectorEqual(cidr, otherCIDR))
+}
+
 func testReplaceNexthopRoute(t *testing.T, link netlink.Link, routerNet *net.IPNet) {
 	route := Route{
 		Table: 10,

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -6,25 +6,22 @@ package linuxrouting
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/netip"
 	"strconv"
 
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	cslices "github.com/cilium/cilium/pkg/slices"
 )
 
-// RoutingInfo represents information that's required to enable
-// connectivity via the local rule and route tables while in ENI,Azure IPAM mode and delegated IPAM mode.
+// RoutingInfo represents information required to enable connectivity via local
+// policy rules and route tables.
 // The information in this struct is used to create rules and routes which direct
 // traffic out of the interface (egress).
 //
 // This struct is mostly derived from the `ipam.AllocationResult` as the
 // information comes from IPAM.
 type RoutingInfo struct {
-	logger *slog.Logger
 	// Gateway is the gateway where outbound/egress IPv4/IPv6 traffic is directed.
 	Gateway net.IP
 
@@ -45,29 +42,76 @@ type RoutingInfo struct {
 	// the per-ENI tables.
 	InterfaceNumber int
 
-	// IpamMode tells us which IPAM mode is being used (e.g., ENI, AKS).
-	IpamMode string
+	mtu       *int
+	linkState *bool
+
+	// compatEgressPriority determines whether to use the new or old style egress rule.
+	compatEgressPriority bool
 }
 
 func (info *RoutingInfo) GetCIDRs() []netip.Prefix {
 	return info.CIDRs
 }
 
-// NewRoutingInfo creates a new RoutingInfo struct, from data that will be
-// parsed and validated. Note, this code assumes IPv4 values because IPv4
-// (on either ENI or Azure interface) is the only supported path currently.
-func NewRoutingInfo(logger *slog.Logger, gateway string, cidrs []netip.Prefix, masterIfMAC mac.MAC, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
-	return parse(logger, gateway, cidrs, masterIfMAC, ifaceNum, ipamMode, masquerade)
+type RoutingInfoOption func(*RoutingInfo) error
+
+// WithOptions applies functional options to info.
+func (info *RoutingInfo) WithOptions(opts ...RoutingInfoOption) error {
+	for _, opt := range opts {
+		if err := opt(info); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func parse(logger *slog.Logger, gateway string, cidrs []netip.Prefix, masterIfMAC mac.MAC, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
+// WithCIDRsAndMasquerade configures the directly reachable CIDRs and whether
+// masquerading is enabled.
+func WithCIDRsAndMasquerade(cidrs []netip.Prefix, masquerade bool) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		if len(cidrs) == 0 && masquerade {
+			return errors.New("empty cidrs")
+		}
+
+		info.CIDRs = cslices.Map(cidrs, netip.Prefix.Masked)
+		info.Masquerade = masquerade
+		return nil
+	}
+}
+
+// WithLinkState configures whether the master interface should be brought up
+// or down before routes and rules are installed.
+func WithLinkState(up bool) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.linkState = &up
+		return nil
+	}
+}
+
+// WithMTU configures the MTU to apply to the master interface before routes
+// and rules are installed.
+func WithMTU(mtu int) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.mtu = &mtu
+		return nil
+	}
+}
+
+// WithCompatEgressPriority selects the legacy egress priority and ifindex-based
+// route table scheme used by Azure IPAM.
+func WithCompatEgressPriority() RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.compatEgressPriority = true
+		return nil
+	}
+}
+
+// NewRoutingInfo parses the required routing information and applies opts. By
+// default, using the returned information does not change link state or MTU.
+func NewRoutingInfo(gateway string, masterIfMAC mac.MAC, ifaceNum string, opts ...RoutingInfoOption) (*RoutingInfo, error) {
 	ip := net.ParseIP(gateway)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid gateway: %s", gateway)
-	}
-
-	if len(cidrs) == 0 && masquerade {
-		return nil, errors.New("empty cidrs")
 	}
 
 	// The MAC of the master interface is what the routes and rules are keyed
@@ -81,13 +125,13 @@ func parse(logger *slog.Logger, gateway string, cidrs []netip.Prefix, masterIfMA
 		return nil, fmt.Errorf("invalid interface number: %s", ifaceNum)
 	}
 
-	return &RoutingInfo{
-		logger:          logger.With(logfields.LogSubsys, "linux-routing"),
+	info := &RoutingInfo{
 		Gateway:         ip,
-		CIDRs:           cslices.Map(cidrs, netip.Prefix.Masked),
 		MasterIfMAC:     masterIfMAC,
-		Masquerade:      masquerade,
 		InterfaceNumber: parsedIfaceNum,
-		IpamMode:        ipamMode,
-	}, nil
+	}
+	if err := info.WithOptions(opts...); err != nil {
+		return nil, err
+	}
+	return info, nil
 }

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -8,127 +8,114 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 )
 
-func TestPrivilegedParse(t *testing.T) {
-	setupLinuxRoutingSuite(t)
-
-	fakeCIDR := netip.MustParsePrefix("192.168.0.0/16")
-
-	fakeMAC := mac.MustParseMAC("11:22:33:44:55:66")
-
-	validCIDRs := []netip.Prefix{fakeCIDR}
-
-	tests := []struct {
-		name      string
-		gateway   string
-		cidrs     []netip.Prefix
-		macAddr   mac.MAC
-		masq      bool
-		ifaceNum  string
-		wantRInfo *RoutingInfo
-		wantErr   bool
-	}{
-		{
-			name:      "invalid gateway",
-			gateway:   "",
-			cidrs:     []netip.Prefix{fakeCIDR},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "empty cidr",
-			gateway:   "192.168.1.1",
-			cidrs:     []netip.Prefix{},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "nil cidr",
-			gateway:   "192.168.1.1",
-			cidrs:     nil,
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "empty mac address",
-			gateway:   "192.168.1.1",
-			cidrs:     []netip.Prefix{fakeCIDR},
-			macAddr:   mac.MAC{},
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "invalid interface number",
-			gateway:   "192.168.1.1",
-			cidrs:     []netip.Prefix{fakeCIDR},
-			macAddr:   fakeMAC,
-			ifaceNum:  "a",
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:     "valid IPv4 input",
-			gateway:  "192.168.1.1",
-			cidrs:    []netip.Prefix{fakeCIDR},
-			macAddr:  fakeMAC,
-			ifaceNum: "1",
-			wantRInfo: &RoutingInfo{
-				Gateway:         net.ParseIP("192.168.1.1"),
-				CIDRs:           validCIDRs,
-				MasterIfMAC:     fakeMAC,
-				InterfaceNumber: 1,
-				IpamMode:        ipamOption.IPAMENI,
+func TestNewRoutingInfo(t *testing.T) {
+	t.Run("no options", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			gateway  string
+			macAddr  mac.MAC
+			ifaceNum string
+			wantErr  bool
+		}{
+			{
+				name:     "invalid gateway",
+				gateway:  "",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "1",
+				wantErr:  true,
 			},
-			wantErr: false,
-		},
-		{
-			name:     "disabled masquerade",
-			gateway:  "192.168.1.1",
-			cidrs:    []netip.Prefix{},
-			macAddr:  fakeMAC,
-			masq:     false,
-			ifaceNum: "0",
-			wantRInfo: &RoutingInfo{
-				Gateway:     net.ParseIP("192.168.1.1"),
-				CIDRs:       []netip.Prefix{},
-				MasterIfMAC: fakeMAC,
-				IpamMode:    ipamOption.IPAMENI,
+			{
+				name:     "empty mac address",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MAC{},
+				ifaceNum: "1",
+				wantErr:  true,
 			},
-			wantErr: false,
-		},
-		{
-			name:      "masquerade lacking cidrs",
-			gateway:   "192.168.1.1",
-			cidrs:     []netip.Prefix{},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := hivetest.Logger(t)
-			rInfo, err := NewRoutingInfo(logger, tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, ipamOption.IPAMENI, tt.masq)
-			if err == nil {
-				// Do not compare loggers
-				rInfo.logger = nil
-			}
-			require.Equal(t, tt.wantRInfo, rInfo)
-			require.Equal(t, tt.wantErr, err != nil)
-		})
-	}
+			{
+				name:     "invalid interface number",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "a",
+				wantErr:  true,
+			},
+			{
+				name:     "valid input",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "1",
+				wantErr:  false,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rInfo, err := NewRoutingInfo(tt.gateway, tt.macAddr, tt.ifaceNum)
+				require.Equal(t, tt.wantErr, err != nil)
+				if tt.wantErr {
+					require.Nil(t, rInfo)
+					return
+				}
+
+				require.Equal(t, net.ParseIP(tt.gateway), rInfo.Gateway)
+				require.Nil(t, rInfo.CIDRs)
+				require.Equal(t, tt.macAddr, rInfo.MasterIfMAC)
+				require.False(t, rInfo.Masquerade)
+				require.Equal(t, 1, rInfo.InterfaceNumber)
+				require.Nil(t, rInfo.mtu)
+				require.Nil(t, rInfo.linkState)
+				require.False(t, rInfo.compatEgressPriority)
+			})
+		}
+	})
+	t.Run("with options", func(t *testing.T) {
+		rInfo, err := NewRoutingInfo(
+			"192.168.1.1",
+			mac.MustParseMAC("11:22:33:44:55:66"),
+			"2",
+			WithCIDRsAndMasquerade([]netip.Prefix{netip.MustParsePrefix("192.168.0.0/16")}, true),
+			WithMTU(1500),
+			WithLinkState(true),
+			WithCompatEgressPriority(),
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("192.168.0.0/16")}, rInfo.CIDRs)
+		require.True(t, rInfo.Masquerade)
+		require.NotNil(t, rInfo.mtu)
+		require.Equal(t, 1500, *rInfo.mtu)
+		require.NotNil(t, rInfo.linkState)
+		require.True(t, *rInfo.linkState)
+		require.True(t, rInfo.compatEgressPriority)
+
+		require.NoError(t, rInfo.WithOptions(WithMTU(1400), WithLinkState(false)))
+		require.Equal(t, 1400, *rInfo.mtu)
+		require.False(t, *rInfo.linkState)
+	})
+	t.Run("CIDR option validation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			cidrs      []netip.Prefix
+			masquerade bool
+		}{
+			{
+				name:       "empty CIDRs with masquerading",
+				masquerade: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				rInfo, err := NewRoutingInfo(
+					"192.168.1.1",
+					mac.MustParseMAC("11:22:33:44:55:66"),
+					"1",
+					WithCIDRsAndMasquerade(tt.cidrs, tt.masquerade),
+				)
+				require.Error(t, err)
+				require.Nil(t, rInfo)
+			})
+		}
+	})
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
@@ -222,77 +221,18 @@ func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
 // succeed (albeit very rarely that egress deletion fails) because we are able
 // to perform a narrower search on the rule because we know it references the
 // main routing table. Due to multiple routing CIDRs, there might be more than
-// one egress rule. Deletion of any rule only proceeds if the rule matches
-// the IP & priority. In order to avoid leaving stale rules behind, all the
-// matching rules are removed.
+// one egress rule. Deletion only proceeds for unmarked Cilium rules matching
+// the IP and one of the known priority/table schemes. Missing rules are treated
+// as already deleted, and all matching rules are removed to avoid leaving stale
+// rules.
 func Delete(logger *slog.Logger, ip netip.Addr) error {
-	if !ip.IsValid() {
-		logger.Warn(
-			"Unable to delete rules because IP is not a valid IP address",
-			logfields.IPAddr, ip,
-		)
-		return errors.New("IP not compatible")
+	if err := DeleteRulesIfExists(logger, ip); err != nil {
+		return err
 	}
-
-	ipWithMask := netipx.AddrIPNet(ip)
-
-	var family int
-	if ip.Is4() {
-		family = netlink.FAMILY_V4
-	} else {
-		family = netlink.FAMILY_V6
-	}
-
-	// Ingress rules
-	ingress := route.Rule{
-		Priority: linux_defaults.RulePriorityIngress,
-		To:       ipWithMask,
-		Table:    route.MainTable,
-	}
-
-	if err := deleteRulesFiltered(
-		logger, ingress, family,
-		deleteRuleFilter{
-			fn:  func(r netlink.Rule) bool { return true }, // no further check needed, delete all rules found
-			msg: "",
-		},
-	); err != nil {
-		return fmt.Errorf("unable to delete ingress rule from main table with ip %s: %w", ipWithMask.String(), err)
-	}
-	logger.Debug("Deleted ingress rule",
-		logfields.Rule, ingress,
-		logfields.IPAddr, ipWithMask,
-	)
-
-	compat := option.Config.IPAM == ipamOption.IPAMAzure
-	priority := linux_defaults.RulePriorityEgressv2
-	if compat {
-		priority = linux_defaults.RulePriorityEgress
-	}
-
-	// Egress rules
-	withENIRouteTableID := deleteRuleFilter{
-		fn:  func(r netlink.Rule) bool { return r.Table >= computeTableIDFromIfaceNumber(compat, 0) },
-		msg: "rule does not refer to a per-ENI routing table ID",
-	}
-
-	// Delete all egress rules matching the priority and source IP.
-	// This covers the unconditional rule (from <IP> lookup <table>) and
-	// any CIDR-specific rules (from <IP> to <CIDR> lookup <table>).
-	egress := route.Rule{
-		Priority: priority,
-		From:     ipWithMask,
-	}
-	if err := deleteRulesFiltered(
-		logger, egress, family, withENIRouteTableID); err != nil {
-		return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
-	}
-	logger.Debug("Deleted egress rule",
-		logfields.Rule, egress,
-		logfields.IPAddr, ipWithMask,
-	)
 
 	if option.Config.EnableUnreachableRoutes {
+		ipWithMask := netipx.AddrIPNet(ip)
+
 		// Replace route to old IP with an unreachable route. This will
 		//   - trigger ICMP error messages for clients attempting to connect to the stale IP
 		//   - avoid hitting rp_filter and getting Martian packet warning
@@ -312,37 +252,130 @@ func Delete(logger *slog.Logger, ip netip.Addr) error {
 	return nil
 }
 
-type deleteRuleFilter struct {
-	fn  func(r netlink.Rule) bool
-	msg string
-}
-
-func deleteRulesFiltered(logger *slog.Logger, template route.Rule, family int, filters ...deleteRuleFilter) error {
-	rules, err := route.ListRules(family, &template)
-	if err != nil {
-		return err
+// DeleteRulesIfExists removes Cilium endpoint routing rules for ip without
+// installing an unreachable route. It is intended for rollback of a partially
+// completed endpoint setup and for asynchronous rule reconciliation.
+func DeleteRulesIfExists(logger *slog.Logger, ip netip.Addr) error {
+	if !ip.IsValid() {
+		logger.Warn(
+			"Unable to delete rules because IP is not a valid IP address",
+			logfields.IPAddr, ip,
+		)
+		return errors.New("IP not compatible")
 	}
 
-	if len(rules) == 0 {
-		logger.Warn("No rule matching found", logfields.Rule, template)
-		return errors.New("no rule found to delete")
+	family := netlink.FAMILY_V6
+	if ip.Is4() {
+		family = netlink.FAMILY_V4
 	}
+	ipWithMask := netipx.AddrIPNet(ip)
 
 	var errs []error
-next:
-	for _, rule := range rules {
-		for _, filter := range filters {
-			if !filter.fn(rule) {
-				logger.Info("Skipping deletion of matching rule",
-					logfields.Rule, rule,
-					logfields.Message, filter.msg,
-				)
-				continue next
-			}
-		}
-		errs = append(errs, netlink.RuleDel(&rule))
+	ingressRules, err := route.ListRules(family, &route.Rule{
+		Priority: linux_defaults.RulePriorityIngress,
+		To:       ipWithMask,
+		Table:    route.MainTable,
+	})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list ingress rules for %s: %w", ip, err))
 	}
+
+	for _, rule := range ingressRules {
+		if !isCiliumEndpointIngressRule(rule) {
+			continue
+		}
+		deleted, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("delete ingress rule for %s: %w", ip, err))
+			continue
+		}
+		if deleted {
+			logger.Debug("Deleted endpoint ingress rule",
+				logfields.Rule, rule,
+				logfields.IPAddr, ip,
+			)
+		}
+	}
+
+	egressRules, err := route.ListRules(family, &route.Rule{
+		From: ipWithMask,
+	})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list egress rules for %s: %w", ip, err))
+	}
+	for _, rule := range egressRules {
+		if !isCiliumEndpointEgressRule(rule) {
+			continue
+		}
+		deleted, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("delete egress rule for %s: %w", ip, err))
+			continue
+		}
+		if deleted {
+			logger.Debug("Deleted endpoint egress rule",
+				logfields.Rule, rule,
+				logfields.IPAddr, ip,
+			)
+		}
+	}
+
 	return errors.Join(errs...)
+}
+
+func isCiliumEndpointIngressRule(rule netlink.Rule) bool {
+	return rule.Dst != nil &&
+		rule.Priority == linux_defaults.RulePriorityIngress &&
+		rule.Table == route.MainTable &&
+		rule.Mark == 0 &&
+		rule.Mask == nil &&
+		rule.Protocol == linux_defaults.RTProto
+}
+
+func isCiliumEndpointEgressRule(rule netlink.Rule) bool {
+	// Endpoint egress rules are unmarked Cilium-owned source rules.
+	if rule.Src == nil ||
+		rule.Protocol != linux_defaults.RTProto ||
+		rule.Mark != 0 ||
+		rule.Mask != nil {
+		return false
+	}
+
+	switch rule.Priority {
+	case linux_defaults.RulePriorityEgress:
+		// Legacy rules and current Azure rules may use any non-reserved table.
+		return isNonReservedTable(rule.Table)
+	case linux_defaults.RulePriorityEgressv2:
+		// Current ENI and AlibabaCloud rules use Cilium's interface-number table range.
+		return isCiliumInterfaceRouteTable(rule.Table)
+	default:
+		return false
+	}
+}
+
+func deleteRuleIfExists(rule *netlink.Rule) (bool, error) {
+	err := netlink.RuleDel(rule)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ESRCH):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func isCiliumInterfaceRouteTable(table int) bool {
+	return table >= computeTableIDFromIfaceNumber(false, 0) && table < unix.RT_TABLE_DEFAULT
+}
+
+func isNonReservedTable(table int) bool {
+	switch table {
+	case unix.RT_TABLE_UNSPEC, unix.RT_TABLE_DEFAULT, unix.RT_TABLE_MAIN, unix.RT_TABLE_LOCAL:
+		return false
+	default:
+		return true
+	}
 }
 
 // retrieveLinkFromMAC finds the corresponding device for a MAC address,

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -323,6 +323,66 @@ func DeleteRulesIfExists(logger *slog.Logger, ip netip.Addr) error {
 	return errors.Join(errs...)
 }
 
+// GCOrphanRules removes Cilium endpoint policy-routing rules left behind when
+// endpoint teardown was missed or interrupted, for example by a CNI or agent
+// crash. A recognized rule is removed only when shouldCollect confirms that
+// its endpoint address is no longer in use.
+func GCOrphanRules(logger *slog.Logger, shouldCollect func(netip.Addr) bool) error {
+	if shouldCollect == nil {
+		return errors.New("orphan rule collection predicate must not be nil")
+	}
+
+	var errs []error
+	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		rules, err := route.ListRules(family, nil)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		for _, rule := range rules {
+			var network *net.IPNet
+
+			switch {
+			// Cilium endpoint ingress rules in the main table.
+			case isCiliumEndpointIngressRule(rule):
+				network = rule.Dst
+			// Cilium endpoint egress rules from current and legacy schemes.
+			case isCiliumEndpointEgressRule(rule):
+				network = rule.Src
+			}
+			if network == nil {
+				continue
+			}
+
+			prefix, ok := netipx.FromStdIPNet(network)
+			// Endpoint rules select one pod IP; preserve subnet-wide prefixes.
+			if !ok || prefix.Bits() != prefix.Addr().BitLen() {
+				continue
+			}
+			addr := prefix.Addr()
+
+			if !shouldCollect(addr) {
+				continue
+			}
+
+			deleted, err := deleteRuleIfExists(&rule)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("delete orphan rule for %s: %w", addr, err))
+				continue
+			}
+
+			if deleted {
+				logger.Info("Deleted orphan endpoint routing rule",
+					logfields.Rule, rule,
+					logfields.IPAddr, addr,
+				)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func isCiliumEndpointIngressRule(rule netlink.Rule) bool {
 	return rule.Dst != nil &&
 		rule.Priority == linux_defaults.RulePriorityIngress &&

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -26,31 +26,18 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// useCompatEgressPriority determines whether to use the new or old style egress rule.
-// Old style rules are only used in Azure IPAM mode.
-func (info *RoutingInfo) useCompatEgressPriority() bool {
-	return info.IpamMode == ipamOption.IPAMAzure
-}
-
-// Configure sets up the rules and routes needed when running in ENI or
-// Azure IPAM mode.
-// These rules and routes direct egress traffic out of the interface and
-// ingress traffic back to the endpoint (`ip`).
+// Configure sets up the rules and routes that direct egress traffic out of the
+// interface and ingress traffic back to the endpoint (ip).
 //
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
-// mtu: The interface MTU.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
-func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
+func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 	if !ip.IsValid() {
-		info.logger.Warn(
-			"Unable to configure rules and routes because IP is not a valid IP address",
-			logfields.IPAddr, ip,
-		)
-		return errors.New("IP not compatible")
+		return fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
 	}
 
-	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
+	ifindex, err := info.prepareInterface()
 	if err != nil {
 		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
@@ -81,14 +68,14 @@ func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
 	}
 
 	var egressPriority, ifaceNum, tableID int
-	if info.useCompatEgressPriority() {
+	if info.compatEgressPriority {
 		egressPriority = linux_defaults.RulePriorityEgress
 		ifaceNum = ifindex
 	} else {
 		egressPriority = linux_defaults.RulePriorityEgressv2
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Install an unconditional rule so all traffic from the endpoint
 	// (including external/internet traffic) is routed through the correct ENI.
@@ -108,21 +95,21 @@ func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
 	return info.installRoutes(ifindex, tableID)
 }
 
-func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
+func (info *RoutingInfo) ReconcileGatewayRoutes(rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
 	set := statedb.NewWatchSet()
 
-	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
+	ifindex, err := info.prepareInterface()
 	if err != nil {
 		return set, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
 
 	var ifaceNum, tableID int
-	if info.useCompatEgressPriority() {
+	if info.compatEgressPriority {
 		ifaceNum = ifindex
 	} else {
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Get the desired routes.
 	gwRoutes := info.gatewayRoutes(ifindex, tableID)
@@ -358,16 +345,14 @@ next:
 	return errors.Join(errs...)
 }
 
-// retrieveIfIndexFromMAC finds the corresponding device index (ifindex) for a
-// given MAC address, excluding Linux slave devices. This is useful for
-// creating rules and routes in order to specify the table. When the ifindex is
-// found, the device is brought up and its MTU is set.
-func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
+// retrieveLinkFromMAC finds the corresponding device for a MAC address,
+// excluding Linux slave devices.
+func retrieveLinkFromMAC(mac mac.MAC) (netlink.Link, error) {
 	var link netlink.Link
 
 	links, err := safenetlink.LinkList()
 	if err != nil {
-		return -1, fmt.Errorf("unable to list interfaces: %w", err)
+		return nil, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
 	for _, l := range links {
@@ -378,28 +363,47 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {
 			if link != nil {
-				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
+				return nil, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
 			}
 			link = l
 		}
 	}
 
 	if link == nil {
-		return -1, fmt.Errorf("interface with MAC %s not found", mac)
+		return nil, fmt.Errorf("interface with MAC %s not found", mac)
+	}
+	return link, nil
+}
+
+// prepareInterface resolves the interface and applies any explicitly requested
+// link configuration.
+func (info *RoutingInfo) prepareInterface() (int, error) {
+	link, err := retrieveLinkFromMAC(info.MasterIfMAC)
+	if err != nil {
+		return -1, err
 	}
 
-	if err = netlink.LinkSetMTU(link, mtu); err != nil {
-		return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, mtu, err)
+	if info.mtu != nil {
+		if err = netlink.LinkSetMTU(link, *info.mtu); err != nil {
+			return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, *info.mtu, err)
+		}
 	}
-	if err = netlink.LinkSetUp(link); err != nil {
-		return -1, fmt.Errorf("unable to up link %s: %w", link.Attrs().Name, err)
+	if info.linkState != nil {
+		if *info.linkState {
+			err = netlink.LinkSetUp(link)
+		} else {
+			err = netlink.LinkSetDown(link)
+		}
+		if err != nil {
+			return -1, fmt.Errorf("unable to set link %s up state to %t: %w", link.Attrs().Name, *info.linkState, err)
+		}
 	}
 
 	return link.Attrs().Index, nil
 }
 
-// computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given
-// ENI interface number.
+// computeTableIDFromIfaceNumber returns a computed per-interface route table
+// ID for the given routing interface number.
 func computeTableIDFromIfaceNumber(compat bool, num int) int {
 	if compat {
 		return num

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
+var errEgressRuleConflict = errors.New("egress rule conflicts with an existing rule")
+
 // Configure sets up the rules and routes that direct egress traffic out of the
 // interface and ingress traffic back to the endpoint (ip).
 //
@@ -32,13 +34,58 @@ import (
 // info: The interface routing info used to create rules and routes.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
 func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
+	_, _, err := info.installEndpointRules(ip, host)
+	if errors.Is(err, errEgressRuleConflict) {
+		// Leave the stale rule for the reconciler to delete before it installs the
+		// new unconditional rule.
+		return nil
+	}
+	return err
+}
+
+// ReconcileEndpointRules installs the desired routes and ingress rule for ip,
+// removes obsolete Cilium egress rules for the same source address, then ensures
+// that the desired unconditional egress rule is installed.
+func (info *RoutingInfo) ReconcileEndpointRules(ip netip.Addr, host bool) error {
+	egressPriority, tableID, err := info.installEndpointRules(ip, host)
+	if err != nil && !errors.Is(err, errEgressRuleConflict) {
+		return err
+	}
+
+	// Remove obsolete egress rules regardless of whether the first installation
+	// succeeded. Retrying below installs the desired unconditional rule after a
+	// conflict, and is idempotent when it was already present.
+	if err := deleteObsoleteEgressRules(ip, egressPriority, tableID); err != nil {
+		return fmt.Errorf("unable to remove obsolete egress rules: %w", err)
+	}
+
+	_, _, err = info.installEndpointRules(ip, host)
+	return err
+}
+
+func (info *RoutingInfo) installEndpointRules(ip netip.Addr, host bool) (egressPriority, tableID int, err error) {
 	if !ip.IsValid() {
-		return fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
+		return 0, 0, fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
 	}
 
 	ifindex, err := info.prepareInterface()
 	if err != nil {
-		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		return 0, 0, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+	}
+
+	var ifaceNum int
+	if info.compatEgressPriority {
+		egressPriority = linux_defaults.RulePriorityEgress
+		ifaceNum = ifindex
+	} else {
+		egressPriority = linux_defaults.RulePriorityEgressv2
+		ifaceNum = info.InterfaceNumber
+	}
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
+
+	// Make the desired table usable before directing any new traffic to it.
+	if err := info.installRoutes(ifindex, tableID); err != nil {
+		return 0, 0, err
 	}
 
 	ipWithMask := netipx.AddrIPNet(ip)
@@ -62,19 +109,9 @@ func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 			Table:    route.MainTable,
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
-			return fmt.Errorf("unable to install ip rule: %w", err)
+			return 0, 0, fmt.Errorf("unable to install ip rule: %w", err)
 		}
 	}
-
-	var egressPriority, ifaceNum, tableID int
-	if info.compatEgressPriority {
-		egressPriority = linux_defaults.RulePriorityEgress
-		ifaceNum = ifindex
-	} else {
-		egressPriority = linux_defaults.RulePriorityEgressv2
-		ifaceNum = info.InterfaceNumber
-	}
-	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Install an unconditional rule so all traffic from the endpoint
 	// (including external/internet traffic) is routed through the correct ENI.
@@ -88,10 +125,50 @@ func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 		Table:    tableID,
 		Protocol: linux_defaults.RTProto,
 	}); err != nil {
-		return fmt.Errorf("unable to install ip rule: %w", err)
+		// Linux treats an omitted destination selector as a wildcard when checking
+		// for duplicate rules. The new unconditional rule may therefore be rejected
+		// with EEXIST while a stale destination-scoped rule is still installed.
+		if errors.Is(err, unix.EEXIST) {
+			return egressPriority, tableID, fmt.Errorf("%w: %w", errEgressRuleConflict, err)
+		}
+		return 0, 0, fmt.Errorf("unable to install ip rule: %w", err)
 	}
 
-	return info.installRoutes(ifindex, tableID)
+	return egressPriority, tableID, nil
+}
+
+func deleteObsoleteEgressRules(ip netip.Addr, desiredPriority, desiredTable int) error {
+	family := netlink.FAMILY_V6
+	if ip.Is4() {
+		family = netlink.FAMILY_V4
+	}
+
+	rules, err := route.ListRules(family, &route.Rule{
+		From: netipx.AddrIPNet(ip),
+	})
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, rule := range rules {
+		// Ignore rules outside the two Cilium endpoint-egress schemes.
+		if !isCiliumEndpointEgressRule(rule) {
+			continue
+		}
+		// Preserve the desired unconditional rule installed for this endpoint.
+		if rule.Priority == desiredPriority &&
+			rule.Table == desiredTable &&
+			rule.Dst == nil {
+			continue
+		}
+
+		_, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (info *RoutingInfo) ReconcileGatewayRoutes(rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -442,6 +442,145 @@ func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
 	})
 }
 
+func TestPrivilegedGCOrphanRules(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		orphan := netip.MustParseAddr("192.0.2.10")
+		inUse := netip.MustParseAddr("192.0.2.11")
+		_, subnet, err := net.ParseCIDR("198.51.100.0/24")
+		require.NoError(t, err)
+
+		// rules that should be preserved after GCOrphanRules is called, even if they match the orphan IP
+		preservedRules := []route.Rule{
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     subnet,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.20")),
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.21")),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityIngress,
+				To:       netipx.AddrIPNet(netip.MustParseAddr("192.0.2.22")),
+				Table:    route.MainTable,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.23")),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.24")),
+				Table:    300,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+		}
+
+		// create rules for both the orphan and in-use IPs
+		for _, addr := range []netip.Addr{orphan, inUse} {
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				To:       netipx.AddrIPNet(addr),
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto,
+			}))
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(addr),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto,
+			}))
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     netipx.AddrIPNet(addr),
+				Table:    300,
+				Protocol: linux_defaults.RTProto,
+			}))
+		}
+		for _, rule := range preservedRules {
+			require.NoError(t, route.ReplaceRule(rule))
+		}
+
+		err = GCOrphanRules(hivetest.Logger(t), func(addr netip.Addr) bool {
+			return addr != inUse
+		})
+		require.NoError(t, err)
+
+		// verify that the rules for the orphan IP have been deleted, and the rules for the in-use IP remain
+		orphanIngressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityIngress,
+			To:       netipx.AddrIPNet(orphan),
+			Table:    route.MainTable,
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanIngressRules)
+
+		orphanEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(orphan),
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanEgressRules)
+
+		orphanLegacyEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgress,
+			From:     netipx.AddrIPNet(orphan),
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanLegacyEgressRules)
+
+		inUseIngressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityIngress,
+			To:       netipx.AddrIPNet(inUse),
+			Table:    route.MainTable,
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseIngressRules, 1)
+
+		inUseEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(inUse),
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseEgressRules, 1)
+
+		inUseLegacyEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgress,
+			From:     netipx.AddrIPNet(inUse),
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseLegacyEgressRules, 1)
+
+		// verify that the preserved rules are still present
+		for _, rule := range preservedRules {
+			rules, err := route.ListRules(netlink.FAMILY_V4, &rule)
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+		}
+		return nil
+	})
+}
+
 func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {
 	// Create rules and routes
 	beforeCreationRules, beforeCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -33,6 +33,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 	ns1 := netns.NewNetNS(t)
 	ns1.Do(func() error {
 		ip, ri := getFakes(t, ipamOption.IPAMENI, true, false)
+		require.NoError(t, ri.WithOptions(WithMTU(1500), WithLinkState(true)))
 		masterMAC := ri.MasterIfMAC
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
@@ -74,6 +75,7 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 	ns1 := netns.NewNetNS(t)
 	ns1.Do(func() error {
 		ip, ri := getFakes(t, ipamOption.IPAMENI, true, true)
+		require.NoError(t, ri.WithOptions(WithMTU(1500), WithLinkState(true)))
 		masterMAC := ri.MasterIfMAC
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
@@ -105,6 +107,7 @@ func TestPrivilegedDelete(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	fakeIP, fakeRoutingInfo := getFakes(t, ipamOption.IPAMENI, true, false)
+	require.NoError(t, fakeRoutingInfo.WithOptions(WithMTU(1500), WithLinkState(true)))
 	masterMAC := fakeRoutingInfo.MasterIfMAC
 
 	tests := []struct {
@@ -311,8 +314,9 @@ func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool)
 
 	options := []RoutingInfoOption{
 		WithCIDRsAndMasquerade(cidrs, masquerade),
-		WithMTU(1500),
-		WithLinkState(true),
+	}
+	if ipamMode != ipamOption.IPAMENI {
+		options = append(options, WithMTU(1500), WithLinkState(true))
 	}
 	if ipamMode == ipamOption.IPAMAzure {
 		options = append(options, WithCompatEgressPriority())

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -413,6 +413,120 @@ func TestIsCiliumEndpointEgressRule(t *testing.T) {
 	}
 }
 
+func TestPrivilegedReconcileObsoleteRules(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	for _, ipamMode := range []string{
+		ipamOption.IPAMENI,
+		ipamOption.IPAMAzure,
+		ipamOption.IPAMAlibabaCloud,
+	} {
+		t.Run(ipamMode, func(t *testing.T) {
+			ns := netns.NewNetNS(t)
+			ns.Do(func() error {
+				ip, routingInfo := getFakes(t, ipamMode, true, false)
+				ifaceCleanup := createDummyDevice(t, routingInfo.MasterIfMAC)
+				defer ifaceCleanup()
+
+				link, err := retrieveLinkFromMAC(routingInfo.MasterIfMAC)
+				require.NoError(t, err)
+				ifindex := link.Attrs().Index
+
+				if ipamMode == ipamOption.IPAMENI {
+					require.NoError(t, netlink.LinkSetMTU(link, 1400))
+					require.NoError(t, netlink.LinkSetUp(link))
+				}
+
+				desiredPriority := linux_defaults.RulePriorityEgressv2
+				desiredTable := linux_defaults.RouteTableInterfacesOffset + routingInfo.InterfaceNumber
+				obsoleteSameSchemeTable := desiredTable + 1
+				obsoleteOtherPriority := linux_defaults.RulePriorityEgress
+				obsoleteOtherSchemeTable := 100
+				if routingInfo.compatEgressPriority {
+					desiredPriority = linux_defaults.RulePriorityEgress
+					desiredTable = ifindex
+					obsoleteSameSchemeTable = 100
+					obsoleteOtherPriority = linux_defaults.RulePriorityEgressv2
+					obsoleteOtherSchemeTable = linux_defaults.RouteTableInterfacesOffset + routingInfo.InterfaceNumber
+				}
+
+				_, legacyDestination, err := net.ParseCIDR("10.0.0.0/8")
+				require.NoError(t, err)
+				for _, rule := range []route.Rule{
+					{
+						Priority: desiredPriority,
+						From:     netipx.AddrIPNet(ip),
+						To:       legacyDestination,
+						Table:    desiredTable,
+						Protocol: linux_defaults.RTProto,
+					},
+					{
+						Priority: desiredPriority,
+						From:     netipx.AddrIPNet(ip),
+						Table:    obsoleteSameSchemeTable,
+						Protocol: linux_defaults.RTProto,
+					},
+					{
+						Priority: obsoleteOtherPriority,
+						From:     netipx.AddrIPNet(ip),
+						Table:    obsoleteOtherSchemeTable,
+						Protocol: linux_defaults.RTProto,
+					},
+				} {
+					require.NoError(t, route.ReplaceRule(rule))
+				}
+
+				// Configure is the additive CNI path. Obsolete rules are left for the
+				// agent-side StateDB reconciler.
+				require.NoError(t, routingInfo.Configure(ip, false))
+				if ipamMode != ipamOption.IPAMENI {
+					link, err := netlink.LinkByIndex(ifindex)
+					require.NoError(t, err)
+					require.Equal(t, 1500, link.Attrs().MTU)
+					require.NotZero(t, link.Attrs().Flags&net.FlagUp)
+				}
+				rules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 3)
+
+				// The first pass must replace destination-scoped legacy rules with
+				// the unconditional desired rule.
+				require.NoError(t, routingInfo.ReconcileEndpointRules(ip, false))
+				if ipamMode != ipamOption.IPAMENI {
+					link, err := netlink.LinkByIndex(ifindex)
+					require.NoError(t, err)
+					require.Equal(t, 1500, link.Attrs().MTU)
+					require.NotZero(t, link.Attrs().Flags&net.FlagUp)
+				}
+				rules, err = route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 1)
+				require.Equal(t, desiredPriority, rules[0].Priority)
+				require.Equal(t, desiredTable, rules[0].Table)
+				require.Nil(t, rules[0].Dst)
+				require.Equal(t, uint8(linux_defaults.RTProto), rules[0].Protocol)
+
+				// The second verifies idempotency.
+				require.NoError(t, routingInfo.ReconcileEndpointRules(ip, false))
+				rules, err = route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 1)
+				require.Equal(t, desiredPriority, rules[0].Priority)
+				require.Equal(t, desiredTable, rules[0].Table)
+				require.Nil(t, rules[0].Dst)
+				require.Equal(t, uint8(linux_defaults.RTProto), rules[0].Protocol)
+				return nil
+			})
+		})
+	}
+}
+
 func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -37,7 +37,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 
@@ -48,7 +48,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -63,7 +63,7 @@ func TestPrivilegedConfigureAzureMasquerade(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -78,7 +78,7 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -87,9 +87,9 @@ func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, ipamOption.IPAMENI, true, false)
-	err := ri.Configure(netip.Addr{}, 1500, false)
+	err := ri.Configure(netip.Addr{}, false)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "IP not compatible")
+	require.ErrorContains(t, err, "unable to install endpoint rules: invalid endpoint IP address")
 }
 
 func TestPrivilegedDeleteRouteWithIncompatibleIP(t *testing.T) {
@@ -115,7 +115,7 @@ func TestPrivilegedDelete(t *testing.T) {
 		{
 			name: "valid IP addr matching a single rule",
 			preRun: func() netip.Addr {
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return fakeIP
 			},
 			wantErr: false,
@@ -125,7 +125,7 @@ func TestPrivilegedDelete(t *testing.T) {
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return ip
 			},
 			wantErr: true,
@@ -135,7 +135,7 @@ func TestPrivilegedDelete(t *testing.T) {
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
-				runConfigure(t, fakeRoutingInfo, ip, 1500)
+				runConfigure(t, fakeRoutingInfo, ip)
 
 				// Find interface ingress rules so that we can create a
 				// near-duplicate.
@@ -160,7 +160,7 @@ func TestPrivilegedDelete(t *testing.T) {
 		{
 			name: "delete rules with dest CIDR after masquerade is disabled",
 			preRun: func() netip.Addr {
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				option.Config.EnableIPv4Masquerade = false
 				return fakeIP
 			},
@@ -184,10 +184,10 @@ func TestPrivilegedDelete(t *testing.T) {
 	}
 }
 
-func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
+func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {
 	// Create rules and routes
 	beforeCreationRules, beforeCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)
-	runConfigure(t, ri, ip, mtu)
+	runConfigure(t, ri, ip)
 	afterCreationRules, afterCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)
 
 	require.NotEmpty(t, afterCreationRules)
@@ -208,8 +208,8 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 	require.Len(t, afterDeletionRoutes, len(beforeCreationRoutes))
 }
 
-func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
-	err := ri.Configure(ip, mtu, false)
+func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr) {
+	err := ri.Configure(ip, false)
 	require.NoError(t, err)
 }
 
@@ -296,8 +296,6 @@ func createDummyDevice(t *testing.T, macAddr mac.MAC) func() {
 func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool) (netip.Addr, RoutingInfo) {
 	t.Helper()
 
-	logger := hivetest.Logger(t)
-
 	fakeGateway := "192.168.2.1"
 	fakeSubnet1CIDR := netip.MustParsePrefix("192.168.0.0/16")
 	fakeSubnet2CIDR := netip.MustParsePrefix("192.170.0.0/16")
@@ -311,21 +309,22 @@ func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool)
 		}
 	}
 
-	fakeRoutingInfo, err := NewRoutingInfo(
-		logger,
-		fakeGateway,
-		cidrs,
-		fakeMAC,
-		"1",
-		ipamMode,
-		masquerade,
-	)
+	options := []RoutingInfoOption{
+		WithCIDRsAndMasquerade(cidrs, masquerade),
+		WithMTU(1500),
+		WithLinkState(true),
+	}
+	if ipamMode == ipamOption.IPAMAzure {
+		options = append(options, WithCompatEgressPriority())
+	}
+
+	fakeRoutingInfo, err := NewRoutingInfo(fakeGateway, fakeMAC, "1", options...)
 
 	require.NoError(t, err)
 	require.NotNil(t, fakeRoutingInfo)
 
 	node.SetRouterInfo(fakeRoutingInfo)
-	option.Config.IPAM = fakeRoutingInfo.IpamMode
+	option.Config.IPAM = ipamMode
 	option.Config.EnableIPv4Masquerade = fakeRoutingInfo.Masquerade
 
 	return netip.MustParseAddr("192.168.2.123"), *fakeRoutingInfo

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -131,7 +132,7 @@ func TestPrivilegedDelete(t *testing.T) {
 				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return ip
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "IP addr matches multiple rules",
@@ -185,6 +186,260 @@ func TestPrivilegedDelete(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestPrivilegedDeleteRulesAllEgressSchemes(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip := netip.MustParseAddr("192.0.2.10")
+		ipWithMask := netipx.AddrIPNet(ip)
+		for _, rule := range []route.Rule{
+			{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto,
+			},
+		} {
+			require.NoError(t, route.ReplaceRule(rule))
+		}
+
+		// A rule outside the known endpoint-egress priorities must be preserved.
+		require.NoError(t, route.ReplaceRule(route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2 + 1,
+			From:     ipWithMask,
+			Table:    100,
+			Protocol: linux_defaults.RTProto,
+		}))
+
+		require.NoError(t, DeleteRulesIfExists(hivetest.Logger(t), ip))
+		// call DeleteRulesIfExists again to ensure that it is idempotent and
+		// does not return an error if the rules have already been deleted
+		require.NoError(t, DeleteRulesIfExists(hivetest.Logger(t), ip))
+
+		rules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{From: ipWithMask})
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+		require.Equal(t, linux_defaults.RulePriorityEgressv2+1, rules[0].Priority)
+		return nil
+	})
+}
+
+func TestIsCiliumEndpointIngressRule(t *testing.T) {
+	mask := uint32(0xffffffff)
+	dst := netipx.AddrIPNet(netip.MustParseAddr("192.0.2.10"))
+
+	tests := []struct {
+		name string
+		rule netlink.Rule
+		want bool
+	}{
+		{
+			"ingress-rule",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"missing-destination",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress + 1,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-table",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"marked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"masked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Mask:     &mask,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-protocol",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCiliumEndpointIngressRule(tt.rule))
+		})
+	}
+}
+
+func TestIsCiliumEndpointEgressRule(t *testing.T) {
+	ipWithMask := netipx.AddrIPNet(netip.MustParseAddr("192.0.2.10"))
+	mask := uint32(0xffffffff)
+
+	tests := []struct {
+		name string
+		rule netlink.Rule
+		want bool
+	}{
+		{
+			"legacy-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"current-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				Src:      ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"legacy-priority-reserved-table",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"current-priority-outside-interface-table-range",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				Src:      ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset - 1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"marked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"masked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Mask:     &mask,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-protocol",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100},
+			false,
+		},
+		{
+			"missing-source",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2 + 1,
+				Src:      ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCiliumEndpointEgressRule(tt.rule))
+		})
+	}
+}
+
+func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip := netip.MustParseAddr("192.0.2.10")
+		spec := route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(ip),
+			Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+			Protocol: linux_defaults.RTProto,
+		}
+		require.NoError(t, route.ReplaceRule(spec))
+
+		rules, err := route.ListRules(netlink.FAMILY_V4, &spec)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+
+		deleted, err := deleteRuleIfExists(&rules[0])
+		require.NoError(t, err)
+		require.True(t, deleted)
+
+		deleted, err = deleteRuleIfExists(&rules[0])
+		require.NoError(t, err)
+		require.False(t, deleted)
+		return nil
+	})
 }
 
 func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -396,7 +396,6 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		}
 		if err := ri.Configure(
 			healthIP,
-			mtuConfig.GetDeviceMTU(),
 			false,
 		); err != nil {
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %w", err)

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -29,7 +29,15 @@ var (
 
 	// ErrIPv6Disabled is returned when Ipv6 allocation is disabled
 	ErrIPv6Disabled = errors.New("IPv6 allocation disabled")
+
+	// ErrRoutingMetadataUnsupported is returned when an allocator cannot
+	// resolve routing metadata for a given address.
+	ErrRoutingMetadataUnsupported = errors.New("routing metadata lookup unsupported")
 )
+
+type routingMetadataResolver interface {
+	ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error)
+}
 
 func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	pool, err := ipam.metadata.GetIPPoolForPod(owner, family)
@@ -51,6 +59,27 @@ func (ipam *IPAM) AllocateIP(ip netip.Addr, owner string, pool Pool) error {
 func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	needSyncUpstream := false
 	return ipam.allocateIP(ip, owner, pool, needSyncUpstream)
+}
+
+// ResolveRoutingMetadata returns the routing metadata for an address without
+// changing its allocation or synchronizing any state upstream.
+func (ipam *IPAM) ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error) {
+	if !addr.IsValid() {
+		return nil, fmt.Errorf("invalid IP address: %v", addr)
+	}
+	addr = addr.Unmap()
+
+	ipam.allocatorMutex.RLock()
+	resolver := ipam.ipv6RoutingMetadataResolver
+	if addr.Is4() {
+		resolver = ipam.ipv4RoutingMetadataResolver
+	}
+	ipam.allocatorMutex.RUnlock()
+
+	if resolver == nil {
+		return nil, ErrRoutingMetadataUnsupported
+	}
+	return resolver.ResolveRoutingMetadata(addr, PoolOrDefault(string(pool)))
 }
 
 // AllocateIPString is identical to AllocateIP but takes a string

--- a/pkg/ipam/cloud_multipool.go
+++ b/pkg/ipam/cloud_multipool.go
@@ -39,7 +39,7 @@ func (a *cloudMultiPoolAllocator) enrichResult(result *AllocationResult, err err
 	// The node is only read by the resolver, so the pointer is handed over
 	// as-is: the multi-pool manager replaces it wholesale on every update and
 	// deep-copies it before any mutation, so it is effectively immutable.
-	enriched, enrichErr := a.resolver.ResolveRoutingMetadata(a.manager.getNode(), result.IP, result.IPPoolName)
+	enriched, enrichErr := a.ResolveRoutingMetadata(result.IP, result.IPPoolName)
 	if enrichErr != nil {
 		// The underlying Allocate* call already reserved the IP in the
 		// allocator. Release it to avoid leaking the reservation when the
@@ -50,6 +50,10 @@ func (a *cloudMultiPoolAllocator) enrichResult(result *AllocationResult, err err
 		return nil, enrichErr
 	}
 	return enriched, nil
+}
+
+func (a *cloudMultiPoolAllocator) ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error) {
+	return a.resolver.ResolveRoutingMetadata(a.manager.getNode(), addr, pool)
 }
 
 func (a *cloudMultiPoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -151,9 +151,11 @@ func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 		}
 		if ipam.config.IPv6Enabled() {
 			ipam.ipv6Allocator = v6Allocator
+			ipam.ipv6RoutingMetadataResolver = v6Allocator
 		}
 		if ipam.config.IPv4Enabled() {
 			ipam.ipv4Allocator = v4Allocator
+			ipam.ipv4RoutingMetadataResolver = v4Allocator
 		}
 
 		return nil

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -106,6 +106,9 @@ type IPAM struct {
 	ipv6Allocator Allocator
 	ipv4Allocator Allocator
 
+	ipv6RoutingMetadataResolver routingMetadataResolver
+	ipv4RoutingMetadataResolver routingMetadataResolver
+
 	// metadata provides information about a particular IP owner.
 	metadata Metadata
 

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -824,14 +824,14 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 
 	if needsEndpointRoutingOnHost(conf) {
 		if ipam.IPv4 != nil && ipConfig != nil {
-			err = interfaceAdd(scopedLogger, ipConfig, ipam.IPv4, conf)
+			err = interfaceAdd(ipConfig, ipam.IPv4, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
 			}
 		}
 
 		if ipam.IPv6 != nil && ipv6Config != nil {
-			err = interfaceAdd(scopedLogger, ipv6Config, ipam.IPv6, conf)
+			err = interfaceAdd(ipv6Config, ipam.IPv6, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
 			}

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"net/netip"
 	"slices"
 
@@ -15,9 +14,10 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/ip"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
-func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf *models.DaemonConfigurationStatus) error {
+func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf *models.DaemonConfigurationStatus) error {
 	if ipam == nil {
 		return fmt.Errorf("missing IPAM configuration")
 	}
@@ -60,14 +60,22 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 		masq = conf.MasqueradeProtocols.IPv4
 	}
 
+	options := []linuxrouting.RoutingInfoOption{
+		linuxrouting.WithCIDRsAndMasquerade(coalescedPrefixes, masq),
+		// Ensure CNI ADD can repair interface MTU and state after a transient
+		// setup failure before installing endpoint routing state.
+		linuxrouting.WithMTU(int(conf.DeviceMTU)),
+		linuxrouting.WithLinkState(true),
+	}
+	if conf.IpamMode == ipamOption.IPAMAzure {
+		options = append(options, linuxrouting.WithCompatEgressPriority())
+	}
+
 	routingInfo, err := linuxrouting.NewRoutingInfo(
-		logger,
 		ipam.Gateway.String(),
-		coalescedPrefixes,
 		ipam.MasterMac,
 		ipam.InterfaceNumber,
-		conf.IpamMode,
-		masq,
+		options...,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %w", err)
@@ -75,7 +83,6 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 
 	if err := routingInfo.Configure(
 		ip.AddrFromIP(ipConfig.Address.IP),
-		int(conf.DeviceMTU),
 		false,
 	); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %w", err)


### PR DESCRIPTION
This is the first PR in a three-part series that moves cloud endpoint routing management into the Cilium agent.

https://github.com/cilium/cilium/pull/47008 introduced unconditional endpoint egress rules to correctly route traffic outside the VPC. However, rules installed by older agents may remain after an upgrade, conflict with the new rule, or become orphaned after missed endpoint cleanup.

This PR prepares the Linux routing package for safe reconciliation. It separates immutable routing metadata from caller-specific behavior, makes link-state ownership explicit, provides read-only ENI routing metadata lookup, and makes endpoint-rule cleanup idempotent. It also adds the primitives needed to identify orphan rules and replace obsolete destination-scoped egress rules without affecting unrelated policy rules.

The runtime endpoint reconciler and periodic garbage collection are introduced by the next PR in the series (refer to https://github.com/cilium/cilium/pull/47938 to see the intended final result).

**Notes to reviewers**

Please review commit by commit for the implementation details.

---

AIL3 - bot wrote code; human reviewed, adjusted and tested