### PR TITLE
[v1.19] Reconfigure ENI endpoint egress routing rules during restore

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"os"
 	"slices"
@@ -20,6 +21,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/daemon/cmd/legacy"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -29,7 +31,9 @@ import (
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -40,10 +44,12 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/mtu"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	"github.com/cilium/cilium/pkg/promise"
+	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -91,6 +97,7 @@ type endpointRestorerParams struct {
 	EndpointAPIFence    endpointapi.Fence
 	IPSecAgent          datapath.IPsecAgent
 	IPAMManager         *ipam.IPAM
+	MTUManager          mtu.MTU
 	CacheStatus         k8sSynced.CacheStatus
 	DirReadStatus       policyDirectory.DirectoryWatcherReadStatus
 	IPCache             *ipcache.IPCache
@@ -109,6 +116,7 @@ type endpointRestorer struct {
 	endpointAPIFence    endpointapi.Fence
 	ipSecAgent          datapath.IPsecAgent
 	ipamManager         *ipam.IPAM
+	mtuManager          mtu.MTU
 	lxcMap              lxcmap.Map
 
 	cacheStatus   k8sSynced.CacheStatus
@@ -135,6 +143,7 @@ func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
 		endpointAPIFence:    params.EndpointAPIFence,
 		ipSecAgent:          params.IPSecAgent,
 		ipamManager:         params.IPAMManager,
+		mtuManager:          params.MTUManager,
 		lxcMap:              params.LXCMap,
 
 		cacheStatus:   params.CacheStatus,
@@ -543,7 +552,6 @@ func (r *endpointRestorer) regenerateRestoredEndpoints(state *endpointRestoreSta
 	// purpose, all endpoints being restored must already be in the
 	// endpoint list.
 	for i, ep := range slices.Backward(state.restored) {
-
 		// Insert into endpoint manager so it can be regenerated when calls to
 		// RegenerateAllEndpoints() are made. This must be done synchronously (i.e.,
 		// not in a goroutine) because regenerateRestoredEndpoints must guarantee
@@ -676,9 +684,11 @@ func (r *endpointRestorer) handleRestoredEndpointsRegeneration(endpoints []*endp
 }
 
 func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
+	var res *ipam.AllocationResult
+
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
-		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
+		res, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
@@ -688,11 +698,15 @@ func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) 
 				r.ipamManager.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
 			}
 		}()
+
+		if err = r.configureRoutingInfo(res); err != nil {
+			return fmt.Errorf("failed to configure routing info: %w", err)
+		}
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
 		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
-		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
+		res, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes
@@ -717,8 +731,88 @@ func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) 
 		case err != nil:
 			return fmt.Errorf("unable to reallocate %s IPv4 address: %w", ep.IPv4, err)
 		}
+
+		if err == nil {
+			defer func() {
+				if err != nil {
+					r.ipamManager.ReleaseIP(ep.IPv4.AsSlice(), ipv4Pool)
+				}
+			}()
+
+			if err = r.configureRoutingInfo(res); err != nil {
+				return fmt.Errorf("failed to configure routing info: %w", err)
+			}
+		}
 	}
 
