### PR TITLE
bpf: icmp*: catch errors from ctx_adjust_troom()

### DIFF
--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -50,7 +50,8 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		sample_len = full_len - sizeof(struct ethhdr);
 	}
 
-	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
+	if (ctx_adjust_troom(ctx, (__s32)(new_len - full_len)) < 0)
+		return DROP_INVALID;
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -617,7 +617,8 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		sample_len = full_len - sizeof(struct ethhdr);
 	}
 
-	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
+	if (ctx_adjust_troom(ctx, (__s32)(new_len - full_len)) < 0)
+		return DROP_INVALID;
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);


### PR DESCRIPTION
Let's respect when the kernel helper reports an error.