### PR TITLE
[v1.18] Reconfigure ENI endpoint egress routing rules during restore

### DIFF
--- a/daemon/cmd/daemon_privileged_test.go
+++ b/daemon/cmd/daemon_privileged_test.go
@@ -5,15 +5,22 @@ package cmd
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
@@ -121,4 +128,107 @@ func TestPrivilegedRemoveStaleEPIfaces(t *testing.T) {
 
 		return nil
 	})
+}
+
+// TestPrivilegedConfigureRoutingInfoOnRestore verifies that configureRoutingInfo,
+// called during endpoint restore, reconciles the egress ip rules of a restored
+// endpoint to match the *current* masquerade configuration, even though those
+// rules were originally installed once by CNI ADD under a potentially
+// different configuration.
+func TestPrivilegedConfigureRoutingInfoOnRestore(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		fakeMAC, err := net.ParseMAC("00:11:22:33:44:66")
+		require.NoError(t, err)
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "epres-test",
+				HardwareAddr: fakeMAC,
+			},
+		}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		defer func() {
+			require.NoError(t, netlink.LinkDel(dummy))
+		}()
+
+		oldIPAM := option.Config.IPAM
+		oldMasq := option.Config.EnableIPv4Masquerade
+		defer func() {
+			option.Config.IPAM = oldIPAM
+			option.Config.EnableIPv4Masquerade = oldMasq
+		}()
+		option.Config.IPAM = ipamOption.IPAMENI
+
+		result := &ipam.AllocationResult{
+			IP: net.ParseIP("192.168.2.123"),
+			CIDRs: []string{
+				"192.168.0.0/16",
+				"192.170.0.0/16",
+			},
+			PrimaryMAC:      fakeMAC.String(),
+			GatewayIP:       "192.168.2.1",
+			InterfaceNumber: "1",
+		}
+
+		d := &Daemon{
+			logger:    hivetest.Logger(t),
+			mtuConfig: &fakeTypes.MTU{},
+		}
+
+		// The endpoint was originally created (CNI ADD) while masquerading
+		// was disabled, so an unconditional/catch-all egress rule is in place.
+		option.Config.EnableIPv4Masquerade = false
+		require.NoError(t, d.configureRoutingInfo(result))
+		rules, err := safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific := countEgressRulesForIP(rules, result.IP)
+		require.Equal(t, 1, catchAll, "expected a single catch-all egress rule")
+		require.Zero(t, cidrSpecific, "expected no CIDR-specific egress rules")
+
+		// The datapath is reconfigured with masquerading enabled before the
+		// agent restarts and endpoints are restored. The restore path must
+		// reconcile the stale catch-all rule into per-CIDR rules.
+		option.Config.EnableIPv4Masquerade = true
+		require.NoError(t, d.configureRoutingInfo(result))
+		rules, err = safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, result.IP)
+		require.Zero(t, catchAll, "stale catch-all egress rule should have been removed")
+		require.Equal(t, len(result.CIDRs), cidrSpecific, "expected one egress rule per CIDR")
+
+		// The datapath is reconfigured again with masquerading disabled
+		// before the next restart. The restore path must reconcile the
+		// stale per-CIDR rules back into a single catch-all rule.
+		option.Config.EnableIPv4Masquerade = false
+		require.NoError(t, d.configureRoutingInfo(result))
+		rules, err = safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, result.IP)
+		require.Equal(t, 1, catchAll, "expected a single catch-all egress rule")
+		require.Zero(t, cidrSpecific, "stale CIDR-specific egress rules should have been removed")
+
+		addr, ok := netip.AddrFromSlice(result.IP)
+		require.True(t, ok)
+		require.NoError(t, linuxrouting.Delete(hivetest.Logger(t), addr.Unmap(), option.Config.EgressMultiHomeIPRuleCompat))
+		return nil
+	})
+}
+
+// countEgressRulesForIP returns the number of catch-all (no 'to' field) and
+// CIDR-specific ('to' field set) egress rules configured for the given
+// source IP.
+func countEgressRulesForIP(rules []netlink.Rule, ip net.IP) (catchAll, cidrSpecific int) {
+	for _, rule := range rules {
+		if rule.Src == nil || !rule.Src.IP.Equal(ip) {
+			continue
+		}
+		if rule.Dst == nil {
+			catchAll++
+		} else {
+			cidrSpecific++
+		}
+	}
+	return catchAll, cidrSpecific
 }

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -14,9 +14,12 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/endpoint"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
@@ -432,9 +435,11 @@ func (d *Daemon) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpo
 }
 
 func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