+	return nil
+}
+
+// Should match CNI implementation in: plugins/cilium-cni/cmd/cmd.go
+//
+// needsEndpointRoutingOnHost returns true if extra routes/rules need to be installed
+// on host for the Pod. This is needed for following IPAM modes:
+// - Cloud ENI IPAM modes.
+// - DelegatedPlugin mode with InstallUplinkRoutesForDelegatedIPAM set to true.
+func (r *endpointRestorer) needsEndpointRoutingOnHost() bool {
+	switch option.Config.IPAMMode() {
+	case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		return true
+	case ipamOption.IPAMDelegatedPlugin:
+		return option.Config.InstallUplinkRoutesForDelegatedIPAM
+	}
+	return false
+}
+
+// configureRoutingInfo configures the routing rules for endpoint's ip allocation result.
+//
+// In endpoint create path, the routing configuration is handled by CNI ADD: plugins/cilium-cni/cmd/interface.go
+// and is not reconciled by cilium-agent. During agent restart its possible that datapath configuration changes
+// (eg. masquerade config), which requires routing rules to be re-configured.
+func (r *endpointRestorer) configureRoutingInfo(result *ipam.AllocationResult) error {
+	if !r.needsEndpointRoutingOnHost() {
+		return nil
+	}
+
+	cidrs := make([]*net.IPNet, 0, len(result.CIDRs))
+	for _, cidrString := range result.CIDRs {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return fmt.Errorf("invalid CIDR '%s': %w", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	ipv4CIDRs, ipv6CIDRs := iputil.CoalesceCIDRs(cidrs)
+
+	var (
+		coalescedCIDRs []string
+		masq           bool
+	)
+
+	if result.IP.To4() != nil {
+		coalescedCIDRs = cslices.Map(ipv4CIDRs, func(p *net.IPNet) string { return p.String() })
+		masq = option.Config.EnableIPv4Masquerade
+	} else {
+		coalescedCIDRs = cslices.Map(ipv6CIDRs, func(p *net.IPNet) string { return p.String() })
+		masq = option.Config.EnableIPv6Masquerade
+	}
+
+	routingInfo, err := linuxrouting.NewRoutingInfo(
+		r.logger,
+		result.GatewayIP,
+		coalescedCIDRs,
+		result.PrimaryMAC,
+		result.InterfaceNumber,
+		option.Config.IPAMMode(),
+		masq,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to parse routing info: %w", err)
+	}
+
+	if err := routingInfo.Configure(result.IP, r.mtuManager.GetDeviceMTU(), false); err != nil {
+		return fmt.Errorf("unable to install ip rules and routes: %w", err)
+	}
 	return nil
 }
 

--- a/daemon/cmd/endpoint_restore_test.go
+++ b/daemon/cmd/endpoint_restore_test.go
@@ -4,13 +4,22 @@
 package cmd
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
@@ -44,4 +53,169 @@ func TestPrivilegedRemoveStaleEPIfaces(t *testing.T) {
 
 		return nil
 	})
+}
+
+func TestNeedsEndpointRoutingOnHost(t *testing.T) {
+	oldIPAM := option.Config.IPAM
+	oldInstallUplinkRoutes := option.Config.InstallUplinkRoutesForDelegatedIPAM
+	defer func() {
+		option.Config.IPAM = oldIPAM
+		option.Config.InstallUplinkRoutesForDelegatedIPAM = oldInstallUplinkRoutes
+	}()
+
+	tests := []struct {
+		name                                string
+		ipam                                string
+		installUplinkRoutesForDelegatedIPAM bool
+		want                                bool
+	}{
+		{
+			name: "ENI IPAM",
+			ipam: ipamOption.IPAMENI,
+			want: true,
+		},
+		{
+			name: "Azure IPAM",
+			ipam: ipamOption.IPAMAzure,
+			want: true,
+		},
+		{
+			name: "AlibabaCloud IPAM",
+			ipam: ipamOption.IPAMAlibabaCloud,
+			want: true,
+		},
+		{
+			name: "cluster pool CIDR IPAM",
+			ipam: ipamOption.IPAMKubernetes,
+			want: false,
+		},
+		{
+			name: "CRD IPAM",
+			ipam: ipamOption.IPAMCRD,
+			want: false,
+		},
+		{
+			name:                                "delegated plugin without uplink routes",
+			ipam:                                ipamOption.IPAMDelegatedPlugin,
+			installUplinkRoutesForDelegatedIPAM: false,
+			want:                                false,
+		},
+		{
+			name:                                "delegated plugin with uplink routes",
+			ipam:                                ipamOption.IPAMDelegatedPlugin,
+			installUplinkRoutesForDelegatedIPAM: true,
+			want:                                true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option.Config.IPAM = tt.ipam
+			option.Config.InstallUplinkRoutesForDelegatedIPAM = tt.installUplinkRoutesForDelegatedIPAM
+
+			r := &endpointRestorer{}
+			require.Equal(t, tt.want, r.needsEndpointRoutingOnHost())
+		})
+	}
+}
+
+// TestPrivilegedConfigureRoutingInfoOnRestore verifies that configureRoutingInfo,
+// called during endpoint restore, reconciles the egress ip rules of a restored
+// endpoint to match the *current* masquerade configuration, even though those
+// rules were originally installed once by CNI ADD under a potentially
+// different configuration.
+func TestPrivilegedConfigureRoutingInfoOnRestore(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		fakeMAC := "00:11:22:33:44:66"
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "epres-test",
+				HardwareAddr: net.HardwareAddr(mac.MustParseMAC(fakeMAC)),
+			},
+		}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		defer func() {
+			require.NoError(t, netlink.LinkDel(dummy))
+		}()
+
+		oldIPAM := option.Config.IPAM
+		oldMasq := option.Config.EnableIPv4Masquerade
+		defer func() {
+			option.Config.IPAM = oldIPAM
+			option.Config.EnableIPv4Masquerade = oldMasq
+		}()
+		option.Config.IPAM = ipamOption.IPAMENI
+
+		result := &ipam.AllocationResult{
+			IP: net.ParseIP("192.168.2.123"),
+			CIDRs: []string{
+				"192.168.0.0/16",
+				"192.170.0.0/16",
+			},
+			PrimaryMAC:      fakeMAC,
+			GatewayIP:       "192.168.2.1",
+			InterfaceNumber: "1",
+		}
+
+		restorer := &endpointRestorer{
+			logger:     hivetest.Logger(t),
+			mtuManager: &fakeTypes.MTU{},
+		}
+
+		// The endpoint was originally created (CNI ADD) while masquerading
+		// was disabled, so an unconditional/catch-all egress rule is in place.
+		option.Config.EnableIPv4Masquerade = false
+		require.NoError(t, restorer.configureRoutingInfo(result))
+		rules, err := safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific := countEgressRulesForIP(rules, result.IP)
+		require.Equal(t, 1, catchAll, "expected a single catch-all egress rule")
+		require.Zero(t, cidrSpecific, "expected no CIDR-specific egress rules")
+
+		// The datapath is reconfigured with masquerading enabled before the
+		// agent restarts and endpoints are restored. The restore path must
+		// reconcile the stale catch-all rule into per-CIDR rules.
+		option.Config.EnableIPv4Masquerade = true
+		require.NoError(t, restorer.configureRoutingInfo(result))
+		rules, err = safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, result.IP)
+		require.Zero(t, catchAll, "stale catch-all egress rule should have been removed")
+		require.Equal(t, len(result.CIDRs), cidrSpecific, "expected one egress rule per CIDR")
+
+		// The datapath is reconfigured again with masquerading disabled
+		// before the next restart. The restore path must reconcile the
+		// stale per-CIDR rules back into a single catch-all rule.
+		option.Config.EnableIPv4Masquerade = false
+		require.NoError(t, restorer.configureRoutingInfo(result))
+		rules, err = safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, result.IP)
+		require.Equal(t, 1, catchAll, "expected a single catch-all egress rule")
+		require.Zero(t, cidrSpecific, "stale CIDR-specific egress rules should have been removed")
+
+		addr, ok := netip.AddrFromSlice(result.IP.To4())
+		require.True(t, ok)
+		require.NoError(t, linuxrouting.Delete(hivetest.Logger(t), addr))
+		return nil
+	})
+}
+
+// countEgressRulesForIP returns the number of catch-all (no 'to' field) and
+// CIDR-specific ('to' field set) egress rules configured for the given
+// source IP.
+func countEgressRulesForIP(rules []netlink.Rule, ip net.IP) (catchAll, cidrSpecific int) {
+	for _, rule := range rules {
+		if rule.Src == nil || !rule.Src.IP.Equal(ip) {
+			continue
+		}
+		if rule.Dst == nil {
+			catchAll++
+		} else {
+			cidrSpecific++
+		}
+	}
+	return catchAll, cidrSpecific
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -110,6 +110,13 @@ const (
 	// RulePriorityVtep is the priority of the rule used for routing packets to VTEP device
 	RulePriorityVtep = 112
 
+	// RulePriorityEgressMasqueradeBridge is a transient priority used while
+	// migrating an endpoint's egress rules between per-CIDR and catch-all
+	// in ENI mode when masquerade configuration changes.
+	// This priority should be higher than the default(32767) and main(32766)
+	// table lookup rules.
+	RulePriorityEgressMasqueradeBridge = 32765
+
 	// IPSec offset value for node rules
 	IPsecMaxKeyVersion = 15
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -39,6 +39,11 @@ func (info *RoutingInfo) useCompatEgressPriority() bool {
 // These rules and routes direct egress traffic out of the interface and
 // ingress traffic back to the endpoint (`ip`).
 //
+// RoutingInfo configuration is a one time operation that happens during:
+// * AgentStartup for infra ip components
+// * Endpoint Restore
+// * CNI ADD
+//
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
 // mtu: The interface MTU.
@@ -58,15 +63,17 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	}
 
 	var ipWithMask net.IPNet
+	var family int
 	var replaceRule func(route.Rule) error
-
 	if ip.To4() != nil {
+		family = netlink.FAMILY_V4
 		replaceRule = route.ReplaceRule
 		ipWithMask = net.IPNet{
 			IP:   ip,
 			Mask: net.CIDRMask(32, 32),
 		}
 	} else {
+		family = netlink.FAMILY_V6
 		replaceRule = route.ReplaceRuleIPv6
 		ipWithMask = net.IPNet{
 			IP:   ip,
@@ -99,6 +106,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		ifaceNum = info.InterfaceNumber
 	}
 	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
+	ruleFilter := route.Rule{
+		Priority: egressPriority,
+		From:     &ipWithMask,
+		Table:    tableID,
+		Protocol: linux_defaults.RTProto,
+	}
 
 	// The condition here should mirror the condition in Delete.
 	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
@@ -106,18 +119,82 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
 		// so we need to normalize the rule to cidr here and in Delete
+		var installedCatchAllEquivalent bool
 		for _, cidr := range info.CIDRs {
+			to := normalizeRuleToCIDR(&cidr)
+			if to == nil {
+				// A 0.0.0.0/0 (or ::/0) CIDR normalizes to an unconditional
+				// rule identical in shape to the stale catch-all rule we'd
+				// otherwise clean up below. Track this so we don't delete
+				// the rule we just installed.
+				installedCatchAllEquivalent = true
+			}
 			if err := replaceRule(route.Rule{
 				Priority: egressPriority,
 				From:     &ipWithMask,
-				To:       normalizeRuleToCIDR(&cidr),
+				To:       to,
 				Table:    tableID,
 				Protocol: linux_defaults.RTProto,
 			}); err != nil {
 				return fmt.Errorf("unable to install ip rule: %w", err)
 			}
 		}
+
+		// After creating cidr specific rules for ENI remove the catch-all rule if present.
+		// This ensures cleanup of the rule when masquerading configuration changes(best-effort).
+		if !installedCatchAllEquivalent {
+			_ = deleteRulesFiltered(info.logger, ruleFilter, family, deleteRuleFilter{
+				fn: func(r netlink.Rule) bool {
+					return r.Dst == nil
+				},
+			})
+		}
 	} else {
+		// Cleanup CIDR specific rules if present and create catch-all rule.
+		// This cleanup needs to happen before installing the new rule as
+		// creating a catch all rule on top of CIDR specific rule results in
+		// error: RTNETLINK answers: File exists
+		existingRules, err := route.ListRules(family, &ruleFilter)
+		if err != nil {
+			return fmt.Errorf("unable to list existing egress rules: %w", err)
+		}
+		var staleCIDRRules []netlink.Rule
+		for _, r := range existingRules {
+			if r.Dst != nil {
+				staleCIDRRules = append(staleCIDRRules, r)
+			}
+		}
+
+		// Deleting the stale rules first leaves a window with no matching
+		// egress rule for the endpoint. If there's any stale rule to
+		// remove, bridge that window with a rule installed at a transient
+		// priority so the traffic is not impacted.
+		// The transient rule is removed once the catch-all rule is in place.
+		hasStaleCIDRRules := len(staleCIDRRules) > 0
+		tempRule := route.Rule{
+			Priority: linux_defaults.RulePriorityEgressMasqueradeBridge,
+			From:     &ipWithMask,
+			Table:    tableID,
+			Protocol: linux_defaults.RTProto,
+		}
+		if hasStaleCIDRRules {
+			info.logger.Info("Cleaning up stale CIDR specific egress rules",
+				logfields.Count, len(staleCIDRRules),
+			)
+			if err := replaceRule(tempRule); err != nil {
+				return fmt.Errorf("unable to install transient ip rule: %w", err)
+			}
+
+			for i := range staleCIDRRules {
+				if err := netlink.RuleDel(&staleCIDRRules[i]); err != nil {
+					info.logger.Warn("Failed to delete stale egress rule",
+						logfields.Error, err,
+						logfields.Rule, staleCIDRRules[i],
+					)
+				}
+			}
+		}
+
 		// Lookup a VPC specific table for all traffic from an endpoint.
 		if err := replaceRule(route.Rule{
 			Priority: egressPriority,
@@ -126,6 +203,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
 			return fmt.Errorf("unable to install ip rule: %w", err)
+		}
+
+		if hasStaleCIDRRules {
+			if err := route.DeleteRule(family, tempRule); err != nil {
+				info.logger.Warn("Failed to remove transient egress rule", logfields.Error, err)
+			}
 		}
 	}
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -83,6 +83,57 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 	})
 }
 
