### PR TITLE
Fix nodeport egress tuple reuse for closed connections [2]

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -815,6 +815,9 @@ nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
 		return false;
 
 	if (entry->node_port) {
+		if (!ct_entry_alive(entry))
+			return false;
+
 		if (entry->rev_nat_index) {
 			__u16 rev_nat_index = entry->rev_nat_index;
 			const struct lb6_reverse_nat *tmp;
@@ -2112,6 +2115,9 @@ nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
 		return false;
 
 	if (entry->node_port) {
+		if (!ct_entry_alive(entry))
+			return false;
+
 		if (entry->rev_nat_index) {
 			__u16 rev_nat_index = entry->rev_nat_index;
 			const struct lb4_reverse_nat *tmp;


### PR DESCRIPTION
Follow up for the fix made in: 4c654dae328037e2bf5b1998b725afe3884b3a9a

Tested manually with below script that fails on `main`:

```nushell
#!/usr/bin/env nu

let cilium_root = ($env.HOME | path join "ws/cilium/cilium/main")

let kind_config = '
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  disableDefaultCNI: true
  ipFamily: dual
  kubeProxyMode: none
  podSubnet: "10.244.0.0/16,fd00:10:244::/56"
  serviceSubnet: "10.96.0.0/16,fd00:10:96::/112"
nodes:
  - role: control-plane
  - role: worker
  - role: worker
'
$kind_config | kind create cluster --config=-

make -C $cilium_root kind-image-agent
let helm_config = '
image:
  override: "localhost:5000/cilium/cilium-dev:local"
  pullPolicy: Never

ipv4:
  enabled: true
ipv6:
  enabled: true

kubeProxyReplacement: true
k8sServiceHost: kind-control-plane
k8sServicePort: 6443

routingMode: native
autoDirectNodeRoutes: true

ipv4NativeRoutingCIDR: 10.244.0.0/16
ipv6NativeRoutingCIDR: fd00:10:244::/56

bpf:
  masquerade: true
'
$helm_config | save -f /tmp/test-helm-values.yaml

(
  cilium install --wait
    --chart-directory=$"($cilium_root)/install/kubernetes/cilium"
    --helm-values=$"($cilium_root)/contrib/testing/kind-common.yaml"
    --helm-values=/tmp/test-helm-values.yaml
)
cilium status --wait

let client_node = "kind-worker"
let server_node = "kind-worker2"

let client_pod = $'
apiVersion: v1
kind: Pod
metadata:
  name: client
spec:
  nodeName: ($client_node)
  terminationGracePeriodSeconds: 1
  containers:
  - name: netshoot
    image: nicolaka/netshoot
    command: ["tail", "-f", "/dev/null"]
    securityContext:
      capabilities:
        add:
        - ALL
'
$client_pod | kubectl apply -f -

let server_pod = $'
apiVersion: v1
kind: Pod
metadata:
  name: server
spec:
  nodeName: ($server_node)
  terminationGracePeriodSeconds: 1
  containers:
  - name: fortio
    image: fortio/fortio:latest
    args: ["server"]
    ports:
    - containerPort: 8080
      hostPort: 4000
      protocol: TCP
      name: http
'
$server_pod | kubectl apply -f -


sleep 10sec

let server_pod_json = (^kubectl get pods server -o json)

let server_pod_ip = (
  $server_pod_json | jq -r '.status.podIPs[].ip | select(. | contains(":") | not)'
)
let server_node_ip = (
  $server_pod_json | jq -r '.status.hostIPs[].ip | select(. | contains(":") | not)'
)

let port = "42000"
let curl_w_opt = "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n"

kubectl exec -it client -- curl --silent --fail --show-error --connect-timeout 2 --max-time 10 -w $curl_w_opt --output /dev/null --local-port $port $"http://($server_node_ip):4000/"

kubectl exec -it client -- ss -ta -K

kubectl exec -it client -- curl --silent --fail --show-error --connect-timeout 2 --max-time 10 -w $curl_w_opt --output /dev/null --local-port $port $"http://($server_pod_ip):8080/"
```