### PR TITLE
helm: add cilium-envoy extensions for readiness/liveness/startup probes

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -104,6 +104,39 @@ Allow packagers to add extra arguments to the clustermesh-apiserver kvstoremesh 
 {{- end }}
 
 {{/*
+Allow packagers to define the startup probe handler for the cilium-envoy container.
+*/}}
+{{- define "envoy.startupProbe" -}}
+httpGet:
+  host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+  path: /healthz
+  port: {{ .Values.envoy.healthPort }}
+  scheme: HTTP
+{{- end }}
+
+{{/*
+Allow packagers to define the liveness probe handler for the cilium-envoy container.
+*/}}
+{{- define "envoy.livenessProbe" -}}
+httpGet:
+  host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+  path: /healthz
+  port: {{ .Values.envoy.healthPort }}
+  scheme: HTTP
+{{- end }}
+
+{{/*
+Allow packagers to define the readiness probe handler for the cilium-envoy container.
+*/}}
+{{- define "envoy.readinessProbe" -}}
+httpGet:
+  host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+  path: /healthz
+  port: {{ .Values.envoy.healthPort }}
+  scheme: HTTP
+{{- end }}
+
+{{/*
 Allow packagers to add lifecycle hooks to the cilium-envoy container.
 */}}
 {{- define "envoy.lifecycle" -}}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -155,11 +155,7 @@ spec:
         {{- end }}
         {{- if .Values.envoy.startupProbe.enabled }}
         startupProbe:
-          httpGet:
-            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
-            path: /healthz
-            port: {{ .Values.envoy.healthPort }}
-            scheme: HTTP
+          {{- include "envoy.startupProbe" . | nindent 10 }}
           failureThreshold: {{ .Values.envoy.startupProbe.failureThreshold }}
           periodSeconds: {{ .Values.envoy.startupProbe.periodSeconds }}
           successThreshold: 1
@@ -168,11 +164,7 @@ spec:
         {{- end }}
         {{- if .Values.envoy.livenessProbe.enabled }}
         livenessProbe:
-          httpGet:
-            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
-            path: /healthz
-            port: {{ .Values.envoy.healthPort }}
-            scheme: HTTP
+          {{- include "envoy.livenessProbe" . | nindent 10 }}
           periodSeconds: {{ .Values.envoy.livenessProbe.periodSeconds }}
           successThreshold: 1
           failureThreshold: {{ .Values.envoy.livenessProbe.failureThreshold }}
@@ -180,11 +172,7 @@ spec:
           timeoutSeconds: {{ .Values.envoy.livenessProbe.timeoutSeconds }}
         {{- end }}
         readinessProbe:
-          httpGet:
-            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
-            path: /healthz
-            port: {{ .Values.envoy.healthPort }}
-            scheme: HTTP
+          {{- include "envoy.readinessProbe" . | nindent 10 }}
           periodSeconds: {{ .Values.envoy.readinessProbe.periodSeconds }}
           successThreshold: 1
           failureThreshold: {{ .Values.envoy.readinessProbe.failureThreshold }}


### PR DESCRIPTION
Adds extension points to cilium-envoy readinessProbe, livenessProbe and startupProbe so downstream packagers can configure alternate probe methods.

```release-note
Add extension points for cilium-envoy Daemonset readiness, liveness and startup probes
```