### PR TITLE
Use `netip.Addr.Is{4,6}` to check address family

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -702,29 +702,29 @@ func (ct *ConnectivityTest) detectPodCIDRs() {
 		hostIPs := pod.Pod.Status.PodIPs
 
 		for _, cidr := range n.Spec.IPAM.PodCIDRs {
-			ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(cidr.String(), hostIPs...)...)
+			ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(cidr.Prefix, hostIPs...)...)
 		}
 
 		// additional IP pools from multi-pool IPAM mode
 		for _, pool := range n.Spec.IPAM.Pools.Allocated {
 			for _, podCIDR := range pool.CIDRs {
-				ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(podCIDR.String(), hostIPs...)...)
+				ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(podCIDR.Prefix, hostIPs...)...)
 			}
 		}
 	}
 }
 
-func toPodCIDRs(cidr string, podIPs ...corev1.PodIP) []podCIDRs {
+func toPodCIDRs(prefix netip.Prefix, podIPs ...corev1.PodIP) []podCIDRs {
 	var podCIDRsInfo []podCIDRs
 	for _, ip := range podIPs {
 		f := features.GetIPFamily(ip.IP)
-		if strings.Contains(cidr, ":") != (f == features.IPFamilyV6) {
+		if prefix.Addr().Is6() != (f == features.IPFamilyV6) {
 			// Skip if the host IP of the pod mismatches with pod CIDR.
 			// Cannot create a route with the gateway IP family
 			// mismatching the subnet.
 			continue
 		}
-		podCIDRsInfo = append(podCIDRsInfo, podCIDRs{cidr, ip.IP})
+		podCIDRsInfo = append(podCIDRsInfo, podCIDRs{prefix.String(), ip.IP})
 	}
 	return podCIDRsInfo
 }

--- a/cilium-cli/utils/features/utils.go
+++ b/cilium-cli/utils/features/utils.go
@@ -4,7 +4,6 @@
 package features
 
 import (
-	"net"
 	"net/netip"
 
 	"github.com/cilium/cilium/pkg/subnet/topology"
@@ -53,14 +52,20 @@ func NewIPFamily(s string) IPFamily {
 	}
 }
 
-func GetIPFamily(addr string) IPFamily {
-	ip := net.ParseIP(addr)
+func GetIPFamily(ip string) IPFamily {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return IPFamilyAny
+	}
 
-	if ip.To4() != nil {
+	// Treat IPv4-mapped IPv6 addresses as IPv4
+	addr = addr.Unmap()
+
+	if addr.Is4() {
 		return IPFamilyV4
 	}
 
-	if ip.To16() != nil {
+	if addr.Is6() {
 		return IPFamilyV6
 	}
 

--- a/cilium-cli/utils/features/utils_test.go
+++ b/cilium-cli/utils/features/utils_test.go
@@ -181,3 +181,84 @@ func TestSameSubnet(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIPFamily(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		ip     string
+		family IPFamily
+	}{
+		{
+			name:   "empty",
+			ip:     "",
+			family: IPFamilyAny,
+		},
+		{
+			name:   "invalid IPv4",
+			ip:     "10.0.1.",
+			family: IPFamilyAny,
+		},
+		{
+			name:   "hostname",
+			ip:     "example.com",
+			family: IPFamilyAny,
+		},
+		{
+			name:   "IPv4",
+			ip:     "10.0.13.12",
+			family: IPFamilyV4,
+		},
+		{
+			name:   "IPv4 unspecified",
+			ip:     "0.0.0.0",
+			family: IPFamilyV4,
+		},
+		{
+			name:   "IPv4 mapped IPv6",
+			ip:     "::ffff:192.0.2.128",
+			family: IPFamilyV4,
+		},
+		{
+			name:   "IPv4 mapped IPv6 in hexadecimal",
+			ip:     "::ffff:c000:280",
+			family: IPFamilyV4,
+		},
+		{
+			name:   "IPv4 compatible IPv6",
+			ip:     "::192.0.2.128",
+			family: IPFamilyV6,
+		},
+		{
+			name:   "IPv6",
+			ip:     "2001:db8::1",
+			family: IPFamilyV6,
+		},
+		{
+			name:   "IPv6 loopback",
+			ip:     "::1",
+			family: IPFamilyV6,
+		},
+		{
+			name:   "IPv6 unspecified",
+			ip:     "::",
+			family: IPFamilyV6,
+		},
+		{
+			name:   "IPv6 with zone",
+			ip:     "fe80::1%eth0",
+			family: IPFamilyV6,
+		},
+		{
+			name:   "Prefix",
+			ip:     "192.0.2.1/32",
+			family: IPFamilyAny,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			family := GetIPFamily(tt.ip)
+			if family != tt.family {
+				t.Errorf("GetFamily(%q) = %v, want %v", tt.ip, family, tt.family)
+			}
+		})
+	}
+}

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"net/netip"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -139,8 +139,8 @@ func (p *prober) getResults() *healthReport {
 }
 
 func isIPv4(ip string) bool {
-	netIP := net.ParseIP(ip)
-	return netIP != nil && !strings.Contains(ip, ":")
+	netIP, err := netip.ParseAddr(ip)
+	return err == nil && netIP.Is4()
 }
 
 func skipAddress(elem *ciliumModels.NodeAddressingElement) bool {

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
-	"strings"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
@@ -148,21 +147,21 @@ func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) n
 	if p.cgroupGetter != nil {
 		if m := p.cgroupGetter.GetPodMetadataForContainer(cgroupId); m != nil {
 			for _, podIP := range m.IPs {
-				isIPv6 := strings.Contains(podIP, ":")
-				if isIPv6 && ipVersion == flowpb.IPVersion_IPv6 ||
-					!isIPv6 && ipVersion == flowpb.IPVersion_IPv4 {
-					ip, err := netip.ParseAddr(podIP)
-					if err != nil {
-						p.log.Debug(
-							"failed to parse pod IP",
-							logfields.Error, err,
-							logfields.CGroupID, cgroupId,
-							logfields.K8sPodName, m.Name,
-							logfields.K8sNamespace, m.Namespace,
-							logfields.IPAddr, podIP,
-						)
-						return netip.Addr{}
-					}
+				ip, err := netip.ParseAddr(podIP)
+				if err != nil {
+					p.log.Debug(
+						"failed to parse pod IP",
+						logfields.Error, err,
+						logfields.CGroupID, cgroupId,
+						logfields.K8sPodName, m.Name,
+						logfields.K8sNamespace, m.Namespace,
+						logfields.IPAddr, podIP,
+					)
+					return netip.Addr{}
+				}
+
+				if ip.Is6() && ipVersion == flowpb.IPVersion_IPv6 ||
+					ip.Is4() && ipVersion == flowpb.IPVersion_IPv4 {
 					return ip
 				}
 			}


### PR DESCRIPTION
Rather than using `strings.Contain(ip, ":")` use the dedicated `netip.Addr` methods in cases where the IP/prefix is parsed anyway.

AIL: 0
Related: #24246