+// TestPrivilegedConfigureMasqueradeReconciliation verifies that re-running
+// Configure after the masquerade configuration changes reconciles the
+// egress rules accordingly: stale rules from the previous configuration are
+// removed and replaced by the rules matching the new configuration. This is
+// the behavior relied upon by endpoint restore to fix up rules that were
+// installed once by CNI ADD under a since-changed configuration.
+func TestPrivilegedConfigureMasqueradeReconciliation(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip, ri := getFakes(t, ipamOption.IPAMENI, true, false)
+		masterMAC := ri.MasterIfMAC
+		ifaceCleanup := createDummyDevice(t, masterMAC)
+		defer ifaceCleanup()
+
+		// Masquerading enabled: only CIDR-specific rules should be present.
+		runConfigure(t, ri, ip, 1500)
+		rules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific := countEgressRulesForIP(rules, ip)
+		require.Zero(t, catchAll, "no catch-all rule should be present with masquerading enabled")
+		require.Equal(t, len(ri.CIDRs), cidrSpecific)
+
+		// Masquerading gets disabled and Configure is re-run (e.g. during
+		// endpoint restore after an agent restart): the stale CIDR-specific
+		// rules must be replaced by a single catch-all rule.
+		ri.Masquerade = false
+		option.Config.EnableIPv4Masquerade = false
+		runConfigure(t, ri, ip, 1500)
+		rules, _ = listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, ip)
+		require.Equal(t, 1, catchAll)
+		require.Zero(t, cidrSpecific)
+
+		// Re-enabling masquerading must clean up the catch-all rule again.
+		ri.Masquerade = true
+		option.Config.EnableIPv4Masquerade = true
+		runConfigure(t, ri, ip, 1500)
+		rules, _ = listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, ip)
+		require.Zero(t, catchAll)
+		require.Equal(t, len(ri.CIDRs), cidrSpecific)
+
+		runDelete(t, ip)
+		return nil
+	})
+}
+
 func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
