### PR TITLE
Fix cilium-cli clustermesh 'inspect-policy-default-cluster-local' command

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -44,6 +44,7 @@ cilium-operator-alibabacloud [flags]
       --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-extended-ip-protocols                               Enable traffic with extended IP protocols in datapath
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -46,6 +46,7 @@ cilium-operator-aws [flags]
       --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-extended-ip-protocols                               Enable traffic with extended IP protocols in datapath
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -46,6 +46,7 @@ cilium-operator-azure [flags]
       --enable-bgp-legacy-origin-attribute                         Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-extended-ip-protocols                               Enable traffic with extended IP protocols in datapath
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -48,6 +48,7 @@ cilium-operator-generic [flags]
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
+      --enable-extended-ip-protocols                               Enable traffic with extended IP protocols in datapath
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -58,6 +58,7 @@ cilium-operator [flags]
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
+      --enable-extended-ip-protocols                               Enable traffic with extended IP protocols in datapath
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.

--- a/Documentation/cmdref/cilium_clustermesh_inspect-policy-default-local-cluster.md
+++ b/Documentation/cmdref/cilium_clustermesh_inspect-policy-default-local-cluster.md
@@ -11,10 +11,10 @@ cilium clustermesh inspect-policy-default-local-cluster [flags]
 ### Options
 
 ```
-  -A, --all-namespaces     If present, list the resources across all namespace. Namespace in current context or specified with --namespace is ignored.
-  -h, --help               help for inspect-policy-default-local-cluster
-  -n, --namespace string   Namespace used for listing resources
-  -o, --output string      Output format. One of: json, summary (default "summary")
+  -A, --all-namespaces            If present, list the resources across all namespace. Namespace in current context or specified with --policy-namespace is ignored.
+  -h, --help                      help for inspect-policy-default-local-cluster
+  -o, --output string             Output format. One of: json, summary (default "summary")
+  -p, --policy-namespace string   Namespace used for listing policy resources
 ```
 
 ### Options inherited from parent commands
