### PR TITLE
cni: Leave cloud endpoint routing to the agent

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
+	routingreconciler "github.com/cilium/cilium/pkg/datapath/linux/routing/reconciler"
 	debugapi "github.com/cilium/cilium/pkg/debug/api"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/dial"
@@ -313,6 +314,9 @@ var (
 
 		// Provides the AWS ENI customization of the multi-pool IPAM allocator.
 		awsAgent.Cell,
+
+		// Reconciles desired cloud endpoint routing rules and removes orphan rules.
+		routingreconciler.Cell,
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -337,9 +337,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		r.daemonConfig.IPAM == ipamOption.IPAMAlibabaCloud ||
 		r.daemonConfig.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
-		routingInfo, err = linuxrouting.NewRoutingInfo(r.logger, result.GatewayIP.String(), prefixesToStrings(result.CIDRs),
-			result.PrimaryMAC, result.InterfaceNumber, r.daemonConfig.IPAM,
-			masq)
+		routingInfo, err = r.newRoutingInfo(result, masq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create router info: %w", err)
 		}
@@ -356,7 +354,6 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 
 		if err = routingInfo.Configure(
 			result.IP,
-			r.mtuManager.GetDeviceMTU(),
 			true,
 		); err != nil {
 			return nil, fmt.Errorf("failed to configure router IP rules and routes: %w", err)
@@ -371,8 +368,15 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			limiter := rate.NewLimiter(30*time.Second, 1)
 
 			for {
+				// Refresh the device MTU on every run so reconciliation applies the latest value.
+				if err := routingInfo.WithOptions(
+					linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+				); err != nil {
+					health.Degraded("Failed to refresh egress route MTU", err)
+					limiter.Wait(ctx)
+					continue
+				}
 				watchSet, err := routingInfo.ReconcileGatewayRoutes(
-					r.mtuManager.GetDeviceMTU(),
 					r.db.ReadTxn(),
 					r.routes,
 				)
@@ -555,7 +559,6 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 
 				if err := ingressRouting.Configure(
 					result.IP,
-					r.mtuManager.GetDeviceMTU(),
 					false,
 				); err != nil {
 					r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)
@@ -622,11 +625,7 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 					)
 				}
 
-				if err := ingressRouting.Configure(
-					result.IP,
-					r.mtuManager.GetDeviceMTU(),
-					false,
-				); err != nil {
+				if err := ingressRouting.Configure(result.IP, false); err != nil {
 					r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)
 				}
 			}
