### PR TITLE
ci: cleanup disk space in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,6 +64,10 @@ jobs:
           persist-credentials: false
           # Needed to detect missing redirects
           fetch-depth: 0
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Build HTML
         uses: docker://quay.io/cilium/docs-builder:e6773ed21ab03066c0f24e68f342f18804a8ee0a@sha256:d3beff6d6408c09f6e1dbc637f7e98962b7d1fd2a81bf1d2a27ff8817dafb51f
         with:
@@ -81,6 +85,10 @@ jobs:
           persist-credentials: false
           # Needed to detect missing redirects
           fetch-depth: 0
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
Sometimes, the workflow fails because it's running out of disk space while building Cilium to check the generated documentation:

    CGO_ENABLED=0 GOARCH=amd64 go build -mod=vendor -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.21.0-dev 939f936c106 2026-09-03T06:51:51Z" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=0512632eff02ed4971b16926ae6b82a3c0e07a70" ' -tags=osusergo,ipam_provider_aws,ipam_provider_azure,ipam_provider_operator,ipam_provider_alibabacloud  -o cilium-operator
    github.com/cilium/cilium/operator: go build github.com/cilium/cilium/operator: copying /tmp/go-build673170913/b001/exe/a.out to cilium-operator: write cilium-operator: no space left on device

AIL: 0