+	var res *ipam.AllocationResult
+
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
+		res, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
@@ -444,11 +449,15 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 				d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
 			}
 		}()
+
+		if err = d.configureRoutingInfo(res); err != nil {
+			return fmt.Errorf("failed to configure routing info: %w", err)
+		}
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
 		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
+		res, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes
@@ -473,8 +482,99 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 		case err != nil:
 			return fmt.Errorf("unable to reallocate %s IPv4 address: %w", ep.IPv4, err)
 		}
+
+		if err == nil {
+			defer func() {
+				if err != nil {
+					d.ipam.ReleaseIP(ep.IPv4.AsSlice(), ipv4Pool)
+				}
+			}()
+
+			if err = d.configureRoutingInfo(res); err != nil {
+				return fmt.Errorf("failed to configure routing info: %w", err)
+			}
+		}
 	}
 
+	return nil
+}
+
+// Should match CNI implementation in: plugins/cilium-cni/cmd/interface.go
+//
+// needsEndpointRoutingOnHost returns true if extra routes/rules need to be installed
+// on host for the Pod. This is needed for following IPAM modes:
+// - Cloud ENI IPAM modes.
+// - DelegatedPlugin mode with InstallUplinkRoutesForDelegatedIPAM set to true.
+func (d *Daemon) needsEndpointRoutingOnHost() bool {
+	switch option.Config.IPAMMode() {
+	case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		return true
+	case ipamOption.IPAMDelegatedPlugin:
+		return option.Config.InstallUplinkRoutesForDelegatedIPAM
+	}
+	return false
+}
+
+// configureRoutingInfo configures the routing rules for endpoint's ip allocation result.
+//
+// In endpoint create path, the routing configuration is handled by CNI ADD: plugins/cilium-cni/cmd/interface.go
+// and is not reconciled by cilium-agent. During agent restart its possible that datapath configuration changes
+// (eg. masquerade config), which requires routing rules to be re-configured.
+func (d *Daemon) configureRoutingInfo(result *ipam.AllocationResult) error {
+	if !d.needsEndpointRoutingOnHost() {
+		return nil
+	}
+
+	cidrs := make([]*net.IPNet, 0, len(result.CIDRs))
+	for _, cidrString := range result.CIDRs {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return fmt.Errorf("invalid CIDR '%s': %w", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	ipv4CIDRs, ipv6CIDRs := iputil.CoalesceCIDRs(cidrs)
+
+	var (
+		coalescedCIDRs []string
+		masq           bool
+	)
+
+	if result.IP.To4() != nil {
+		coalescedCIDRs = make([]string, 0, len(ipv4CIDRs))
+		for _, cidr := range ipv4CIDRs {
+			coalescedCIDRs = append(coalescedCIDRs, cidr.String())
+		}
+		masq = option.Config.EnableIPv4Masquerade
+	} else {
+		coalescedCIDRs = make([]string, 0, len(ipv6CIDRs))
+		for _, cidr := range ipv6CIDRs {
+			coalescedCIDRs = append(coalescedCIDRs, cidr.String())
+		}
+		masq = option.Config.EnableIPv6Masquerade
+	}
+
+	routingInfo, err := linuxrouting.NewRoutingInfo(
+		d.logger,
+		result.GatewayIP,
+		coalescedCIDRs,
+		result.PrimaryMAC,
+		result.InterfaceNumber,
+		option.Config.IPAMMode(),
+		masq,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to parse routing info: %w", err)
+	}
+
+	if err := routingInfo.Configure(
+		result.IP,
+		d.mtuConfig.GetDeviceMTU(),
+		option.Config.EgressMultiHomeIPRuleCompat,
+		false,
+	); err != nil {
+		return fmt.Errorf("unable to install ip rules and routes: %w", err)
+	}
 	return nil
 }
 

--- a/daemon/cmd/state_test.go
+++ b/daemon/cmd/state_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestNeedsEndpointRoutingOnHost(t *testing.T) {
+	oldIPAM := option.Config.IPAM
+	oldInstallUplinkRoutes := option.Config.InstallUplinkRoutesForDelegatedIPAM
+	defer func() {
+		option.Config.IPAM = oldIPAM
+		option.Config.InstallUplinkRoutesForDelegatedIPAM = oldInstallUplinkRoutes
+	}()
+
+	tests := []struct {
+		name                                string
+		ipam                                string
+		installUplinkRoutesForDelegatedIPAM bool
+		want                                bool
+	}{
+		{
+			name: "ENI IPAM",
+			ipam: ipamOption.IPAMENI,
+			want: true,
+		},
+		{
+			name: "Azure IPAM",
+			ipam: ipamOption.IPAMAzure,
+			want: true,
+		},
+		{
+			name: "AlibabaCloud IPAM",
+			ipam: ipamOption.IPAMAlibabaCloud,
+			want: true,
+		},
+		{
+			name: "cluster pool CIDR IPAM",
+			ipam: ipamOption.IPAMKubernetes,
+			want: false,
+		},
+		{
+			name: "CRD IPAM",
+			ipam: ipamOption.IPAMCRD,
+			want: false,
+		},
+		{
+			name:                                "delegated plugin without uplink routes",
+			ipam:                                ipamOption.IPAMDelegatedPlugin,
+			installUplinkRoutesForDelegatedIPAM: false,
+			want:                                false,
+		},
+		{
+			name:                                "delegated plugin with uplink routes",
+			ipam:                                ipamOption.IPAMDelegatedPlugin,
+			installUplinkRoutesForDelegatedIPAM: true,
+			want:                                true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option.Config.IPAM = tt.ipam
+			option.Config.InstallUplinkRoutesForDelegatedIPAM = tt.installUplinkRoutesForDelegatedIPAM
+
+			d := &Daemon{}
+			require.Equal(t, tt.want, d.needsEndpointRoutingOnHost())
+		})
+	}
+}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -109,6 +109,13 @@ const (
 	// RulePriorityVtep is the priority of the rule used for routing packets to VTEP device
 	RulePriorityVtep = 112
 
+	// RulePriorityEgressMasqueradeBridge is a transient priority used while
+	// migrating an endpoint's egress rules between per-CIDR and catch-all
+	// in ENI mode when masquerade configuration changes.
+	// This priority should be higher than the default(32767) and main(32766)
+	// table lookup rules.
+	RulePriorityEgressMasqueradeBridge = 32765
+
 	// IPSec offset value for node rules
 	IPsecMaxKeyVersion = 15
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -35,6 +35,11 @@ import (
 // egress priority to consider when deleting the egress rules (see
 // option.Config.EgressMultiHomeIPRuleCompat).
 //
+// RoutingInfo configuration is a one time operation that happens during:
+// * AgentStartup for infra ip components
+// * Endpoint Restore
+// * CNI ADD
+//
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
 // mtu: The interface MTU.
@@ -55,15 +60,17 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	}
 
 	var ipWithMask net.IPNet
+	var family int
 	var replaceRule func(route.Rule) error
-
 	if ip.To4() != nil {
+		family = netlink.FAMILY_V4
 		replaceRule = route.ReplaceRule
 		ipWithMask = net.IPNet{
 			IP:   ip,
 			Mask: net.CIDRMask(32, 32),
 		}
 	} else {
+		family = netlink.FAMILY_V6
 		replaceRule = route.ReplaceRuleIPv6
 		ipWithMask = net.IPNet{
 			IP:   ip,
@@ -96,6 +103,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 		ifaceNum = info.InterfaceNumber
 	}
 	tableID = computeTableIDFromIfaceNumber(compat, ifaceNum)
+	ruleFilter := route.Rule{
+		Priority: egressPriority,
+		From:     &ipWithMask,
+		Table:    tableID,
+		Protocol: linux_defaults.RTProto,
+	}
 
 	// The condition here should mirror the condition in Delete.
 	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {
@@ -103,18 +116,82 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
 		// so we need to normalize the rule to cidr here and in Delete
+		var installedCatchAllEquivalent bool
 		for _, cidr := range info.CIDRs {
+			to := normalizeRuleToCIDR(&cidr)
+			if to == nil {
+				// A 0.0.0.0/0 (or ::/0) CIDR normalizes to an unconditional
+				// rule identical in shape to the stale catch-all rule we'd
+				// otherwise clean up below. Track this so we don't delete
+				// the rule we just installed.
+				installedCatchAllEquivalent = true
+			}
 			if err := replaceRule(route.Rule{
 				Priority: egressPriority,
 				From:     &ipWithMask,
-				To:       normalizeRuleToCIDR(&cidr),
+				To:       to,
 				Table:    tableID,
 				Protocol: linux_defaults.RTProto,
 			}); err != nil {
 				return fmt.Errorf("unable to install ip rule: %w", err)
 			}
 		}
+
+		// After creating cidr specific rules for ENI remove the catch-all rule if present.
+		// This ensures cleanup of the rule when masquerading configuration changes(best-effort).
+		if !installedCatchAllEquivalent {
+			_ = deleteRulesFiltered(info.logger, ruleFilter, family, deleteRuleFilter{
+				fn: func(r netlink.Rule) bool {
+					return r.Dst == nil
+				},
+			})
+		}
 	} else {
+		// Cleanup CIDR specific rules if present and create catch-all rule.
+		// This cleanup needs to happen before installing the new rule as
+		// creating a catch all rule on top of CIDR specific rule results in
+		// error: RTNETLINK answers: File exists
+		existingRules, err := route.ListRules(family, &ruleFilter)
+		if err != nil {
+			return fmt.Errorf("unable to list existing egress rules: %w", err)
+		}
+		var staleCIDRRules []netlink.Rule
+		for _, r := range existingRules {
+			if r.Dst != nil {
+				staleCIDRRules = append(staleCIDRRules, r)
+			}
+		}
+
+		// Deleting the stale rules first leaves a window with no matching
+		// egress rule for the endpoint. If there's any stale rule to
+		// remove, bridge that window with a rule installed at a transient
+		// priority so the traffic is not impacted.
+		// The transient rule is removed once the catch-all rule is in place.
+		hasStaleCIDRRules := len(staleCIDRRules) > 0
+		tempRule := route.Rule{
+			Priority: linux_defaults.RulePriorityEgressMasqueradeBridge,
+			From:     &ipWithMask,
+			Table:    tableID,
+			Protocol: linux_defaults.RTProto,
+		}
+		if hasStaleCIDRRules {
+			info.logger.Info("Cleaning up stale CIDR specific egress rules",
+				logfields.Count, len(staleCIDRRules),
+			)
+			if err := replaceRule(tempRule); err != nil {
+				return fmt.Errorf("unable to install transient ip rule: %w", err)
+			}
+
+			for i := range staleCIDRRules {
+				if err := netlink.RuleDel(&staleCIDRRules[i]); err != nil {
+					info.logger.Warn("Failed to delete stale egress rule",
+						logfields.Error, err,
+						logfields.Rule, staleCIDRRules[i],
+					)
+				}
+			}
+		}
+
 		// Lookup a VPC specific table for all traffic from an endpoint.
 		if err := replaceRule(route.Rule{
 			Priority: egressPriority,
@@ -123,6 +200,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
 			return fmt.Errorf("unable to install ip rule: %w", err)
+		}
+
+		if hasStaleCIDRRules {
+			if err := route.DeleteRule(family, tempRule); err != nil {
+				info.logger.Warn("Failed to remove transient egress rule", logfields.Error, err)
+			}
 		}
 	}
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -68,6 +68,57 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 	})
 }
 
+// TestPrivilegedConfigureMasqueradeReconciliation verifies that re-running
+// Configure after the masquerade configuration changes reconciles the
+// egress rules accordingly: stale rules from the previous configuration are
+// removed and replaced by the rules matching the new configuration. This is
+// the behavior relied upon by endpoint restore to fix up rules that were
+// installed once by CNI ADD under a since-changed configuration.
+func TestPrivilegedConfigureMasqueradeReconciliation(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip, ri := getFakes(t, true, false)
+		masterMAC := ri.MasterIfMAC
+		ifaceCleanup := createDummyDevice(t, masterMAC)
+		defer ifaceCleanup()
+
+		// Masquerading enabled: only CIDR-specific rules should be present.
+		runConfigure(t, ri, ip, 1500)
+		rules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific := countEgressRulesForIP(rules, ip)
+		require.Zero(t, catchAll, "no catch-all rule should be present with masquerading enabled")
+		require.Equal(t, len(ri.CIDRs), cidrSpecific)
+
+		// Masquerading gets disabled and Configure is re-run (e.g. during
+		// endpoint restore after an agent restart): the stale CIDR-specific
+		// rules must be replaced by a single catch-all rule.
+		ri.Masquerade = false
+		option.Config.EnableIPv4Masquerade = false
+		runConfigure(t, ri, ip, 1500)
+		rules, _ = listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, ip)
+		require.Equal(t, 1, catchAll)
+		require.Zero(t, cidrSpecific)
+
+		// Re-enabling masquerading must clean up the catch-all rule again.
+		ri.Masquerade = true
+		option.Config.EnableIPv4Masquerade = true
+		runConfigure(t, ri, ip, 1500)
+		rules, _ = listRulesAndRoutes(t, netlink.FAMILY_V4)
+		verifyMasqueradeRules(t, rules, ri, ip)
+		catchAll, cidrSpecific = countEgressRulesForIP(rules, ip)
+		require.Zero(t, catchAll)
+		require.Equal(t, len(ri.CIDRs), cidrSpecific)
+
+		runDelete(t, ip)
+		return nil
+	})
+}
+
 func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