@@ -25,6 +25,7 @@ cilium clustermesh inspect-policy-default-local-cluster [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -352,7 +352,7 @@ Migrating network policies in practice
 
 The command ``cilium clustermesh inspect-policy-default-local-cluster --all-namespaces`` can help you
 discover all the policies that will change as a result of changing ``policy-default-local-cluster``.
-You can also replace ``--all-namespaces`` with ``-n my-namespace`` if you want to only inspect
+You can also replace ``--all-namespaces`` with ``-p my-namespace`` if you want to only inspect
 policies from a particular namespace.
 
 Below is an example where there is one network policy that needs to be updated:

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -221,8 +221,8 @@ func newCmdClusterMeshPolicyDefaultClusterInspect() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace used for listing resources")
-	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", allNamespaces, "If present, list the resources across all namespace. Namespace in current context or specified with --namespace is ignored.")
+	cmd.Flags().StringVarP(&namespace, "policy-namespace", "p", namespace, "Namespace used for listing policy resources")
+	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", allNamespaces, "If present, list the resources across all namespace. Namespace in current context or specified with --policy-namespace is ignored.")
 	cmd.Flags().StringVarP(&output, "output", "o", output, "Output format. One of: json, summary")
 
 	return cmd

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -6,16 +6,21 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/cilium-cli/clustermesh"
+	"github.com/cilium/cilium/cilium-cli/config"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/status"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func newCmdClusterMesh() *cobra.Command {
@@ -191,6 +196,12 @@ func newCmdClusterMeshPolicyDefaultClusterInspect() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var err error
+
+			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			if err = populatePolicyOptionsFromConfigMap(cmd.Context(), logger); err != nil {
+				fatalf("Unable to parse Cilium configuration: %s", err)
+			}
+
 			if namespace == "" {
 				if namespace, _, err = RootK8sClient.RESTClientGetter.ToRawKubeConfigLoader().Namespace(); err != nil {
 					namespace = metav1.NamespaceDefault
@@ -199,7 +210,7 @@ func newCmdClusterMeshPolicyDefaultClusterInspect() *cobra.Command {
 			if allNamespaces {
 				namespace = corev1.NamespaceAll
 			}
-			res, err := clustermesh.PolicyDefaultLocalClusterInspect(cmd.Context(), RootK8sClient, namespace)
+			res, err := clustermesh.PolicyDefaultLocalClusterInspect(cmd.Context(), logger, RootK8sClient, namespace)
 			if err != nil {
 				fatalf("Unable to inspect policy default local cluster: %s", err)
 			}
@@ -215,6 +226,30 @@ func newCmdClusterMeshPolicyDefaultClusterInspect() *cobra.Command {
 	cmd.Flags().StringVarP(&output, "output", "o", output, "Output format. One of: json, summary")
 
 	return cmd
+}
+
+func populatePolicyOptionsFromConfigMap(ctx context.Context, logger *slog.Logger) error {
+	vp := viper.New()
+	flags := pflag.NewFlagSet("cm-policy", pflag.ContinueOnError)
+
+	clusterConfig := config.NewK8sConfig(RootK8sClient, config.Parameters{
+		Namespace: RootParams.Namespace,
+	})
+	configMap, err := clusterConfig.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to get Cilium configuration: %w", err)
+	}
+
+	option.RegisterCommonPolicyFlags(vp, flags)
+	if err := vp.BindPFlags(flags); err != nil {
+		return fmt.Errorf("unable to bind policy validation flags: %w", err)
+	}
+	for key, value := range configMap {
+		vp.Set(key, value)
+	}
+
+	option.Config.Populate(logger, vp)
+	return nil
 }
 
 func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -16,7 +16,6 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -1850,8 +1849,7 @@ type PolicyDefaultLocalClusterInspectResult struct {
 	NetworkPolicies                  map[string]bool `json:"networkPolicies,omitempty"`
 }
 
-func PolicyDefaultLocalClusterInspect(ctx context.Context, k8sClient *k8s.Client, namespace string) (*PolicyDefaultLocalClusterInspectResult, error) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+func PolicyDefaultLocalClusterInspect(ctx context.Context, logger *slog.Logger, k8sClient *k8s.Client, namespace string) (*PolicyDefaultLocalClusterInspectResult, error) {
 	res := PolicyDefaultLocalClusterInspectResult{
 		CiliumNetworkPolicies:            map[string]bool{},
 		CiliumClusterWideNetworkPolicies: map[string]bool{},

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1858,54 +1858,57 @@ func PolicyDefaultLocalClusterInspect(ctx context.Context, logger *slog.Logger, 
 
 	nps, err := k8sClient.ListSlimNetworkPolicies(ctx, namespace, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Error listing network policies: %w", err)
+		return nil, fmt.Errorf("error listing network policies: %w", err)
 	}
 	for _, np := range nps.Items {
+		npKey := client.ObjectKeyFromObject(&np).String()
 		rulesAny, err := cmk8s.ParseNetworkPolicy(logger, cmtypes.PolicyAnyCluster, &np)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing network policies: %w", err)
+			return nil, fmt.Errorf("error parsing network policy(%s): %w", npKey, err)
 		}
 		rulesLocal, err := cmk8s.ParseNetworkPolicy(logger, "some-cluster", &np)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing network policies: %w", err)
+			return nil, fmt.Errorf("error parsing network policy(%s): %w", npKey, err)
 		}
 
-		res.NetworkPolicies[client.ObjectKeyFromObject(&np).String()] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *types.PolicyEntry) bool { return a.DeepEqual(b) })
+		res.NetworkPolicies[npKey] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *types.PolicyEntry) bool { return a.DeepEqual(b) })
 	}
 
 	cnps, err := k8sClient.ListCiliumNetworkPolicies(ctx, namespace, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Error listing Cilium network policies: %w", err)
+		return nil, fmt.Errorf("error listing Cilium network policies: %w", err)
 	}
 	for _, cnp := range cnps.Items {
+		cnpKey := client.ObjectKeyFromObject(&cnp).String()
 		rulesAny, err := cnp.Parse(logger, cmtypes.PolicyAnyCluster)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing Cilium network policies: %w", err)
+			return nil, fmt.Errorf("error parsing Cilium network policy(%s): %w", cnpKey, err)
 		}
 		rulesLocal, err := cnp.Parse(logger, "some-cluster")
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing Cilium network policies: %w", err)
+			return nil, fmt.Errorf("error parsing Cilium network policy(%s): %w", cnpKey, err)
 		}
 