@@ -763,27 +762,29 @@ func (r *infraIPAllocator) allocateRouterIPs(ctx context.Context, restoredRouter
 }
 
 func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*linuxrouting.RoutingInfo, error) {
+	masquerade := r.daemonConfig.EnableIPv6Masquerade
 	if result.IP.Is4() {
-		return linuxrouting.NewRoutingInfo(
-			r.logger,
-			result.GatewayIP.String(),
-			prefixesToStrings(result.CIDRs),
-			result.PrimaryMAC,
-			result.InterfaceNumber,
-			r.daemonConfig.IPAM,
-			r.daemonConfig.EnableIPv4Masquerade,
-		)
-	} else {
-		return linuxrouting.NewRoutingInfo(
-			r.logger,
-			result.GatewayIP.String(),
-			prefixesToStrings(result.CIDRs),
-			result.PrimaryMAC,
-			result.InterfaceNumber,
-			r.daemonConfig.IPAM,
-			r.daemonConfig.EnableIPv6Masquerade,
-		)
+		masquerade = r.daemonConfig.EnableIPv4Masquerade
 	}
+	return r.newRoutingInfo(result, masquerade)
+}
+
+func (r *infraIPAllocator) newRoutingInfo(result *ipam.AllocationResult, masquerade bool) (*linuxrouting.RoutingInfo, error) {
+	options := []linuxrouting.RoutingInfoOption{
+		linuxrouting.WithCIDRsAndMasquerade(prefixesToStrings(result.CIDRs), masquerade),
+		linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+		linuxrouting.WithLinkState(true),
+	}
+	if r.daemonConfig.IPAM == ipamOption.IPAMAzure {
+		options = append(options, linuxrouting.WithCompatEgressPriority())
+	}
+
+	return linuxrouting.NewRoutingInfo(
+		result.GatewayIP.String(),
+		result.PrimaryMAC,
+		result.InterfaceNumber,
+		options...,
+	)
 }
 
 func prefixesToStrings(prefixes []netip.Prefix) []string {

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -368,13 +368,15 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			limiter := rate.NewLimiter(30*time.Second, 1)
 
 			for {
-				// Refresh the device MTU on every run so reconciliation applies the latest value.
-				if err := routingInfo.WithOptions(
-					linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
-				); err != nil {
-					health.Degraded("Failed to refresh egress route MTU", err)
-					limiter.Wait(ctx)
-					continue
+				// The ENI device configurator owns ENI MTU; other modes still rely on RoutingInfo.
+				if r.daemonConfig.IPAM != ipamOption.IPAMENI {
+					if err := routingInfo.WithOptions(
+						linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+					); err != nil {
+						health.Degraded("Failed to refresh egress route MTU", err)
+						limiter.Wait(ctx)
+						continue
+					}
 				}
 				watchSet, err := routingInfo.ReconcileGatewayRoutes(
 					r.db.ReadTxn(),
@@ -772,8 +774,12 @@ func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*lin
 func (r *infraIPAllocator) newRoutingInfo(result *ipam.AllocationResult, masquerade bool) (*linuxrouting.RoutingInfo, error) {
 	options := []linuxrouting.RoutingInfoOption{
 		linuxrouting.WithCIDRsAndMasquerade(prefixesToStrings(result.CIDRs), masquerade),
-		linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
-		linuxrouting.WithLinkState(true),
+	}
+	if r.daemonConfig.IPAM != ipamOption.IPAMENI {
+		options = append(options,
+			linuxrouting.WithMTU(r.mtuManager.GetDeviceMTU()),
+			linuxrouting.WithLinkState(true),
+		)
 	}
 	if r.daemonConfig.IPAM == ipamOption.IPAMAzure {
 		options = append(options, linuxrouting.WithCompatEgressPriority())

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -352,11 +352,11 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			}
 		}
 
-		if err = routingInfo.Configure(
+		if err = routingInfo.ReconcileEndpointRules(
 			result.IP,
 			true,
 		); err != nil {
-			return nil, fmt.Errorf("failed to configure router IP rules and routes: %w", err)
+			return nil, fmt.Errorf("failed to reconcile router IP rules and routes: %w", err)
 		}
 
 		node.SetRouterInfo(routingInfo)

--- a/pkg/aws/agent/device.go
+++ b/pkg/aws/agent/device.go
@@ -272,6 +272,7 @@ func waitForNetlinkDevices(logger *slog.Logger, configByMac configMap) (linkByMa
 	return linkByMac, errors.New("timed out waiting for ENIs to be attached")
 }
 
+// configureENINetlinkDevice owns the MTU and up-state of ENI links.
 func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sysctl.Sysctl) error {
 	if err := netlink.LinkSetMTU(link, cfg.mtu); err != nil {
 		return fmt.Errorf("failed to change MTU of link %s to %d: %w", link.Attrs().Name, cfg.mtu, err)

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -400,11 +400,13 @@ func lookupRule(spec Rule, family int) (bool, error) {
 			continue
 		}
 
-		if spec.From != nil && (r.Src == nil || r.Src.String() != spec.From.String()) {
+		// Match selectors exactly. A nil selector represents all addresses;
+		// it is not a wildcard that may match a scoped rule.
+		if !ruleSelectorEqual(r.Src, spec.From) {
 			continue
 		}
 
-		if spec.To != nil && (r.Dst == nil || r.Dst.String() != spec.To.String()) {
+		if !ruleSelectorEqual(r.Dst, spec.To) {
 			continue
 		}
 
@@ -425,6 +427,16 @@ func lookupRule(spec Rule, family int) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func ruleSelectorEqual(a, b *net.IPNet) bool {
+	if a == nil || b == nil {
+		// IPNet.String returns "<nil>" for both a nil selector and some
+		// malformed non-nil selectors. Keep absence distinct because a nil
+		// selector specifically represents all addresses.
+		return a == nil && b == nil
+	}
+	return a.String() == b.String()
 }
 
 // ListRules will list IP routing rules on Linux, filtered by `filter`. When

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -23,6 +23,21 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 }
 
+func TestRuleSelectorEqual(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("10.0.0.0/8")
+	require.NoError(t, err)
+	_, otherCIDR, err := net.ParseCIDR("192.0.2.0/24")
+	require.NoError(t, err)
+	malformedSelector := &net.IPNet{}
+
+	require.True(t, ruleSelectorEqual(nil, nil))
+	require.True(t, ruleSelectorEqual(cidr, cidr))
+	require.False(t, ruleSelectorEqual(nil, cidr))
+	require.False(t, ruleSelectorEqual(cidr, nil))
+	require.False(t, ruleSelectorEqual(malformedSelector, nil))
+	require.False(t, ruleSelectorEqual(cidr, otherCIDR))
+}
+
 func testReplaceNexthopRoute(t *testing.T, link netlink.Link, routerNet *net.IPNet) {
 	route := Route{
 		Table: 10,

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -6,23 +6,20 @@ package linuxrouting
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"strconv"
 
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 )
 
-// RoutingInfo represents information that's required to enable
-// connectivity via the local rule and route tables while in ENI,Azure IPAM mode and delegated IPAM mode.
+// RoutingInfo represents information required to enable connectivity via local
+// policy rules and route tables.
 // The information in this struct is used to create rules and routes which direct
 // traffic out of the interface (egress).
 //
 // This struct is mostly derived from the `ipam.AllocationResult` as the
 // information comes from IPAM.
 type RoutingInfo struct {
-	logger *slog.Logger
 	// Gateway is the gateway where outbound/egress IPv4/IPv6 traffic is directed.
 	Gateway net.IP
 
@@ -43,38 +40,85 @@ type RoutingInfo struct {
 	// the per-ENI tables.
 	InterfaceNumber int
 
-	// IpamMode tells us which IPAM mode is being used (e.g., ENI, AKS).
-	IpamMode string
+	mtu       *int
+	linkState *bool
+
+	// compatEgressPriority determines whether to use the new or old style egress rule.
+	compatEgressPriority bool
 }
 
 func (info *RoutingInfo) GetCIDRs() []net.IPNet {
 	return info.CIDRs
 }
 
-// NewRoutingInfo creates a new RoutingInfo struct, from data that will be
-// parsed and validated. Note, this code assumes IPv4 values because IPv4
-// (on either ENI or Azure interface) is the only supported path currently.
-func NewRoutingInfo(logger *slog.Logger, gateway string, cidrs []string, masterIfMAC mac.MAC, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
-	return parse(logger, gateway, cidrs, masterIfMAC, ifaceNum, ipamMode, masquerade)
+type RoutingInfoOption func(*RoutingInfo) error
+
+// WithOptions applies functional options to info.
+func (info *RoutingInfo) WithOptions(opts ...RoutingInfoOption) error {
+	for _, opt := range opts {
+		if err := opt(info); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func parse(logger *slog.Logger, gateway string, cidrs []string, masterIfMAC mac.MAC, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
+// WithCIDRsAndMasquerade configures the directly reachable CIDRs and whether
+// masquerading is enabled.
+func WithCIDRsAndMasquerade(cidrs []string, masquerade bool) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		if len(cidrs) == 0 && masquerade {
+			return errors.New("empty cidrs")
+		}
+
+		parsedCIDRs := make([]net.IPNet, 0, len(cidrs))
+		for _, cidr := range cidrs {
+			_, parsed, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("invalid cidr: %s", cidr)
+			}
+			parsedCIDRs = append(parsedCIDRs, *parsed)
+		}
+
+		info.CIDRs = parsedCIDRs
+		info.Masquerade = masquerade
+		return nil
+	}
+}
+
+// WithLinkState configures whether the master interface should be brought up
+// or down before routes and rules are installed.
+func WithLinkState(up bool) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.linkState = &up
+		return nil
+	}
+}
+
+// WithMTU configures the MTU to apply to the master interface before routes
+// and rules are installed.
+func WithMTU(mtu int) RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.mtu = &mtu
+		return nil
+	}
+}
+
+// WithCompatEgressPriority selects the legacy egress priority and ifindex-based
+// route table scheme used by Azure IPAM.
+func WithCompatEgressPriority() RoutingInfoOption {
+	return func(info *RoutingInfo) error {
+		info.compatEgressPriority = true
+		return nil
+	}
+}
+
+// NewRoutingInfo parses the required routing information and applies opts. By
+// default, using the returned information does not change link state or MTU.
+func NewRoutingInfo(gateway string, masterIfMAC mac.MAC, ifaceNum string, opts ...RoutingInfoOption) (*RoutingInfo, error) {
 	ip := net.ParseIP(gateway)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid gateway: %s", gateway)
-	}
-
-	if len(cidrs) == 0 && masquerade {
-		return nil, errors.New("empty cidrs")
-	}
-
-	parsedCIDRs := make([]net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, c, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cidr: %s", cidr)
-		}
-		parsedCIDRs = append(parsedCIDRs, *c)
 	}
 
 	// The MAC of the master interface is what the routes and rules are keyed
@@ -88,13 +132,13 @@ func parse(logger *slog.Logger, gateway string, cidrs []string, masterIfMAC mac.
 		return nil, fmt.Errorf("invalid interface number: %s", ifaceNum)
 	}
 
-	return &RoutingInfo{
-		logger:          logger.With(logfields.LogSubsys, "linux-routing"),
+	info := &RoutingInfo{
 		Gateway:         ip,
-		CIDRs:           parsedCIDRs,
 		MasterIfMAC:     masterIfMAC,
-		Masquerade:      masquerade,
 		InterfaceNumber: parsedIfaceNum,
-		IpamMode:        ipamMode,
-	}, nil
+	}
+	if err := info.WithOptions(opts...); err != nil {
+		return nil, err
+	}
+	return info, nil
 }

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -35,9 +35,9 @@ type RoutingInfo struct {
 	// Masquerade represents whether masquerading is enabled or not.
 	Masquerade bool
 
-	// InterfaceNumber is the generic number of the master interface that
-	// egress traffic is directed to. This is used to compute the table ID for
-	// the per-ENI tables.
+	// InterfaceNumber is the provider-specific number of the master interface
+	// that egress traffic is directed to. It is used to compute the
+	// per-interface route table when the compatibility scheme is disabled.
 	InterfaceNumber int
 
 	mtu       *int

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -7,137 +7,122 @@ import (
 	"net"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
 )
 
-func TestPrivilegedParse(t *testing.T) {
-	setupLinuxRoutingSuite(t)
-
-	_, fakeCIDR, err := net.ParseCIDR("192.168.0.0/16")
-	require.NoError(t, err)
-
-	fakeMAC := mac.MustParseMAC("11:22:33:44:55:66")
-
-	validCIDRs := []net.IPNet{*fakeCIDR}
-
-	tests := []struct {
-		name      string
-		gateway   string
-		cidrs     []string
-		macAddr   mac.MAC
-		masq      bool
-		ifaceNum  string
-		wantRInfo *RoutingInfo
-		wantErr   bool
-	}{
-		{
-			name:      "invalid gateway",
-			gateway:   "",
-			cidrs:     []string{"192.168.0.0/16"},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "invalid cidr",
-			gateway:   "192.168.1.1",
-			cidrs:     []string{"192.168.0.0/16", "192.168.0.0/33"},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "empty cidr",
-			gateway:   "192.168.1.1",
-			cidrs:     []string{},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "nil cidr",
-			gateway:   "192.168.1.1",
-			cidrs:     nil,
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "empty mac address",
-			gateway:   "192.168.1.1",
-			cidrs:     []string{"192.168.0.0/16"},
-			macAddr:   mac.MAC{},
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:      "invalid interface number",
-			gateway:   "192.168.1.1",
-			cidrs:     []string{"192.168.0.0/16"},
-			macAddr:   fakeMAC,
-			ifaceNum:  "a",
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-		{
-			name:     "valid IPv4 input",
-			gateway:  "192.168.1.1",
-			cidrs:    []string{"192.168.0.0/16"},
-			macAddr:  fakeMAC,
-			ifaceNum: "1",
-			wantRInfo: &RoutingInfo{
-				Gateway:         net.ParseIP("192.168.1.1"),
-				CIDRs:           validCIDRs,
-				MasterIfMAC:     fakeMAC,
-				InterfaceNumber: 1,
-				IpamMode:        ipamOption.IPAMENI,
+func TestNewRoutingInfo(t *testing.T) {
+	t.Run("no options", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			gateway  string
+			macAddr  mac.MAC
+			ifaceNum string
+			wantErr  bool
+		}{
+			{
+				name:     "invalid gateway",
+				gateway:  "",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "1",
+				wantErr:  true,
 			},
-			wantErr: false,
-		},
-		{
-			name:     "disabled masquerade",
-			gateway:  "192.168.1.1",
-			cidrs:    []string{},
-			macAddr:  fakeMAC,
-			masq:     false,
-			ifaceNum: "0",
-			wantRInfo: &RoutingInfo{
-				Gateway:     net.ParseIP("192.168.1.1"),
-				CIDRs:       []net.IPNet{},
-				MasterIfMAC: fakeMAC,
-				IpamMode:    ipamOption.IPAMENI,
+			{
+				name:     "empty mac address",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MAC{},
+				ifaceNum: "1",
+				wantErr:  true,
 			},
-			wantErr: false,
-		},
-		{
-			name:      "masquerade lacking cidrs",
-			gateway:   "192.168.1.1",
-			cidrs:     []string{},
-			macAddr:   fakeMAC,
-			masq:      true,
-			wantRInfo: nil,
-			wantErr:   true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := hivetest.Logger(t)
-			rInfo, err := NewRoutingInfo(logger, tt.gateway, tt.cidrs, tt.macAddr, tt.ifaceNum, ipamOption.IPAMENI, tt.masq)
-			if err == nil {
-				// Do not compare loggers
-				rInfo.logger = nil
-			}
-			require.Equal(t, tt.wantRInfo, rInfo)
-			require.Equal(t, tt.wantErr, err != nil)
-		})
-	}
+			{
+				name:     "invalid interface number",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "a",
+				wantErr:  true,
+			},
+			{
+				name:     "valid input",
+				gateway:  "192.168.1.1",
+				macAddr:  mac.MustParseMAC("11:22:33:44:55:66"),
+				ifaceNum: "1",
+				wantErr:  false,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rInfo, err := NewRoutingInfo(tt.gateway, tt.macAddr, tt.ifaceNum)
+				require.Equal(t, tt.wantErr, err != nil)
+				if tt.wantErr {
+					require.Nil(t, rInfo)
+					return
+				}
+
+				require.Equal(t, net.ParseIP(tt.gateway), rInfo.Gateway)
+				require.Nil(t, rInfo.CIDRs)
+				require.Equal(t, tt.macAddr, rInfo.MasterIfMAC)
+				require.False(t, rInfo.Masquerade)
+				require.Equal(t, 1, rInfo.InterfaceNumber)
+				require.Nil(t, rInfo.mtu)
+				require.Nil(t, rInfo.linkState)
+				require.False(t, rInfo.compatEgressPriority)
+			})
+		}
+	})
+	t.Run("with options", func(t *testing.T) {
+		rInfo, err := NewRoutingInfo(
+			"192.168.1.1",
+			mac.MustParseMAC("11:22:33:44:55:66"),
+			"2",
+			WithCIDRsAndMasquerade([]string{"192.168.0.0/16"}, true),
+			WithMTU(1500),
+			WithLinkState(true),
+			WithCompatEgressPriority(),
+		)
+		require.NoError(t, err)
+
+		_, cidr, err := net.ParseCIDR("192.168.0.0/16")
+		require.NoError(t, err)
+		require.Equal(t, []net.IPNet{*cidr}, rInfo.CIDRs)
+		require.True(t, rInfo.Masquerade)
+		require.NotNil(t, rInfo.mtu)
+		require.Equal(t, 1500, *rInfo.mtu)
+		require.NotNil(t, rInfo.linkState)
+		require.True(t, *rInfo.linkState)
+		require.True(t, rInfo.compatEgressPriority)
+
+		require.NoError(t, rInfo.WithOptions(WithMTU(1400), WithLinkState(false)))
+		require.Equal(t, 1400, *rInfo.mtu)
+		require.False(t, *rInfo.linkState)
+	})
+	t.Run("CIDR option validation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			cidrs      []string
+			masquerade bool
+		}{
+			{
+				name:       "invalid CIDR",
+				cidrs:      []string{"192.168.0.0/33"},
+				masquerade: true,
+			},
+			{
+				name:       "empty CIDRs with masquerading",
+				masquerade: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				rInfo, err := NewRoutingInfo(
+					"192.168.1.1",
+					mac.MustParseMAC("11:22:33:44:55:66"),
+					"1",
+					WithCIDRsAndMasquerade(tt.cidrs, tt.masquerade),
+				)
+				require.Error(t, err)
+				require.Nil(t, rInfo)
+			})
+		}
+	})
+
 }

--- a/pkg/datapath/linux/routing/reconciler/cell.go
+++ b/pkg/datapath/linux/routing/reconciler/cell.go
@@ -4,22 +4,10 @@
 package reconciler
 
 import (
-	"errors"
-	"log/slog"
-
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 
-	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/endpointstate"
-	"github.com/cilium/cilium/pkg/ipam"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -28,86 +16,40 @@ var Cell = cell.Module(
 	"cloud-routing-rule-reconciler",
 	"Reconciles endpoint routing rules for cloud IPAM",
 
-	cell.ProvidePrivate(newEndpointRulesTable),
-	cell.Provide(statedb.RWTable[*EndpointRules].ToTable),
-	cell.Invoke(registerEndpointRulesReconciler),
+	cell.ProvidePrivate(
+		newEndpointRulesTable,
+		newEndpointRulesManager,
+		newEndpointRulesOperations,
+	),
+	cell.Provide(
+		statedb.RWTable[*EndpointRules].ToTable,
+	),
+	cell.Invoke(
+		registerEndpointRulesReconciler,
+	),
 )
 
-type params struct {
+type endpointRulesReconcilerParams struct {
 	cell.In
 
-	Logger           *slog.Logger
-	Lifecycle        cell.Lifecycle
-	JobGroup         job.Group
 	ReconcilerParams statedbReconciler.Params
-	DB               *statedb.DB
 	Table            statedb.RWTable[*EndpointRules]
-	DaemonConfig     *option.DaemonConfig
-	IPAM             *ipam.IPAM
-	EndpointManager  endpointmanager.EndpointManager
-	Restorer         promise.Promise[endpointstate.Restorer]
-	LocalNodeStore   *node.LocalNodeStore
+	Manager          *endpointRulesManager
+	Operations       *endpointRulesOperations
 }
 
-func registerEndpointRulesReconciler(p params) error {
-	if p.DaemonConfig.DryMode {
+func registerEndpointRulesReconciler(p endpointRulesReconcilerParams) error {
+	if !p.Manager.enabled {
 		return nil
 	}
 
-	ipamMode := p.DaemonConfig.IPAMMode()
-	if ipamMode == ipamOption.IPAMAlibabaCloud && p.DaemonConfig.EnableIPv6 {
-		// AlibabaCloud only supplies IPv4 routing metadata, so disable the whole
-		// reconciler to avoid repeatedly failing to reconcile endpoint IPv6
-		// addresses. This also disables IPv4 repair and garbage collection.
-		p.Logger.Error("Endpoint routing rule reconciliation is disabled",
-			logfields.Error, errors.New("routing metadata for IPv6 is not supported by AlibabaCloud IPAM"))
-		return nil
-	}
-
-	if !isCloudIPAMMode(ipamMode) {
-		return nil
-	}
-
-	manager := newEndpointRulesManager(
-		p.Logger,
-		p.DB,
-		p.Table,
-		p.IPAM,
-		p.EndpointManager,
-		p.Restorer,
-	)
-	// Subscribe during cell registration so no restored endpoint event is lost.
-	p.EndpointManager.Subscribe(manager)
-	p.Lifecycle.Append(cell.Hook{
-		OnStop: func(ctx cell.HookContext) error {
-			p.EndpointManager.Unsubscribe(manager)
-			return nil
-		},
-	})
-
-	p.JobGroup.Add(job.OneShot(
-		"initialize-cloud-endpoint-routing-rules",
-		manager.initialize,
-		job.WithRetry(-1, &job.ExponentialBackoff{
-			Min: time.Second,
-			Max: time.Minute,
-		}),
-	))
-
-	ops := &endpointRulesOperations{
-		logger:          p.Logger,
-		ipam:            p.IPAM,
-		ipamMode:        ipamMode,
-		endpointManager: p.EndpointManager,
-		localNodeStore:  p.LocalNodeStore,
-	}
 	if _, err := statedbReconciler.Register(
 		p.ReconcilerParams,
 		p.Table,
 		(*EndpointRules).Clone,
 		(*EndpointRules).SetStatus,
 		(*EndpointRules).GetStatus,
-		ops,
+		p.Operations,
 		nil,
 		statedbReconciler.WithPruning(30*time.Minute),
 		statedbReconciler.WithRefreshing(30*time.Minute, nil),
@@ -116,10 +58,4 @@ func registerEndpointRulesReconciler(p params) error {
 	}
 
 	return nil
-}
-
-func isCloudIPAMMode(ipamMode string) bool {
-	return ipamMode == ipamOption.IPAMENI ||
-		ipamMode == ipamOption.IPAMAzure ||
-		ipamMode == ipamOption.IPAMAlibabaCloud
 }

--- a/pkg/datapath/linux/routing/reconciler/cell.go
+++ b/pkg/datapath/linux/routing/reconciler/cell.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Cell maintains desired endpoint policy-routing rules for ENI IPAM.
+var Cell = cell.Module(
+	"cloud-routing-rule-reconciler",
+	"Reconciles endpoint routing rules for cloud IPAM",
+
+	cell.ProvidePrivate(newEndpointRulesTable),
+	cell.Provide(statedb.RWTable[*EndpointRules].ToTable),
+	cell.Invoke(registerEndpointRulesReconciler),
+)
+
+type params struct {
+	cell.In
+
+	Logger           *slog.Logger
+	Lifecycle        cell.Lifecycle
+	JobGroup         job.Group
+	ReconcilerParams statedbReconciler.Params
+	DB               *statedb.DB
+	Table            statedb.RWTable[*EndpointRules]
+	DaemonConfig     *option.DaemonConfig
+	IPAM             *ipam.IPAM
+	EndpointManager  endpointmanager.EndpointManager
+	Restorer         promise.Promise[endpointstate.Restorer]
+	LocalNodeStore   *node.LocalNodeStore
+}
+
+func registerEndpointRulesReconciler(p params) error {
+	if p.DaemonConfig.DryMode || p.DaemonConfig.IPAMMode() != ipamOption.IPAMENI {
+		return nil
+	}
+
+	manager := newEndpointRulesManager(
+		p.Logger,
+		p.DB,
+		p.Table,
+		p.IPAM,
+		p.EndpointManager,
+		p.Restorer,
+	)
+	// Subscribe during cell registration so no restored endpoint event is lost.
+	p.EndpointManager.Subscribe(manager)
+	p.Lifecycle.Append(cell.Hook{
+		OnStop: func(ctx cell.HookContext) error {
+			p.EndpointManager.Unsubscribe(manager)
+			return nil
+		},
+	})
+
+	p.JobGroup.Add(job.OneShot(
+		"initialize-cloud-endpoint-routing-rules",
+		manager.initialize,
+		job.WithRetry(-1, &job.ExponentialBackoff{
+			Min: time.Second,
+			Max: time.Minute,
+		}),
+	))
+
+	ops := &endpointRulesOperations{
+		logger:          p.Logger,
+		ipam:            p.IPAM,
+		endpointManager: p.EndpointManager,
+		localNodeStore:  p.LocalNodeStore,
+	}
+	if _, err := statedbReconciler.Register(
+		p.ReconcilerParams,
+		p.Table,
+		(*EndpointRules).Clone,
+		(*EndpointRules).SetStatus,
+		(*EndpointRules).GetStatus,
+		ops,
+		nil,
+		statedbReconciler.WithPruning(30*time.Minute),
+		statedbReconciler.WithRefreshing(30*time.Minute, nil),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/datapath/linux/routing/reconciler/cell.go
+++ b/pkg/datapath/linux/routing/reconciler/cell.go
@@ -4,6 +4,7 @@
 package reconciler
 
 import (
+	"errors"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -15,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -53,6 +55,15 @@ func registerEndpointRulesReconciler(p params) error {
 	}
 
 	ipamMode := p.DaemonConfig.IPAMMode()
+	if ipamMode == ipamOption.IPAMAlibabaCloud && p.DaemonConfig.EnableIPv6 {
+		// AlibabaCloud only supplies IPv4 routing metadata, so disable the whole
+		// reconciler to avoid repeatedly failing to reconcile endpoint IPv6
+		// addresses. This also disables IPv4 repair and garbage collection.
+		p.Logger.Error("Endpoint routing rule reconciliation is disabled",
+			logfields.Error, errors.New("routing metadata for IPv6 is not supported by AlibabaCloud IPAM"))
+		return nil
+	}
+
 	if !isCloudIPAMMode(ipamMode) {
 		return nil
 	}
@@ -108,5 +119,7 @@ func registerEndpointRulesReconciler(p params) error {
 }
 
 func isCloudIPAMMode(ipamMode string) bool {
-	return ipamMode == ipamOption.IPAMENI || ipamMode == ipamOption.IPAMAzure
+	return ipamMode == ipamOption.IPAMENI ||
+		ipamMode == ipamOption.IPAMAzure ||
+		ipamMode == ipamOption.IPAMAlibabaCloud
 }

--- a/pkg/datapath/linux/routing/reconciler/cell.go
+++ b/pkg/datapath/linux/routing/reconciler/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -23,11 +24,16 @@ var Cell = cell.Module(
 	),
 	cell.Provide(
 		statedb.RWTable[*EndpointRules].ToTable,
+		asEndpointRoutingWaiter,
 	),
 	cell.Invoke(
 		registerEndpointRulesReconciler,
 	),
 )
+
+func asEndpointRoutingWaiter(manager *endpointRulesManager) endpointmanager.EndpointRoutingWaiter {
+	return manager
+}
 
 type endpointRulesReconcilerParams struct {
 	cell.In

--- a/pkg/datapath/linux/routing/reconciler/cell.go
+++ b/pkg/datapath/linux/routing/reconciler/cell.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-// Cell maintains desired endpoint policy-routing rules for ENI IPAM.
+// Cell maintains desired endpoint policy-routing rules for supported cloud IPAM modes.
 var Cell = cell.Module(
 	"cloud-routing-rule-reconciler",
 	"Reconciles endpoint routing rules for cloud IPAM",
@@ -48,7 +48,12 @@ type params struct {
 }
 
 func registerEndpointRulesReconciler(p params) error {
-	if p.DaemonConfig.DryMode || p.DaemonConfig.IPAMMode() != ipamOption.IPAMENI {
+	if p.DaemonConfig.DryMode {
+		return nil
+	}
+
+	ipamMode := p.DaemonConfig.IPAMMode()
+	if !isCloudIPAMMode(ipamMode) {
 		return nil
 	}
 
@@ -81,6 +86,7 @@ func registerEndpointRulesReconciler(p params) error {
 	ops := &endpointRulesOperations{
 		logger:          p.Logger,
 		ipam:            p.IPAM,
+		ipamMode:        ipamMode,
 		endpointManager: p.EndpointManager,
 		localNodeStore:  p.LocalNodeStore,
 	}
@@ -99,4 +105,8 @@ func registerEndpointRulesReconciler(p params) error {
 	}
 
 	return nil
+}
+
+func isCloudIPAMMode(ipamMode string) bool {
+	return ipamMode == ipamOption.IPAMENI || ipamMode == ipamOption.IPAMAzure
 }

--- a/pkg/datapath/linux/routing/reconciler/manager.go
+++ b/pkg/datapath/linux/routing/reconciler/manager.go
@@ -4,25 +4,47 @@
 package reconciler
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/netip"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointTypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 const internalEndpointOwner = "internal"
 
 type endpointRulesManager struct {
-	logger *slog.Logger
-	db     *statedb.DB
-	table  statedb.RWTable[*EndpointRules]
+	logger          *slog.Logger
+	db              *statedb.DB
+	table           statedb.RWTable[*EndpointRules]
+	ipam            *ipam.IPAM
+	endpointManager endpointmanager.EndpointManager
+	restorer        promise.Promise[endpointstate.Restorer]
+	initDone        func(statedb.WriteTxn)
+
+	mu           lock.Mutex
+	initializing bool
+	// pending holds the latest owner-aware operation for each address while
+	// endpoint and IPAM restoration are in progress.
+	pending map[netip.Addr]pendingEndpointRules
+}
+
+type pendingEndpointRules struct {
+	owner      string
+	generation uint64
+	deleted    bool
 }
 
 var _ endpointmanager.Subscriber = (*endpointRulesManager)(nil)
@@ -31,12 +53,68 @@ func newEndpointRulesManager(
 	logger *slog.Logger,
 	db *statedb.DB,
 	table statedb.RWTable[*EndpointRules],
+	ipam *ipam.IPAM,
+	endpointManager endpointmanager.EndpointManager,
+	restorer promise.Promise[endpointstate.Restorer],
 ) *endpointRulesManager {
+	txn := db.WriteTxn(table)
+	initDone := table.RegisterInitializer(txn, "endpoint-restoration")
+	txn.Commit()
+
 	return &endpointRulesManager{
-		logger: logger,
-		db:     db,
-		table:  table,
+		logger:          logger,
+		db:              db,
+		table:           table,
+		ipam:            ipam,
+		endpointManager: endpointManager,
+		restorer:        restorer,
+		initDone:        initDone,
+		initializing:    true,
+		pending:         map[netip.Addr]pendingEndpointRules{},
 	}
+}
+
+func (mgr *endpointRulesManager) initialize(ctx context.Context, health cell.Health) error {
+	// Wait until IPAM has restored the routing metadata needed to reconcile endpoint rules.
+	if err := mgr.ipam.WaitForRestoreFinished(ctx); err != nil {
+		return err
+	}
+
+	restorer, err := mgr.restorer.Await(ctx)
+	if err != nil {
+		return fmt.Errorf("wait for endpoint restorer: %w", err)
+	}
+	// Wait until every restored endpoint event is queued before enabling pruning.
+	if err := restorer.WaitForEndpointRestoreWithoutRegeneration(ctx); err != nil {
+		return fmt.Errorf("wait for endpoint restoration: %w", err)
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	txn := mgr.db.WriteTxn(mgr.table)
+	defer txn.Abort()
+
+	for address, pending := range mgr.pending {
+		var err error
+		if pending.deleted {
+			err = mgr.handleEndpointDeletion(txn, []netip.Addr{address}, pending.owner, pending.generation)
+		} else {
+			err = mgr.handleEndpointCreation(txn, []netip.Addr{address}, pending.owner, pending.generation)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	mgr.initDone(txn)
+	txn.Commit()
+
+	mgr.pending = nil
+	mgr.initializing = false
+
+	health.OK(fmt.Sprintf("Published desired routing rules for %d endpoint addresses", mgr.table.NumObjects(mgr.db.ReadTxn())))
+
+	return nil
 }
 
 func (mgr *endpointRulesManager) EndpointCreated(ep *endpoint.Endpoint) {
@@ -68,6 +146,14 @@ func (mgr *endpointRulesManager) handleEvent(
 		return
 	}
 
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	if mgr.initializing {
+		mgr.queuePending(addresses, owner, generation, deleted)
+		return
+	}
+
 	txn := mgr.db.WriteTxn(mgr.table)
 	defer txn.Abort()
 
@@ -86,6 +172,31 @@ func (mgr *endpointRulesManager) handleEvent(
 	}
 
 	txn.Commit()
+}
+
+// queuePending records the latest desired endpoint generation for each address
+// while the initial state is being restored. A deletion from an older
+// generation must not overwrite a replacement endpoint that has already
+// claimed the address.
+func (mgr *endpointRulesManager) queuePending(
+	addresses []netip.Addr,
+	owner string,
+	generation uint64,
+	deleted bool,
+) {
+	for _, address := range addresses {
+		current, found := mgr.pending[address]
+		// A different owner or generation means that a replacement endpoint
+		// now owns this address, so ignore the delayed deletion for the old one.
+		if deleted && found && (current.owner != owner || current.generation != generation) {
+			continue
+		}
+		mgr.pending[address] = pendingEndpointRules{
+			owner:      owner,
+			generation: generation,
+			deleted:    deleted,
+		}
+	}
 }
 
 func (mgr *endpointRulesManager) handleEndpointCreation(txn statedb.WriteTxn, addresses []netip.Addr, owner string, generation uint64) error {

--- a/pkg/datapath/linux/routing/reconciler/manager.go
+++ b/pkg/datapath/linux/routing/reconciler/manager.go
@@ -31,7 +31,8 @@ import (
 const internalEndpointOwner = "internal"
 
 type endpointRulesManager struct {
-	enabled bool
+	enabled  bool
+	ipamMode string
 
 	logger          *slog.Logger
 	db              *statedb.DB
@@ -73,6 +74,7 @@ type endpointRulesManagerParams struct {
 
 func newEndpointRulesManager(p endpointRulesManagerParams) *endpointRulesManager {
 	manager := &endpointRulesManager{
+		ipamMode:        p.DaemonConfig.IPAMMode(),
 		logger:          p.Logger,
 		db:              p.DB,
 		table:           p.Table,
@@ -88,12 +90,11 @@ func newEndpointRulesManager(p endpointRulesManagerParams) *endpointRulesManager
 	}
 
 	if p.DaemonConfig.IPAMMode() == ipamOption.IPAMAlibabaCloud && p.DaemonConfig.EnableIPv6 {
-		// AlibabaCloud only supplies IPv4 routing metadata, so disable the whole
-		// reconciler to avoid repeatedly failing to reconcile endpoint IPv6
-		// addresses. This also disables IPv4 repair and garbage collection.
-		p.Logger.Error("Endpoint routing rule reconciliation is disabled",
-			logfields.Error, errors.New("routing metadata for IPv6 is not supported by AlibabaCloud IPAM"))
-		return manager
+		// AlibabaCloud only supplies IPv4 routing metadata. Keep the manager
+		// enabled to reconcile IPv4, while rejecting actual IPv6 endpoints.
+		p.Logger.Error("AlibabaCloud IPv6 endpoint routing reconciliation is not supported",
+			logfields.Error, errors.New("routing metadata for IPv6 is not supported by AlibabaCloud IPAM"),
+		)
 	}
 
 	manager.enabled = true
@@ -201,6 +202,9 @@ func (mgr *endpointRulesManager) WaitForEndpointRouting(ctx context.Context, ep 
 	owner := endpointRulesOwner(ep)
 	generation := ep.GetLifecycleGeneration()
 	for _, address := range endpointAddrs(ep) {
+		if mgr.ipamMode == ipamOption.IPAMAlibabaCloud && address.Is6() {
+			return fmt.Errorf("AlibabaCloud IPAM does not support IPv6 endpoint routing for %s", address)
+		}
 		if err := mgr.waitForRules(ctx, address, owner, generation); err != nil {
 			return err
 		}
@@ -253,6 +257,16 @@ func (mgr *endpointRulesManager) handleEvent(
 	generation uint64,
 	deleted bool,
 ) {
+	if mgr.ipamMode == ipamOption.IPAMAlibabaCloud {
+		filtered := make([]netip.Addr, 0, len(addresses))
+		for _, address := range addresses {
+			if address.Is4() {
+				filtered = append(filtered, address)
+			}
+		}
+		addresses = filtered
+	}
+
 	if len(addresses) == 0 {
 		return
 	}

--- a/pkg/datapath/linux/routing/reconciler/manager.go
+++ b/pkg/datapath/linux/routing/reconciler/manager.go
@@ -5,11 +5,13 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 
@@ -18,14 +20,19 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const internalEndpointOwner = "internal"
 
 type endpointRulesManager struct {
+	enabled bool
+
 	logger          *slog.Logger
 	db              *statedb.DB
 	table           statedb.RWTable[*EndpointRules]
@@ -49,29 +56,76 @@ type pendingEndpointRules struct {
 
 var _ endpointmanager.Subscriber = (*endpointRulesManager)(nil)
 
-func newEndpointRulesManager(
-	logger *slog.Logger,
-	db *statedb.DB,
-	table statedb.RWTable[*EndpointRules],
-	ipam *ipam.IPAM,
-	endpointManager endpointmanager.EndpointManager,
-	restorer promise.Promise[endpointstate.Restorer],
-) *endpointRulesManager {
-	txn := db.WriteTxn(table)
-	initDone := table.RegisterInitializer(txn, "endpoint-restoration")
-	txn.Commit()
+type endpointRulesManagerParams struct {
+	cell.In
 
-	return &endpointRulesManager{
-		logger:          logger,
-		db:              db,
-		table:           table,
-		ipam:            ipam,
-		endpointManager: endpointManager,
-		restorer:        restorer,
-		initDone:        initDone,
+	Logger          *slog.Logger
+	Lifecycle       cell.Lifecycle
+	JobGroup        job.Group
+	DB              *statedb.DB
+	Table           statedb.RWTable[*EndpointRules]
+	DaemonConfig    *option.DaemonConfig
+	IPAM            *ipam.IPAM
+	EndpointManager endpointmanager.EndpointManager
+	Restorer        promise.Promise[endpointstate.Restorer]
+}
+
+func newEndpointRulesManager(p endpointRulesManagerParams) *endpointRulesManager {
+	manager := &endpointRulesManager{
+		logger:          p.Logger,
+		db:              p.DB,
+		table:           p.Table,
+		ipam:            p.IPAM,
+		endpointManager: p.EndpointManager,
+		restorer:        p.Restorer,
 		initializing:    true,
 		pending:         map[netip.Addr]pendingEndpointRules{},
 	}
+
+	if p.DaemonConfig.DryMode || !isCloudIPAMMode(p.DaemonConfig.IPAMMode()) {
+		return manager
+	}
+
+	if p.DaemonConfig.IPAMMode() == ipamOption.IPAMAlibabaCloud && p.DaemonConfig.EnableIPv6 {
+		// AlibabaCloud only supplies IPv4 routing metadata, so disable the whole
+		// reconciler to avoid repeatedly failing to reconcile endpoint IPv6
+		// addresses. This also disables IPv4 repair and garbage collection.
+		p.Logger.Error("Endpoint routing rule reconciliation is disabled",
+			logfields.Error, errors.New("routing metadata for IPv6 is not supported by AlibabaCloud IPAM"))
+		return manager
+	}
+
+	manager.enabled = true
+
+	txn := p.DB.WriteTxn(p.Table)
+	manager.initDone = p.Table.RegisterInitializer(txn, "endpoint-restoration")
+	txn.Commit()
+
+	// Subscribe during cell registration so no restored endpoint event is lost.
+	manager.endpointManager.Subscribe(manager)
+	p.Lifecycle.Append(cell.Hook{
+		OnStop: func(ctx cell.HookContext) error {
+			manager.endpointManager.Unsubscribe(manager)
+			return nil
+		},
+	})
+
+	p.JobGroup.Add(job.OneShot(
+		"initialize-cloud-endpoint-routing-rules",
+		manager.initialize,
+		job.WithRetry(-1, &job.ExponentialBackoff{
+			Min: time.Second,
+			Max: time.Minute,
+		}),
+	))
+
+	return manager
+}
+
+func isCloudIPAMMode(ipamMode string) bool {
+	return ipamMode == ipamOption.IPAMENI ||
+		ipamMode == ipamOption.IPAMAzure ||
+		ipamMode == ipamOption.IPAMAlibabaCloud
 }
 
 func (mgr *endpointRulesManager) initialize(ctx context.Context, health cell.Health) error {

--- a/pkg/datapath/linux/routing/reconciler/manager.go
+++ b/pkg/datapath/linux/routing/reconciler/manager.go
@@ -55,6 +55,7 @@ type pendingEndpointRules struct {
 }
 
 var _ endpointmanager.Subscriber = (*endpointRulesManager)(nil)
+var _ endpointmanager.EndpointRoutingWaiter = (*endpointRulesManager)(nil)
 
 type endpointRulesManagerParams struct {
 	cell.In
@@ -188,6 +189,62 @@ func (mgr *endpointRulesManager) EndpointRestored(ep *endpoint.Endpoint) {
 		return
 	}
 	mgr.handleEvent(endpointAddrs(ep), endpointRulesOwner(ep), ep.GetLifecycleGeneration(), false)
+}
+
+// WaitForEndpointRouting blocks endpoint creation until all desired routing
+// objects for the endpoint have reached a terminal status in the reconciler.
+func (mgr *endpointRulesManager) WaitForEndpointRouting(ctx context.Context, ep *endpoint.Endpoint) error {
+	if !mgr.enabled || !endpointRulesRequired(ep) {
+		return nil
+	}
+
+	owner := endpointRulesOwner(ep)
+	generation := ep.GetLifecycleGeneration()
+	for _, address := range endpointAddrs(ep) {
+		if err := mgr.waitForRules(ctx, address, owner, generation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mgr *endpointRulesManager) waitForRules(
+	ctx context.Context,
+	address netip.Addr,
+	owner string,
+	generation uint64,
+) error {
+	for {
+		rules, _, watch, found := mgr.table.GetWatch(
+			mgr.db.ReadTxn(), endpointRulesAddressIndex.Query(address),
+		)
+		if !found {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("wait for endpoint routing rules for %s: %w", address, ctx.Err())
+			case <-watch:
+				continue
+			}
+		}
+
+		if rules.Owner != owner || rules.Generation != generation {
+			return fmt.Errorf("endpoint routing rules for %s belong to owner %q generation %d, want owner %q generation %d",
+				address, rules.Owner, rules.Generation, owner, generation)
+		}
+
+		switch rules.Status.Kind {
+		case statedbReconciler.StatusKindDone:
+			return nil
+		case statedbReconciler.StatusKindError:
+			return fmt.Errorf("reconcile endpoint routing rules for %s: %w", address, errors.New(rules.Status.GetError()))
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for endpoint routing rules for %s: %w", address, ctx.Err())
+		case <-watch:
+		}
+	}
 }
 
 func (mgr *endpointRulesManager) handleEvent(

--- a/pkg/datapath/linux/routing/reconciler/manager.go
+++ b/pkg/datapath/linux/routing/reconciler/manager.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+
+	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	endpointTypes "github.com/cilium/cilium/pkg/endpoint/types"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const internalEndpointOwner = "internal"
+
+type endpointRulesManager struct {
+	logger *slog.Logger
+	db     *statedb.DB
+	table  statedb.RWTable[*EndpointRules]
+}
+
+var _ endpointmanager.Subscriber = (*endpointRulesManager)(nil)
+
+func newEndpointRulesManager(
+	logger *slog.Logger,
+	db *statedb.DB,
+	table statedb.RWTable[*EndpointRules],
+) *endpointRulesManager {
+	return &endpointRulesManager{
+		logger: logger,
+		db:     db,
+		table:  table,
+	}
+}
+
+func (mgr *endpointRulesManager) EndpointCreated(ep *endpoint.Endpoint) {
+	if !endpointRulesRequired(ep) {
+		return
+	}
+
+	mgr.handleEvent(endpointAddrs(ep), endpointRulesOwner(ep), ep.GetLifecycleGeneration(), false)
+}
+
+func (mgr *endpointRulesManager) EndpointDeleted(ep *endpoint.Endpoint, _ endpoint.DeleteConfig) {
+	mgr.handleEvent(endpointAddrs(ep), endpointRulesOwner(ep), ep.GetLifecycleGeneration(), true)
+}
+
+func (mgr *endpointRulesManager) EndpointRestored(ep *endpoint.Endpoint) {
+	if !endpointRulesRequired(ep) {
+		return
+	}
+	mgr.handleEvent(endpointAddrs(ep), endpointRulesOwner(ep), ep.GetLifecycleGeneration(), false)
+}
+
+func (mgr *endpointRulesManager) handleEvent(
+	addresses []netip.Addr,
+	owner string,
+	generation uint64,
+	deleted bool,
+) {
+	if len(addresses) == 0 {
+		return
+	}
+
+	txn := mgr.db.WriteTxn(mgr.table)
+	defer txn.Abort()
+
+	var err error
+	if deleted {
+		err = mgr.handleEndpointDeletion(txn, addresses, owner, generation)
+	} else {
+		err = mgr.handleEndpointCreation(txn, addresses, owner, generation)
+	}
+	if err != nil {
+		mgr.logger.Error("Failed to handle endpoint event",
+			logfields.Error, err,
+			logfields.Addresses, addresses,
+		)
+		return
+	}
+
+	txn.Commit()
+}
+
+func (mgr *endpointRulesManager) handleEndpointCreation(txn statedb.WriteTxn, addresses []netip.Addr, owner string, generation uint64) error {
+	for _, address := range addresses {
+		current, _, found := mgr.table.Get(txn, endpointRulesAddressIndex.Query(address))
+		if found && current.Owner == owner && current.Generation == generation {
+			// This endpoint already owns the desired state.
+			continue
+		}
+
+		if _, _, err := mgr.table.Insert(txn, &EndpointRules{
+			Address:    address,
+			Owner:      owner,
+			Generation: generation,
+			Status:     statedbReconciler.StatusPending(),
+		}); err != nil {
+			return fmt.Errorf("failed to insert desired endpoint routing rules for %s: %w", address, err)
+		}
+	}
+	return nil
+}
+
+func (mgr *endpointRulesManager) handleEndpointDeletion(
+	txn statedb.WriteTxn,
+	addresses []netip.Addr,
+	owner string,
+	generation uint64,
+) error {
+	for _, address := range addresses {
+		current, _, found := mgr.table.Get(txn, endpointRulesAddressIndex.Query(address))
+		if !found {
+			continue
+		}
+		// A different owner or generation means that a replacement endpoint
+		// now owns this address, so ignore the delayed deletion for the old one.
+		if current.Owner != owner || current.Generation != generation {
+			continue
+		}
+		if _, _, err := mgr.table.Delete(txn, current); err != nil {
+			return fmt.Errorf("failed to delete desired endpoint routing rules for %s: %w", address, err)
+		}
+	}
+	return nil
+}
+
+func endpointRulesRequired(ep *endpoint.Endpoint) bool {
+	if ep.IsHost() {
+		return false
+	}
+
+	if ep.IsProperty(endpointTypes.PropertyFakeEndpoint) {
+		return false
+	}
+
+	if ep.DatapathConfiguration.ExternalIpam {
+		return false
+	}
+
+	return true
+}
+
+func endpointAddrs(ep *endpoint.Endpoint) []netip.Addr {
+	addrs := make([]netip.Addr, 0, 2)
+	if addr := ep.IPv4Address(); addr.IsValid() {
+		addrs = append(addrs, addr)
+	}
+	if addr := ep.IPv6Address(); addr.IsValid() {
+		addrs = append(addrs, addr)
+	}
+	return addrs
+}
+
+func endpointRulesOwner(ep *endpoint.Endpoint) string {
+	if cniAttachmentID := ep.GetCNIAttachmentID(); cniAttachmentID != "" {
+		return cniAttachmentID
+	}
+	return internalEndpointOwner
+}

--- a/pkg/datapath/linux/routing/reconciler/manager_test.go
+++ b/pkg/datapath/linux/routing/reconciler/manager_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/policy"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+func TestEndpointRulesManager(t *testing.T) {
+	db := statedb.New()
+	table, err := newEndpointRulesTable(db)
+	require.NoError(t, err)
+
+	manager := newEndpointRulesManager(slog.Default(), db, table)
+	ep := newTestEndpoint(t, 1, "container-a", "192.0.2.10", "2001:db8::10")
+
+	manager.EndpointCreated(ep)
+
+	v4, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(netip.MustParseAddr("192.0.2.10")))
+	require.True(t, found)
+	require.Equal(t, statedbReconciler.StatusKindPending, v4.Status.Kind)
+	require.Equal(t, "container-a:eth0", v4.Owner)
+	require.Equal(t, ep.GetLifecycleGeneration(), v4.Generation)
+
+	v6, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(netip.MustParseAddr("2001:db8::10")))
+	require.True(t, found)
+	require.Equal(t, statedbReconciler.StatusKindPending, v6.Status.Kind)
+	require.Equal(t, "container-a:eth0", v6.Owner)
+	require.Equal(t, ep.GetLifecycleGeneration(), v6.Generation)
+
+	txn := db.WriteTxn(table)
+	v4 = v4.Clone().SetStatus(statedbReconciler.StatusDone())
+	_, _, err = table.Insert(txn, v4)
+	require.NoError(t, err)
+	txn.Commit()
+
+	// A duplicate lifecycle event must not reset a successfully reconciled
+	// object to Pending.
+	manager.EndpointRestored(ep)
+	v4, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(netip.MustParseAddr("192.0.2.10")))
+	require.True(t, found)
+	require.Equal(t, statedbReconciler.StatusKindDone, v4.Status.Kind)
+
+	manager.EndpointDeleted(ep, endpoint.DeleteConfig{})
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(netip.MustParseAddr("192.0.2.10")))
+	require.False(t, found)
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(netip.MustParseAddr("2001:db8::10")))
+	require.False(t, found)
+}
+
+func TestEndpointRulesManagerFencesStaleEndpointDeletion(t *testing.T) {
+	db := statedb.New()
+	table, err := newEndpointRulesTable(db)
+	require.NoError(t, err)
+
+	manager := newEndpointRulesManager(slog.Default(), db, table)
+	address := netip.MustParseAddr("192.0.2.10")
+	// same owner and IP address but different lifecycle generations
+	oldEndpoint := newTestEndpoint(t, 1, "container-a", address.String(), "")
+	newEndpoint := newTestEndpoint(t, 2, "container-a", address.String(), "")
+
+	// insert the old endpoint into the table
+	manager.EndpointCreated(oldEndpoint)
+	oldRules, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(address))
+	require.True(t, found)
+
+	txn := db.WriteTxn(table)
+	oldRules = oldRules.Clone().SetStatus(statedbReconciler.StatusDone())
+	_, _, err = table.Insert(txn, oldRules)
+	require.NoError(t, err)
+	txn.Commit()
+
+	// simulate the creation of a new endpoint with the same owner and IP but a different lifecycle generation
+	manager.EndpointCreated(newEndpoint)
+	newRules, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(address))
+	require.True(t, found)
+	require.Equal(t, oldRules.Owner, newRules.Owner)
+	require.NotEqual(t, oldRules.Generation, newRules.Generation)
+	require.Equal(t, statedbReconciler.StatusKindPending, newRules.Status.Kind)
+
+	// a delay in dispatching the deletion event should not remove new endpoint (and its rules) from the table
+	manager.EndpointDeleted(oldEndpoint, endpoint.DeleteConfig{})
+	current, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(address))
+	require.True(t, found)
+	require.Equal(t, newRules.Owner, current.Owner)
+	require.Equal(t, newRules.Generation, current.Generation)
+
+	// deleting the new endpoint should remove it from the table
+	manager.EndpointDeleted(newEndpoint, endpoint.DeleteConfig{})
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(address))
+	require.False(t, found)
+}
+
+func newTestEndpoint(t *testing.T, generation uint64, containerID, ipv4, ipv6 string) *endpoint.Endpoint {
+	t.Helper()
+
+	logger := slog.Default()
+	ep, err := endpoint.NewEndpointFromChangeModel(
+		endpoint.EndpointParams{
+			Logger:     logger,
+			PolicyRepo: policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
+		},
+		nil,
+		nil,
+		&models.EndpointChangeRequest{
+			ContainerID:            containerID,
+			ContainerInterfaceName: "eth0",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	ep.InitLifecycleGeneration(generation)
+	if ipv4 != "" {
+		ep.IPv4 = netip.MustParseAddr(ipv4)
+	}
+	if ipv6 != "" {
+		ep.IPv6 = netip.MustParseAddr(ipv6)
+	}
+	return ep
+}

--- a/pkg/datapath/linux/routing/reconciler/manager_test.go
+++ b/pkg/datapath/linux/routing/reconciler/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,9 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/promise"
@@ -140,14 +143,24 @@ func TestEndpointRulesManagerInitialization(t *testing.T) {
 
 	resolver, restorerPromise := promise.New[endpointstate.Restorer]()
 	resolver.Resolve(fakeRestorer{})
-	manager := newEndpointRulesManager(
-		slog.Default(),
-		db,
-		table,
-		ipamManager,
-		endpointManager,
-		restorerPromise,
-	)
+	var jobGroup job.Group
+	require.NoError(t, hive.New(
+		cell.Invoke(func(group job.Group) {
+			jobGroup = group
+		}),
+	).Populate(slog.Default()))
+
+	manager := newEndpointRulesManager(endpointRulesManagerParams{
+		Logger:          slog.Default(),
+		Lifecycle:       cell.NewDefaultLifecycle(nil, 0, 0),
+		JobGroup:        jobGroup,
+		DB:              db,
+		Table:           table,
+		DaemonConfig:    &option.DaemonConfig{IPAM: ipamOption.IPAMENI},
+		IPAM:            ipamManager,
+		EndpointManager: endpointManager,
+		Restorer:        restorerPromise,
+	})
 
 	initialized, _ := table.Initialized(db.ReadTxn())
 	require.False(t, initialized)

--- a/pkg/datapath/linux/routing/reconciler/manager_test.go
+++ b/pkg/datapath/linux/routing/reconciler/manager_test.go
@@ -76,6 +76,42 @@ func TestEndpointRulesManager(t *testing.T) {
 	require.False(t, found)
 }
 
+func TestEndpointRulesManagerAlibabaCloudIPv6(t *testing.T) {
+	db := statedb.New()
+	table, err := newEndpointRulesTable(db)
+	require.NoError(t, err)
+
+	manager := &endpointRulesManager{
+		enabled:      true,
+		ipamMode:     ipamOption.IPAMAlibabaCloud,
+		logger:       slog.Default(),
+		db:           db,
+		table:        table,
+		initializing: false,
+	}
+	ep := newTestEndpoint(t, 1, "container-a", "192.0.2.10", "2001:db8::10")
+
+	manager.EndpointCreated(ep)
+
+	v4, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(ep.IPv4Address()))
+	require.True(t, found)
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(ep.IPv6Address()))
+	require.False(t, found)
+
+	txn := db.WriteTxn(table)
+	v4 = v4.Clone().SetStatus(statedbReconciler.StatusDone())
+	_, _, err = table.Insert(txn, v4)
+	require.NoError(t, err)
+	txn.Commit()
+
+	err = manager.WaitForEndpointRouting(t.Context(), ep)
+	require.ErrorContains(t, err, "AlibabaCloud IPAM does not support IPv6 endpoint routing")
+
+	manager.EndpointDeleted(ep, endpoint.DeleteConfig{})
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(ep.IPv4Address()))
+	require.False(t, found)
+}
+
 func TestEndpointRulesManagerFencesStaleEndpointDeletion(t *testing.T) {
 	db := statedb.New()
 	table, err := newEndpointRulesTable(db)

--- a/pkg/datapath/linux/routing/reconciler/manager_test.go
+++ b/pkg/datapath/linux/routing/reconciler/manager_test.go
@@ -4,10 +4,12 @@
 package reconciler
 
 import (
+	"context"
 	"log/slog"
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
@@ -15,7 +17,12 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/promise"
+	testendpointmanager "github.com/cilium/cilium/pkg/testutils/endpointmanager"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
 
@@ -24,7 +31,12 @@ func TestEndpointRulesManager(t *testing.T) {
 	table, err := newEndpointRulesTable(db)
 	require.NoError(t, err)
 
-	manager := newEndpointRulesManager(slog.Default(), db, table)
+	manager := &endpointRulesManager{
+		logger:       slog.Default(),
+		db:           db,
+		table:        table,
+		initializing: false,
+	}
 	ep := newTestEndpoint(t, 1, "container-a", "192.0.2.10", "2001:db8::10")
 
 	manager.EndpointCreated(ep)
@@ -66,7 +78,12 @@ func TestEndpointRulesManagerFencesStaleEndpointDeletion(t *testing.T) {
 	table, err := newEndpointRulesTable(db)
 	require.NoError(t, err)
 
-	manager := newEndpointRulesManager(slog.Default(), db, table)
+	manager := &endpointRulesManager{
+		logger:       slog.Default(),
+		db:           db,
+		table:        table,
+		initializing: false,
+	}
 	address := netip.MustParseAddr("192.0.2.10")
 	// same owner and IP address but different lifecycle generations
 	oldEndpoint := newTestEndpoint(t, 1, "container-a", address.String(), "")
@@ -104,6 +121,65 @@ func TestEndpointRulesManagerFencesStaleEndpointDeletion(t *testing.T) {
 	require.False(t, found)
 }
 
+func TestEndpointRulesManagerInitialization(t *testing.T) {
+	db := statedb.New()
+	table, err := newEndpointRulesTable(db)
+	require.NoError(t, err)
+
+	live := newTestEndpoint(t, 1, "live-container", "192.0.2.10", "")
+	deletedDuringInitialization := newTestEndpoint(t, 2, "deleted-container", "192.0.2.11", "")
+	replacedDuringInitialization := newTestEndpoint(t, 3, "reused-container", "192.0.2.12", "")
+	replacement := newTestEndpoint(t, 4, "reused-container", "192.0.2.12", "")
+	endpointManager := testendpointmanager.NewMockEndpointManager()
+
+	ipamManager := ipam.NewIPAM(ipam.NewIPAMParams{
+		Logger:      slog.Default(),
+		AgentConfig: &option.DaemonConfig{},
+	})
+	ipamManager.RestoreFinished()
+
+	resolver, restorerPromise := promise.New[endpointstate.Restorer]()
+	resolver.Resolve(fakeRestorer{})
+	manager := newEndpointRulesManager(
+		slog.Default(),
+		db,
+		table,
+		ipamManager,
+		endpointManager,
+		restorerPromise,
+	)
+
+	initialized, _ := table.Initialized(db.ReadTxn())
+	require.False(t, initialized)
+
+	// Subscription is established before endpoint restoration starts, so
+	// restored endpoints and concurrent lifecycle events are queued until the
+	// IPAM and endpoint restoration barriers have completed.
+	manager.EndpointRestored(live)
+	manager.EndpointCreated(deletedDuringInitialization)
+	manager.EndpointDeleted(deletedDuringInitialization, endpoint.DeleteConfig{})
+	manager.EndpointCreated(replacedDuringInitialization)
+	manager.EndpointCreated(replacement)
+	manager.EndpointDeleted(replacedDuringInitialization, endpoint.DeleteConfig{})
+	require.Zero(t, table.NumObjects(db.ReadTxn()))
+
+	health, _ := cell.NewSimpleHealth()
+	require.NoError(t, manager.initialize(t.Context(), health))
+
+	initialized, _ = table.Initialized(db.ReadTxn())
+	require.True(t, initialized)
+	require.Equal(t, 2, table.NumObjects(db.ReadTxn()))
+
+	_, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(live.IPv4Address()))
+	require.True(t, found)
+	_, _, found = table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(deletedDuringInitialization.IPv4Address()))
+	require.False(t, found)
+	rules, _, found := table.Get(db.ReadTxn(), endpointRulesAddressIndex.Query(replacement.IPv4Address()))
+	require.True(t, found)
+	require.Equal(t, endpointRulesOwner(replacement), rules.Owner)
+	require.Equal(t, replacement.GetLifecycleGeneration(), rules.Generation)
+}
+
 func newTestEndpoint(t *testing.T, generation uint64, containerID, ipv4, ipv6 string) *endpoint.Endpoint {
 	t.Helper()
 
@@ -130,4 +206,18 @@ func newTestEndpoint(t *testing.T, generation uint64, containerID, ipv4, ipv6 st
 		ep.IPv6 = netip.MustParseAddr(ipv6)
 	}
 	return ep
+}
+
+type fakeRestorer struct{}
+
+func (fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(context.Context) error {
+	return nil
+}
+
+func (fakeRestorer) WaitForEndpointRestore(context.Context) error {
+	return nil
+}
+
+func (fakeRestorer) WaitForInitialPolicy(context.Context) error {
+	return nil
 }

--- a/pkg/datapath/linux/routing/reconciler/ops.go
+++ b/pkg/datapath/linux/routing/reconciler/ops.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+type endpointRulesOperations struct {
+	logger          *slog.Logger
+	ipam            *ipam.IPAM
+	endpointManager endpointmanager.EndpointManager
+	localNodeStore  *node.LocalNodeStore
+}
+
+var _ statedbReconciler.Operations[*EndpointRules] = (*endpointRulesOperations)(nil)
+
+func (ops *endpointRulesOperations) Update(
+	_ context.Context,
+	_ statedb.ReadTxn,
+	_ statedb.Revision,
+	desired *EndpointRules,
+) error {
+	result, err := ops.ipam.ResolveRoutingMetadata(desired.Address, "")
+	if err != nil {
+		return fmt.Errorf("resolve routing metadata for %s: %w", desired.Address, err)
+	}
+
+	info, err := linuxrouting.NewRoutingInfo(
+		result.GatewayIP.String(),
+		result.PrimaryMAC,
+		result.InterfaceNumber,
+	)
+	if err != nil {
+		return fmt.Errorf("build routing information for %s: %w", desired.Address, err)
+	}
+
+	if err := info.ReconcileEndpointRules(desired.Address, false); err != nil {
+		return fmt.Errorf("reconcile endpoint routing rules for %s: %w", desired.Address, err)
+	}
+	return nil
+}
+
+func (ops *endpointRulesOperations) Delete(
+	_ context.Context,
+	_ statedb.ReadTxn,
+	_ statedb.Revision,
+	desired *EndpointRules,
+) error {
+	if err := linuxrouting.DeleteRulesIfExists(ops.logger, desired.Address); err != nil {
+		return fmt.Errorf("delete endpoint routing rules for %s: %w", desired.Address, err)
+	}
+	return nil
+}
+
+func (ops *endpointRulesOperations) Prune(
+	ctx context.Context,
+	_ statedb.ReadTxn,
+	objects iter.Seq2[*EndpointRules, statedb.Revision],
+) error {
+	desired := sets.New[netip.Addr]()
+	for obj := range objects {
+		desired.Insert(obj.Address)
+	}
+
+	infraAddrs, err := infrastructureAddresses(ctx, ops.localNodeStore)
+	if err != nil {
+		return err
+	}
+
+	return linuxrouting.GCOrphanRules(ops.logger, func(addr netip.Addr) bool {
+		// The address is still present in the desired state.
+		if desired.Has(addr) {
+			return false
+		}
+		// The address belongs to local infrastructure.
+		if infraAddrs.Has(addr) {
+			return false
+		}
+		// The endpoint manager still has a live owner for the address.
+		if ops.endpointManager.LookupIP(addr) != nil {
+			return false
+		}
+		// Preserve IPAM allocations that may not have reached desired state yet.
+		return !ops.ipam.IsAllocatedIP(addr)
+	})
+}
+
+func infrastructureAddresses(ctx context.Context, localNodeStore *node.LocalNodeStore) (sets.Set[netip.Addr], error) {
+	localNode, err := localNodeStore.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get local node infrastructure addresses: %w", err)
+	}
+
+	protected := sets.New[netip.Addr]()
+	add := func(addr netip.Addr) {
+		if addr.IsValid() {
+			protected.Insert(addr)
+		}
+	}
+
+	add(localNode.IPv4HealthIP.Addr)
+	add(localNode.IPv6HealthIP.Addr)
+	add(localNode.IPv4IngressIP.Addr)
+	add(localNode.IPv6IngressIP.Addr)
+	for _, raw := range []net.IP{
+		localNode.GetCiliumInternalIP(false),
+		localNode.GetCiliumInternalIP(true),
+	} {
+		if addr, ok := netip.AddrFromSlice(raw); ok {
+			// LocalNode's legacy net.IP fields may represent IPv4 addresses as
+			// IPv4-mapped IPv6 addresses.
+			add(addr.Unmap())
+		}
+	}
+	return protected, nil
+}

--- a/pkg/datapath/linux/routing/reconciler/ops.go
+++ b/pkg/datapath/linux/routing/reconciler/ops.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type endpointRulesOperations struct {
@@ -28,6 +29,22 @@ type endpointRulesOperations struct {
 	ipamMode        string
 	endpointManager endpointmanager.EndpointManager
 	localNodeStore  *node.LocalNodeStore
+}
+
+func newEndpointRulesOperations(
+	logger *slog.Logger,
+	ipamManager *ipam.IPAM,
+	daemonConfig *option.DaemonConfig,
+	endpointManager endpointmanager.EndpointManager,
+	localNodeStore *node.LocalNodeStore,
+) *endpointRulesOperations {
+	return &endpointRulesOperations{
+		logger:          logger,
+		ipam:            ipamManager,
+		ipamMode:        daemonConfig.IPAMMode(),
+		endpointManager: endpointManager,
+		localNodeStore:  localNodeStore,
+	}
 }
 
 var _ statedbReconciler.Operations[*EndpointRules] = (*endpointRulesOperations)(nil)

--- a/pkg/datapath/linux/routing/reconciler/ops.go
+++ b/pkg/datapath/linux/routing/reconciler/ops.go
@@ -44,7 +44,8 @@ func (ops *endpointRulesOperations) Update(
 	}
 
 	var options []linuxrouting.RoutingInfoOption
-	// Azure uses the legacy ifindex-based priority/table scheme.
+	// Azure uses the legacy ifindex-based priority/table scheme. ENI and
+	// AlibabaCloud use the interface-number-based scheme.
 	if ops.ipamMode == ipamOption.IPAMAzure {
 		options = append(options, linuxrouting.WithCompatEgressPriority())
 	}

--- a/pkg/datapath/linux/routing/reconciler/ops.go
+++ b/pkg/datapath/linux/routing/reconciler/ops.go
@@ -18,12 +18,14 @@ import (
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/node"
 )
 
 type endpointRulesOperations struct {
 	logger          *slog.Logger
 	ipam            *ipam.IPAM
+	ipamMode        string
 	endpointManager endpointmanager.EndpointManager
 	localNodeStore  *node.LocalNodeStore
 }
@@ -41,10 +43,17 @@ func (ops *endpointRulesOperations) Update(
 		return fmt.Errorf("resolve routing metadata for %s: %w", desired.Address, err)
 	}
 
+	var options []linuxrouting.RoutingInfoOption
+	// Azure uses the legacy ifindex-based priority/table scheme.
+	if ops.ipamMode == ipamOption.IPAMAzure {
+		options = append(options, linuxrouting.WithCompatEgressPriority())
+	}
+
 	info, err := linuxrouting.NewRoutingInfo(
 		result.GatewayIP.String(),
 		result.PrimaryMAC,
 		result.InterfaceNumber,
+		options...,
 	)
 	if err != nil {
 		return fmt.Errorf("build routing information for %s: %w", desired.Address, err)

--- a/pkg/datapath/linux/routing/reconciler/script_test.go
+++ b/pkg/datapath/linux/routing/reconciler/script_test.go
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/netip"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/api/v1/models"
+	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	awsAgent "github.com/cilium/cilium/pkg/aws/agent"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
+	routingReconciler "github.com/cilium/cilium/pkg/datapath/linux/routing/reconciler"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	sysctlFake "github.com/cilium/cilium/pkg/datapath/linux/sysctl/fake"
+	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint"
+	endpointTypes "github.com/cilium/cilium/pkg/endpoint/types"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	fqdnRules "github.com/cilium/cilium/pkg/fqdn/rules"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipmasq"
+	k8sClientTest "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/metrics"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/mtu"
+	mtuFake "github.com/cilium/cilium/pkg/mtu/fake"
+	"github.com/cilium/cilium/pkg/node"
+	nodeFake "github.com/cilium/cilium/pkg/node/fake"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testmonitor "github.com/cilium/cilium/pkg/testutils/monitor"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	"github.com/cilium/cilium/pkg/testutils/scriptnet"
+	"github.com/cilium/cilium/pkg/time"
+	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
+)
+
+const (
+	testENILinkName = "cilium-rr-test"
+	testENILinkMAC  = "02:ca:fe:00:00:01"
+)
+
+func TestPrivilegedScript(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	defer testutils.GoleakVerifyNone(t,
+		// Endpoint-manager policy-map pressure triggers live for the process lifetime.
+		// Disable them to avoid a false negative from Goleak.
+		testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	nodeTypes.SetName("test-node")
+
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			daemonCfg := daemonConfig(t, args)
+			daemonCfg.StateDir = t.TempDir()
+
+			nsManager, err := scriptnet.NewNSManager(t)
+			require.NoError(t, err, "NewNSManager")
+
+			// Keep the test in the process network namespace so asynchronous ENI
+			// provider jobs operate on the links created by the script.
+			require.NoError(t, nsManager.LockThreadAndInitialize(t, false), "LockThreadAndInitialize")
+
+			// Remove state left by an interrupted prior run, and register the same
+			// cleanup in case this scenario fails before removing its state.
+			registerTestCleanup(t)
+
+			restorerResolver, restorerPromise := promise.New[endpointstate.Restorer]()
+			restorerResolver.Resolve(fakeRestorer{})
+
+			var (
+				initializer   *ipamcell.IPAMInitializer
+				ipamManager   *ipam.IPAM
+				epManager     endpointmanager.EndpointManager
+				routingWaiter endpointmanager.EndpointRoutingWaiter
+			)
+
+			h := hive.New(
+				k8sClientTest.FakeClientCell(),
+				agentK8s.ResourcesCell,
+				k8sTables.TablesCell,
+				datapathTables.DirectRoutingDeviceCell,
+				endpointmanager.TestCell,
+
+				// Exercise the production ENI pool accessor, device configurator,
+				// native-routing-CIDR observer, and routing metadata resolver.
+				awsAgent.Cell,
+				ipamcell.Cell,
+				routingReconciler.Cell,
+
+				cell.Config(metrics.RegistryConfig{}),
+				cell.Provide(
+					metrics.NewRegistry,
+					func() *option.DaemonConfig { return daemonCfg },
+					func() *node.LocalNodeStore {
+						localNode := node.LocalNode{
+							Node: nodeTypes.Node{
+								Name: nodeTypes.GetName(),
+							},
+							Local: &node.LocalNodeInfo{},
+						}
+						if daemonCfg.EnableIPv4 {
+							localNode.IPv4AllocCIDR = nodeTypes.PrefixFrom(netip.MustParsePrefix("192.0.2.0/24"))
+						}
+						if daemonCfg.EnableIPv6 {
+							localNode.IPv6AllocCIDR = nodeTypes.PrefixFrom(netip.MustParsePrefix("2001:db8:1::/80"))
+						}
+						return node.NewTestLocalNodeStore(localNode)
+					},
+					func() node.Addressing { return nodeFake.NewAddressing() },
+					func() *watchers.K8sEventReporter { return &watchers.K8sEventReporter{} },
+					func() *nodediscovery.NodeDiscovery { return &nodediscovery.NodeDiscovery{} },
+					func() *ipmasq.IPMasqAgent { return nil },
+					func() mtu.MTU { return &mtuFake.MTU{} },
+					func() sysctl.Sysctl { return &sysctlFake.Sysctl{} },
+					func() monitorAgent.Agent { return &testmonitor.TestMonitorAgent{} },
+					func() promise.Promise[endpointstate.Restorer] { return restorerPromise },
+					datapathTables.NewDeviceTable,
+					statedb.RWTable[*datapathTables.Device].ToTable,
+				),
+				cell.Invoke(func(
+					initializer_ *ipamcell.IPAMInitializer,
+					ipamManager_ *ipam.IPAM,
+					epManager_ endpointmanager.EndpointManager,
+					routingWaiter_ endpointmanager.EndpointRoutingWaiter,
+				) {
+					initializer = initializer_
+					ipamManager = ipamManager_
+					epManager = epManager_
+					routingWaiter = routingWaiter_
+				}),
+			)
+
+			log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.Background()))
+			})
+
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Copy(cmds, script.DefaultCmds())
+			maps.Copy(cmds, nsManager.Commands())
+			maps.Copy(cmds, cloudEndpointCommands(
+				log, daemonCfg, initializer, ipamManager, epManager, routingWaiter,
+			))
+
+			return &script.Engine{Cmds: cmds}
+		},
+		[]string{"PATH=" + os.Getenv("PATH")},
+		"testdata/*.txtar",
+		scripttest.NoParallel,
+	)
+}
+
+func daemonConfig(t testing.TB, args []string) *option.DaemonConfig {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	families := flags.StringArray("family", nil, "address family to enable")
+	require.NoError(t, flags.Parse(args))
+
+	daemonCfg := *option.Config
+	daemonCfg.EnableIPv4 = false
+	daemonCfg.EnableIPv6 = false
+	for _, family := range *families {
+		switch family {
+		case "ipv4":
+			daemonCfg.EnableIPv4 = true
+		case "ipv6":
+			daemonCfg.EnableIPv6 = true
+		default:
+			t.Fatalf("unsupported address family %q", family)
+		}
+	}
+	if !daemonCfg.EnableIPv4 && !daemonCfg.EnableIPv6 {
+		t.Fatal("at least one address family must be enabled")
+	}
+	daemonCfg.EnableCiliumNodeCRD = true
+	daemonCfg.EnableUnreachableRoutes = false
+	daemonCfg.IPAM = ipamOption.IPAMENI
+	daemonCfg.IPAMCiliumNodeUpdateRate = time.Nanosecond
+	daemonCfg.IPv4Range = "auto"
+	daemonCfg.IPv6Range = "auto"
+
+	// Some endpoint and IPAM lifecycle paths still read the global config,
+	// so keep it aligned with the config provided through Hive.
+	oldDaemonConfig := option.Config
+	option.Config = &daemonCfg
+	t.Cleanup(func() { option.Config = oldDaemonConfig })
+
+	return &daemonCfg
+}
+
+func registerTestCleanup(t testing.TB) {
+	t.Helper()
+
+	require.NoError(t, cleanupTestState())
+
+	t.Cleanup(func() {
+		assert.NoError(t, cleanupTestState())
+	})
+}
+
+func cleanupTestState() error {
+	var cleanupErrors []error
+
+	// The privileged test environment assumes that any Cilium-shaped endpoint
+	// rules were left by a previous run of this test.
+	if err := linuxrouting.GCOrphanRules(slog.Default(), func(netip.Addr) bool { return true }); err != nil {
+		cleanupErrors = append(cleanupErrors,
+			fmt.Errorf("delete Cilium endpoint routing rules: %w", err))
+	}
+
+	link, err := safenetlink.LinkByName(testENILinkName)
+	switch {
+	case errors.As(err, new(netlink.LinkNotFoundError)):
+		// The link is absent before the first run or was already removed.
+	case err != nil:
+		cleanupErrors = append(cleanupErrors,
+			fmt.Errorf("look up test ENI link: %w", err))
+	case link.Attrs().HardwareAddr.String() != testENILinkMAC:
+		cleanupErrors = append(cleanupErrors, fmt.Errorf(
+			"refusing to delete link %q with unexpected MAC %s",
+			testENILinkName,
+			link.Attrs().HardwareAddr,
+		))
+	default:
+		if err := netlink.LinkDel(link); err != nil && !errors.Is(err, unix.ENODEV) {
+			cleanupErrors = append(cleanupErrors,
+				fmt.Errorf("delete test ENI link: %w", err))
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}
+
+func cloudEndpointCommands(
+	logger *slog.Logger,
+	daemonCfg *option.DaemonConfig,
+	initializer *ipamcell.IPAMInitializer,
+	ipamManager *ipam.IPAM,
+	epManager endpointmanager.EndpointManager,
+	routingWaiter endpointmanager.EndpointRoutingWaiter,
+) map[string]script.Cmd {
+	endpoints := map[string]*endpoint.Endpoint{}
+	policyRepo := policy.NewPolicyRepository(logger, cmtypes.DefaultClusterInfo.ID, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+
+	return map[string]script.Cmd{
+		"ipam/start": script.Command(
+			script.CmdUsage{Summary: "Start agent IPAM"},
+			func(state *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 0 {
+					return nil, script.ErrUsage
+				}
+				return nil, initializer.ConfigureAndStartIPAM(state.Context())
+			},
+		),
+		"ipam/restore-finished": script.Command(
+			script.CmdUsage{Summary: "Finish IPAM restoration"},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 0 {
+					return nil, script.ErrUsage
+				}
+				initializer.RestoreFinished()
+				return nil, nil
+			},
+		),
+		"endpoint/add": script.Command(
+			script.CmdUsage{
+				Summary: "Allocate an ENI address, publish an endpoint, and wait for its routing state",
+				Args:    "container-id expected-address...",
+			},
+			func(state *script.State, args ...string) (script.WaitFunc, error) {
+				expectedAddressCount := 0
+				if daemonCfg.EnableIPv4 {
+					expectedAddressCount++
+				}
+				if daemonCfg.EnableIPv6 {
+					expectedAddressCount++
+				}
+				if len(args) != 1+expectedAddressCount {
+					return nil, script.ErrUsage
+				}
+
+				containerID := args[0]
+				if _, found := endpoints[containerID]; found {
+					return nil, fmt.Errorf("endpoint %q already exists", containerID)
+				}
+
+				expectedIPv4, expectedIPv6, err := expectedEndpointPrefixes(
+					daemonCfg.EnableIPv4, daemonCfg.EnableIPv6, args[1:]...,
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				family := ""
+				switch {
+				case daemonCfg.EnableIPv4 && !daemonCfg.EnableIPv6:
+					family = "ipv4"
+				case daemonCfg.EnableIPv6 && !daemonCfg.EnableIPv4:
+					family = "ipv6"
+				}
+
+				ipv4Result, ipv6Result, err := ipamManager.AllocateNext(family, "default/"+containerID, ipam.PoolDefault())
+				if err != nil {
+					return nil, fmt.Errorf("allocate endpoint address: %w", err)
+				}
+				releaseResults := func() error {
+					return releaseAllocationResults(ipamManager, ipv4Result, ipv6Result)
+				}
+				if daemonCfg.EnableIPv4 && ipv4Result == nil {
+					return nil, errors.Join(errors.New("IPAM returned no IPv4 allocation result"), releaseResults())
+				}
+				if daemonCfg.EnableIPv6 && ipv6Result == nil {
+					return nil, errors.Join(errors.New("IPAM returned no IPv6 allocation result"), releaseResults())
+				}
+
+				if ipv4Result != nil && !expectedIPv4.Contains(ipv4Result.IP) {
+					return nil, errors.Join(
+						fmt.Errorf("allocated IPv4 address %s outside expected prefix %s", ipv4Result.IP, expectedIPv4),
+						releaseResults(),
+					)
+				}
+				if ipv6Result != nil && !expectedIPv6.Contains(ipv6Result.IP) {
+					return nil, errors.Join(
+						fmt.Errorf("allocated IPv6 address %s outside expected prefix %s", ipv6Result.IP, expectedIPv6),
+						releaseResults(),
+					)
+				}
+
+				addressing := &models.AddressPair{}
+				if ipv4Result != nil {
+					addressing.IPv4 = ipv4Result.IP.String()
+					addressing.IPv4PoolName = string(ipv4Result.IPPoolName)
+				}
+				if ipv6Result != nil {
+					addressing.IPv6 = ipv6Result.IP.String()
+					addressing.IPv6PoolName = string(ipv6Result.IPPoolName)
+				}
+				endpointState := models.EndpointStateReady
+				ep, err := endpoint.NewEndpointFromChangeModel(
+					endpoint.EndpointParams{
+						Logger:          logger,
+						EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
+						PolicyRepo:      policyRepo,
+						IdentityManager: identitymanager.NewIDManager(logger),
+						IPSecConfig:     fakeipsec.Config{},
+						WgConfig:        fakewireguard.Config{},
+						CTMapGC:         ctmap.NewFakeGCRunner(),
+						Allocator:       testidentity.NewMockIdentityAllocator(nil),
+					},
+					fqdnRules.NewDNSRulesService(logger, nil, policyRepo),
+					&endpoint.FakeEndpointProxy{},
+					&models.EndpointChangeRequest{
+						ContainerID:            containerID,
+						ContainerInterfaceName: "eth0",
+						State:                  &endpointState,
+						Addressing:             addressing,
+					},
+					nil,
+				)
+				if err != nil {
+					return nil, errors.Join(fmt.Errorf("build endpoint: %w", err), releaseResults())
+				}
+
+				if err := epManager.AddEndpoint(ep); err != nil {
+					ep.Stop()
+					return nil, errors.Join(fmt.Errorf("add endpoint: %w", err), releaseResults())
+				}
+				endpoints[containerID] = ep
+
+				if err := routingWaiter.WaitForEndpointRouting(state.Context(), ep); err != nil {
+					delete(endpoints, containerID)
+
+					// Avoid unrelated endpoint datapath cleanup while still exercising the
+					// real endpoint-manager deletion notification and IPAM release paths.
+					ep.SetPropertyValue(endpointTypes.PropertyFakeEndpoint, true)
+					cleanupErr := errors.Join(epManager.RemoveEndpoint(ep, endpoint.DeleteConfig{NoIdentityRelease: true})...)
+					return nil, errors.Join(fmt.Errorf("wait for endpoint routing: %w", err), cleanupErr)
+				}
+
+				return func(*script.State) (stdout, stderr string, err error) {
+					addresses := make([]string, 0, 2)
+					if ipv4Result != nil {
+						addresses = append(addresses, ipv4Result.IP.String())
+					}
+					if ipv6Result != nil {
+						addresses = append(addresses, ipv6Result.IP.String())
+					}
+					return strings.Join(addresses, "\n") + "\n", "", nil
+				}, nil
+			},
+		),
+		"endpoint/del": script.Command(
+			script.CmdUsage{
+				Summary: "Remove an endpoint and release its ENI address",
+				Args:    "container-id",
+			},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, script.ErrUsage
+				}
+				ep, found := endpoints[args[0]]
+				if !found {
+					return nil, fmt.Errorf("endpoint %q not found", args[0])
+				}
+
+				delete(endpoints, args[0])
+
+				// Avoid unrelated endpoint datapath cleanup while still exercising the
+				// real endpoint-manager deletion notification and IPAM release paths.
+				ep.SetPropertyValue(endpointTypes.PropertyFakeEndpoint, true)
+				return nil, errors.Join(epManager.RemoveEndpoint(ep, endpoint.DeleteConfig{NoIdentityRelease: true})...)
+			},
+		),
+	}
+}
+
+func expectedEndpointPrefixes(enableIPv4, enableIPv6 bool, args ...string) (ipv4, ipv6 netip.Prefix, err error) {
+	for _, arg := range args {
+		prefix, parseErr := netip.ParsePrefix(arg)
+		if parseErr != nil {
+			addr, addrErr := netip.ParseAddr(arg)
+			if addrErr != nil {
+				return netip.Prefix{}, netip.Prefix{}, fmt.Errorf("parse expected endpoint address or prefix %q: %w", arg, parseErr)
+			}
+			prefix = netip.PrefixFrom(addr, addr.BitLen())
+		}
+
+		switch {
+		case prefix.Addr().Is4() && !enableIPv4:
+			return netip.Prefix{}, netip.Prefix{}, fmt.Errorf("IPv4 prefix %s provided while IPv4 is disabled", prefix)
+		case prefix.Addr().Is4():
+			ipv4 = prefix
+		case !enableIPv6:
+			return netip.Prefix{}, netip.Prefix{}, fmt.Errorf("IPv6 prefix %s provided while IPv6 is disabled", prefix)
+		default:
+			ipv6 = prefix
+		}
+	}
+
+	if enableIPv4 && !ipv4.IsValid() {
+		return netip.Prefix{}, netip.Prefix{}, errors.New("no expected IPv4 address or prefix provided")
+	}
+	if enableIPv6 && !ipv6.IsValid() {
+		return netip.Prefix{}, netip.Prefix{}, errors.New("no expected IPv6 address or prefix provided")
+	}
+	return ipv4, ipv6, nil
+}
+
+func releaseAllocationResults(ipamManager *ipam.IPAM, results ...*ipam.AllocationResult) error {
+	var errs []error
+	for _, result := range results {
+		if result != nil {
+			errs = append(errs, ipamManager.ReleaseIP(result.IP, result.IPPoolName))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type fakeRestorer struct{}
+
+func (fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(context.Context) error { return nil }
+func (fakeRestorer) WaitForEndpointRestore(context.Context) error                    { return nil }
+func (fakeRestorer) WaitForInitialPolicy(context.Context) error                      { return nil }

--- a/pkg/datapath/linux/routing/reconciler/table.go
+++ b/pkg/datapath/linux/routing/reconciler/table.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"net/netip"
+	"strconv"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
+)
+
+const endpointRulesTableName = "endpoint-routing-rules"
+
+// EndpointRules is the desired policy-routing state for one local endpoint address.
+type EndpointRules struct {
+	Address netip.Addr
+
+	// Owner identifies the endpoint that published the desired state.
+	Owner string
+	// Generation distinguishes successive endpoints that use the same owner and
+	// address.
+	Generation uint64
+
+	Status statedbReconciler.Status
+}
+
+func (er *EndpointRules) Clone() *EndpointRules {
+	er2 := *er
+	return &er2
+}
+
+func (er *EndpointRules) SetStatus(status statedbReconciler.Status) *EndpointRules {
+	er.Status = status
+	return er
+}
+
+func (er *EndpointRules) GetStatus() statedbReconciler.Status {
+	return er.Status
+}
+
+func (er *EndpointRules) TableHeader() []string {
+	return []string{"Address", "Owner", "Generation", "Status"}
+}
+
+func (er *EndpointRules) TableRow() []string {
+	return []string{
+		er.Address.String(),
+		er.Owner,
+		strconv.FormatUint(er.Generation, 10),
+		er.Status.String(),
+	}
+}
+
+var endpointRulesAddressIndex = statedb.Index[*EndpointRules, netip.Addr]{
+	Name: "address",
+	FromObject: func(obj *EndpointRules) index.KeySet {
+		return index.NewKeySet(index.NetIPAddr(obj.Address))
+	},
+	FromKey:    index.NetIPAddr,
+	FromString: index.NetIPAddrString,
+	Unique:     true,
+}
+
+func newEndpointRulesTable(db *statedb.DB) (statedb.RWTable[*EndpointRules], error) {
+	return statedb.NewTable(
+		db,
+		endpointRulesTableName,
+		endpointRulesAddressIndex,
+	)
+}

--- a/pkg/datapath/linux/routing/reconciler/testdata/dual-stack-endpoint-lifecycle.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/dual-stack-endpoint-lifecycle.txtar
@@ -1,0 +1,90 @@
+#! --family=ipv4 --family=ipv6
+
+# Configure one dual-stack ENI as the operator would report it to the agent.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+ipam/restore-finished
+
+# Endpoint creation waits for both address families to be reconciled.
+endpoint/add pod-a 192.0.2.10 2001:db8:1::/80
+stdout --count=1 '^192[.]0[.]2[.]10$'
+stdout --count=1 '^2001:db8:1:[0-9a-f:]+$'
+
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 192[.]0[.]2[.]10/32 table main protocol kernel$'
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 192[.]0[.]2[.]10/32 to all table 11 protocol kernel$'
+
+rule/list --family=ipv6 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 2001:db8:1:[0-9a-f:]+/128 table main protocol kernel$'
+
+rule/list --family=ipv6 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 2001:db8:1:[0-9a-f:]+/128 to all table 11 protocol kernel$'
+
+route/list --table=11
+stdout '192.0.2.1/32.*dev cilium-rr-test.*scope link.*table 11'
+stdout '0.0.0.0/0.*via 192.0.2.1.*table 11'
+stdout 'fe80:ec2::1/128.*dev cilium-rr-test.*scope universe.*table 11'
+stdout '::/0.*via fe80:ec2::1.*dev cilium-rr-test.*table 11'
+
+# Endpoint deletion removes both rule families but leaves the shared routes.
+endpoint/del pod-a
+
+# Wait for asynchronous rule deletion without replaying endpoint/del.
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv6 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv6 --priority=111 --protocol=kernel
+* empty stdout
+
+route/list --table=11
+stdout '192.0.2.1/32.*dev cilium-rr-test.*scope link.*table 11'
+stdout '0.0.0.0/0.*via 192.0.2.1.*table 11'
+stdout 'fe80:ec2::1/128.*dev cilium-rr-test.*scope universe.*table 11'
+stdout '::/0.*via fe80:ec2::1.*dev cilium-rr-test.*table 11'
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        addresses:
+        - 192.0.2.10
+        ipv6-prefixes:
+        - 2001:db8:1::/80
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/reconciler/testdata/ipv4-endpoint-lifecycle.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/ipv4-endpoint-lifecycle.txtar
@@ -1,0 +1,71 @@
+#! --family=ipv4
+
+# Configure one ENI as the operator would report it to the agent.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+ipam/restore-finished
+
+# Endpoint creation installs both endpoint rules and the shared ENI routes.
+endpoint/add pod-a 192.0.2.10
+stdout '^192.0.2.10$'
+
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 192[.]0[.]2[.]10/32 table main protocol kernel$'
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 192[.]0[.]2[.]10/32 to all table 11 protocol kernel$'
+
+route/list --table=11
+stdout '192.0.2.1/32.*dev cilium-rr-test.*scope link.*table 11'
+stdout '0.0.0.0/0.*via 192.0.2.1.*table 11'
+
+# Endpoint deletion removes its rules but leaves routes shared by the ENI.
+endpoint/del pod-a
+
+# Wait for asynchronous rule deletion without replaying endpoint/del.
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+* empty stdout
+
+route/list --table=11
+stdout '192.0.2.1/32.*dev cilium-rr-test.*scope link.*table 11'
+stdout '0.0.0.0/0.*via 192.0.2.1.*table 11'
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        addresses:
+        - 192.0.2.10
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/reconciler/testdata/ipv6-endpoint-lifecycle.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/ipv6-endpoint-lifecycle.txtar
@@ -1,0 +1,72 @@
+#! --family=ipv6
+
+# Configure one ENI with an IPv6 delegated prefix as the operator would report it.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+ipam/restore-finished
+
+# Endpoint creation installs IPv6 endpoint rules and routes through the AWS
+# link-local gateway.
+endpoint/add pod-a 2001:db8:1::/80
+stdout --count=1 '^2001:db8:1:[0-9a-f:]+$'
+
+rule/list --family=ipv6 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 2001:db8:1:[0-9a-f:]+/128 table main protocol kernel$'
+
+rule/list --family=ipv6 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 2001:db8:1:[0-9a-f:]+/128 to all table 11 protocol kernel$'
+
+route/list --table=11
+stdout 'fe80:ec2::1/128.*dev cilium-rr-test.*scope universe.*table 11'
+stdout '::/0.*via fe80:ec2::1.*dev cilium-rr-test.*table 11'
+
+# Endpoint deletion removes its rules but leaves routes shared by the ENI.
+endpoint/del pod-a
+
+# Wait for asynchronous rule deletion without replaying endpoint/del.
+rule/list --family=ipv6 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv6 --priority=111 --protocol=kernel
+* empty stdout
+
+route/list --table=11
+stdout 'fe80:ec2::1/128.*dev cilium-rr-test.*scope universe.*table 11'
+stdout '::/0.*via fe80:ec2::1.*dev cilium-rr-test.*table 11'
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        ipv6-prefixes:
+        - 2001:db8:1::/80
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/reconciler/testdata/reconciliation-failure.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/reconciliation-failure.txtar
@@ -1,0 +1,55 @@
+#! --family=ipv4
+
+# Configure one ENI as the operator would report it to the agent.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+ipam/restore-finished
+
+# Losing the parent ENI makes reconciliation fail. Because endpoint/add waits
+# for terminal StateDB status, the simulated agent request reports the error
+# instead of returning a partially configured endpoint.
+link/del cilium-rr-test
+! endpoint/add pod-a 192.0.2.10
+
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+empty stdout
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+empty stdout
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        addresses:
+        - 192.0.2.10
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/reconciler/testdata/stale-rule-migration.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/stale-rule-migration.txtar
@@ -1,0 +1,68 @@
+#! --family=ipv4
+
+# Configure one ENI as the operator would report it to the agent.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+ipam/restore-finished
+
+# Simulate an upgrade with an old destination-scoped egress rule. Endpoint
+# creation replaces it with the desired unconditional rule.
+rule/add --family=ipv4 --from=192.0.2.10/32 --to=192.0.2.0/24 --priority=111 --table=11 --protocol=kernel
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 192[.]0[.]2[.]10/32 to 192[.]0[.]2[.]0/24 table 11 protocol kernel$'
+
+endpoint/add pod-a 192.0.2.10
+stdout '^192.0.2.10$'
+
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 192[.]0[.]2[.]10/32 table main protocol kernel$'
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 192[.]0[.]2[.]10/32 to all table 11 protocol kernel$'
+
+endpoint/del pod-a
+
+# Wait for asynchronous rule deletion without replaying endpoint/del.
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+* empty stdout
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        addresses:
+        - 192.0.2.10
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/reconciler/testdata/startup-garbage-collection.txtar
+++ b/pkg/datapath/linux/routing/reconciler/testdata/startup-garbage-collection.txtar
@@ -1,0 +1,61 @@
+#! --family=ipv4
+
+# Configure one ENI as the operator would report it to the agent.
+k8s/add cilium-node.yaml
+link/add cilium-rr-test dummy
+link/set cilium-rr-test hwaddr=02:ca:fe:00:00:01 mtu=1400
+
+hive start
+ipam/start
+
+# Wait for the production ENI device configurator before reconciling routing.
+link/list
+* stdout 'addr: 192[.]0[.]2[.]5/24'
+stdout 'cilium-rr-test dummy <up[|>]'
+stdout 'mtu: 1500'
+
+# Seed rules left by an endpoint that is absent from both restored endpoints
+# and IPAM allocations. Finishing restoration enables the initial prune.
+rule/add --family=ipv4 --to=192.0.2.99/32 --priority=20 --table=main --protocol=kernel
+rule/add --family=ipv4 --from=192.0.2.99/32 --priority=111 --table=11 --protocol=kernel
+
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+stdout --count=1 '^priority 20 from all to 192[.]0[.]2[.]99/32 table main protocol kernel$'
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+stdout --count=1 '^priority 111 from 192[.]0[.]2[.]99/32 to all table 11 protocol kernel$'
+
+ipam/restore-finished
+
+# Wait for the initial reconciler prune without replaying the rule additions.
+rule/list --family=ipv4 --priority=20 --protocol=kernel
+* empty stdout
+
+rule/list --family=ipv4 --priority=111 --protocol=kernel
+* empty stdout
+
+hive stop
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  eni: {}
+status:
+  eni:
+    enis:
+      eni-1:
+        id: eni-1
+        ip: 192.0.2.5
+        mac: 02:ca:fe:00:00:01
+        number: 1
+        addresses:
+        - 192.0.2.10
+        subnet:
+          id: subnet-1
+          cidr: 192.0.2.0/24
+        vpc:
+          id: vpc-1
+          primary-cidr: 192.0.2.0/24

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
@@ -222,77 +221,18 @@ func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
 // succeed (albeit very rarely that egress deletion fails) because we are able
 // to perform a narrower search on the rule because we know it references the
 // main routing table. Due to multiple routing CIDRs, there might be more than
-// one egress rule. Deletion of any rule only proceeds if the rule matches
-// the IP & priority. In order to avoid leaving stale rules behind, all the
-// matching rules are removed.
+// one egress rule. Deletion only proceeds for unmarked Cilium rules matching
+// the IP and one of the known priority/table schemes. Missing rules are treated
+// as already deleted, and all matching rules are removed to avoid leaving stale
+// rules.
 func Delete(logger *slog.Logger, ip netip.Addr) error {
-	if !ip.IsValid() {
-		logger.Warn(
-			"Unable to delete rules because IP is not a valid IP address",
-			logfields.IPAddr, ip,
-		)
-		return errors.New("IP not compatible")
+	if err := DeleteRulesIfExists(logger, ip); err != nil {
+		return err
 	}
-
-	ipWithMask := netipx.AddrIPNet(ip)
-
-	var family int
-	if ip.Is4() {
-		family = netlink.FAMILY_V4
-	} else {
-		family = netlink.FAMILY_V6
-	}
-
-	// Ingress rules
-	ingress := route.Rule{
-		Priority: linux_defaults.RulePriorityIngress,
-		To:       ipWithMask,
-		Table:    route.MainTable,
-	}
-
-	if err := deleteRulesFiltered(
-		logger, ingress, family,
-		deleteRuleFilter{
-			fn:  func(r netlink.Rule) bool { return true }, // no further check needed, delete all rules found
-			msg: "",
-		},
-	); err != nil {
-		return fmt.Errorf("unable to delete ingress rule from main table with ip %s: %w", ipWithMask.String(), err)
-	}
-	logger.Debug("Deleted ingress rule",
-		logfields.Rule, ingress,
-		logfields.IPAddr, ipWithMask,
-	)
-
-	compat := option.Config.IPAM == ipamOption.IPAMAzure
-	priority := linux_defaults.RulePriorityEgressv2
-	if compat {
-		priority = linux_defaults.RulePriorityEgress
-	}
-
-	// Egress rules
-	withENIRouteTableID := deleteRuleFilter{
-		fn:  func(r netlink.Rule) bool { return r.Table >= computeTableIDFromIfaceNumber(compat, 0) },
-		msg: "rule does not refer to a per-ENI routing table ID",
-	}
-
-	// Delete all egress rules matching the priority and source IP.
-	// This covers the unconditional rule (from <IP> lookup <table>) and
-	// any CIDR-specific rules (from <IP> to <CIDR> lookup <table>).
-	egress := route.Rule{
-		Priority: priority,
-		From:     ipWithMask,
-	}
-	if err := deleteRulesFiltered(
-		logger, egress, family, withENIRouteTableID); err != nil {
-		return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
-	}
-	logger.Debug("Deleted egress rule",
-		logfields.Rule, egress,
-		logfields.IPAddr, ipWithMask,
-	)
 
 	if option.Config.EnableUnreachableRoutes {
+		ipWithMask := netipx.AddrIPNet(ip)
+
 		// Replace route to old IP with an unreachable route. This will
 		//   - trigger ICMP error messages for clients attempting to connect to the stale IP
 		//   - avoid hitting rp_filter and getting Martian packet warning
@@ -312,37 +252,130 @@ func Delete(logger *slog.Logger, ip netip.Addr) error {
 	return nil
 }
 
-type deleteRuleFilter struct {
-	fn  func(r netlink.Rule) bool
-	msg string
-}
-
-func deleteRulesFiltered(logger *slog.Logger, template route.Rule, family int, filters ...deleteRuleFilter) error {
-	rules, err := route.ListRules(family, &template)
-	if err != nil {
-		return err
+// DeleteRulesIfExists removes Cilium endpoint routing rules for ip without
+// installing an unreachable route. It is intended for rollback of a partially
+// completed endpoint setup and for asynchronous rule reconciliation.
+func DeleteRulesIfExists(logger *slog.Logger, ip netip.Addr) error {
+	if !ip.IsValid() {
+		logger.Warn(
+			"Unable to delete rules because IP is not a valid IP address",
+			logfields.IPAddr, ip,
+		)
+		return errors.New("IP not compatible")
 	}
 
-	if len(rules) == 0 {
-		logger.Warn("No rule matching found", logfields.Rule, template)
-		return errors.New("no rule found to delete")
+	family := netlink.FAMILY_V6
+	if ip.Is4() {
+		family = netlink.FAMILY_V4
 	}
+	ipWithMask := netipx.AddrIPNet(ip)
 
 	var errs []error
-next:
-	for _, rule := range rules {
-		for _, filter := range filters {
-			if !filter.fn(rule) {
-				logger.Info("Skipping deletion of matching rule",
-					logfields.Rule, rule,
-					logfields.Message, filter.msg,
-				)
-				continue next
-			}
-		}
-		errs = append(errs, netlink.RuleDel(&rule))
+	ingressRules, err := route.ListRules(family, &route.Rule{
+		Priority: linux_defaults.RulePriorityIngress,
+		To:       ipWithMask,
+		Table:    route.MainTable,
+	})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list ingress rules for %s: %w", ip, err))
 	}
+
+	for _, rule := range ingressRules {
+		if !isCiliumEndpointIngressRule(rule) {
+			continue
+		}
+		deleted, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("delete ingress rule for %s: %w", ip, err))
+			continue
+		}
+		if deleted {
+			logger.Debug("Deleted endpoint ingress rule",
+				logfields.Rule, rule,
+				logfields.IPAddr, ip,
+			)
+		}
+	}
+
+	egressRules, err := route.ListRules(family, &route.Rule{
+		From: ipWithMask,
+	})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list egress rules for %s: %w", ip, err))
+	}
+	for _, rule := range egressRules {
+		if !isCiliumEndpointEgressRule(rule) {
+			continue
+		}
+		deleted, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("delete egress rule for %s: %w", ip, err))
+			continue
+		}
+		if deleted {
+			logger.Debug("Deleted endpoint egress rule",
+				logfields.Rule, rule,
+				logfields.IPAddr, ip,
+			)
+		}
+	}
+
 	return errors.Join(errs...)
+}
+
+func isCiliumEndpointIngressRule(rule netlink.Rule) bool {
+	return rule.Dst != nil &&
+		rule.Priority == linux_defaults.RulePriorityIngress &&
+		rule.Table == route.MainTable &&
+		rule.Mark == 0 &&
+		rule.Mask == nil &&
+		rule.Protocol == linux_defaults.RTProto
+}
+
+func isCiliumEndpointEgressRule(rule netlink.Rule) bool {
+	// Endpoint egress rules are unmarked Cilium-owned source rules.
+	if rule.Src == nil ||
+		rule.Protocol != linux_defaults.RTProto ||
+		rule.Mark != 0 ||
+		rule.Mask != nil {
+		return false
+	}
+
+	switch rule.Priority {
+	case linux_defaults.RulePriorityEgress:
+		// Legacy rules and current Azure rules may use any non-reserved table.
+		return isNonReservedTable(rule.Table)
+	case linux_defaults.RulePriorityEgressv2:
+		// Current ENI and AlibabaCloud rules use Cilium's interface-number table range.
+		return isCiliumInterfaceRouteTable(rule.Table)
+	default:
+		return false
+	}
+}
+
+func deleteRuleIfExists(rule *netlink.Rule) (bool, error) {
+	err := netlink.RuleDel(rule)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ESRCH):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func isCiliumInterfaceRouteTable(table int) bool {
+	return table >= computeTableIDFromIfaceNumber(false, 0) && table < unix.RT_TABLE_DEFAULT
+}
+
+func isNonReservedTable(table int) bool {
+	switch table {
+	case unix.RT_TABLE_UNSPEC, unix.RT_TABLE_DEFAULT, unix.RT_TABLE_MAIN, unix.RT_TABLE_LOCAL:
+		return false
+	default:
+		return true
+	}
 }
 
 // retrieveLinkFromMAC finds the corresponding device for a MAC address,

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -323,6 +323,66 @@ func DeleteRulesIfExists(logger *slog.Logger, ip netip.Addr) error {
 	return errors.Join(errs...)
 }
 
+// GCOrphanRules removes Cilium endpoint policy-routing rules left behind when
+// endpoint teardown was missed or interrupted, for example by a CNI or agent
+// crash. A recognized rule is removed only when shouldCollect confirms that
+// its endpoint address is no longer in use.
+func GCOrphanRules(logger *slog.Logger, shouldCollect func(netip.Addr) bool) error {
+	if shouldCollect == nil {
+		return errors.New("orphan rule collection predicate must not be nil")
+	}
+
+	var errs []error
+	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		rules, err := route.ListRules(family, nil)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		for _, rule := range rules {
+			var network *net.IPNet
+
+			switch {
+			// Cilium endpoint ingress rules in the main table.
+			case isCiliumEndpointIngressRule(rule):
+				network = rule.Dst
+			// Cilium endpoint egress rules from current and legacy schemes.
+			case isCiliumEndpointEgressRule(rule):
+				network = rule.Src
+			}
+			if network == nil {
+				continue
+			}
+
+			prefix, ok := netipx.FromStdIPNet(network)
+			// Endpoint rules select one pod IP; preserve subnet-wide prefixes.
+			if !ok || prefix.Bits() != prefix.Addr().BitLen() {
+				continue
+			}
+			addr := prefix.Addr()
+
+			if !shouldCollect(addr) {
+				continue
+			}
+
+			deleted, err := deleteRuleIfExists(&rule)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("delete orphan rule for %s: %w", addr, err))
+				continue
+			}
+
+			if deleted {
+				logger.Info("Deleted orphan endpoint routing rule",
+					logfields.Rule, rule,
+					logfields.IPAddr, addr,
+				)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func isCiliumEndpointIngressRule(rule netlink.Rule) bool {
 	return rule.Dst != nil &&
 		rule.Priority == linux_defaults.RulePriorityIngress &&

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -26,31 +26,18 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// useCompatEgressPriority determines whether to use the new or old style egress rule.
-// Old style rules are only used in Azure IPAM mode.
-func (info *RoutingInfo) useCompatEgressPriority() bool {
-	return info.IpamMode == ipamOption.IPAMAzure
-}
-
-// Configure sets up the rules and routes needed when running in ENI or
-// Azure IPAM mode.
-// These rules and routes direct egress traffic out of the interface and
-// ingress traffic back to the endpoint (`ip`).
+// Configure sets up the rules and routes that direct egress traffic out of the
+// interface and ingress traffic back to the endpoint (ip).
 //
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
-// mtu: The interface MTU.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
-func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
+func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 	if !ip.IsValid() {
-		info.logger.Warn(
-			"Unable to configure rules and routes because IP is not a valid IP address",
-			logfields.IPAddr, ip,
-		)
-		return errors.New("IP not compatible")
+		return fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
 	}
 
-	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
+	ifindex, err := info.prepareInterface()
 	if err != nil {
 		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
@@ -81,14 +68,14 @@ func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
 	}
 
 	var egressPriority, ifaceNum, tableID int
-	if info.useCompatEgressPriority() {
+	if info.compatEgressPriority {
 		egressPriority = linux_defaults.RulePriorityEgress
 		ifaceNum = ifindex
 	} else {
 		egressPriority = linux_defaults.RulePriorityEgressv2
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Install an unconditional rule so all traffic from the endpoint
 	// (including external/internet traffic) is routed through the correct ENI.
@@ -108,21 +95,21 @@ func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
 	return info.installRoutes(ifindex, tableID)
 }
 
-func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
+func (info *RoutingInfo) ReconcileGatewayRoutes(rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
 	set := statedb.NewWatchSet()
 
-	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
+	ifindex, err := info.prepareInterface()
 	if err != nil {
 		return set, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
 
 	var ifaceNum, tableID int
-	if info.useCompatEgressPriority() {
+	if info.compatEgressPriority {
 		ifaceNum = ifindex
 	} else {
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Get the desired routes.
 	gwRoutes := info.gatewayRoutes(ifindex, tableID)
@@ -358,16 +345,14 @@ next:
 	return errors.Join(errs...)
 }
 
-// retrieveIfIndexFromMAC finds the corresponding device index (ifindex) for a
-// given MAC address, excluding Linux slave devices. This is useful for
-// creating rules and routes in order to specify the table. When the ifindex is
-// found, the device is brought up and its MTU is set.
-func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
+// retrieveLinkFromMAC finds the corresponding device for a MAC address,
+// excluding Linux slave devices.
+func retrieveLinkFromMAC(mac mac.MAC) (netlink.Link, error) {
 	var link netlink.Link
 
 	links, err := safenetlink.LinkList()
 	if err != nil {
-		return -1, fmt.Errorf("unable to list interfaces: %w", err)
+		return nil, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
 	for _, l := range links {
@@ -378,28 +363,47 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 		}
 		if l.Attrs().HardwareAddr.String() == mac.String() {
 			if link != nil {
-				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
+				return nil, fmt.Errorf("several interfaces found with MAC %s: %s and %s", mac, link.Attrs().Name, l.Attrs().Name)
 			}
 			link = l
 		}
 	}
 
 	if link == nil {
-		return -1, fmt.Errorf("interface with MAC %s not found", mac)
+		return nil, fmt.Errorf("interface with MAC %s not found", mac)
+	}
+	return link, nil
+}
+
+// prepareInterface resolves the interface and applies any explicitly requested
+// link configuration.
+func (info *RoutingInfo) prepareInterface() (int, error) {
+	link, err := retrieveLinkFromMAC(info.MasterIfMAC)
+	if err != nil {
+		return -1, err
 	}
 
-	if err = netlink.LinkSetMTU(link, mtu); err != nil {
-		return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, mtu, err)
+	if info.mtu != nil {
+		if err = netlink.LinkSetMTU(link, *info.mtu); err != nil {
+			return -1, fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, *info.mtu, err)
+		}
 	}
-	if err = netlink.LinkSetUp(link); err != nil {
-		return -1, fmt.Errorf("unable to up link %s: %w", link.Attrs().Name, err)
+	if info.linkState != nil {
+		if *info.linkState {
+			err = netlink.LinkSetUp(link)
+		} else {
+			err = netlink.LinkSetDown(link)
+		}
+		if err != nil {
+			return -1, fmt.Errorf("unable to set link %s up state to %t: %w", link.Attrs().Name, *info.linkState, err)
+		}
 	}
 
 	return link.Attrs().Index, nil
 }
 
-// computeTableIDFromIfaceNumber returns a computed per-ENI route table ID for the given
-// ENI interface number.
+// computeTableIDFromIfaceNumber returns a computed per-interface route table
+// ID for the given routing interface number.
 func computeTableIDFromIfaceNumber(compat bool, num int) int {
 	if compat {
 		return num

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
+var errEgressRuleConflict = errors.New("egress rule conflicts with an existing rule")
+
 // Configure sets up the rules and routes that direct egress traffic out of the
 // interface and ingress traffic back to the endpoint (ip).
 //
@@ -32,13 +34,58 @@ import (
 // info: The interface routing info used to create rules and routes.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
 func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
+	_, _, err := info.installEndpointRules(ip, host)
+	if errors.Is(err, errEgressRuleConflict) {
+		// Leave the stale rule for the reconciler to delete before it installs the
+		// new unconditional rule.
+		return nil
+	}
+	return err
+}
+
+// ReconcileEndpointRules installs the desired routes and ingress rule for ip,
+// removes obsolete Cilium egress rules for the same source address, then ensures
+// that the desired unconditional egress rule is installed.
+func (info *RoutingInfo) ReconcileEndpointRules(ip netip.Addr, host bool) error {
+	egressPriority, tableID, err := info.installEndpointRules(ip, host)
+	if err != nil && !errors.Is(err, errEgressRuleConflict) {
+		return err
+	}
+
+	// Remove obsolete egress rules regardless of whether the first installation
+	// succeeded. Retrying below installs the desired unconditional rule after a
+	// conflict, and is idempotent when it was already present.
+	if err := deleteObsoleteEgressRules(ip, egressPriority, tableID); err != nil {
+		return fmt.Errorf("unable to remove obsolete egress rules: %w", err)
+	}
+
+	_, _, err = info.installEndpointRules(ip, host)
+	return err
+}
+
+func (info *RoutingInfo) installEndpointRules(ip netip.Addr, host bool) (egressPriority, tableID int, err error) {
 	if !ip.IsValid() {
-		return fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
+		return 0, 0, fmt.Errorf("unable to install endpoint rules: invalid endpoint IP address %s", ip)
 	}
 
 	ifindex, err := info.prepareInterface()
 	if err != nil {
-		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		return 0, 0, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+	}
+
+	var ifaceNum int
+	if info.compatEgressPriority {
+		egressPriority = linux_defaults.RulePriorityEgress
+		ifaceNum = ifindex
+	} else {
+		egressPriority = linux_defaults.RulePriorityEgressv2
+		ifaceNum = info.InterfaceNumber
+	}
+	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
+
+	// Make the desired table usable before directing any new traffic to it.
+	if err := info.installRoutes(ifindex, tableID); err != nil {
+		return 0, 0, err
 	}
 
 	ipWithMask := netipx.AddrIPNet(ip)
@@ -62,19 +109,9 @@ func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 			Table:    route.MainTable,
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
-			return fmt.Errorf("unable to install ip rule: %w", err)
+			return 0, 0, fmt.Errorf("unable to install ip rule: %w", err)
 		}
 	}
-
-	var egressPriority, ifaceNum, tableID int
-	if info.compatEgressPriority {
-		egressPriority = linux_defaults.RulePriorityEgress
-		ifaceNum = ifindex
-	} else {
-		egressPriority = linux_defaults.RulePriorityEgressv2
-		ifaceNum = info.InterfaceNumber
-	}
-	tableID = computeTableIDFromIfaceNumber(info.compatEgressPriority, ifaceNum)
 
 	// Install an unconditional rule so all traffic from the endpoint
 	// (including external/internet traffic) is routed through the correct ENI.
@@ -88,10 +125,50 @@ func (info *RoutingInfo) Configure(ip netip.Addr, host bool) error {
 		Table:    tableID,
 		Protocol: linux_defaults.RTProto,
 	}); err != nil {
-		return fmt.Errorf("unable to install ip rule: %w", err)
+		// Linux treats an omitted destination selector as a wildcard when checking
+		// for duplicate rules. The new unconditional rule may therefore be rejected
+		// with EEXIST while a stale destination-scoped rule is still installed.
+		if errors.Is(err, unix.EEXIST) {
+			return egressPriority, tableID, fmt.Errorf("%w: %w", errEgressRuleConflict, err)
+		}
+		return 0, 0, fmt.Errorf("unable to install ip rule: %w", err)
 	}
 
-	return info.installRoutes(ifindex, tableID)
+	return egressPriority, tableID, nil
+}
+
+func deleteObsoleteEgressRules(ip netip.Addr, desiredPriority, desiredTable int) error {
+	family := netlink.FAMILY_V6
+	if ip.Is4() {
+		family = netlink.FAMILY_V4
+	}
+
+	rules, err := route.ListRules(family, &route.Rule{
+		From: netipx.AddrIPNet(ip),
+	})
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, rule := range rules {
+		// Ignore rules outside the two Cilium endpoint-egress schemes.
+		if !isCiliumEndpointEgressRule(rule) {
+			continue
+		}
+		// Preserve the desired unconditional rule installed for this endpoint.
+		if rule.Priority == desiredPriority &&
+			rule.Table == desiredTable &&
+			rule.Dst == nil {
+			continue
+		}
+
+		_, err := deleteRuleIfExists(&rule)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (info *RoutingInfo) ReconcileGatewayRoutes(rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -308,24 +308,32 @@ func Delete(logger *slog.Logger, ip netip.Addr) error {
 	}
 
 	if option.Config.EnableUnreachableRoutes {
-		ipWithMask := netipx.AddrIPNet(ip)
-
-		// Replace route to old IP with an unreachable route. This will
-		//   - trigger ICMP error messages for clients attempting to connect to the stale IP
-		//   - avoid hitting rp_filter and getting Martian packet warning
-		// When the IP is reused, the unreachable route will be replaced to target the new pod veth
-		// In CRD-based IPAM, when an IP is unassigned from the CiliumNode, we delete this route
-		// to avoid blackholing traffic to this IP if it gets reassigned to another node
-		if err := netlink.RouteReplace(&netlink.Route{
-			Dst:      ipWithMask,
-			Table:    route.MainTable,
-			Type:     unix.RTN_UNREACHABLE,
-			Protocol: linux_defaults.RTProto,
-		}); err != nil {
-			return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
-		}
+		return InstallUnreachableRoute(ip)
 	}
 
+	return nil
+}
+
+// InstallUnreachableRoute replaces the route to an old endpoint IP with an
+// unreachable route. This triggers ICMP errors for clients attempting to reach
+// the stale IP and avoids rp_filter producing martian packet warnings. A new
+// endpoint route replaces it when the IP is reused. In CRD-based IPAM, the
+// route is removed when the IP is unassigned from the CiliumNode to avoid
+// blackholing traffic if the IP is reassigned to another node.
+func InstallUnreachableRoute(ip netip.Addr) error {
+	if !ip.IsValid() {
+		return fmt.Errorf("invalid IP address %s", ip)
+	}
+
+	ipWithMask := netipx.AddrIPNet(ip)
+	if err := netlink.RouteReplace(&netlink.Route{
+		Dst:      ipWithMask,
+		Table:    route.MainTable,
+		Type:     unix.RTN_UNREACHABLE,
+		Protocol: linux_defaults.RTProto,
+	}); err != nil {
+		return fmt.Errorf("unable to add unreachable route for ip %s: %w", ipWithMask.String(), err)
+	}
 	return nil
 }
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -442,6 +442,145 @@ func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
 	})
 }
 
+func TestPrivilegedGCOrphanRules(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		orphan := netip.MustParseAddr("192.0.2.10")
+		inUse := netip.MustParseAddr("192.0.2.11")
+		_, subnet, err := net.ParseCIDR("198.51.100.0/24")
+		require.NoError(t, err)
+
+		// rules that should be preserved after GCOrphanRules is called, even if they match the orphan IP
+		preservedRules := []route.Rule{
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     subnet,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.20")),
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.21")),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityIngress,
+				To:       netipx.AddrIPNet(netip.MustParseAddr("192.0.2.22")),
+				Table:    route.MainTable,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.23")),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 2,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     netipx.AddrIPNet(netip.MustParseAddr("192.0.2.24")),
+				Table:    300,
+				Mask:     0xff,
+				Protocol: linux_defaults.RTProto,
+			},
+		}
+
+		// create rules for both the orphan and in-use IPs
+		for _, addr := range []netip.Addr{orphan, inUse} {
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				To:       netipx.AddrIPNet(addr),
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto,
+			}))
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     netipx.AddrIPNet(addr),
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto,
+			}))
+			require.NoError(t, route.ReplaceRule(route.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     netipx.AddrIPNet(addr),
+				Table:    300,
+				Protocol: linux_defaults.RTProto,
+			}))
+		}
+		for _, rule := range preservedRules {
+			require.NoError(t, route.ReplaceRule(rule))
+		}
+
+		err = GCOrphanRules(hivetest.Logger(t), func(addr netip.Addr) bool {
+			return addr != inUse
+		})
+		require.NoError(t, err)
+
+		// verify that the rules for the orphan IP have been deleted, and the rules for the in-use IP remain
+		orphanIngressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityIngress,
+			To:       netipx.AddrIPNet(orphan),
+			Table:    route.MainTable,
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanIngressRules)
+
+		orphanEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(orphan),
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanEgressRules)
+
+		orphanLegacyEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgress,
+			From:     netipx.AddrIPNet(orphan),
+		})
+		require.NoError(t, err)
+		require.Empty(t, orphanLegacyEgressRules)
+
+		inUseIngressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityIngress,
+			To:       netipx.AddrIPNet(inUse),
+			Table:    route.MainTable,
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseIngressRules, 1)
+
+		inUseEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(inUse),
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseEgressRules, 1)
+
+		inUseLegacyEgressRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+			Priority: linux_defaults.RulePriorityEgress,
+			From:     netipx.AddrIPNet(inUse),
+		})
+		require.NoError(t, err)
+		require.Len(t, inUseLegacyEgressRules, 1)
+
+		// verify that the preserved rules are still present
+		for _, rule := range preservedRules {
+			rules, err := route.ListRules(netlink.FAMILY_V4, &rule)
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+		}
+		return nil
+	})
+}
+
 func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {
 	// Create rules and routes
 	beforeCreationRules, beforeCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -33,6 +33,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 	ns1 := netns.NewNetNS(t)
 	ns1.Do(func() error {
 		ip, ri := getFakes(t, ipamOption.IPAMENI, true, false)
+		require.NoError(t, ri.WithOptions(WithMTU(1500), WithLinkState(true)))
 		masterMAC := ri.MasterIfMAC
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
@@ -74,6 +75,7 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 	ns1 := netns.NewNetNS(t)
 	ns1.Do(func() error {
 		ip, ri := getFakes(t, ipamOption.IPAMENI, true, true)
+		require.NoError(t, ri.WithOptions(WithMTU(1500), WithLinkState(true)))
 		masterMAC := ri.MasterIfMAC
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
@@ -105,6 +107,7 @@ func TestPrivilegedDelete(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	fakeIP, fakeRoutingInfo := getFakes(t, ipamOption.IPAMENI, true, false)
+	require.NoError(t, fakeRoutingInfo.WithOptions(WithMTU(1500), WithLinkState(true)))
 	masterMAC := fakeRoutingInfo.MasterIfMAC
 
 	tests := []struct {
@@ -311,8 +314,9 @@ func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool)
 
 	options := []RoutingInfoOption{
 		WithCIDRsAndMasquerade(cidrs, masquerade),
-		WithMTU(1500),
-		WithLinkState(true),
+	}
+	if ipamMode != ipamOption.IPAMENI {
+		options = append(options, WithMTU(1500), WithLinkState(true))
 	}
 	if ipamMode == ipamOption.IPAMAzure {
 		options = append(options, WithCompatEgressPriority())

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -413,6 +413,120 @@ func TestIsCiliumEndpointEgressRule(t *testing.T) {
 	}
 }
 
+func TestPrivilegedReconcileObsoleteRules(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	for _, ipamMode := range []string{
+		ipamOption.IPAMENI,
+		ipamOption.IPAMAzure,
+		ipamOption.IPAMAlibabaCloud,
+	} {
+		t.Run(ipamMode, func(t *testing.T) {
+			ns := netns.NewNetNS(t)
+			ns.Do(func() error {
+				ip, routingInfo := getFakes(t, ipamMode, true, false)
+				ifaceCleanup := createDummyDevice(t, routingInfo.MasterIfMAC)
+				defer ifaceCleanup()
+
+				link, err := retrieveLinkFromMAC(routingInfo.MasterIfMAC)
+				require.NoError(t, err)
+				ifindex := link.Attrs().Index
+
+				if ipamMode == ipamOption.IPAMENI {
+					require.NoError(t, netlink.LinkSetMTU(link, 1400))
+					require.NoError(t, netlink.LinkSetUp(link))
+				}
+
+				desiredPriority := linux_defaults.RulePriorityEgressv2
+				desiredTable := linux_defaults.RouteTableInterfacesOffset + routingInfo.InterfaceNumber
+				obsoleteSameSchemeTable := desiredTable + 1
+				obsoleteOtherPriority := linux_defaults.RulePriorityEgress
+				obsoleteOtherSchemeTable := 100
+				if routingInfo.compatEgressPriority {
+					desiredPriority = linux_defaults.RulePriorityEgress
+					desiredTable = ifindex
+					obsoleteSameSchemeTable = 100
+					obsoleteOtherPriority = linux_defaults.RulePriorityEgressv2
+					obsoleteOtherSchemeTable = linux_defaults.RouteTableInterfacesOffset + routingInfo.InterfaceNumber
+				}
+
+				_, legacyDestination, err := net.ParseCIDR("10.0.0.0/8")
+				require.NoError(t, err)
+				for _, rule := range []route.Rule{
+					{
+						Priority: desiredPriority,
+						From:     netipx.AddrIPNet(ip),
+						To:       legacyDestination,
+						Table:    desiredTable,
+						Protocol: linux_defaults.RTProto,
+					},
+					{
+						Priority: desiredPriority,
+						From:     netipx.AddrIPNet(ip),
+						Table:    obsoleteSameSchemeTable,
+						Protocol: linux_defaults.RTProto,
+					},
+					{
+						Priority: obsoleteOtherPriority,
+						From:     netipx.AddrIPNet(ip),
+						Table:    obsoleteOtherSchemeTable,
+						Protocol: linux_defaults.RTProto,
+					},
+				} {
+					require.NoError(t, route.ReplaceRule(rule))
+				}
+
+				// Configure is the additive CNI path. Obsolete rules are left for the
+				// agent-side StateDB reconciler.
+				require.NoError(t, routingInfo.Configure(ip, false))
+				if ipamMode != ipamOption.IPAMENI {
+					link, err := netlink.LinkByIndex(ifindex)
+					require.NoError(t, err)
+					require.Equal(t, 1500, link.Attrs().MTU)
+					require.NotZero(t, link.Attrs().Flags&net.FlagUp)
+				}
+				rules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 3)
+
+				// The first pass must replace destination-scoped legacy rules with
+				// the unconditional desired rule.
+				require.NoError(t, routingInfo.ReconcileEndpointRules(ip, false))
+				if ipamMode != ipamOption.IPAMENI {
+					link, err := netlink.LinkByIndex(ifindex)
+					require.NoError(t, err)
+					require.Equal(t, 1500, link.Attrs().MTU)
+					require.NotZero(t, link.Attrs().Flags&net.FlagUp)
+				}
+				rules, err = route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 1)
+				require.Equal(t, desiredPriority, rules[0].Priority)
+				require.Equal(t, desiredTable, rules[0].Table)
+				require.Nil(t, rules[0].Dst)
+				require.Equal(t, uint8(linux_defaults.RTProto), rules[0].Protocol)
+
+				// The second verifies idempotency.
+				require.NoError(t, routingInfo.ReconcileEndpointRules(ip, false))
+				rules, err = route.ListRules(netlink.FAMILY_V4, &route.Rule{
+					From: netipx.AddrIPNet(ip),
+				})
+				require.NoError(t, err)
+				require.Len(t, rules, 1)
+				require.Equal(t, desiredPriority, rules[0].Priority)
+				require.Equal(t, desiredTable, rules[0].Table)
+				require.Nil(t, rules[0].Dst)
+				require.Equal(t, uint8(linux_defaults.RTProto), rules[0].Protocol)
+				return nil
+			})
+		})
+	}
+}
+
 func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -37,7 +37,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 
@@ -48,7 +48,7 @@ func TestPrivilegedConfigure(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -63,7 +63,7 @@ func TestPrivilegedConfigureAzureMasquerade(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -78,7 +78,7 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 		ifaceCleanup := createDummyDevice(t, masterMAC)
 		defer ifaceCleanup()
 
-		runConfigureThenDelete(t, ri, ip, 1500)
+		runConfigureThenDelete(t, ri, ip)
 		return nil
 	})
 }
@@ -87,9 +87,9 @@ func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, ipamOption.IPAMENI, true, false)
-	err := ri.Configure(netip.Addr{}, 1500, false)
+	err := ri.Configure(netip.Addr{}, false)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "IP not compatible")
+	require.ErrorContains(t, err, "unable to install endpoint rules: invalid endpoint IP address")
 }
 
 func TestPrivilegedDeleteRouteWithIncompatibleIP(t *testing.T) {
@@ -115,7 +115,7 @@ func TestPrivilegedDelete(t *testing.T) {
 		{
 			name: "valid IP addr matching a single rule",
 			preRun: func() netip.Addr {
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return fakeIP
 			},
 			wantErr: false,
@@ -125,7 +125,7 @@ func TestPrivilegedDelete(t *testing.T) {
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return ip
 			},
 			wantErr: true,
@@ -135,7 +135,7 @@ func TestPrivilegedDelete(t *testing.T) {
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
-				runConfigure(t, fakeRoutingInfo, ip, 1500)
+				runConfigure(t, fakeRoutingInfo, ip)
 
 				// Find interface ingress rules so that we can create a
 				// near-duplicate.
@@ -160,7 +160,7 @@ func TestPrivilegedDelete(t *testing.T) {
 		{
 			name: "delete rules with dest CIDR after masquerade is disabled",
 			preRun: func() netip.Addr {
-				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
+				runConfigure(t, fakeRoutingInfo, fakeIP)
 				option.Config.EnableIPv4Masquerade = false
 				return fakeIP
 			},
@@ -184,10 +184,10 @@ func TestPrivilegedDelete(t *testing.T) {
 	}
 }
 
-func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
+func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {
 	// Create rules and routes
 	beforeCreationRules, beforeCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)
-	runConfigure(t, ri, ip, mtu)
+	runConfigure(t, ri, ip)
 	afterCreationRules, afterCreationRoutes := listRulesAndRoutes(t, netlink.FAMILY_V4)
 
 	require.NotEmpty(t, afterCreationRules)
@@ -208,8 +208,8 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 	require.Len(t, afterDeletionRoutes, len(beforeCreationRoutes))
 }
 
-func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
-	err := ri.Configure(ip, mtu, false)
+func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr) {
+	err := ri.Configure(ip, false)
 	require.NoError(t, err)
 }
 
@@ -296,8 +296,6 @@ func createDummyDevice(t *testing.T, macAddr mac.MAC) func() {
 func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool) (netip.Addr, RoutingInfo) {
 	t.Helper()
 
-	logger := hivetest.Logger(t)
-
 	fakeGateway := "192.168.2.1"
 	fakeSubnet1CIDR := "192.168.0.0/16"
 	fakeSubnet2CIDR := "192.170.0.0/16"
@@ -311,21 +309,22 @@ func getFakes(t *testing.T, ipamMode string, masquerade bool, withZeroCIDR bool)
 		}
 	}
 
-	fakeRoutingInfo, err := NewRoutingInfo(
-		logger,
-		fakeGateway,
-		cidrs,
-		fakeMAC,
-		"1",
-		ipamMode,
-		masquerade,
-	)
+	options := []RoutingInfoOption{
+		WithCIDRsAndMasquerade(cidrs, masquerade),
+		WithMTU(1500),
+		WithLinkState(true),
+	}
+	if ipamMode == ipamOption.IPAMAzure {
+		options = append(options, WithCompatEgressPriority())
+	}
+
+	fakeRoutingInfo, err := NewRoutingInfo(fakeGateway, fakeMAC, "1", options...)
 
 	require.NoError(t, err)
 	require.NotNil(t, fakeRoutingInfo)
 
 	node.SetRouterInfo(fakeRoutingInfo)
-	option.Config.IPAM = fakeRoutingInfo.IpamMode
+	option.Config.IPAM = ipamMode
 	option.Config.EnableIPv4Masquerade = fakeRoutingInfo.Masquerade
 
 	return netip.MustParseAddr("192.168.2.123"), *fakeRoutingInfo

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -131,7 +132,7 @@ func TestPrivilegedDelete(t *testing.T) {
 				runConfigure(t, fakeRoutingInfo, fakeIP)
 				return ip
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "IP addr matches multiple rules",
@@ -185,6 +186,260 @@ func TestPrivilegedDelete(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestPrivilegedDeleteRulesAllEgressSchemes(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip := netip.MustParseAddr("192.0.2.10")
+		ipWithMask := netipx.AddrIPNet(ip)
+		for _, rule := range []route.Rule{
+			{
+				Priority: linux_defaults.RulePriorityEgress,
+				From:     ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto,
+			},
+			{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				From:     ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto,
+			},
+		} {
+			require.NoError(t, route.ReplaceRule(rule))
+		}
+
+		// A rule outside the known endpoint-egress priorities must be preserved.
+		require.NoError(t, route.ReplaceRule(route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2 + 1,
+			From:     ipWithMask,
+			Table:    100,
+			Protocol: linux_defaults.RTProto,
+		}))
+
+		require.NoError(t, DeleteRulesIfExists(hivetest.Logger(t), ip))
+		// call DeleteRulesIfExists again to ensure that it is idempotent and
+		// does not return an error if the rules have already been deleted
+		require.NoError(t, DeleteRulesIfExists(hivetest.Logger(t), ip))
+
+		rules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{From: ipWithMask})
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+		require.Equal(t, linux_defaults.RulePriorityEgressv2+1, rules[0].Priority)
+		return nil
+	})
+}
+
+func TestIsCiliumEndpointIngressRule(t *testing.T) {
+	mask := uint32(0xffffffff)
+	dst := netipx.AddrIPNet(netip.MustParseAddr("192.0.2.10"))
+
+	tests := []struct {
+		name string
+		rule netlink.Rule
+		want bool
+	}{
+		{
+			"ingress-rule",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"missing-destination",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress + 1,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-table",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"marked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"masked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable,
+				Mask:     &mask,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-protocol",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityIngress,
+				Dst:      dst,
+				Table:    route.MainTable},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCiliumEndpointIngressRule(tt.rule))
+		})
+	}
+}
+
+func TestIsCiliumEndpointEgressRule(t *testing.T) {
+	ipWithMask := netipx.AddrIPNet(netip.MustParseAddr("192.0.2.10"))
+	mask := uint32(0xffffffff)
+
+	tests := []struct {
+		name string
+		rule netlink.Rule
+		want bool
+	}{
+		{
+			"legacy-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"current-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				Src:      ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+				Protocol: linux_defaults.RTProto},
+			true,
+		},
+		{
+			"legacy-priority-reserved-table",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    route.MainTable,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"current-priority-outside-interface-table-range",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2,
+				Src:      ipWithMask,
+				Table:    linux_defaults.RouteTableInterfacesOffset - 1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"marked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Mark:     1,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"masked",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100,
+				Mask:     &mask,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-protocol",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Src:      ipWithMask,
+				Table:    100},
+			false,
+		},
+		{
+			"missing-source",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgress,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+		{
+			"different-priority",
+			netlink.Rule{
+				Priority: linux_defaults.RulePriorityEgressv2 + 1,
+				Src:      ipWithMask,
+				Table:    100,
+				Protocol: linux_defaults.RTProto},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCiliumEndpointEgressRule(tt.rule))
+		})
+	}
+}
+
+func TestPrivilegedDeleteRuleIfExists(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip := netip.MustParseAddr("192.0.2.10")
+		spec := route.Rule{
+			Priority: linux_defaults.RulePriorityEgressv2,
+			From:     netipx.AddrIPNet(ip),
+			Table:    linux_defaults.RouteTableInterfacesOffset + 1,
+			Protocol: linux_defaults.RTProto,
+		}
+		require.NoError(t, route.ReplaceRule(spec))
+
+		rules, err := route.ListRules(netlink.FAMILY_V4, &spec)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+
+		deleted, err := deleteRuleIfExists(&rules[0])
+		require.NoError(t, err)
+		require.True(t, deleted)
+
+		deleted, err = deleteRuleIfExists(&rules[0])
+		require.NoError(t, err)
+		require.False(t, deleted)
+		return nil
+	})
 }
 
 func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr) {

--- a/pkg/endpoint/api/cell.go
+++ b/pkg/endpoint/api/cell.go
@@ -58,10 +58,11 @@ type endpointAPIManagerParams struct {
 
 	Logger *slog.Logger
 
-	EndpointManager   endpointmanager.EndpointManager
-	EndpointCreator   endpointcreator.EndpointCreator
-	EndpointCreations EndpointCreationManager
-	EndpointMetadata  endpointmetadata.EndpointMetadataFetcher
+	EndpointManager       endpointmanager.EndpointManager
+	EndpointCreator       endpointcreator.EndpointCreator
+	EndpointCreations     EndpointCreationManager
+	EndpointMetadata      endpointmetadata.EndpointMetadataFetcher
+	EndpointRoutingWaiter endpointmanager.EndpointRoutingWaiter
 
 	BandwidthManager bandwidth.Manager
 	Clientset        k8sClient.Clientset
@@ -71,15 +72,16 @@ type endpointAPIManagerParams struct {
 
 func newEndpointAPIManager(params endpointAPIManagerParams) EndpointAPIManager {
 	return &endpointAPIManager{
-		logger:            params.Logger,
-		endpointManager:   params.EndpointManager,
-		endpointCreator:   params.EndpointCreator,
-		endpointCreations: params.EndpointCreations,
-		endpointMetadata:  params.EndpointMetadata,
-		bandwidthManager:  params.BandwidthManager,
-		clientset:         params.Clientset,
-		cniConfigManager:  params.CNIConfigManager,
-		ipam:              params.IPAM,
+		logger:                params.Logger,
+		endpointManager:       params.EndpointManager,
+		endpointCreator:       params.EndpointCreator,
+		endpointCreations:     params.EndpointCreations,
+		endpointMetadata:      params.EndpointMetadata,
+		endpointRoutingWaiter: params.EndpointRoutingWaiter,
+		bandwidthManager:      params.BandwidthManager,
+		clientset:             params.Clientset,
+		cniConfigManager:      params.CNIConfigManager,
+		ipam:                  params.IPAM,
 	}
 }
 

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -52,10 +52,11 @@ type EndpointAPIManager interface {
 type endpointAPIManager struct {
 	logger *slog.Logger
 
-	endpointManager   endpointmanager.EndpointManager
-	endpointCreator   endpointcreator.EndpointCreator
-	endpointCreations EndpointCreationManager
-	endpointMetadata  endpointmetadata.EndpointMetadataFetcher
+	endpointManager       endpointmanager.EndpointManager
+	endpointCreator       endpointcreator.EndpointCreator
+	endpointCreations     EndpointCreationManager
+	endpointMetadata      endpointmetadata.EndpointMetadataFetcher
+	endpointRoutingWaiter endpointmanager.EndpointRoutingWaiter
 
 	bandwidthManager bandwidth.Manager
 	clientset        k8sClient.Clientset
@@ -336,6 +337,10 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 		if err := ep.WaitForFirstRegeneration(ctx); err != nil {
 			return m.errorDuringCreation(ep, err)
 		}
+	}
+
+	if err := m.endpointRoutingWaiter.WaitForEndpointRouting(ctx, ep); err != nil {
+		return m.errorDuringCreation(ep, fmt.Errorf("unable to reconcile endpoint routing: %w", err))
 	}
 
 	// The endpoint has been successfully created, stop the expiration

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1260,12 +1260,10 @@ type DeleteConfig struct {
 	NoIdentityRelease bool
 
 	// EndpointOwnsIP reports whether the given IP is still owned by the
-	// endpoint being deleted. It guards the per-endpoint routing rule
-	// teardown against a stale delete: in ENI/Azure IPAM mode the rules are
-	// keyed solely by IP address, so a late teardown for an IP that has since
-	// been reused by another endpoint would otherwise strip the live owner's
-	// rules, silently breaking its egress. When nil, the check is skipped and
-	// rules are always deleted.
+	// endpoint being deleted. It guards synchronous endpoint routing cleanup
+	// against a stale delete after IP reuse. Cloud IPAM uses it before replacing
+	// the endpoint route with an unreachable route, while delegated IPAM also
+	// uses it before deleting endpoint rules. When nil, the check is skipped.
 	EndpointOwnsIP func(ip netip.Addr) bool
 }
 
@@ -2746,39 +2744,46 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	}
 	e.setState(StateDisconnecting, "Deleting endpoint")
 
-	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure || option.Config.IPAM == ipamOption.IPAMAlibabaCloud ||
-		(option.Config.IPAM == ipamOption.IPAMDelegatedPlugin && option.Config.InstallUplinkRoutesForDelegatedIPAM) {
+	cloudIPAM := option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure || option.Config.IPAM == ipamOption.IPAMAlibabaCloud
+	delegatedRouting := option.Config.IPAM == ipamOption.IPAMDelegatedPlugin && option.Config.InstallUplinkRoutesForDelegatedIPAM
+	if (cloudIPAM && option.Config.EnableUnreachableRoutes) || delegatedRouting {
 		e.getLogger().Debug(
-			"Deleting endpoint routing rules",
+			"Cleaning up endpoint routing",
 		)
 
-		// This is a best-effort attempt to cleanup. We expect there to be one
-		// ingress rule and multiple egress rules. If we find more rules than
-		// expected, we delete all rules referring to a per-ENI routing table ID.
-		//
-		// The routing rules are keyed solely by IP address, so a stale teardown
-		// for an IP that has since been reused by another endpoint would strip
-		// the live owner's rules. Guard against that by only deleting the rules
-		// if this endpoint still owns the IP.
-		deleteRoutingRules := func(ip netip.Addr) {
+		// Endpoint routing is keyed solely by IP address. Guard synchronous
+		// cleanup so that a stale teardown cannot alter routing for a new endpoint
+		// which has reused the address.
+		cleanupEndpointRouting := func(ip netip.Addr) {
 			if conf.EndpointOwnsIP != nil && !conf.EndpointOwnsIP(ip) {
 				e.getLogger().Info(
-					"Skipping deletion of endpoint routing rules: IP is no longer owned by this endpoint",
+					"Skipping endpoint routing cleanup: IP is no longer owned by this endpoint",
 					logfields.IPAddr, ip,
 				)
 				return
 			}
-			if err := linuxrouting.Delete(e.getLogger(), ip); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
+
+			var err error
+			if cloudIPAM {
+				// The reconciler owns cloud routing rules. Keep the unreachable
+				// route synchronous so the endpoint IP is blocked before release.
+				err = linuxrouting.InstallUnreachableRoute(ip)
+			} else {
+				// Delegated routing metadata is unavailable to the reconciler, so
+				// its rules and unreachable route remain synchronously managed.
+				err = linuxrouting.Delete(e.getLogger(), ip)
+			}
+			if err != nil {
+				errs = append(errs, fmt.Errorf("unable to clean up endpoint routing: %w", err))
 			}
 		}
 
 		if e.IPv4.IsValid() {
-			deleteRoutingRules(e.IPv4)
+			cleanupEndpointRouting(e.IPv4)
 		}
 
 		if e.IPv6.IsValid() {
-			deleteRoutingRules(e.IPv6)
+			cleanupEndpointRouting(e.IPv6)
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -155,6 +155,10 @@ type Endpoint struct {
 	// recalculated on endpoint restore.
 	createdAt time.Time
 
+	// lifecycleGeneration uniquely identifies a period during which this
+	// Endpoint object is exposed by the endpoint manager.
+	lifecycleGeneration uint64
+
 	initialEnvoyPolicyComputed chan struct{}
 
 	// mutex protects write operations to this endpoint structure
@@ -630,7 +634,6 @@ func createEndpoint(
 		policyDebugLog:     policyDebugLog,
 		forcePolicyCompute: true,
 	}
-
 	ep.initialEnvoyPolicyComputed = make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/endpoint/identifiers.go
+++ b/pkg/endpoint/identifiers.go
@@ -79,6 +79,19 @@ func (e *Endpoint) GetContainerID() string {
 	return *cid
 }
 
+// GetLifecycleGeneration returns the generation identifying the endpoint's
+// current managed lifecycle.
+func (e *Endpoint) GetLifecycleGeneration() uint64 {
+	return e.lifecycleGeneration
+}
+
+// InitLifecycleGeneration assigns the generation identifying the endpoint's
+// next managed lifecycle. It must be called before the endpoint is exposed and
+// the generation must remain unchanged until the endpoint is unexposed.
+func (e *Endpoint) InitLifecycleGeneration(generation uint64) {
+	e.lifecycleGeneration = generation
+}
+
 // GetShortContainerID returns the endpoint's shortened container ID
 func (e *Endpoint) GetShortContainerID() string {
 	if e == nil {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -497,11 +497,11 @@ func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.
 
 	mgr.unexpose(ep)
 
-	// Guard the per-endpoint routing rule teardown against a stale delete. By
+	// Guard synchronous endpoint routing cleanup against a stale delete. By
 	// this point unexpose has removed ep from the IP index, so LookupIP returns
-	// nil when no one owns the IP (safe to delete our rules) and the new owner
-	// when the IP has already been reused (skip, deleting would strip its
-	// rules). It can never return ep itself.
+	// nil when no one owns the IP (safe to clean up) and the new owner when the
+	// IP has already been reused (skip, cleanup would disrupt its routing). It
+	// can never return ep itself.
 	conf.EndpointOwnsIP = func(ip netip.Addr) bool {
 		owner := mgr.LookupIP(ip)
 		return owner == nil || owner == ep

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -56,8 +56,12 @@ type endpointManager struct {
 
 	health cell.Health
 
-	// mutex protects endpoints and endpointsAux
+	// mutex protects endpoints, endpointsAux, and nextLifecycleGeneration.
 	mutex lock.RWMutex
+
+	// nextLifecycleGeneration assigns a unique generation to each endpoint
+	// exposed during this manager's lifetime.
+	nextLifecycleGeneration uint64
 
 	// endpoints is the global list of endpoints indexed by ID. mutex must
 	// be held to read and write.
@@ -680,6 +684,8 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	// Get a copy of the identifiers before exposing the endpoint
 	identifiers := ep.Identifiers()
 	ep.PolicyMapPressureUpdater = mgr.policyMapPressure
+	mgr.nextLifecycleGeneration++
+	ep.InitLifecycleGeneration(mgr.nextLifecycleGeneration)
 	ep.Start(newID)
 	mgr.mcastManager.AddAddress(ep.IPv6)
 	mgr.updateIDReferenceLocked(ep)

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -126,6 +126,36 @@ func TestWaitForProxyCompletionsReturnsBlockingCompletionDetailsOnTimeout(t *tes
 	require.ErrorContains(t, err, "Waiting on "+blockingCompletionID)
 }
 
+func TestExposeAssignsLifecycleGeneration(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	newEndpoint := func(id int) *endpoint.Endpoint {
+		ep, err := endpoint.NewEndpointFromChangeModel(
+			makeTestEndpointParams(logger, s.repo),
+			nil,
+			&endpoint.FakeEndpointProxy{},
+			newTestEndpointModel(id, endpoint.StateReady),
+			nil,
+		)
+		require.NoError(t, err)
+		t.Cleanup(ep.Stop)
+		return ep
+	}
+
+	first := newEndpoint(1)
+	second := newEndpoint(2)
+	require.Zero(t, first.GetLifecycleGeneration())
+	require.Zero(t, second.GetLifecycleGeneration())
+
+	require.NoError(t, mgr.expose(first))
+	require.NoError(t, mgr.expose(second))
+	require.NotZero(t, first.GetLifecycleGeneration())
+	require.NotZero(t, second.GetLifecycleGeneration())
+	require.NotEqual(t, first.GetLifecycleGeneration(), second.GetLifecycleGeneration())
+}
+
 func TestLookup(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 

--- a/pkg/endpointmanager/routing.go
+++ b/pkg/endpointmanager/routing.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+)
+
+// EndpointRoutingWaiter waits until agent-managed routes and rules for cloud
+// vendor IPAM endpoints have been reconciled. It is called after
+// EndpointManager.AddEndpoint has returned.
+type EndpointRoutingWaiter interface {
+	WaitForEndpointRouting(context.Context, *endpoint.Endpoint) error
+}

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -396,7 +396,6 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		}
 		if err := ri.Configure(
 			healthIP,
-			mtuConfig.GetDeviceMTU(),
 			false,
 		); err != nil {
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %w", err)

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -29,7 +29,15 @@ var (
 
 	// ErrIPv6Disabled is returned when Ipv6 allocation is disabled
 	ErrIPv6Disabled = errors.New("IPv6 allocation disabled")
+
+	// ErrRoutingMetadataUnsupported is returned when an allocator cannot
+	// resolve routing metadata for a given address.
+	ErrRoutingMetadataUnsupported = errors.New("routing metadata lookup unsupported")
 )
+
+type routingMetadataResolver interface {
+	ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error)
+}
 
 func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	pool, err := ipam.metadata.GetIPPoolForPod(owner, family)
@@ -51,6 +59,27 @@ func (ipam *IPAM) AllocateIP(ip netip.Addr, owner string, pool Pool) error {
 func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	needSyncUpstream := false
 	return ipam.allocateIP(ip, owner, pool, needSyncUpstream)
+}
+
+// ResolveRoutingMetadata returns the routing metadata for an address without
+// changing its allocation or synchronizing any state upstream.
+func (ipam *IPAM) ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error) {
+	if !addr.IsValid() {
+		return nil, fmt.Errorf("invalid IP address: %v", addr)
+	}
+	addr = addr.Unmap()
+
+	ipam.allocatorMutex.RLock()
+	resolver := ipam.ipv6RoutingMetadataResolver
+	if addr.Is4() {
+		resolver = ipam.ipv4RoutingMetadataResolver
+	}
+	ipam.allocatorMutex.RUnlock()
+
+	if resolver == nil {
+		return nil, ErrRoutingMetadataUnsupported
+	}
+	return resolver.ResolveRoutingMetadata(addr, PoolOrDefault(string(pool)))
 }
 
 // AllocateIPString is identical to AllocateIP but takes a string

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -82,6 +82,23 @@ func (ipam *IPAM) ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*Allocatio
 	return resolver.ResolveRoutingMetadata(addr, PoolOrDefault(string(pool)))
 }
 
+// IsAllocatedIP reports whether addr is currently owned in any IPAM pool.
+func (ipam *IPAM) IsAllocatedIP(addr netip.Addr) bool {
+	if !addr.IsValid() {
+		return false
+	}
+	addr = addr.Unmap()
+
+	ipam.allocatorMutex.RLock()
+	defer ipam.allocatorMutex.RUnlock()
+	for _, owners := range ipam.owner {
+		if _, ok := owners[addr.String()]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // AllocateIPString is identical to AllocateIP but takes a string
 func (ipam *IPAM) AllocateIPString(ipAddr, owner string, pool Pool) error {
 	addr, err := netip.ParseAddr(ipAddr)

--- a/pkg/ipam/cloud_multipool.go
+++ b/pkg/ipam/cloud_multipool.go
@@ -39,7 +39,7 @@ func (a *cloudMultiPoolAllocator) enrichResult(result *AllocationResult, err err
 	// The node is only read by the resolver, so the pointer is handed over
 	// as-is: the multi-pool manager replaces it wholesale on every update and
 	// deep-copies it before any mutation, so it is effectively immutable.
-	enriched, enrichErr := a.resolver.ResolveRoutingMetadata(a.manager.getNode(), result.IP, result.IPPoolName)
+	enriched, enrichErr := a.ResolveRoutingMetadata(result.IP, result.IPPoolName)
 	if enrichErr != nil {
 		// The underlying Allocate* call already reserved the IP in the
 		// allocator. Release it to avoid leaking the reservation when the
@@ -50,6 +50,10 @@ func (a *cloudMultiPoolAllocator) enrichResult(result *AllocationResult, err err
 		return nil, enrichErr
 	}
 	return enriched, nil
+}
+
+func (a *cloudMultiPoolAllocator) ResolveRoutingMetadata(addr netip.Addr, pool Pool) (*AllocationResult, error) {
+	return a.resolver.ResolveRoutingMetadata(a.manager.getNode(), addr, pool)
 }
 
 func (a *cloudMultiPoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -683,7 +683,7 @@ type crdAllocator struct {
 }
 
 // newCRDAllocator creates a new CRD-backed IP allocator
-func newCRDAllocator(logger *slog.Logger, family Family, c *option.DaemonConfig, owner Owner, localNodeStore *node.LocalNodeStore, clientset client.Clientset, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration, sysctl sysctl.Sysctl, ipMasqAgent *ipmasq.IPMasqAgent) Allocator {
+func newCRDAllocator(logger *slog.Logger, family Family, c *option.DaemonConfig, owner Owner, localNodeStore *node.LocalNodeStore, clientset client.Clientset, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration, sysctl sysctl.Sysctl, ipMasqAgent *ipmasq.IPMasqAgent) *crdAllocator {
 	initNodeStore.Do(func() {
 		sharedNodeStore = newNodeStore(logger, nodeTypes.GetName(), c, owner, localNodeStore, clientset, k8sEventReg, mtuConfig, sysctl)
 	})
@@ -700,6 +700,17 @@ func newCRDAllocator(logger *slog.Logger, family Family, c *option.DaemonConfig,
 	sharedNodeStore.addAllocator(allocator)
 
 	return allocator
+}
+
+func (a *crdAllocator) ResolveRoutingMetadata(addr netip.Addr, _ Pool) (*AllocationResult, error) {
+	a.mutex.RLock()
+	ipInfo, allocated := a.allocated[addr.String()]
+	a.mutex.RUnlock()
+	if !allocated {
+		return nil, fmt.Errorf("IP %s is not allocated", addr)
+	}
+
+	return a.buildAllocationResult(addr, &ipInfo)
 }
 
 func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.AllocationIP) (result *AllocationResult, err error) {

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -339,4 +340,56 @@ func TestAutoDetectIPv4NativeRoutingCIDR(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "10.10.0.0/16", localNode.Local.IPv4NativeRoutingCIDR.String())
 	})
+}
+
+func TestAlibabaCloudRoutingMetadata(t *testing.T) {
+	const resource = "eni-1"
+	addr := netip.MustParseAddr("10.10.1.5")
+	subnet := netip.MustParsePrefix("10.10.1.0/24")
+
+	cn := newCiliumNode("node1", 4, 4, 0)
+	cn.Spec.IPAM.Pool[addr.String()] = ipamTypes.AllocationIP{Resource: resource}
+	cn.Status.AlibabaCloud.ENIs = map[string]alibabaCloudTypes.ENI{
+		resource: {
+			NetworkInterfaceID: resource,
+			MACAddress:         "00:00:5e:00:53:01",
+			VSwitch: alibabaCloudTypes.VSwitch{
+				CIDRBlock: iputil.PrefixFrom(subnet),
+			},
+			Tags: map[string]string{"cilium-eni-index": "1"},
+		},
+	}
+
+	conf := testDaemonConfig()
+	conf.IPAM = ipamOption.IPAMAlibabaCloud
+	conf.EnableIPv6 = true
+	initNodeStore.Do(func() {}) // Ensure the real initNodeStore is not called
+	sharedNodeStore = newFakeNodeStore(conf, t)
+	sharedNodeStore.ownNode = cn
+
+	ipam := NewIPAM(NewIPAMParams{
+		Logger:         hivetest.Logger(t),
+		NodeAddressing: fakenode.NewAddressing(),
+		AgentConfig:    conf,
+		NodeDiscovery:  &ownerMock{},
+		LocalNodeStore: node.NewTestLocalNodeStore(node.LocalNode{}),
+		K8sEventReg:    &ownerMock{},
+		NodeResource:   &resourceMock{},
+		MTUConfig:      &mtuMock,
+	})
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
+
+	result, err := ipam.ipv4Allocator.Allocate(addr, "test1", PoolDefault())
+	require.NoError(t, err)
+
+	resolved, err := ipam.ResolveRoutingMetadata(addr, PoolDefault())
+	require.NoError(t, err)
+	require.Equal(t, result, resolved)
+	require.Equal(t, mac.MustParseMAC("00:00:5e:00:53:01"), resolved.PrimaryMAC)
+	require.Equal(t, "1", resolved.InterfaceNumber)
+	require.Equal(t, netip.MustParseAddr("10.10.1.253"), resolved.GatewayIP)
+	require.Equal(t, []netip.Prefix{subnet}, resolved.CIDRs)
+
+	_, err = ipam.ResolveRoutingMetadata(netip.MustParseAddr("2001:db8::1"), PoolDefault())
+	require.ErrorIs(t, err, ErrRoutingMetadataUnsupported)
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -273,6 +273,14 @@ func TestAzureIPMasq(t *testing.T) {
 		result.CIDRs,
 	)
 
+	resolved, err := ipam.ResolveRoutingMetadata(epipv4, PoolDefault())
+	require.NoError(t, err)
+	require.Equal(t, result.IP, resolved.IP)
+	require.Equal(t, result.PrimaryMAC, resolved.PrimaryMAC)
+	require.Equal(t, result.GatewayIP, resolved.GatewayIP)
+	require.Equal(t, result.InterfaceNumber, resolved.InterfaceNumber)
+	require.ElementsMatch(t, result.CIDRs, resolved.CIDRs)
+
 	ipMasqAgent.Stop()
 }
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -151,9 +151,11 @@ func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 		}
 		if ipam.config.IPv6Enabled() {
 			ipam.ipv6Allocator = v6Allocator
+			ipam.ipv6RoutingMetadataResolver = v6Allocator
 		}
 		if ipam.config.IPv4Enabled() {
 			ipam.ipv4Allocator = v4Allocator
+			ipam.ipv4RoutingMetadataResolver = v4Allocator
 		}
 
 		return nil

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -119,6 +119,7 @@ func NewIPAM(params NewIPAMParams) *IPAM {
 		podIPPools:                params.PodIPPools,
 		onlyMasqueradeDefaultPool: params.OnlyMasqueradeDefaultPool,
 		cloudProviders:            params.CloudProviders,
+		restoreFinished:           make(chan struct{}),
 	}
 }
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -217,6 +217,9 @@ func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 		if ipam.config.IPv6Enabled() {
 			allocator := newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 			ipam.ipv6Allocator = allocator
+			// Do not register AlibabaCloud as the IPv6 routing metadata resolver:
+			// it only supplies IPv4 metadata, so resolving an IPv6 endpoint for
+			// routing-rule reconciliation would fail.
 			if ipam.config.IPAMMode() == ipamOption.IPAMAzure {
 				ipam.ipv6RoutingMetadataResolver = allocator
 			}
@@ -225,7 +228,8 @@ func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 		if ipam.config.IPv4Enabled() {
 			allocator := newCRDAllocator(ipam.logger, IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 			ipam.ipv4Allocator = allocator
-			if ipam.config.IPAMMode() == ipamOption.IPAMAzure {
+			if ipam.config.IPAMMode() == ipamOption.IPAMAzure ||
+				ipam.config.IPAMMode() == ipamOption.IPAMAlibabaCloud {
 				ipam.ipv4RoutingMetadataResolver = allocator
 			}
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -215,11 +215,19 @@ func (ipam *IPAM) ConfigureAllocator(ctx context.Context) error {
 	case ipamOption.IPAMCRD, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		ipam.logger.Info("Initializing CRD-based IPAM")
 		if ipam.config.IPv6Enabled() {
-			ipam.ipv6Allocator = newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			allocator := newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			ipam.ipv6Allocator = allocator
+			if ipam.config.IPAMMode() == ipamOption.IPAMAzure {
+				ipam.ipv6RoutingMetadataResolver = allocator
+			}
 		}
 
 		if ipam.config.IPv4Enabled() {
-			ipam.ipv4Allocator = newCRDAllocator(ipam.logger, IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			allocator := newCRDAllocator(ipam.logger, IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			ipam.ipv4Allocator = allocator
+			if ipam.config.IPAMMode() == ipamOption.IPAMAzure {
+				ipam.ipv4RoutingMetadataResolver = allocator
+			}
 		}
 	case ipamOption.IPAMDelegatedPlugin:
 		ipam.logger.Info("Initializing no-op IPAM since we're using a CNI delegated plugin")

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -209,6 +209,30 @@ func TestRestoreReadiness(t *testing.T) {
 	require.NotPanics(t, ipam.RestoreFinished)
 }
 
+func TestIsAllocatedIP(t *testing.T) {
+	fakeAddressing := fakenode.NewAddressing()
+	ipam := NewIPAM(NewIPAMParams{
+		Logger:         hivetest.Logger(t),
+		NodeAddressing: fakeAddressing,
+		AgentConfig:    testConfiguration,
+		NodeDiscovery:  &ownerMock{},
+		LocalNodeStore: node.NewTestLocalNodeStore(node.LocalNode{}),
+		K8sEventReg:    &ownerMock{},
+		NodeResource:   &resourceMock{},
+		MTUConfig:      &mtuMock,
+	})
+	require.NoError(t, ipam.ConfigureAllocator(t.Context()))
+
+	addr := fakeIPv4AllocCIDRIP(fakeAddressing).Next()
+	_, err := ipam.AllocateIPWithoutSyncUpstream(addr, "test-owner", PoolDefault())
+	require.NoError(t, err)
+
+	require.True(t, ipam.IsAllocatedIP(addr))
+	require.True(t, ipam.IsAllocatedIP(netip.MustParseAddr("::ffff:"+addr.String())))
+	require.False(t, ipam.IsAllocatedIP(netip.Addr{}))
+	require.False(t, ipam.IsAllocatedIP(addr.Next()))
+}
+
 func TestIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakenode.NewAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -4,6 +4,7 @@
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"net/netip"
@@ -190,6 +191,22 @@ func TestExcludeIP(t *testing.T) {
 func TestDeriveFamily(t *testing.T) {
 	require.Equal(t, IPv4, DeriveFamily(netip.MustParseAddr("1.1.1.1")))
 	require.Equal(t, IPv6, DeriveFamily(netip.MustParseAddr("f00d::1")))
+}
+
+func TestRestoreReadiness(t *testing.T) {
+	ipam := NewIPAM(NewIPAMParams{
+		Logger:      hivetest.Logger(t),
+		AgentConfig: &option.DaemonConfig{},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, ipam.WaitForRestoreFinished(ctx), context.Canceled)
+
+	ipam.RestoreFinished()
+	require.NoError(t, ipam.WaitForRestoreFinished(t.Context()))
+	// RestoreFinished may be reported by more than one shutdown/restoration path.
+	require.NotPanics(t, ipam.RestoreFinished)
 }
 
 func TestIPAMMetadata(t *testing.T) {

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -57,8 +57,9 @@ type AllocationResult struct {
 	// only set if AllocateNextWithExpiration is used.
 	ExpirationUUID string
 
-	// InterfaceNumber is a field for generically identifying an interface.
-	// This is only useful in ENI mode.
+	// InterfaceNumber identifies a cloud interface using provider-specific
+	// numbering. ENI and AlibabaCloud use it to derive the per-interface
+	// routing table.
 	InterfaceNumber string
 
 	// SkipMasquerade indicates whether the datapath should avoid masquerading connections from this IP when the cluster is in tunneling mode.

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -106,6 +106,9 @@ type IPAM struct {
 	ipv6Allocator Allocator
 	ipv4Allocator Allocator
 
+	ipv6RoutingMetadataResolver routingMetadataResolver
+	ipv4RoutingMetadataResolver routingMetadataResolver
+
 	// metadata provides information about a particular IP owner.
 	metadata Metadata
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -4,8 +4,10 @@
 package ipam
 
 import (
+	"context"
 	"log/slog"
 	"net/netip"
+	"sync"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -146,6 +148,9 @@ type IPAM struct {
 	// cloudProviders holds the registered cloud providers, keyed by the IPAM
 	// mode each one handles.
 	cloudProviders map[string]CloudProvider
+
+	restoreFinished     chan struct{}
+	restoreFinishedOnce sync.Once
 }
 
 func (ipam *IPAM) EndpointCreated(ep *endpoint.Endpoint) {}
@@ -174,6 +179,18 @@ func (ipam *IPAM) RestoreFinished() {
 	}
 	if ipam.config.EnableIPv4 {
 		ipam.ipv4Allocator.RestoreFinished()
+	}
+	ipam.restoreFinishedOnce.Do(func() { close(ipam.restoreFinished) })
+}
+
+// WaitForRestoreFinished waits until IPAM has restored endpoint allocations and
+// the agent has allocated its infrastructure addresses.
+func (ipam *IPAM) WaitForRestoreFinished(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ipam.restoreFinished:
+		return nil
 	}
 }
 

--- a/pkg/testutils/scriptnet/scriptnet.go
+++ b/pkg/testutils/scriptnet/scriptnet.go
@@ -123,6 +123,9 @@ func (nsm *NetNSManager) Commands() map[string]script.Cmd {
 		"route/add":     routeAddCmd(nsm),
 		"route/replace": routeReplaceCmd(nsm),
 		"route/del":     routeDelCmd(nsm),
+		"rule/list":     ruleListCmd(nsm),
+		"rule/add":      ruleAddCmd(nsm),
+		"rule/del":      ruleDelCmd(nsm),
 		"sysctl/get":    sysctlGetCmd(nsm),
 		"sysctl/set":    sysctlSetCmd(nsm),
 	}
@@ -588,6 +591,333 @@ func addAddCmd(nsm *NetNSManager) script.Cmd {
 			}, err
 		},
 	)
+}
+
+func ruleFamily(value string, allowAll bool) (int, error) {
+	switch value {
+	case "ipv4":
+		return netlink.FAMILY_V4, nil
+	case "ipv6":
+		return netlink.FAMILY_V6, nil
+	case "all":
+		if allowAll {
+			return netlink.FAMILY_ALL, nil
+		}
+	}
+	valid := "'ipv4', 'ipv6'"
+	if allowAll {
+		valid += ", 'all'"
+	}
+	return 0, fmt.Errorf("invalid family %q: must be one of %s", value, valid)
+}
+
+func ruleTable(value string, allowAll bool) (int, error) {
+	switch value {
+	case "main":
+		return unix.RT_TABLE_MAIN, nil
+	case "local":
+		return unix.RT_TABLE_LOCAL, nil
+	case "default":
+		return unix.RT_TABLE_DEFAULT, nil
+	case "all":
+		if allowAll {
+			return unix.RT_TABLE_UNSPEC, nil
+		}
+	}
+
+	table, err := strconv.Atoi(value)
+	if err != nil {
+		valid := "'main', 'local', 'default'"
+		if allowAll {
+			valid += ", 'all'"
+		}
+		return 0, fmt.Errorf("invalid table %q: must be an integer or one of %s", value, valid)
+	}
+	return table, nil
+}
+
+func ruleProtocol(value string) (uint8, error) {
+	switch value {
+	case "kernel":
+		return unix.RTPROT_KERNEL, nil
+	case "static":
+		return unix.RTPROT_STATIC, nil
+	case "unspec":
+		return unix.RTPROT_UNSPEC, nil
+	}
+
+	protocol, err := strconv.ParseUint(value, 10, 8)
+	if err != nil {
+		return 0, fmt.Errorf("invalid protocol %q: must be an integer or one of 'kernel', 'static', 'unspec'", value)
+	}
+	return uint8(protocol), nil
+}
+
+func rulePrefix(value string) (*net.IPNet, error) {
+	if value == "all" {
+		return nil, nil
+	}
+
+	prefix, err := netlink.ParseIPNet(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rule prefix %q: %w", value, err)
+	}
+	return prefix, nil
+}
+
+func ruleFlags(fs *pflag.FlagSet, family, table string) {
+	fs.String("netns", "", "Execute in the specified network namespace")
+	fs.String("family", family, "Address family: ipv4, ipv6, or all")
+	fs.String("from", "all", "Source prefix")
+	fs.String("to", "all", "Destination prefix")
+	fs.Int("priority", -1, "Rule priority")
+	fs.String("table", table, "Routing table")
+	fs.String("protocol", "unspec", "Rule protocol")
+}
+
+func ruleFromFlags(fs *pflag.FlagSet, allowAll bool) (*netlink.Rule, error) {
+	rule := netlink.NewRule()
+
+	family, err := fs.GetString("family")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get family flag: %w", err)
+	}
+	rule.Family, err = ruleFamily(family, allowAll)
+	if err != nil {
+		return nil, err
+	}
+
+	from, err := fs.GetString("from")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get from flag: %w", err)
+	}
+	rule.Src, err = rulePrefix(from)
+	if err != nil {
+		return nil, err
+	}
+
+	to, err := fs.GetString("to")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get to flag: %w", err)
+	}
+	rule.Dst, err = rulePrefix(to)
+	if err != nil {
+		return nil, err
+	}
+
+	rule.Priority, err = fs.GetInt("priority")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get priority flag: %w", err)
+	}
+
+	table, err := fs.GetString("table")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get table flag: %w", err)
+	}
+	rule.Table, err = ruleTable(table, allowAll)
+	if err != nil {
+		return nil, err
+	}
+
+	protocol, err := fs.GetString("protocol")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get protocol flag: %w", err)
+	}
+	rule.Protocol, err = ruleProtocol(protocol)
+	if err != nil {
+		return nil, err
+	}
+
+	return rule, nil
+}
+
+func ruleAddCmd(nsm *NetNSManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Add a policy routing rule",
+			Args:    "",
+			Flags: func(fs *pflag.FlagSet) {
+				ruleFlags(fs, "ipv4", "main")
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 0 {
+				return nil, script.ErrUsage
+			}
+
+			rule, err := ruleFromFlags(s.Flags, false)
+			if err != nil {
+				return nil, err
+			}
+
+			nsName, err := s.Flags.GetString("netns")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get netns flag: %w", err)
+			}
+			if nsName == "" {
+				nsName = nsm.currentNamespaceName()
+			}
+
+			err = nsm.exec(nsName, func() error {
+				if err := netlink.RuleAdd(rule); err != nil {
+					return fmt.Errorf("failed to add rule: %w", err)
+				}
+				return nil
+			})
+			return nil, err
+		},
+	)
+}
+
+func ruleDelCmd(nsm *NetNSManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Delete a policy routing rule",
+			Args:    "",
+			Flags: func(fs *pflag.FlagSet) {
+				ruleFlags(fs, "ipv4", "main")
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 0 {
+				return nil, script.ErrUsage
+			}
+
+			rule, err := ruleFromFlags(s.Flags, false)
+			if err != nil {
+				return nil, err
+			}
+
+			nsName, err := s.Flags.GetString("netns")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get netns flag: %w", err)
+			}
+			if nsName == "" {
+				nsName = nsm.currentNamespaceName()
+			}
+
+			err = nsm.exec(nsName, func() error {
+				if err := netlink.RuleDel(rule); err != nil {
+					return fmt.Errorf("failed to delete rule: %w", err)
+				}
+				return nil
+			})
+			return nil, err
+		},
+	)
+}
+
+func ruleListCmd(nsm *NetNSManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List policy routing rules",
+			Args:    "",
+			Flags: func(fs *pflag.FlagSet) {
+				ruleFlags(fs, "all", "all")
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 0 {
+				return nil, script.ErrUsage
+			}
+
+			filter, err := ruleFromFlags(s.Flags, true)
+			if err != nil {
+				return nil, err
+			}
+
+			nsName, err := s.Flags.GetString("netns")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get netns flag: %w", err)
+			}
+			if nsName == "" {
+				nsName = nsm.currentNamespaceName()
+			}
+
+			var output []string
+			err = nsm.exec(nsName, func() error {
+				rules, err := safenetlink.RuleList(filter.Family)
+				if err != nil {
+					return fmt.Errorf("failed to list rules: %w", err)
+				}
+
+				for _, rule := range rules {
+					if s.Flags.Changed("from") && !ruleSelectorEqual(rule.Src, filter.Src) {
+						continue
+					}
+					if s.Flags.Changed("to") && !ruleSelectorEqual(rule.Dst, filter.Dst) {
+						continue
+					}
+					if filter.Priority >= 0 && rule.Priority != filter.Priority {
+						continue
+					}
+					if s.Flags.Changed("table") && filter.Table != unix.RT_TABLE_UNSPEC && rule.Table != filter.Table {
+						continue
+					}
+					if s.Flags.Changed("protocol") && rule.Protocol != filter.Protocol {
+						continue
+					}
+
+					output = append(output, formatRule(rule))
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			slices.Sort(output)
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				if len(output) == 0 {
+					return "", "", nil
+				}
+				return strings.Join(output, "\n") + "\n", "", nil
+			}, nil
+		},
+	)
+}
+
+func ruleSelectorEqual(a, b *net.IPNet) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.IP.Equal(b.IP) && slices.Equal(a.Mask, b.Mask)
+}
+
+func formatRule(rule netlink.Rule) string {
+	prefix := func(value *net.IPNet) string {
+		if value == nil {
+			return "all"
+		}
+		return value.String()
+	}
+	table := strconv.Itoa(rule.Table)
+	switch rule.Table {
+	case unix.RT_TABLE_MAIN:
+		table = "main"
+	case unix.RT_TABLE_LOCAL:
+		table = "local"
+	case unix.RT_TABLE_DEFAULT:
+		table = "default"
+	}
+	protocol := strconv.Itoa(int(rule.Protocol))
+	switch rule.Protocol {
+	case unix.RTPROT_KERNEL:
+		protocol = "kernel"
+	case unix.RTPROT_STATIC:
+		protocol = "static"
+	case unix.RTPROT_UNSPEC:
+		protocol = "unspec"
+	}
+
+	formatted := fmt.Sprintf("priority %d from %s to %s table %s protocol %s", rule.Priority, prefix(rule.Src), prefix(rule.Dst), table, protocol)
+	if rule.Mark != 0 {
+		formatted += fmt.Sprintf(" mark %#x", rule.Mark)
+	}
+	if rule.Mask != nil {
+		formatted += fmt.Sprintf(" mask %#x", *rule.Mask)
+	}
+	return formatted
 }
 
 func destinationString(via netlink.Destination) string {

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -824,14 +824,14 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 
 	if needsEndpointRoutingOnHost(conf) {
 		if ipam.IPv4 != nil && ipConfig != nil {
-			err = interfaceAdd(scopedLogger, ipConfig, ipam.IPv4, conf)
+			err = interfaceAdd(ipConfig, ipam.IPv4, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
 			}
 		}
 
 		if ipam.IPv6 != nil && ipv6Config != nil {
-			err = interfaceAdd(scopedLogger, ipv6Config, ipam.IPv6, conf)
+			err = interfaceAdd(ipv6Config, ipam.IPv6, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
 			}

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -651,17 +652,54 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			args.IfName, args.Netns, err)
 	}
 
-	var ipam *models.IPAMResponse
-	var releaseIPsFunc func(context.Context)
+	var (
+		ipam                 *models.IPAMResponse
+		releaseIPsFunc       func(context.Context)
+		endpointIPsToCleanup []netip.Addr
+		endpointCreated      bool
+	)
 	if conf.IpamMode == ipamOption.IPAMDelegatedPlugin {
 		ipam, releaseIPsFunc, err = allocateIPsWithDelegatedPlugin(context.TODO(), conf, n, args.StdinData)
 	} else {
 		ipam, releaseIPsFunc, err = allocateIPsWithCiliumAgent(scopedLogger, c, cniArgs)
 	}
 
-	// release addresses on failure
+	// Roll back CNI-owned state on failure. Once the endpoint has been created,
+	// its deletion owns the cleanup of Cilium-managed IPs and routing rules.
 	defer func() {
-		if err != nil && releaseIPsFunc != nil {
+		if err == nil {
+			return
+		}
+
+		if endpointCreated {
+			// Endpoint creation completed, so Cilium owns IP and routing cleanup.
+			if cleanupErr := c.EndpointDelete(endpointid.NewCNIAttachmentID(args.ContainerID, args.IfName)); cleanupErr != nil {
+				scopedLogger.Warn(
+					"Failed to delete endpoint after CNI ADD failure",
+					logfields.Error, cleanupErr,
+					logfields.ContainerID, args.ContainerID,
+				)
+			}
+
+			// Delegated IPAM addresses remain owned by the external plugin.
+			if conf.IpamMode == ipamOption.IPAMDelegatedPlugin && releaseIPsFunc != nil {
+				releaseIPsFunc(context.TODO())
+			}
+			return
+		}
+
+		// Before endpoint creation, CNI owns and removes any rules it installed.
+		for _, addr := range endpointIPsToCleanup {
+			if cleanupErr := linuxrouting.DeleteRulesIfExists(scopedLogger, addr); cleanupErr != nil {
+				scopedLogger.Warn(
+					"Failed to clean up endpoint routing rules",
+					logfields.Error, cleanupErr,
+					logfields.IPAddr, addr,
+				)
+			}
+		}
+		// No endpoint owns the allocation yet, so CNI must release it.
+		if releaseIPsFunc != nil {
 			releaseIPsFunc(context.TODO())
 		}
 	}()
@@ -824,6 +862,9 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 
 	if needsEndpointRoutingOnHost(conf) {
 		if ipam.IPv4 != nil && ipConfig != nil {
+			if addr, ok := netipx.FromStdIP(ipConfig.Address.IP); ok {
+				endpointIPsToCleanup = append(endpointIPsToCleanup, addr)
+			}
 			err = interfaceAdd(ipConfig, ipam.IPv4, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
@@ -831,6 +872,9 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		}
 
 		if ipam.IPv6 != nil && ipv6Config != nil {
+			if addr, ok := netipx.FromStdIP(ipv6Config.Address.IP); ok {
+				endpointIPsToCleanup = append(endpointIPsToCleanup, addr)
+			}
 			err = interfaceAdd(ipv6Config, ipam.IPv6, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
@@ -898,6 +942,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		)
 		return fmt.Errorf("unable to create endpoint: %w", err)
 	}
+	endpointCreated = true
 	if newEp != nil && newEp.Status != nil && newEp.Status.Networking != nil && newEp.Status.Networking.Mac.IsValid() {
 		// Set the MAC address on the interface in the container namespace
 		if isLayer2 {

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -513,12 +513,12 @@ func configureCongestionControl(conf *models.DaemonConfigurationStatus, sysctl s
 	})
 }
 
-func ifindexFromMac(m mac.MAC) (int64, error) {
+func linkFromMac(m mac.MAC) (netlink.Link, error) {
 	var iface netlink.Link
 
 	links, err := safenetlink.LinkList()
 	if err != nil {
-		return -1, fmt.Errorf("unable to list interfaces: %w", err)
+		return nil, fmt.Errorf("unable to list interfaces: %w", err)
 	}
 
 	for _, l := range links {
@@ -529,16 +529,24 @@ func ifindexFromMac(m mac.MAC) (int64, error) {
 		}
 		if bytes.Equal(l.Attrs().HardwareAddr, m.HardwareAddr()) {
 			if iface != nil {
-				return -1, fmt.Errorf("several interfaces found with MAC %s: %s and %s", m, iface.Attrs().Name, l.Attrs().Name)
+				return nil, fmt.Errorf("several interfaces found with MAC %s: %s and %s", m, iface.Attrs().Name, l.Attrs().Name)
 			}
 			iface = l
 		}
 	}
 
 	if iface == nil {
-		return -1, fmt.Errorf("no interface found with MAC %s", m)
+		return nil, fmt.Errorf("no interface found with MAC %s", m)
 	}
 
+	return iface, nil
+}
+
+func ifindexFromMac(m mac.MAC) (int64, error) {
+	iface, err := linkFromMac(m)
+	if err != nil {
+		return -1, err
+	}
 	return int64(iface.Attrs().Index), nil
 }
 
@@ -860,6 +868,17 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		res.Routes = append(res.Routes, routes...)
 	}
 
+	// Keep parent-interface MTU and up-state preparation synchronous for cloud
+	// IPAM. Endpoint routes and rules are installed exclusively by the agent.
+	if needsCloudInterfaceConfiguration(conf) {
+		if err := configureCloudInterfaces(ipam, int(conf.DeviceMTU)); err != nil {
+			return fmt.Errorf("unable to configure cloud interface: %w", err)
+		}
+	}
+
+	// Cloud IPAM endpoint rules and routes are installed by the agent after
+	// endpoint creation. Delegated IPAM remains CNI-local because the agent
+	// cannot resolve its externally supplied routing metadata.
 	if needsEndpointRoutingOnHost(conf) {
 		if ipam.IPv4 != nil && ipConfig != nil {
 			if addr, ok := netipx.FromStdIP(ipConfig.Address.IP); ok {
@@ -1423,18 +1442,19 @@ func buildLogAttrsWithCNIArgs(logger *slog.Logger, cniArgs *types.ArgsSpec) *slo
 	)
 }
 
-// needsEndpointRoutingOnHost returns true if extra routes/rules need to be installed
-// on host for the Pod. This is needed for following IPAM modes:
-// - Cloud ENI IPAM modes.
-// - DelegatedPlugin mode with InstallUplinkRoutesForDelegatedIPAM set to true.
+// needsEndpointRoutingOnHost returns true if delegated IPAM requires extra
+// routes/rules to be installed on the host for the Pod.
 func needsEndpointRoutingOnHost(conf *models.DaemonConfigurationStatus) bool {
+	return conf.IpamMode == ipamOption.IPAMDelegatedPlugin && conf.InstallUplinkRoutesForDelegatedIPAM
+}
+
+func needsCloudInterfaceConfiguration(conf *models.DaemonConfigurationStatus) bool {
 	switch conf.IpamMode {
 	case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		return true
-	case ipamOption.IPAMDelegatedPlugin:
-		return conf.InstallUplinkRoutesForDelegatedIPAM
+	default:
+		return false
 	}
-	return false
 }
 
 const (

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -8,13 +8,53 @@ import (
 	"net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/vishvananda/netlink"
 	"go4.org/netipx"
 
 	"github.com/cilium/cilium/api/v1/models"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/mac"
 )
+
+func configureCloudInterfaces(ipam *models.IPAMResponse, mtu int) error {
+	if ipam == nil {
+		return fmt.Errorf("missing IPAM configuration")
+	}
+
+	configured := map[mac.MAC]struct{}{}
+	for _, address := range []*models.IPAMAddressResponse{ipam.IPv4, ipam.IPv6} {
+		// An absent gateway means that this response does not require host-side
+		// interface setup, matching the existing routing setup behavior.
+		if address == nil || !address.Gateway.IsValid() {
+			continue
+		}
+		if _, found := configured[address.MasterMac]; found {
+			continue
+		}
+
+		if err := configureCloudInterface(address.MasterMac, mtu); err != nil {
+			return err
+		}
+		configured[address.MasterMac] = struct{}{}
+	}
+	return nil
+}
+
+func configureCloudInterface(masterMAC mac.MAC, mtu int) error {
+	link, err := linkFromMac(masterMAC)
+	if err != nil {
+		return err
+	}
+	if err := netlink.LinkSetMTU(link, mtu); err != nil {
+		return fmt.Errorf("unable to change MTU of link %s to %d: %w", link.Attrs().Name, mtu, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("unable to set link %s up: %w", link.Attrs().Name, err)
+	}
+	return nil
+}
 
 func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf *models.DaemonConfigurationStatus) error {
 	if ipam == nil {

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -14,9 +13,10 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/ip"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
-func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf *models.DaemonConfigurationStatus) error {
+func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf *models.DaemonConfigurationStatus) error {
 	if ipam == nil {
 		return fmt.Errorf("missing IPAM configuration")
 	}
@@ -57,14 +57,22 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 		masq = conf.MasqueradeProtocols.IPv6
 	}
 
+	options := []linuxrouting.RoutingInfoOption{
+		linuxrouting.WithCIDRsAndMasquerade(coalescedCIDRs, masq),
+		// Ensure CNI ADD can repair interface MTU and state after a transient
+		// setup failure before installing endpoint routing state.
+		linuxrouting.WithMTU(int(conf.DeviceMTU)),
+		linuxrouting.WithLinkState(true),
+	}
+	if conf.IpamMode == ipamOption.IPAMAzure {
+		options = append(options, linuxrouting.WithCompatEgressPriority())
+	}
+
 	routingInfo, err := linuxrouting.NewRoutingInfo(
-		logger,
 		ipam.Gateway.String(),
-		coalescedCIDRs,
 		ipam.MasterMac,
 		ipam.InterfaceNumber,
-		conf.IpamMode,
-		masq,
+		options...,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %w", err)
@@ -72,7 +80,6 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 
 	if err := routingInfo.Configure(
 		ip.AddrFromIP(ipConfig.Address.IP),
-		int(conf.DeviceMTU),
 		false,
 	); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %w", err)


### PR DESCRIPTION
This is the final PR in a three-part series and is stacked on https://github.com/cilium/cilium/pull/48383 (refer to https://github.com/cilium/cilium/pull/47938 to see the intended final result).

After the previous PR, the agent reconciles the desired routing state and endpoint creation waits for reconciliation, but CNI and synchronous endpoint teardown still modify some of the same pod routes and rules. Keeping multiple owners allows the operations to race and prevents endpoint creation from being the authoritative result of routing setup.

For ENI, Azure, and AlibabaCloud IPAM, this PR removes pod route and policy-rule installation from CNI and leaves rule removal to the agent reconciler. Endpoint creation becomes the IP ownership boundary: failures before it release CNI-owned state, while failures afterward request endpoint deletion so the agent withdraws the desired routing state before releasing the address.

A privileged script tests exercise the complete ENI endpoint lifecycle through the production IPAM provider, endpoint manager, StateDB reconciler, and Linux routing implementation.

### Limitations and possible follow-ups

- Routing based on metadata supplied by delegated IPAM plugins remains CNI-managed because that metadata is unavailable to the agent.
- Parent-interface MTU and up-state preparation remains synchronous in CNI so it can repair transient device-configuration failures.
- Endpoint teardown still installs an unreachable route synchronously before releasing a cloud IP.
- AlibabaCloud IPv6 endpoint routing remains unsupported.
- Shared per-interface gateway routes still have two idempotent agent-side writers. In a follow-up it should be possible to centralize them in the existing desired-route reconciler and make endpoint rules depend on their reconciliation status too.

**Notes to reviewers**

Please review commit by commit for the implementation details.

```release-note
Move cloud-IPAM endpoint route and policy-rule management from CNI to the Cilium agent.
```

---

AIL3 - bot wrote code; human reviewed, adjusted and tested