### PR TITLE
[v1.20] test verifier

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -199,19 +199,6 @@ jobs:
             mv /var/tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /var/tmp/llvm
 
-      - name: Run verifier tests (on base branch)
-        uses: cilium/little-vm-helper@5ae749011735fd77f30f38add52f1a53a5568671 # v0.0.30
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/base
-            export TMPDIR=/var/tmp
-            export GOCACHE=/host/gocache
-            mkdir -p /host/datapath-verifier /host/gocache
-            # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=25m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/base --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
-            mv /host/datapath-verifier/verifier-complexity.json /host/datapath-verifier/verifier-complexity-base.json
-
       - name: Run verifier tests (on PR branch)
         uses: cilium/little-vm-helper@5ae749011735fd77f30f38add52f1a53a5568671 # v0.0.30
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -225,6 +212,19 @@ jobs:
             # Run with cgo disabled, LVH images don't ship with gcc.
             CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=25m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/pull --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
             mv /host/datapath-verifier/verifier-complexity.json /host/datapath-verifier/verifier-complexity-pull.json
+
+      - name: Run verifier tests (on base branch)
+        uses: cilium/little-vm-helper@5ae749011735fd77f30f38add52f1a53a5568671 # v0.0.30
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/base
+            export TMPDIR=/var/tmp
+            export GOCACHE=/host/gocache
+            mkdir -p /host/datapath-verifier /host/gocache
+            # Run with cgo disabled, LVH images don't ship with gcc.
+            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=25m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/base --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
+            mv /host/datapath-verifier/verifier-complexity.json /host/datapath-verifier/verifier-complexity-base.json
 
       - name: Upload artifacts
         if: ${{ always() }}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -460,7 +460,7 @@ snat_v4_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
 	}
 
 	if (*state && (*state)->common.needs_ct) {
-		struct ipv4_ct_tuple tuple_revsnat;
+		struct ipv4_ct_tuple tuple_revsnat __align_stack_8;
 		int ret;
 
 		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
@@ -1155,7 +1155,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct ipv4_nat_entry *state = NULL;
-	struct ipv4_ct_tuple tuple = {};
+	struct ipv4_ct_tuple tuple __align_stack_8 = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
 	fraginfo_t fraginfo;


### PR DESCRIPTION
[ upstream commit 9bb7aa0481f3837257153a21d947aecc48c760d1 ]

struct ipv4_ct_tuple is __packed, so its natural alignment is 1 while its size is 14. __bpf_memcpy() decomposes a 14-byte copy into u16 + u32 + u64 accesses, and the trailing 8-byte access requires the object to sit on an 8-byte aligned stack slot. builtins.h provides __align_stack_8 for exactly this case, but the tuples copied in snat_v4_rev_nat_handle_mapping() were never annotated.

Clang happened to place them on aligned slots so far. Any change to the frame layout of tail_handle_inter_cluster_revsnat() can move them, at which point the verifier rejects the program with:

      misaligned stack access off (0x0; 0x0)+0+-92 size 8

Annotate both ends of the copy so the alignment no longer depends on unrelated stack allocation decisions.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