@@ -194,6 +245,50 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
 	err := ri.Configure(ip.AsSlice(), mtu, false, false)
 	require.NoError(t, err)
+}
+
+// countEgressRulesForIP returns the number of catch-all (no 'to' field) and
+// CIDR-specific ('to' field set) egress rules configured for the given
+// source IP.
+func countEgressRulesForIP(rules []netlink.Rule, ip netip.Addr) (catchAll, cidrSpecific int) {
+	for _, rule := range rules {
+		if rule.Src == nil || !rule.Src.IP.Equal(ip.AsSlice()) {
+			continue
+		}
+		if rule.Dst == nil {
+			catchAll++
+		} else {
+			cidrSpecific++
+		}
+	}
+	return catchAll, cidrSpecific
+}
+
+// verifyMasqueradeRules checks that rules are consistent with the masquerading configuration:
+// - If masquerading is enabled, rules need to have the 'to' field (example: 'from 10.194.0.56 to 10.0.0.0/8 lookup 3')
+// - If masquerading is disabled or if ri.CIDRs has 0.0.0.0/0, the 'to' field should not be there
+func verifyMasqueradeRules(t *testing.T, rules []netlink.Rule, ri RoutingInfo, ip netip.Addr) {
+	t.Helper()
+
+	hasZeroCidr := false
+	for _, cidr := range ri.CIDRs {
+		if cidr.IP.IsUnspecified() {
+			hasZeroCidr = true
+			break
+		}
+	}
+
+	for _, rule := range rules {
+		if rule.Src != nil && rule.Src.IP.Equal(ip.AsSlice()) {
+			if ri.Masquerade && !hasZeroCidr && rule.Dst == nil {
+				require.Fail(t, "rule is missing the 'to' field with masquerading enabled")
+			} else if ri.Masquerade && hasZeroCidr && rule.Dst != nil {
+				require.Fail(t, "rule has the 'to' field with a 0.0.0.0/0 CIDR")
+			} else if !ri.Masquerade && rule.Dst != nil {
+				require.Fail(t, "rule has the 'to' field despite masquerading being disabled")
+			}
+		}
+	}
 }
 
 func runDelete(t *testing.T, ip netip.Addr) {


### PR DESCRIPTION
This is not a backport for the fix from `main`. The behavior of ENI routing rule configuration [has diverged](https://github.com/cilium/cilium/pull/47008) in main and needs some rework. Discussed with @pippolo84 offline and he is working on a complete overhaul of routing rules reconciliation in agent: https://github.com/cilium/cilium/pull/48382
This PR acts as a point fix for routing rule reconfiguration during endpoint restore when masquerading config changes.

```release-note
Fix restored ENI endpoints routing rule configuration when masquerading config changes
```