### PR TITLE
bpf: fix policy-deny ICMP response metrics accounting

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2682,8 +2682,12 @@ out:
 __declare_tail(CILIUM_CALL_IPV4_POLICY_DENIED)
 int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 {
+	int verdict = (int)ctx_load_meta(ctx, CB_VERDICT);
+	/* Capture the length of the denied packet before generate_icmp4_reply()
+	 * rewrites it into the ICMP error message.
+	 */
+	__u64 denied_len = ctx_full_len(ctx);
 	int ret;
-	__u32 verdict = ctx_load_meta(ctx, CB_VERDICT);
 
 	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED, 0);
 	if (!ret) {
@@ -2691,7 +2695,7 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 		ret = redirect_self(ctx);
 
 		if (!IS_ERR(ret)) {
-			update_metrics(ctx_full_len(ctx), METRIC_EGRESS, __DROP_REASON(verdict));
+			update_metrics(denied_len, METRIC_EGRESS, __DROP_REASON(verdict));
 			return ret;
 		}
 	}
@@ -2713,7 +2717,11 @@ int tail_policy_denied_ipv6(struct __ctx_buff *ctx)
 		.tokens_per_topup = 100,
 		.topup_interval_ns = NSEC_PER_SEC,
 	};
-	__u32 verdict = ctx_load_meta(ctx, CB_VERDICT);
+	int verdict = (int)ctx_load_meta(ctx, CB_VERDICT);
+	/* Capture the length of the denied packet before generate_icmp6_reply()
+	 * rewrites it into the ICMP error message.
+	 */
+	__u64 denied_len = ctx_full_len(ctx);
 	int ret;
 
 	rkey.key.icmpv6.netdev_idx = ctx_get_ifindex(ctx);
@@ -2726,7 +2734,7 @@ int tail_policy_denied_ipv6(struct __ctx_buff *ctx)
 		ret = redirect_self(ctx);
 
 		if (!IS_ERR(ret)) {
-			update_metrics(ctx_full_len(ctx), METRIC_EGRESS, __DROP_REASON(verdict));
+			update_metrics(denied_len, METRIC_EGRESS, __DROP_REASON(verdict));
 			return ret;
 		}
 	}

--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -64,7 +64,7 @@
 #define TEST_SKIP 103
 
 /* Max number of cpus to check when doing percpu hash assertions */
-#define NR_CPUS 128
+#define MAX_ASSERT_CPUS 128
 
 /* Use an array map with 1 key and a large value size as buffer to write results */
 /* into. */
@@ -270,12 +270,12 @@ test_result_cursor = 0;
 	__u64 sum = 0; \
 	/* Iterate until lookup encounters null when hitting cpu number */ \
 	/* Assumes at most 128 CPUS */ \
-	for (int i = 0; i < NR_CPUS; i++) { \
-		__entry = map_lookup_percpu_elem(&cilium_metrics, &key, i); \
+	for (int i = 0; i < MAX_ASSERT_CPUS; i++) { \
+		__entry = map_lookup_percpu_elem(&cilium_metrics, &(key), i); \
 		if (!__entry) { \
 			break; \
 		} \
 		sum += __entry->count; \
 	} \
-	assert(sum == __count); \
+	assert(sum == (__count)); \
 })

--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -279,3 +279,22 @@ test_result_cursor = 0;
 	} \
 	assert(sum == (__count)); \
 })
+
+/* Asserts that the sum of per-cpu metrics map byte counters for a key equals
+ * bytes
+ */
+#define assert_metrics_bytes(key, __bytes) \
+({ \
+	struct metrics_value *__entry = NULL; \
+	__u64 sum = 0; \
+	/* Iterate until lookup encounters null when hitting cpu number */ \
+	/* Assumes at most 128 CPUS */ \
+	for (int i = 0; i < MAX_ASSERT_CPUS; i++) { \
+		__entry = map_lookup_percpu_elem(&cilium_metrics, &(key), i); \
+		if (!__entry) { \
+			break; \
+		} \
+		sum += __entry->bytes; \
+	} \
+	assert(sum == (__bytes)); \
+})

--- a/bpf/tests/lib/icmp.h
+++ b/bpf/tests/lib/icmp.h
@@ -9,6 +9,10 @@ struct validate_icmpv6_reply_args {
 	__u16 buf_len;
 	__u32 dst_idx;
 	__u32 retval;
+	__u8 metrics_reason;
+	enum metric_dir metrics_dir;
+	__u64 metrics_count;
+	__u64 metrics_bytes;
 };
 
 static __always_inline int
@@ -52,6 +56,16 @@ validate_icmpv6_reply(const struct validate_icmpv6_reply_args *args)
 		test_fatal("ratelimit map lookup failed");
 
 	assert(value->tokens > 0);
+
+	if (args->metrics_reason) {
+		struct metrics_key mkey = {
+			.reason = args->metrics_reason,
+			.dir = args->metrics_dir,
+		};
+
+		assert_metrics_count(mkey, args->metrics_count);
+		assert_metrics_bytes(mkey, args->metrics_bytes);
+	}
 
 	test_finish();
 }

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -18,6 +18,9 @@ ASSIGN_CONFIG(bool, policy_deny_response_enabled, true)
 #include "lib/ipcache.h"
 #include "lib/policy.h"
 #include "lib/icmp.h"
