### PR TITLE
operator: shut down when the controller-runtime manager fails

### DIFF
--- a/operator/pkg/controller-runtime/cell.go
+++ b/operator/pkg/controller-runtime/cell.go
@@ -82,9 +82,10 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		return nil, fmt.Errorf("failed to create new controller-runtime manager: %w", err)
 	}
 
+	// Fail closed when the manager fails, allowing for the pod to naturally restart + retry
 	params.JobGroup.Add(job.OneShot("manager", func(ctx context.Context, health cell.Health) error {
 		return mgr.Start(ctx)
-	}))
+	}, job.WithShutdown()))
 
 	return mgr, nil
 }


### PR DESCRIPTION
The controller-runtime manager is registered as a bare OneShot job:
 ```
   params.JobGroup.Add(job.OneShot("manager", func(ctx context.Context, health cell.Health) error {
        return mgr.Start(ctx)
    }))
```

Any failure from mgr.Start() is only counted in cilium_operator_hive_jobs_runs_failed. The process keeps running, /healthz keeps returning 200 and a leader elected operator keeps renewing its lease while every controller-runtime controller: Gateway API, CiliumEnvoyConfig, MCS-API service export, is gone, so the standby never takes over and the only recovery is a manual pod delete.

Add job.WithShutdown() so the failure is terminal: the process exits, the kubelet restarts the container and the lease is released.

I've encountered this issue on multiple of my clusters with the following log as a sample:
`20:52:02.877Z level=error msg="Could not wait for Cache to sync"
  module=operator.operator-controlplane.leader-lifecycle.controller-runtime
  controller=gateway controllerGroup=gateway.networking.k8s.io controllerKind=Gateway
  source="kind source: *v1.Node"
  error="failed to wait for gateway caches to sync kind source: *v1.Node: timed out waiting for cache to be synced for kind source: *v1.Node"

20:52:02.973Z level=error msg=Failed
  module=operator.operator-controlplane.leader-lifecycle.controller-runtime name=manager
  func="controller-runtime.newManager.func2 (pkg/controller-runtime/cell.go:85)"
  error="failed to wait for gateway caches to sync kind source: *v1.Node: timed out waiting for cache to be synced for kind source: *v1.Node"
  retry=1 remaining=<none> timeout=0s duration=2m0.379199688s`

The operator continues to startup fine and the error is only observable through logs. This results in MCS endpoints failing to sync with clustermesh, which can blackhole traffic cross-cluster.

Fixes: [#43130] [#32596]

This PR was prepared with AIL:3 (AI-assisted, human-directed and verified). I reviewed the change and own it.

```release-note  
The cilium-operator now exits when its controller-runtime manager fails, instead of continuing to run with its controllers stopped.
