### PR TITLE
[v1.20] golangci-lint: Do not run the modernize linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - modernize
     - sloglint
     - staticcheck
     - testifylint
@@ -115,10 +114,6 @@ linters:
     gosec:
       includes:
         - G402
-    modernize:
-      disable: # TODO: remove each disabled rule and fix it
-        - omitzero
-        - newexpr
     govet:
       enable:
         - nilness


### PR DESCRIPTION
modernize rewrites working code into newer idioms, which is churn a stable
branch should not be taking on. It also tracks whatever x/tools golangci-lint
bundles, so every version bump can widen it: v2.13.1 brought errorsastype,
reflecttypeassert and stringscut, and the Renovate bump to that version reported
28 findings on this branch, all of them from those three:

  https://github.com/cilium/cilium/actions/runs/33285524760/job/99187944650

Drop it from the enabled linters, along with the settings block naming the
analyzers this branch had already opted out of. v1.18 has never enabled it, so
this brings v1.20 into line rather than inventing a new shape. New code on the
branch is no longer checked for idiom, which is the right trade on a branch that
only takes bugfixes.

This PR was prepared with AIL:3. I personally checked a full golangci-lint
v2.13.1 run over the branch, which reports nothing once modernize is gone.