-		res.CiliumNetworkPolicies[client.ObjectKeyFromObject(&cnp).String()] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *api.Rule) bool { return a.DeepEqual(b) })
+		res.CiliumNetworkPolicies[cnpKey] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *api.Rule) bool { return a.DeepEqual(b) })
 	}
 
 	if namespace == corev1.NamespaceAll {
 		ccnps, err := k8sClient.ListCiliumClusterwideNetworkPolicies(ctx, metav1.ListOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("Error listing Cilium Cluster Wide network policies: %w", err)
+			return nil, fmt.Errorf("error listing Cilium Cluster Wide network policies: %w", err)
 		}
 		for _, ccnp := range ccnps.Items {
+			ccnpKey := client.ObjectKeyFromObject(&ccnp).String()
 			rulesAny, err := ccnp.Parse(logger, cmtypes.PolicyAnyCluster)
 			if err != nil {
-				return nil, fmt.Errorf("Error parsing Cilium Cluster Wide network policies: %w", err)
+				return nil, fmt.Errorf("error parsing Cilium Cluster Wide network policy(%s): %w", ccnpKey, err)
 			}
 			rulesLocal, err := ccnp.Parse(logger, "some-cluster")
 			if err != nil {
-				return nil, fmt.Errorf("Error parsing Cilium Cluster Wide network policies: %w", err)
+				return nil, fmt.Errorf("error parsing Cilium Cluster Wide network policy(%s): %w", ccnpKey, err)
 			}
 
-			res.CiliumClusterWideNetworkPolicies[client.ObjectKeyFromObject(&ccnp).String()] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *api.Rule) bool { return a.DeepEqual(b) })
+			res.CiliumClusterWideNetworkPolicies[ccnpKey] = !slices.EqualFunc(rulesAny, rulesLocal, func(a, b *api.Rule) bool { return a.DeepEqual(b) })
 		}
 	}
 

--- a/cilium-cli/config/config.go
+++ b/cilium-cli/config/config.go
@@ -73,18 +73,27 @@ func (k *K8sConfig) Delete(ctx context.Context, key string, params Parameters) e
 	return k.restartPodsUponConfigChange(ctx, params)
 }
 
