### PR TITLE
renovate: raise the golang ceiling for v1.20 to below 1.27

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -552,9 +552,18 @@
         "docker.io/library/golang",
         "go"
       ],
+      "allowedVersions": "<1.27",
+      "matchBaseBranches": [
+        "v1.20"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
       "allowedVersions": "<1.26",
       "matchBaseBranches": [
-        "v1.20",
         "v1.19",
         "v1.18",
       ]


### PR DESCRIPTION
v1.20 branched off a main that was already on Go 1.26, and it targets Go 1.26 in
go.mod and in every go-version pin and GOLANG_IMAGE arg on the branch. It was
still added to the allowedVersions group that caps golang and go at below 1.26.
That reads as below 1.26.0, so no 1.26.x candidate qualifies and Renovate proposes
nothing at all: the branch sits on 1.26.5 while go1.26.8 is out, and the only
golang commits reaching it are digest re-pins of the tag it is already on.

Give v1.20 its own entry capped below 1.27 and leave v1.19 and v1.18, which do
target Go 1.25, on the below-1.26 one. The go.mod language directive itself does
not move, since patch updates for it are disabled a few rules above; this only
frees the toolchain pins and the builder images.

This PR was prepared with AIL:3. I personally checked the renovate diff.

Fixes: 0c15d351eea1 ("Prepare for v1.21 development cycle")

