### PR TITLE
[v1.19] golangci-lint: Do not run the modernize linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,6 @@ linters:
     - ineffassign
     - kubeapilinter
     - misspell
-    - modernize
     - sloglint
     - staticcheck
     - testifylint
@@ -143,11 +142,6 @@ linters:
     gosec:
       includes:
         - G402
-    modernize:
-      disable: # TODO: remove each disabled rule and fix it
-        - omitzero
-        - rangeint
-        - waitgroup
     govet:
       enable:
         - nilness


### PR DESCRIPTION
modernize rewrites working code into newer idioms, which is churn a stable
branch should not be taking on. It also tracks whatever x/tools golangci-lint
bundles, so every version bump can widen it: v2.13.1 brought errorsastype,
reflecttypeassert and stringscut, which together reported 28 findings on v1.20.

None of the three can fire here yet, because errors.AsType and reflect.TypeAssert
are Go 1.26 additions and this branch targets 1.25. They would arrive with the
golangci-lint bump that a future Go update lets in, so take the branch out of the
linter's way now instead of after the fact. v1.18 has never enabled it, so this
brings v1.19 into line rather than inventing a new shape.

The settings block naming the analyzers this branch had already opted out of goes
with it.

This PR was prepared with AIL:3. I personally checked golangci-lint config
verify and the enabled-linter list at v2.12.2.