+func (k *K8sConfig) Get(ctx context.Context) (map[string]string, error) {
+	cm, err := k.client.GetConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get ConfigMap %q: %w", defaults.ConfigMapName, err)
+	}
+
+	return cm.Data, nil
+}
+
 func (k *K8sConfig) View(ctx context.Context) (string, error) {
 	var buf bytes.Buffer
 
 	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
 
-	cm, err := k.client.GetConfigMap(ctx, k.params.Namespace, defaults.ConfigMapName, metav1.GetOptions{})
+	data, err := k.Get(ctx)
 	if err != nil {
-		return "", fmt.Errorf("unable get ConfigMap %q: %w", defaults.ConfigMapName, err)
+		return "", err
 	}
 
-	for _, key := range slices.Sorted(maps.Keys(cm.Data)) {
-		fmt.Fprintf(w, "%s\t%s\n", key, cm.Data[key])
+	for _, key := range slices.Sorted(maps.Keys(data)) {
+		fmt.Fprintf(w, "%s\t%s\n", key, data[key])
 	}
 
 	w.Flush()

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -292,9 +292,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(vp, option.EnablePolicy)
 
-	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
-	option.BindEnv(vp, option.EnableL7Proxy)
-
 	flags.Bool(option.BPFEventsDropEnabled, defaults.BPFEventsDropEnabled, "Expose 'drop' events for Cilium monitor and/or Hubble")
 	option.BindEnv(vp, option.BPFEventsDropEnabled)
 
@@ -727,10 +724,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.DisableExternalIPMitigation, false, "Disable ExternalIP mitigation (CVE-2020-8554, default false)")
 	option.BindEnv(vp, option.DisableExternalIPMitigation)
 
-	flags.Bool(option.EnableICMPRules, defaults.EnableICMPRules, "Enable ICMP-based rule support for Cilium Network Policies")
-	flags.MarkHidden(option.EnableICMPRules)
-	option.BindEnv(vp, option.EnableICMPRules)
-
 	flags.Bool(option.BypassIPAvailabilityUponRestore, false, "Bypasses the IP availability error within IPAM upon endpoint restore")
 	flags.MarkHidden(option.BypassIPAvailabilityUponRestore)
 	option.BindEnv(vp, option.BypassIPAvailabilityUponRestore)
@@ -777,15 +770,8 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.MaxInternalTimerDelay)
 	option.BindEnv(vp, option.MaxInternalTimerDelay)
 
-	flags.Bool(option.EnableNodeSelectorLabels, defaults.EnableNodeSelectorLabels, "Enable use of node label based identity")
-	option.BindEnv(vp, option.EnableNodeSelectorLabels)
-
 	flags.StringSlice(option.NodeLabels, []string{}, "List of label prefixes used to determine identity of a node (used only when enable-node-selector-labels is enabled)")
 	option.BindEnv(vp, option.NodeLabels)
-
-	flags.Bool(option.EnableNonDefaultDenyPolicies, defaults.EnableNonDefaultDenyPolicies, "Enable use of non-default-deny policies")
-	flags.MarkHidden(option.EnableNonDefaultDenyPolicies)
-	option.BindEnv(vp, option.EnableNonDefaultDenyPolicies)
 
 	flags.Bool(option.EnableEndpointLockdownOnPolicyOverflow, false, "When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.")
 	option.BindEnv(vp, option.EnableEndpointLockdownOnPolicyOverflow)
@@ -797,9 +783,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(option.ConnectivityProbeFrequencyRatio, defaults.ConnectivityProbeFrequencyRatio, "Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size.")
 	option.BindEnv(vp, option.ConnectivityProbeFrequencyRatio)
 
-	flags.Bool(option.EnableExtendedIPProtocols, defaults.EnableExtendedIPProtocols, "Enable traffic with extended IP protocols in datapath")
-	option.BindEnv(vp, option.EnableExtendedIPProtocols)
-
 	flags.Uint8(option.IPTracingOptionType, 0, "Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.")
 	option.BindEnv(vp, option.IPTracingOptionType)
 
@@ -810,6 +793,8 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableDatapathPlugins, defaults.EnableDatapathPlugins, "Enable use of datapath plugins and the CiliumDatapathPlugins CRD")
 	flags.MarkHidden(option.EnableDatapathPlugins)
 	option.BindEnv(vp, option.EnableDatapathPlugins)
+
+	option.RegisterCommonPolicyFlags(vp, flags)
 
 	if err := vp.BindPFlags(flags); err != nil {
 		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -183,21 +183,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumClusterwideNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumClusterwideNetworkPolicy)
 
