### PR TITLE
v1.18: helm: Restore hostPort.enabled flag

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1728,6 +1728,10 @@
      - Enables the enforcement of host policies in the eBPF datapath.
      - bool
      - ``false``
+   * - :spelling:ignore:`hostPort.enabled`
+     - Enable hostPort service support.
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.annotations`
      - Annotations to be added to all top-level hubble objects (resources under templates/hubble)
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -482,6 +482,7 @@ contributors across the globe, there is almost always someone available to help.
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
+| hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.annotations | object | `{}` | Annotations to be added to all top-level hubble objects (resources under templates/hubble) |
 | hubble.dropEventEmitter | object | `{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}` | Emit v1.Events related to pods on detection of packet drops.    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975. |
 | hubble.dropEventEmitter.interval | string | `"2m"` | - Minimum time between emitting same events. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -791,6 +791,12 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if hasKey .Values "hostPort" }}
+{{- if eq $kubeProxyReplacement "false" }}
+  enable-host-port: {{ .Values.hostPort.enabled | quote }}
+{{- end }}
+{{- end }}
+
 {{- if hasKey .Values "nodePort" }}
 {{- if eq $kubeProxyReplacement "false" }}
   enable-node-port: {{ .Values.nodePort.enabled | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2586,6 +2586,14 @@
       },
       "type": "object"
     },
+    "hostPort": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "hubble": {
       "properties": {
         "annotations": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1164,6 +1164,9 @@ healthCheckICMPFailureThreshold: 3
 hostFirewall:
   # -- Enables the enforcement of host policies in the eBPF datapath.
   enabled: false
+hostPort:
+  # -- Enable hostPort service support.
+  enabled: false
 # -- Configure socket LB
 socketLB:
   # -- Enable socket LB

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1174,6 +1174,9 @@ healthCheckICMPFailureThreshold: 3
 hostFirewall:
   # -- Enables the enforcement of host policies in the eBPF datapath.
   enabled: false
+hostPort:
+  # -- Enable hostPort service support.
+  enabled: false
 # -- Configure socket LB
 socketLB:
   # -- Enable socket LB


### PR DESCRIPTION
## Description

Using #40480 as a reference for this v1.18 backport.

Commit [88d1e70](https://github.com/cilium/cilium/commit/88d1e705c84a8b151ae34bcab54249ee7806a87c) removed `hostPort.enabled` too early. Individual KPR flags cannot be enabled separately only starting with v1.19, so earlier releases must continue supporting HostPort when `kubeProxyReplacement=false`.

The removal was backported to v1.17 by #40222 to fix #40073.

Once this PR is merged, a GitHub action will update the labels of these PRs:

```upstream-prs
40480
```