### PR TITLE
policy: Regenerate endpoint holding a superseded policy

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1687,7 +1687,12 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	// detached policy.
 	if l4.users != nil {
 		l4.users[user] = struct{}{}
-	} else {
+	}
+	// A hold taken before Supersede keeps 'users' non-nil, so an endpoint can
+	// reach this point holding a policy that a newer one has already replaced.
+	// Its content is stale, so it must be regenerated to pick up the
+	// replacement, the same as when the policy was detached.
+	if l4.users == nil || l4.superseded {
 		go user.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
 			Reason:            regeneration.ReasonSelectorPolicyStale,
 			Message:           "selector policy has changed because of another endpoint with the same identity",


### PR DESCRIPTION
An endpoint takes a hold on its selector policy before registering as a
user of it in insertUser. If the policy is superseded in that window,
the endpoint registers on already-replaced content and, with no
regeneration scheduled, stays on it until the next periodic regeneration
(i.e. every 2m).

Today this cannot actually happen (i.e. this is not actually fixing any
observed bug), because every path that supersedes an in-use policy also
triggers a regeneration of the affected endpoints, which pulls them onto
the new policy. The only gap is in insertUser itself, which regenerated
on a detached policy but not on a superseded one.

This commit plugs that gap by triggering regeneration in that case too,
so the endpoint still recovers on its own in the case the surrounding
code flow stops guaranteeing a regeneration.

---

Related: https://github.com/cilium/cilium/pull/47642