+#include "lib/metrics.h"
+
+#define DENY_REASON ((__u8)-DROP_POLICY_DENY)
 
 #define CLIENT_IP v4_pod_one
 #define TARGET_IP v4_ext_one
@@ -67,12 +70,21 @@ int policy_reject_response_setup(struct __ctx_buff *ctx)
 	/* Add policy that denies egress to target */
 	policy_add_egress_deny_all_entry();
 
+	/* The v4 and v6 egress cases share this metrics key, clear it so that
+	 * the assertions below hold regardless of test ordering.
+	 */
+	metrics_del_entry(DENY_REASON, METRIC_EGRESS);
+
 	return pod_send_packet(ctx);
 }
 
 CHECK(PROG_TYPE, "policy_reject_response_v4")
 int policy_reject_response_check(const struct __ctx_buff *ctx)
 {
+	struct metrics_key key = {
+		.reason = DENY_REASON,
+		.dir = METRIC_EGRESS,
+	};
 	void *data, *data_end;
 	__u32 *status_code;
 
@@ -96,6 +108,12 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 			   v4_lxc_to_external_icmp_unreach,
 			   sizeof(v4_lxc_to_external_icmp_unreach));
 
+	/* The drop must be accounted under the policy-deny reason, and the byte
+	 * counter must reflect the denied packet, not the ICMP error message.
+	 */
+	assert_metrics_count(key, 1);
+	assert_metrics_bytes(key, sizeof(v4_lxc_to_external));
+
 	test_finish();
 }
 
@@ -105,8 +123,10 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 #define CLIENT_IPv6 v6_pod_one
 #define TARGET_IPv6 v6_pod_two
 
+/* metrics_reason of 0 skips the metrics map assertions. */
 static __always_inline int
-validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval)
+validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval,
+			     __u8 metrics_reason)
 {
 	struct validate_icmpv6_reply_args args = {
 		.ctx = ctx,
@@ -114,6 +134,13 @@ validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval)
 		.buf_len = sizeof(v6_lxc_to_external_icmp_unreach),
 		.dst_idx = 1,
 		.retval = retval,
+		.metrics_reason = metrics_reason,
+		.metrics_dir = METRIC_EGRESS,
+		.metrics_count = 1,
+		/* The byte counter must reflect the denied packet, not the ICMP
+		 * error message.
+		 */
+		.metrics_bytes = sizeof(v6_lxc_to_external),
 	};
 	return validate_icmpv6_reply(&args);
 }
@@ -147,14 +174,21 @@ int policy_reject_response_v6_setup(struct __ctx_buff *ctx)
 	/* Add policy that denies egress to target */
 	policy_add_egress_deny_all_entry();
 
+	/* The v4 and v6 egress cases share this metrics key, clear it so that
+	 * the assertions below hold regardless of test ordering.
+	 */
+	metrics_del_entry(DENY_REASON, METRIC_EGRESS);
+
 	return pod_send_packet(ctx);
 }
 
 CHECK(PROG_TYPE, "policy_reject_response_v6")
 int policy_reject_response_v6_check(const struct __ctx_buff *ctx)
 {
-	/* we should have a redirect of the packet on the same interface. */
-	return validate_icmpv6_reply_return(ctx, TC_ACT_REDIRECT);
+	/* we should have a redirect of the packet on the same interface, and
+	 * the denied packet accounted under the policy-deny drop reason.
+	 */
+	return validate_icmpv6_reply_return(ctx, TC_ACT_REDIRECT, DENY_REASON);
 }
 
 /*
@@ -185,5 +219,5 @@ int policy_reject_response_v6_ingress_setup(struct __ctx_buff *ctx)
 CHECK(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_check(const struct __ctx_buff *ctx)
 {
-	return validate_icmpv6_reply_return(ctx, TC_ACT_SHOT);
+	return validate_icmpv6_reply_return(ctx, TC_ACT_SHOT, 0);
 }


### PR DESCRIPTION
# Problem

When `policy-deny-response: icmp` is enabled, users noticed that metrics `drop_count_total` and `drop_bytes_total` stopped reporting drops with reason `policy_denied` on direction `egress`. I checked it out on one of our clusters and the report was correct.

# Cause

`tail_policy_denied_ipv{4,6}()` loaded the verdict from `CB_VERDICT` into a `__u32`. `__DROP_REASON()` branches on `typeof(err)` to fold a negative Cilium error into a positive reason, so an unsigned argument always took the positive branch and merely truncated: `DROP_POLICY_DENY (-181)` became 75 and `DROP_POLICY (-133)` became 123. Both fall below `DropMin`, so `Key.IsDrop()` was false and the packets were reported as forwards. `drop_count_total` lost every `policy_deny_response=icmp` drop while `cilium_forward_count_total` was silently inflated. The same value reached the `send_drop_notify_error()` fallback, mislabelling those drop events.

# Solution

Keep the verdict signed, and capture the packet length before `generate_icmp{4,6}_reply()` rewrites the packet, so `drop_bytes_total` accounts the denied packet rather than the ICMP error message.

Assert both in `tc_policy_reject_response_test`, which previously checked only the ICMP reply.

This PR was prepared with AIL:3. I used AI to find and write a fix for the bug. Then I manually checked the fix and ran it in a real cluster to validate it.

Fixes: #48282

```release-note
bpf: Fixed a bug where enabling policy-deny-response: icmp would cause metrics for policy denied drops on egress to stop getting reported.
```