### PR TITLE
cilium-cli: fix nil node crash in conn-disrupt NS-traffic setup

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2205,12 +2205,23 @@ func (ct *ConnectivityTest) getBackendNodeAndNonBackendNode(ctx context.Context)
 		return nil, fmt.Errorf("unable to list pods with lable %s: %w", appLabel, err)
 	}
 
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found with label %s", appLabel)
+	}
+
 	pod := podList.Items[0]
+	if pod.Spec.NodeName == "" {
+		return nil, fmt.Errorf("pod %s is not scheduled on any node yet", pod.Name)
+	}
+	backendNode, ok := ct.nodes[pod.Spec.NodeName]
+	if !ok {
+		return nil, fmt.Errorf("unable to find node %s hosting pod %s", pod.Spec.NodeName, pod.Name)
+	}
 
 	var nodes []nodeWithType
 	nodes = append(nodes, nodeWithType{
 		nodeType: "backend-node",
-		node:     ct.nodes[pod.Spec.NodeName],
+		node:     backendNode,
 	})
 	for name, node := range ct.Nodes() {
 		if name != pod.Spec.NodeName {


### PR DESCRIPTION
The NS-traffic conn-disrupt setup picks the node hosting the
test-conn-disrupt-server-ns-traffic pod and derives one client deployment
per address of that node. It took the first pod of the list and looked its
node up in ct.nodes without checking either step, so a missing node gave
back a nil *Node and the next dereference of Status.Addresses took the
process down with a SIGSEGV.

That is what the scheduled ci-ipsec run on EKS hit. The server deployment
sat at 0 of 1 available replicas for the whole five-minute wait, and since
WaitForDeployment's failure is only recorded through Failf the setup kept
going with a pod that was still unscheduled, so its empty NodeName missed
in the node map. The panic then replaced the real diagnosis with a stack
trace.

Guard the three steps that can come up empty: an empty pod list, a pod not
yet scheduled, and a node name absent from the node map each return a
descriptive error now, which the caller propagates so the setup reports why
it could not build the client deployments.

https://github.com/cilium/cilium/actions/runs/33718018507/job/100531312300

Fixes: ba1376a422be ("cilium-cli: extend no-interrupted-connections to test NodePort from outside")

This PR was prepared with AIL:3. I personally checked the panic stack
trace in the linked CI run.