@@ -211,6 +262,23 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
 	err := ri.Configure(ip.AsSlice(), mtu, false)
 	require.NoError(t, err)
+}
+
+// countEgressRulesForIP returns the number of catch-all (no 'to' field) and
+// CIDR-specific ('to' field set) egress rules configured for the given
+// source IP.
+func countEgressRulesForIP(rules []netlink.Rule, ip netip.Addr) (catchAll, cidrSpecific int) {
+	for _, rule := range rules {
+		if rule.Src == nil || !rule.Src.IP.Equal(ip.AsSlice()) {
+			continue
+		}
+		if rule.Dst == nil {
+			catchAll++
+		} else {
+			cidrSpecific++
+		}
+	}
+	return catchAll, cidrSpecific
 }
 
 // verifyMasqueradeRules checks that rules are consistent with the masquerading configuration:


### PR DESCRIPTION
This is not a backport for the fix from `main`. The behavior of ENI routing rule configuration [has diverged](https://github.com/cilium/cilium/pull/47008) in main and needs some rework. Discussed with @pippolo84 offline and he is working on a complete overhaul of routing rules reconciliation in agent: https://github.com/cilium/cilium/pull/48382
This PR acts as a point fix for routing rule reconfiguration during endpoint restore when masquerading config changes.

```release-note
Fix restored ENI endpoints routing rule configuration when masquerading config changes
```