### PR TITLE
vendor,pkg/{k8s,datapath}: Bump to StateDB v0.9.1 and fix API change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/cilium/hive v1.0.4
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
-	github.com/cilium/statedb v0.9.0
+	github.com/cilium/statedb v0.9.1
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1 h1:F+SGcs1IpZTuy1bGWBVZQgyr65NiiTOjHli7WExSHnU=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1/go.mod h1:GEiA7dAvPLMMt5drHzjQDAwRtVFcHbVR4ExTN5ISRyg=
-github.com/cilium/statedb v0.9.0 h1:Tnts7Kerm/pfr5pZohjlQsY8tQduHF5iiaLo4Opdfso=
-github.com/cilium/statedb v0.9.0/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
+github.com/cilium/statedb v0.9.1 h1:Y0KM7XtQNZd/TRNmebh2/hGFOU5gTJznZcsv05arOdE=
+github.com/cilium/statedb v0.9.1/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -289,9 +289,10 @@ func (ops *ops) DeleteBatch(ctx context.Context, txn statedb.ReadTxn, batch []re
 	// replace it instead. Otherwise we briefly have no route installed.
 	toDelete := make([]*reconciler.BatchEntry[*DesiredRoute], 0, len(batch))
 	for i := range batch {
-		_, _, found := ops.tbl.Get(txn, DesiredRouteTablePrefixIndex.QueryFromObject(batch[i].Object))
-		if !found {
-			toDelete = append(toDelete, &batch[i])
+		if query, ok := DesiredRouteTablePrefixIndex.QueryFromObject(batch[i].Object); ok {
+			if _, _, found := ops.tbl.Get(txn, query); !found {
+				toDelete = append(toDelete, &batch[i])
+			}
 		}
 	}
 

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -530,19 +530,23 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 						}
 
 						numUpserted++
-						inserted.Insert(string(indexer.ObjectToKey(obj)))
+						if key, exists := indexer.ObjectToKey(obj); exists {
+							inserted.Insert(string(key))
+						}
 					}
 				}
 			}
 
 			// Delete the remaining objects that we did not insert.
 			for obj := range queryAll(txn, table) {
-				if !inserted.Has(string(indexer.ObjectToKey(obj))) {
-					if _, _, err := table.Delete(txn, obj); err != nil {
-						r.log.Error("BUG: Delete failed", logfields.Error, err)
-						continue
+				if key, exists := indexer.ObjectToKey(obj); exists {
+					if !inserted.Has(string(key)) {
+						if _, _, err := table.Delete(txn, obj); err != nil {
+							r.log.Error("BUG: Delete failed", logfields.Error, err)
+							continue
+						}
+						numDeleted++
 					}
-					numDeleted++
 				}
 			}
 

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -6,6 +6,7 @@ package node
 import (
 	"context"
 	"errors"
+	"maps"
 	"net"
 	"net/netip"
 	"slices"
@@ -106,7 +107,7 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 		Name:   "existing",
 		Source: source.Kubernetes,
 	}))
-	require.Empty(t, get("existing").Statuses.All())
+	require.Empty(t, maps.Collect(get("existing").Statuses.All()))
 	existing := get("existing").DeepCopy()
 	existing.Statuses = existing.Statuses.Set("already-done", reconciler.StatusDone())
 	txn := db.WriteTxn(nodes)
@@ -120,7 +121,7 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 		reconciler.StatusKindPending,
 		existing.Statuses.Get("wireguard").Kind,
 	)
-	require.Contains(t, existing.Statuses.All(), "wireguard")
+	require.Contains(t, maps.Collect(existing.Statuses.All()), "wireguard")
 	require.Equal(t,
 		reconciler.StatusKindDone,
 		existing.Statuses.Get("already-done").Kind,
@@ -146,7 +147,7 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 		})
 
 	newNode := get("new").DeepCopy()