-	// Options used for policy validation
-
-	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
-	option.BindEnv(vp, option.EnableL7Proxy)
-
-	flags.Bool(option.EnableICMPRules, defaults.EnableICMPRules, "Enable ICMP-based rule support for Cilium Network Policies")
-	flags.MarkHidden(option.EnableICMPRules)
-	option.BindEnv(vp, option.EnableICMPRules)
-
-	flags.Bool(option.EnableNodeSelectorLabels, defaults.EnableNodeSelectorLabels, "Enable use of node label based identity")
-	option.BindEnv(vp, option.EnableNodeSelectorLabels)
-
 	flags.Bool(option.EnableCiliumNodeCRDName, defaults.EnableCiliumNodeCRD, "Enable CiliumNode CRD")
 	flags.MarkHidden(option.EnableCiliumNodeCRDName)
 	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
+
+	option.RegisterCommonPolicyFlags(vp, flags)
 
 	vp.BindPFlags(flags)
 }

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+// RegisterCommonPolicyFlags registers options used by policy validation.
+func RegisterCommonPolicyFlags(vp *viper.Viper, flags *pflag.FlagSet) {
+	flags.Bool(EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
+	BindEnv(vp, EnableL7Proxy)
+
+	flags.Bool(EnableICMPRules, defaults.EnableICMPRules, "Enable ICMP-based rule support for Cilium Network Policies")
+	flags.MarkHidden(EnableICMPRules)
+	BindEnv(vp, EnableICMPRules)
+
+	flags.Bool(EnableNodeSelectorLabels, defaults.EnableNodeSelectorLabels, "Enable use of node label based identity")
+	BindEnv(vp, EnableNodeSelectorLabels)
+
+	flags.Bool(EnableNonDefaultDenyPolicies, defaults.EnableNonDefaultDenyPolicies, "Enable use of non-default-deny policies")
+	flags.MarkHidden(EnableNonDefaultDenyPolicies)
+	BindEnv(vp, EnableNonDefaultDenyPolicies)
+
+	flags.Bool(EnableExtendedIPProtocols, defaults.EnableExtendedIPProtocols, "Enable traffic with extended IP protocols in datapath")
+	BindEnv(vp, EnableExtendedIPProtocols)
+}

--- a/pkg/option/flags_test.go
+++ b/pkg/option/flags_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+func TestRegisterCommonPolicyFlags(t *testing.T) {
+	vp := viper.New()
+	flags := pflag.NewFlagSet("policy-validation", pflag.ContinueOnError)
+	RegisterCommonPolicyFlags(vp, flags)
+	require.NoError(t, vp.BindPFlags(flags))
+
+	require.Equal(t, defaults.EnableL7Proxy, vp.GetBool(EnableL7Proxy))
+	require.Equal(t, defaults.EnableICMPRules, vp.GetBool(EnableICMPRules))
+	require.Equal(t, defaults.EnableNodeSelectorLabels, vp.GetBool(EnableNodeSelectorLabels))
+	require.Equal(t, defaults.EnableNonDefaultDenyPolicies, vp.GetBool(EnableNonDefaultDenyPolicies))
+	require.Equal(t, defaults.EnableExtendedIPProtocols, vp.GetBool(EnableExtendedIPProtocols))
+
+	vp.Set(EnableL7Proxy, "false")
+	vp.Set(EnableICMPRules, "false")
+	vp.Set(EnableNodeSelectorLabels, "true")
+	vp.Set(EnableNonDefaultDenyPolicies, "false")
+	vp.Set(EnableExtendedIPProtocols, "true")
+	require.False(t, vp.GetBool(EnableL7Proxy))
+	require.False(t, vp.GetBool(EnableICMPRules))
+	require.True(t, vp.GetBool(EnableNodeSelectorLabels))
+	require.False(t, vp.GetBool(EnableNonDefaultDenyPolicies))
+	require.True(t, vp.GetBool(EnableExtendedIPProtocols))
+}


### PR DESCRIPTION
See commit message for details.

Fix failures in `cilium clustermesh inspect-policy-default-local-cluster` command, when cluster has `enable-node-selector-lables` and a policy exists with To/From Nodes selector.
