### PR TITLE
bpf: icmp*: simplify flipping of the L2 addrs (and various XDP cleanups)

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -311,6 +311,8 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 	 */
 	switch (mode) {
 	case BPF_ADJ_ROOM_MAC:
+		move_len = sizeof(struct ethhdr);
+
 		switch (len_diff) {
 		/* ICMP error reply */
 		case 28: /* struct {iphdr + icmphdr} */

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -311,19 +311,32 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		 */
 
 		switch (len_diff) {
+		/* ICMP error reply */
 		case 28: /* struct {iphdr + icmphdr} */
+		case 48: /* struct {ipv6hdr + icmp6hdr} */
 			break;
-		case 20: /* struct iphdr */
-		case 8:  /* struct dsr_opt_v4 */
-			move_len = move_len_v4;
-			break;
+
+		/* IPv4 Overlay encap: */
 		case 50: /* struct {ethhdr + iphdr + udphdr + genevehdr / vxlanhdr} */
+			break;
+
+		/* Geneve DSR: */
 		case 50 + 12: /* geneve with IPv4 DSR option */
 		case 50 + 24: /* geneve with IPv6 DSR option */
 			break;
-		case 48: /* struct {ipv6hdr + icmp6hdr} */
+
+		/* IPIP DSR */
+		case 20: /* struct iphdr */
+			move_len = move_len_v4;
 			break;
 		case 40: /* struct ipv6hdr */
+			move_len = move_len_v6;
+			break;
+
+		/* IP-opt DSR */
+		case 8:  /* struct dsr_opt_v4 */
+			move_len = move_len_v4;
+			break;
 		case 24: /* struct dsr_opt_v6 */
 			move_len = move_len_v6;
 			break;

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -288,28 +288,29 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 {
 	const __u32 move_len_v4 = 14 + 20;
 	const __u32 move_len_v6 = 14 + 40;
+	__u32 move_len = 0;
 	int ret;
 
 	/* Note: when bumping len_diff, consider headroom on popular NICs. */
 	build_bug_on(len_diff <= 0 || len_diff >= 128);
-	build_bug_on(mode != BPF_ADJ_ROOM_NET);
 
 	ret = xdp_adjust_head(ctx, -len_diff);
+	if (ret)
+		return ret;
 
 	/* XXX: Note, this hack is currently tailored to NodePort DSR
 	 * requirements and not a generic helper. If needed elsewhere,
 	 * this must be made more generic.
 	 */
-	if (!ret) {
-		__u32 move_len = 0;
 
-		/* Based on the specified `len_diff`, we now *guess* at what
-		 * location the free space is needed.
-		 *
-		 * We either want to push some additional headers to the front
-		 * (move_len == 0), or insert headers at an offset (move_len > 0).
-		 */
-
+	/* Based on the specified `mode` and `len_diff`, we now *guess* at what
+	 * location the free space is needed.
+	 *
+	 * We either want to push some additional headers to the front
+	 * (move_len == 0), or insert headers at an offset (move_len > 0).
+	 */
+	switch (mode) {
+	case BPF_ADJ_ROOM_MAC:
 		switch (len_diff) {
 		/* ICMP error reply */
 		case 28: /* struct {iphdr + icmphdr} */
@@ -324,7 +325,12 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		case 50 + 12: /* geneve with IPv4 DSR option */
 		case 50 + 24: /* geneve with IPv6 DSR option */
 			break;
-
+		default:
+			__throw_build_bug();
+		}
+		break;
+	case BPF_ADJ_ROOM_NET:
+		switch (len_diff) {
 		/* IPIP DSR */
 		case 20: /* struct iphdr */
 			move_len = move_len_v4;
@@ -343,19 +349,22 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		default:
 			__throw_build_bug();
 		}
+		break;
+	default:
+		__throw_build_bug();
+	}
 
-		/* Move existing headers to the front, to create space for
-		 * inserting additional headers.
-		 */
-		if (move_len) {
-			void *data_end = ctx_data_end(ctx);
-			void *data = ctx_data(ctx);
+	/* Move existing headers to the front, to create space for
+	 * inserting additional headers.
+	 */
+	if (move_len) {
+		void *data_end = ctx_data_end(ctx);
+		void *data = ctx_data(ctx);
 
-			if (data + len_diff + move_len <= data_end)
-				__bpf_memmove_fwd(data, data + len_diff, move_len);
-			else
-				ret = -EFAULT;
-		}
+		if (data + len_diff + move_len <= data_end)
+			__bpf_memmove_fwd(data, data + len_diff, move_len);
+		else
+			ret = -EFAULT;
 	}
 
 	return ret;

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -286,7 +286,6 @@ static __always_inline __maybe_unused int
 ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 		 const __u64 flags __maybe_unused)
 {
-	const __u32 move_len_v4_geneve = 14 + 20 + 8 + 8; /* eth, ipv4, udp, geneve */
 	const __u32 move_len_v4 = 14 + 20;
 	const __u32 move_len_v6 = 14 + 40;
 	int ret;
@@ -313,9 +312,6 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 
 		switch (len_diff) {
 		case 28: /* struct {iphdr + icmphdr} */
-			break;
-		case 12: /* struct geneve_dsr_opt4 */
-			move_len = move_len_v4_geneve;
 			break;
 		case 20: /* struct iphdr */
 		case 8:  /* struct dsr_opt_v4 */

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -116,3 +116,13 @@ static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
 	return ctx_store_bytes(ctx, off + ETH_ALEN + ETH_ALEN,
 			       &proto, sizeof(proto), 0);
 }
+
+static __always_inline void eth_flip_addrs(struct ethhdr *eth)
+{
+	union macaddr tmp = {};
+
+	memcpy(tmp.addr, eth->h_dest, ETH_ALEN);
+
+	memcpy(eth->h_dest, eth->h_source, ETH_ALEN);
+	memcpy(eth->h_source, tmp.addr, ETH_ALEN);
+}

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -33,22 +33,10 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	void *data, *data_end;
 	struct ethhdr *ethhdr;
 	struct icmphdr *icmphdr;
-	union macaddr smac = {};
-	union macaddr dmac = {};
 	__wsum csum;
 	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
-	/* copy the incoming src and dest IPs and mac addresses to the stack.
-	 * the pointers will not be valid after adding headroom.
-	 */
-
-	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
-		return DROP_INVALID;
-
-	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
 		return DROP_INVALID;
 
 	/* Trim down to sample size (IPv4 header + 8 bytes datagram) */
@@ -92,8 +80,7 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		return DROP_INVALID;
 
 	/* Write reversed eth header, ready for egress */
-	memcpy(ethhdr->h_dest, smac.addr, sizeof(smac.addr));
-	memcpy(ethhdr->h_source, dmac.addr, sizeof(dmac.addr));
+	eth_flip_addrs(ethhdr);
 	ethhdr->h_proto = bpf_htons(ETH_P_IP);
 
 	/* Write reversed ip header, ready for egress */

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -602,21 +602,9 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	struct ethhdr *ethhdr;
 	struct icmp6hdr *icmphdr;
 	struct ipv6_pseudo_header_t pseudo_header;
-	union macaddr smac = {};
-	union macaddr dmac = {};
 	__wsum csum;
 	int i;
 	int ret;
-
-	/* copy the incoming src and dest IPs and mac addresses to the stack.
-	 * the pointers will not be valid after adding headroom.
-	 */
-
-	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
-		return DROP_INVALID;
-
-	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
-		return DROP_INVALID;
 
 	/* Trim down to sample size */
 	if (full_len < sizeof(struct ethhdr))
@@ -659,8 +647,7 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		return DROP_INVALID;
 
 	/* Write reversed eth header, ready for egress */
-	memcpy(ethhdr->h_dest, smac.addr, sizeof(smac.addr));
-	memcpy(ethhdr->h_source, dmac.addr, sizeof(dmac.addr));
+	eth_flip_addrs(ethhdr);
 	ethhdr->h_proto = bpf_htons(ETH_P_IPV6);
 
 	/* Write reversed ip header, ready for egress */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -172,7 +172,7 @@ ctx_set_encap_info4(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	/* Add space in front (50 bytes + options) */
 	outer_len = sizeof(*eth) + sizeof(*ip4) + sizeof(*udp) + tunnel_hdr_len + opt_len;
 
-	if (ctx_adjust_hroom(ctx, outer_len, BPF_ADJ_ROOM_NET, BPF_F_ADJ_ROOM_NO_CSUM_RESET))
+	if (ctx_adjust_hroom(ctx, outer_len, BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET))
 		return DROP_INVALID;
 
 	/* validate access to outer headers: */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -245,30 +245,4 @@ ctx_set_encap_info6(struct xdp_md *ctx __maybe_unused,
 {
 	return 0;
 }
-
-static __always_inline __maybe_unused int
-ctx_set_tunnel_opt(struct xdp_md *ctx, void *opt, __u32 opt_len)
-{
-	const __u32 geneve_off = ETH_HLEN + sizeof(struct iphdr) + sizeof(struct udphdr);
-	struct genevehdr geneve;
-
-	/* add free space after GENEVE header: */
-	if (ctx_adjust_hroom(ctx, opt_len, BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET) < 0)
-		return DROP_INVALID;
-
-	/* write the options */
-	if (ctx_store_bytes(ctx, geneve_off + sizeof(geneve), opt, opt_len, 0) < 0)
-		return DROP_WRITE_ERROR;
-
-	/* update the options length in the GENEVE header: */
-	if (ctx_load_bytes(ctx, geneve_off, &geneve, sizeof(geneve)) < 0)
-		return DROP_INVALID;
-
-	geneve.opt_len += (__u8)(opt_len >> 2);
-
-	if (ctx_store_bytes(ctx, geneve_off, &geneve, sizeof(geneve), 0) < 0)
-		return DROP_WRITE_ERROR;
-
-	return 0;
-}
 #endif /* HAVE_ENCAP */


### PR DESCRIPTION
This started as harmless

```
As we re-use the L2 header when building the ICMP header stack, we can simply flip the addresses in-place after having validated the header pointer.
```

but turned into a deep-dive into the XDP code which adds header space for a packet. Enjoy! :rocket: 