-	require.Len(t, newNode.Statuses.All(), 2)
+	require.Len(t, maps.Collect(newNode.Statuses.All()), 2)
 	newNode.Statuses = newNode.Statuses.Set("ipset", reconciler.StatusDone())
 	txn = db.WriteTxn(nodes)
 	_, _, err = nodes.Insert(txn, newNode)
@@ -167,8 +168,8 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 	require.Equal(t, []string{"ipset"}, requiredReconcilers(db, nodes, w))
 	existing = get("existing")
 	newNode = get("new")
-	require.NotContains(t, existing.Statuses.All(), "wireguard")
-	require.NotContains(t, newNode.Statuses.All(), "wireguard")
+	require.NotContains(t, maps.Collect(existing.Statuses.All()), "wireguard")
+	require.NotContains(t, maps.Collect(newNode.Statuses.All()), "wireguard")
 	require.Equal(t,
 		reconciler.StatusKindDone,
 		existing.Statuses.Get("already-done").Kind,
@@ -185,8 +186,8 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 
 	// Re-registering materializes a fresh pending status on all nodes.
 	w.RegisterReconciler("wireguard")
-	require.Contains(t, get("existing").Statuses.All(), "wireguard")
-	require.Contains(t, get("new").Statuses.All(), "wireguard")
+	require.Contains(t, maps.Collect(get("existing").Statuses.All()), "wireguard")
+	require.Contains(t, maps.Collect(get("new").Statuses.All()), "wireguard")
 	require.Equal(t,
 		reconciler.StatusKindPending,
 		get("existing").Statuses.Get("wireguard").Kind,

--- a/vendor/github.com/cilium/statedb/README.md
+++ b/vendor/github.com/cilium/statedb/README.md
@@ -70,7 +70,7 @@ func (o *MyObject) TableRow() []string {
 var IDIndex = statedb.Index[*MyObject, uint32]{
   Name: "id",
   FromObject: func(obj *MyObject) index.KeySet {
-    return index.NewKeySet(index.Uint64(obj.ID))
+    return index.NewKeySet(index.Uint32(obj.ID))
   },
   FromKey: func(id uint32) index.Key {
     return index.Uint32(id)

--- a/vendor/github.com/cilium/statedb/derive.go
+++ b/vendor/github.com/cilium/statedb/derive.go
@@ -90,7 +90,11 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 			case DeriveInsert:
 				_, _, err = out.Insert(wtxn, outObj)
 			case DeriveUpdate:
-				_, _, found := out.Get(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
+				query, hasKey := out.PrimaryIndexer().QueryFromObject(outObj)
+				if !hasKey {
+					continue
+				}
+				_, _, found := out.Get(wtxn, query)
 				if found {
 					_, _, err = out.Insert(wtxn, outObj)
 				}

--- a/vendor/github.com/cilium/statedb/graveyard.go
+++ b/vendor/github.com/cilium/statedb/graveyard.go
@@ -96,7 +96,9 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 					// The dead object still existed (and wasn't replaced by a create->delete),
 					// delete it from the primary index.
 					graveyard := txn.mustIndexWriteTxn(meta, GraveyardIndexPos)
-					graveyard.delete(graveyard.objectToKey(oldObj))
+					if key, ok := graveyard.objectToKey(oldObj); ok {
+						graveyard.delete(key)
+					}
 				}
 			}
 			cleaningTimes[tableName] = time.Since(start)

--- a/vendor/github.com/cilium/statedb/http.go
+++ b/vendor/github.com/cilium/statedb/http.go
@@ -112,7 +112,9 @@ func (h dbHandler) query(w http.ResponseWriter, r *http.Request) {
 			Obj: obj.data,
 		})
 	}
-	runQuery(indexTxn, req.LowerBound, queryKey, onObject)
+	if err := runQuery(indexTxn, req.LowerBound, queryKey, onObject); err != nil {
+		return
+	}
 }
 
 type QueryRequest struct {
@@ -128,7 +130,7 @@ type QueryResponse struct {
 	Err string `json:"err,omitempty"`
 }
 
-func runQuery(reader tableIndexReader, lowerbound bool, queryKey index.Key, onObject func(object) error) {
+func runQuery(reader tableIndexReader, lowerbound bool, queryKey index.Key, onObject func(object) error) error {
 	var iter tableIndexIterator
 	if lowerbound {
 		iter = reader.lowerBoundNoWatch(queryKey)
@@ -137,9 +139,10 @@ func runQuery(reader tableIndexReader, lowerbound bool, queryKey index.Key, onOb
 	}
 	for _, obj := range iter.All {
 		if err := onObject(obj); err != nil {
-			panic(err)
+			return err
 		}
 	}
+	return nil
 }
 
 func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {

--- a/vendor/github.com/cilium/statedb/index/keyset.go
+++ b/vendor/github.com/cilium/statedb/index/keyset.go
@@ -14,17 +14,30 @@ func (k Key) Equal(k2 Key) bool {
 	return bytes.Equal(k, k2)
 }
 
+// KeySet is a collection of keys used to index an object. Its zero value is
+// an empty set; a nil key supplied to NewKeySet is a valid zero-length key.
 type KeySet struct {
-	head Key
-	tail []Key
+	head    Key
+	tail    []Key
+	hasHead bool
 }
 
-func (ks KeySet) First() Key {
-	return ks.head
+// Len returns the number of keys in the set.
+func (ks KeySet) Len() int {
+	if !ks.hasHead {
+		return 0
+	}
+	return 1 + len(ks.tail)
 }
 
+// First returns the first key in the set, or false if the set is empty.
+func (ks KeySet) First() (Key, bool) {
+	return ks.head, ks.hasHead
+}
+
+// Foreach calls fn for each key in the set.
 func (ks KeySet) Foreach(fn func(Key)) {
-	if ks.head == nil {
+	if !ks.hasHead {
 		return
 	}
 	fn(ks.head)
@@ -34,6 +47,9 @@ func (ks KeySet) Foreach(fn func(Key)) {
 }
 
 func (ks KeySet) Exists(k Key) bool {
+	if !ks.hasHead {
+		return false
+	}
 	if ks.head.Equal(k) {
 		return true
 	}
@@ -45,9 +61,11 @@ func (ks KeySet) Exists(k Key) bool {
 	return false
 }
 
+// NewKeySet constructs a set from keys. Every argument is a key, including a
+// nil or zero-length key. Pass no arguments to construct an empty set.
 func NewKeySet(keys ...Key) KeySet {
 	if len(keys) == 0 {
 		return KeySet{}
 	}
-	return KeySet{keys[0], keys[1:]}
+	return KeySet{head: keys[0], tail: keys[1:], hasHead: true}
 }

--- a/vendor/github.com/cilium/statedb/index/set.go
+++ b/vendor/github.com/cilium/statedb/index/set.go
@@ -13,7 +13,7 @@ func Set[T any](s part.Set[T]) KeySet {
 		return KeySet{}
 	case 1:
 		if v, ok := s.First(); ok {
-			return KeySet{head: toBytes(v)}
+			return NewKeySet(toBytes(v))
 		}
 		panic("BUG: Set.Len() == 1, but First returned nothing")
 	default:

--- a/vendor/github.com/cilium/statedb/lpm_index.go
+++ b/vendor/github.com/cilium/statedb/lpm_index.go
@@ -43,22 +43,22 @@ func (a NetIPPrefixIndex[Obj]) QueryPrefix(prefix netip.Prefix) Query[Obj] {
 }
 
 // ObjectToKey implements Indexer.
-func (a NetIPPrefixIndex[Obj]) ObjectToKey(obj Obj) index.Key {
+func (a NetIPPrefixIndex[Obj]) ObjectToKey(obj Obj) (index.Key, bool) {
 	for prefix := range a.FromObject(obj) {
-		return lpm.NetIPPrefixToIndexKey(prefix)
+		return lpm.NetIPPrefixToIndexKey(prefix), true
 	}
-	return nil
+	return nil, false
 }
 
 // QueryFromObject implements Indexer.
-func (a NetIPPrefixIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
+func (a NetIPPrefixIndex[Obj]) QueryFromObject(obj Obj) (Query[Obj], bool) {
 	for prefix := range a.FromObject(obj) {
 		return Query[Obj]{
 			index: a.Name,
 			key:   lpm.NetIPPrefixToIndexKey(prefix),
-		}
+		}, true
 	}
-	return Query[Obj]{}
+	return Query[Obj]{}, false
 }
 
 // fromString implements Indexer.
@@ -145,11 +145,11 @@ func (l LPMIndex[Obj]) indexName() string {
 	return l.Name
 }
 
-func (l LPMIndex[Obj]) ObjectToKey(obj Obj) index.Key {
+func (l LPMIndex[Obj]) ObjectToKey(obj Obj) (index.Key, bool) {
 	for key := range l.FromObject(obj) {
-		return key
+		return key, true
 	}
-	return nil
+	return nil, false
 }
 
 // Query constructs a query against the index with the given prefix. It returns
@@ -165,14 +165,14 @@ func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) (Query[Obj], 
 	}, nil
 }
 
-func (l LPMIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
+func (l LPMIndex[Obj]) QueryFromObject(obj Obj) (Query[Obj], bool) {
 	for key, length := range l.FromObject(obj) {
 		return Query[Obj]{
 			index: l.Name,
 			key:   mustEncodeLPMKey(key, length),
-		}
+		}, true
 	}
-	return Query[Obj]{}
+	return Query[Obj]{}, false
 }
 
 func (l LPMIndex[Obj]) newTableIndex() tableIndex {
@@ -284,7 +284,7 @@ func (l lpmIndex) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, b
 }
 
 // objectToKey implements tableIndex.
-func (l lpmIndex) objectToKey(obj object) index.Key {
+func (l lpmIndex) objectToKey(obj object) (index.Key, bool) {
 	return l.objectToKeys(obj).First()
 }
 
@@ -445,7 +445,7 @@ func (l *lpmIndexTxn) notify() {
 }
 
 // objectToKey implements tableIndexTxn.
-func (l *lpmIndexTxn) objectToKey(obj object) index.Key {
+func (l *lpmIndexTxn) objectToKey(obj object) (index.Key, bool) {
 	return l.index.objectToKey(obj)
 }
 

--- a/vendor/github.com/cilium/statedb/part_index.go
+++ b/vendor/github.com/cilium/statedb/part_index.go
@@ -20,8 +20,8 @@ type Index[Obj any, Key any] struct {
 	Name string
 
 	// FromObject extracts key(s) from the object. The key set
-	// can contain 0, 1 or more keys. Must contain exactly one
-	// key for primary indices.
+	// can contain 0, 1 or more keys. Primary indices may contain
+	// zero or one key; an object with zero keys is not indexed.
 	FromObject func(obj Obj) index.KeySet
 
 	// FromKey converts the index key into a raw key.
@@ -70,11 +70,15 @@ func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
 	}
 }
 
-func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
+func (i Index[Obj, Key]) QueryFromObject(obj Obj) (Query[Obj], bool) {
+	key, ok := i.objectToKey(obj)
+	if !ok {
+		return Query[Obj]{}, false
+	}
 	return Query[Obj]{
 		index: i.Name,
-		key:   i.FromObject(obj).First(),
-	}
+		key:   key,
+	}, true
 }
 
 // QueryFromKey constructs a query against the index using the given
@@ -87,8 +91,16 @@ func (i Index[Obj, Key]) QueryFromKey(key index.Key) Query[Obj] {
 	}
 }
 
-func (i Index[Obj, Key]) ObjectToKey(obj Obj) index.Key {
-	return i.FromObject(obj).First()
+func (i Index[Obj, Key]) ObjectToKey(obj Obj) (index.Key, bool) {
+	return i.objectToKey(obj)
+}
+
+func (i Index[Obj, Key]) objectToKey(obj Obj) (index.Key, bool) {
+	keys := i.FromObject(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	return keys.First()
 }
 
 // newTableIndex constructs a new instance of this index type.
@@ -164,8 +176,12 @@ func (r *partIndex) rootWatch() <-chan struct{} {
 	return r.tree.RootWatch()
 }
 
-func (r *partIndex) objectToKey(obj object) index.Key {
-	return r.objectToKeys(obj).First()
+func (r *partIndex) objectToKey(obj object) (index.Key, bool) {
+	keys := r.objectToKeys(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	return keys.First()
 }
 
 func (r *partIndex) commit() (tableIndex, tableIndexTxnNotify) {
@@ -456,8 +472,12 @@ func (r *partIndexTxn) prefixNoWatch(ikey index.Key) tableIndexIterator {
 	return partPrefixNoWatch(r.unique, &snapshot, ikey)
 }
 
-func (r *partIndexTxn) objectToKey(obj object) index.Key {
-	return r.objectToKeys(obj).First()
+func (r *partIndexTxn) objectToKey(obj object) (index.Key, bool) {
+	keys := r.objectToKeys(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	return keys.First()
 }
 
 // reindex implements tableIndexTxn.

--- a/vendor/github.com/cilium/statedb/reconciler/builder.go
+++ b/vendor/github.com/cilium/statedb/reconciler/builder.go
@@ -71,7 +71,8 @@ func Register[Obj comparable](
 
 	idx := cfg.Table.PrimaryIndexer()
 	objectToKey := func(o any) index.Key {
-		return idx.ObjectToKey(o.(Obj))
+		key, _ := idx.ObjectToKey(o.(Obj))
+		return key
 	}
 	r := &reconciler[Obj]{
 		Params:               params,

--- a/vendor/github.com/cilium/statedb/reconciler/reconciler.go
+++ b/vendor/github.com/cilium/statedb/reconciler/reconciler.go
@@ -192,7 +192,11 @@ func (r *reconciler[Obj]) refreshLoop(ctx context.Context, health cell.Health) e
 				// Mark the object for refreshing. We make the assumption that refreshing is spread over
 				// time enough that batching of the writes is not useful here.
 				wtxn := r.DB.WriteTxn(r.config.Table)
-				obj, newRev, ok := r.config.Table.Get(wtxn, indexer.QueryFromObject(obj))
+				query, hasKey := indexer.QueryFromObject(obj)
+				if !hasKey {
+					continue
+				}
+				obj, newRev, ok := r.config.Table.Get(wtxn, query)
 				if ok && rev == newRev {
 					obj = r.config.SetObjectStatus(r.config.CloneObject(obj), StatusRefreshing())
 					r.config.Table.Insert(wtxn, obj)

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -447,12 +448,36 @@ func (s StatusSet) Delete(name string) StatusSet {
 	return s
 }
 
-func (s StatusSet) All() map[string]Status {
-	m := make(map[string]Status, len(s.statuses))
-	for _, ns := range s.statuses {
-		m[ns.name] = ns.Status
+// All returns an iterator for all reconciler statuses.
+func (s *StatusSet) All() iter.Seq2[string, Status] {
+	return func(yield func(name string, status Status) bool) {
+		for _, ns := range s.statuses {
+			if !yield(ns.name, ns.Status) {
+				break
+			}
+		}
 	}
-	return m
+}
+
+// IsPending returns true if any of the reconcilers are still pending
+// or refreshing.
+func (s *StatusSet) IsPendingOrRefreshing() bool {
+	for _, ns := range s.statuses {
+		if ns.Status.IsPendingOrRefreshing() {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDone returns true if all reconcilers are done.
+func (s *StatusSet) IsDone() bool {
+	for _, ns := range s.statuses {
+		if ns.Status.Kind != StatusKindDone {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *StatusSet) UnmarshalJSON(data []byte) error {
@@ -473,5 +498,5 @@ func (s *StatusSet) UnmarshalJSON(data []byte) error {
 // It carries enough information over to be able to implement String()
 // so this can be used to implement the TableRow() method.
 func (s StatusSet) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.All())
+	return json.Marshal(maps.Collect(s.All()))
 }

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -294,7 +294,11 @@ func newGraveyardIndex(primaryIndex tableIndex) tableIndex {
 		tree: part.New[object](part.RootOnlyWatch),
 		partIndexTxn: partIndexTxn{
 			objectToKeys: func(obj object) index.KeySet {
-				return index.NewKeySet(primaryIndex.objectToKey(obj))
+				key, ok := primaryIndex.objectToKey(obj)
+				if !ok {
+					return index.KeySet{}
+				}
+				return index.NewKeySet(key)
 			},
 			unique: true,
 		},

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -306,11 +306,12 @@ type Query[Obj any] struct {
 
 type Indexer[Obj any] interface {
 	// QueryFromObject constructs a query from an object against the
-	// primary index.
-	QueryFromObject(Obj) Query[Obj]
+	// primary index. The boolean is false when the object has no key.
+	QueryFromObject(Obj) (Query[Obj], bool)
 
-	// ObjectToKey returns the primary key of the object.
-	ObjectToKey(Obj) index.Key
+	// ObjectToKey returns the primary key of the object. The boolean is false
+	// when the object has no key.
+	ObjectToKey(Obj) (index.Key, bool)
 
 	// isIndexerOf is a marker method to constrain the indexer to the 'Obj'
 	// type which enforces that indexer of a wrong type is not used.
@@ -428,7 +429,7 @@ type tableIndexReader interface {
 	all() (tableIndexIterator, <-chan struct{})
 	allNoWatch() tableIndexIterator
 	rootWatch() <-chan struct{}
-	objectToKey(obj object) index.Key
+	objectToKey(obj object) (index.Key, bool)
 }
 
 type tableIndex interface {

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -128,13 +128,16 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		return object{}, false, nil, tableError(tableName, ErrTableNotLockedForWriting)
 	}
 	oldRevision := table.revision
-	table.revision++
-	revision := table.revision
 
 	// Update the primary index first
-	obj := object{data: newData, revision: revision}
+	obj := object{data: newData}
 	idIndexTxn := txn.mustIndexWriteTxn(meta, PrimaryIndexPos)
-	idKey := idIndexTxn.objectToKey(obj)
+	idKey, indexed := idIndexTxn.objectToKey(obj)
+	if !indexed {
+		return object{}, false, nil, nil
+	}
+	table.revision++
+	obj.revision = table.revision
 
 	var (
 		oldObj    object
@@ -254,7 +257,10 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 	// We assume that "data" has only enough defined fields to
 	// compute the primary key.
 	idIndex := txn.mustIndexWriteTxn(meta, PrimaryIndexPos)
-	idKey := idIndex.objectToKey(object{data: data})
+	idKey, indexed := idIndex.objectToKey(object{data: data})
+	if !indexed {
+		return object{}, false, nil
+	}
 	obj, existed := idIndex.delete(idKey)
 	if !existed {
 		return object{}, false, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -386,7 +386,7 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.9.0
+# github.com/cilium/statedb v0.9.1
 ## explicit; go 1.25.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Bump to StateDB [v0.9.1](https://github.com/cilium/statedb/releases/tag/v0.9.1). This brings minor API changes to the ObjectToKey() and QueryFromObject() in order to properly deal with valid 'nil' index.Key's. 

Couple small one-liner fixes were needed to adapt to the API change. v0.9.0 was just released few days ago (and only bumped in `main`) and the API changes were so minor that I ended up being a bit naughty and going with just a patch release this time even though it had a breaking API change.