### PR TITLE
docs: document the iptables requirement for Gateway API TPROXY

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -6,6 +6,13 @@ Prerequisites
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
   (enabled by default).
+* Traffic arriving at the Gateway's Service is transparently forwarded to Envoy
+  using the ``TPROXY`` kernel facility. With the default ``bpf.tproxy=false``,
+  ``TPROXY`` is implemented with iptables, so nodes must provide iptables along
+  with the netfilter modules listed in the :ref:`L7 proxy system requirements
+  <l7_proxy_requirements>`. Some distributions do not ship these by default, in
+  which case connections to the Gateway time out without ever reaching Envoy.
+  The eBPF-based ``bpf.tproxy=true`` (beta) removes this iptables dependency.
 * By default, the Cilium Gateway API controller creates a service of LoadBalancer type,
   so your environment will need to support this. Alternatively, since Cilium 1.16,
   you can directly expose the Cilium L7 proxy on the :ref:`host network <gs_gateway_host_network_mode>`.

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -213,6 +213,8 @@ The following kernel configuration options are required for proper operation:
    The kernel build system uses ``Kconfig`` logic to validate and manage dependencies, 
    so direct edits to ``.config`` may be ignored or silently overridden.
 
+.. _l7_proxy_requirements:
+
 Requirements for L7 and FQDN Policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible. *(documentation only)*
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue. *(not applicable)*
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

Traffic arriving at a Gateway's Service is transparently forwarded to Envoy using
TPROXY. With the default `bpf.tproxy=false`, that redirect is implemented with
iptables actions and `socket` matches, so on a node that does not provide iptables
and the netfilter modules it depends on, the traffic never reaches Envoy and
connections to the Gateway time out.

The Gateway API Prerequisites section listed `kubeProxyReplacement`, `l7Proxy` and
LoadBalancer support, but not this one, so there was nothing in the Gateway API
documentation to point at when an otherwise correct installation failed to serve
traffic. In #47553 the reporter concluded that `bpf.tproxy=true` is mandatory. As
the discussion in that issue established, it is not — it is a beta alternative
that happens to remove the iptables dependency, and the real requirement is
iptables itself. The reporter's nodes ran a distribution that does not ship the
`ip_tables` module by default, and installing it made the Gateway work with
`bpf.tproxy` left at its default.

The kernel module list this depends on already exists in the system requirements,
but only under the heading "Requirements for L7 and FQDN Policies", which a
Gateway API user has no particular reason to open. This adds the missing
prerequisite and cross-references that section, giving it a label so it can be
referenced.

`Documentation/network/servicemesh/ingress.rst` carries the same prerequisites
list with the same gap. I left it out to keep this change scoped to the issue,
but I am happy to add it here if you would prefer it fixed in one go.

This PR was prepared with AIL:3. I reviewed the change and the discussion in
#47553 myself, and confirmed that the requirement the thread landed on is
iptables and the netfilter TPROXY modules, not the `bpf.tproxy=true` setting the
issue originally proposed.

Fixes: #47553

```release-note
Document that Gateway API needs iptables and the netfilter TPROXY modules on nodes when bpf.tproxy is disabled (the default).
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
