### PR TITLE
renovate: cap golangci-lint to the branch's Go version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -547,6 +547,9 @@
         "main"
       ]
     },
+    // Toolchain ceilings for v1.20, which targets Go 1.26. golangci-lint is
+    // compiled with the Go toolchain the branch installs, so raising the branch's
+    // Go version means raising both entries of its bucket.
     {
       "matchPackageNames": [
         "docker.io/library/golang",
@@ -559,10 +562,32 @@
     },
     {
       "matchPackageNames": [
+        "golangci/golangci-lint"
+      ],
+      "allowedVersions": "<2.14",
+      "matchBaseBranches": [
+        "v1.20"
+      ]
+    },
+    // Toolchain ceilings for v1.19 and v1.18, which target Go 1.25.
+    {
+      "matchPackageNames": [
         "docker.io/library/golang",
         "go"
       ],
       "allowedVersions": "<1.26",
+      "matchBaseBranches": [
+        "v1.19",
+        "v1.18",
+      ]
+    },
+    {
+      // v1.18 already sits past this, on a v2.13.1 that only works because the
+      // branch has no .custom-gcl.yaml plugin binary to build.
+      "matchPackageNames": [
+        "golangci/golangci-lint"
+      ],
+      "allowedVersions": "<2.13",
       "matchBaseBranches": [
         "v1.19",
         "v1.18",

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -279,8 +279,9 @@ at any given time – when updating the version used by a Cilium branch, you sho
 choose the older of the two supported versions.
 
 To update the minor version of Golang used by a release, you will first need to
-update the Renovate configuration found in ``.github/renovate.json5``. For each
-minor release, there will be a section that looks like this:
+update the Renovate configuration found in ``.github/renovate.json5``. Each minor
+release has a bucket of two adjacent entries there. The first holds the Golang
+ceiling for that branch:
 
 .. code-block:: json
 
@@ -289,19 +290,37 @@ minor release, there will be a section that looks like this:
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.21",
+      "allowedVersions": "<1.27",
       "matchBaseBranches": [
-        "v1.14"
+        "v1.20"
+      ]
+    }
+
+The second holds its ``golangci-lint`` ceiling:
+
+.. code-block:: json
+
+    {
+      "matchPackageNames": [
+        "golangci/golangci-lint"
+      ],
+      "allowedVersions": "<2.14",
+      "matchBaseBranches": [
+        "v1.20"
       ]
     }
 
 To allow Renovate to create a pull request that updates the minor Golang version,
-bump the ``allowedVersions`` constraint to include the desired minor version. Once
-this change has been merged, Renovate will create a pull request that updates the
-Golang version. Minor version updates may require further changes to ensure that
-all Cilium features are working correctly – use the CI to identify any issues that
-require further changes, and bring them to the attention of the Cilium maintainers
-in the pull request.
+bump the ``allowedVersions`` constraint of both entries to include the desired
+versions. Once this change has been merged, Renovate will create a pull request
+that updates the Golang version. Minor version updates may require further changes
+to ensure that all Cilium features are working correctly – use the CI to identify
+any issues that require further changes, and bring them to the attention of the
+Cilium maintainers in the pull request.
+
+Raise both ceilings in the same change. ``golangci-lint`` is compiled with the Go
+toolchain the branch installs, so it must not move ahead of the branch's Golang
+version.
 
 Once the CI is passing, the PR will be merged as part of the standard version
 upgrade process.


### PR DESCRIPTION
golangci-lint is compiled with the Go toolchain a branch installs, so it must not
be updated on a stable branch without the matching Golang update. Cap it per branch
in the Renovate configuration, and group the entries by branch rather than by
dependency, so each Go version is one bucket holding both ceilings and raising one
is visibly raising the other.

The Golang update instructions in dev_setup.rst describe the bucket and say to
raise both ceilings in the same change.

This PR was prepared with AIL:3. I personally checked the docs-builder
check-build.sh run over the rendered documentation.

