### PR TITLE
[v1.20] bpf: Force-align IPv4 CT tuples used by revSNAT memcpy()

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -460,7 +460,7 @@ snat_v4_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
 	}
 
 	if (*state && (*state)->common.needs_ct) {
-		struct ipv4_ct_tuple tuple_revsnat;
+		struct ipv4_ct_tuple tuple_revsnat __align_stack_8;
 		int ret;
 
 		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
@@ -1155,7 +1155,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct ipv4_nat_entry *state = NULL;
-	struct ipv4_ct_tuple tuple = {};
+	struct ipv4_ct_tuple tuple __align_stack_8 = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
 	fraginfo_t fraginfo;


### PR DESCRIPTION
The [BPF Complexity workflow on v1.20](https://github.com/cilium/cilium/actions/workflows/tests-datapath-verifier.yaml?query=branch%3Av1.20) is currently broken - most likely due to a merge race.

Let's backport an isolated fix from #48249.

Unfortunately the workflow continues to fail, as it also evaluates the base branch (which is currently broken). But in #48394 we see that the `Run verifier tests (on PR branch)` step now succeeds with this fix.