### PR TITLE
[v1.20] gha/e2e-upgrade: gate the after-agent-restart conn-disrupt check

### DIFF
--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -33,6 +33,7 @@ runs:
           --include-unsafe-tests \
           --conn-disrupt-test-setup \
           --conn-disrupt-dispatch-interval 0ms \
+          --conn-disrupt-client-timeout 15s \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \
           --expected-xfrm-errors "+inbound_no_state" \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -670,7 +670,6 @@ jobs:
 
       - name: Test Cilium ${{ steps.vars.outputs.skip_upgrade != 'true' && 'after agent restart' }}
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
-        continue-on-error: true
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-restart-${{ matrix.name }}-precheck


### PR DESCRIPTION
 * [x] #47440 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47440
```

This PR was prepared with AIL:3. I personally checked each commit against its upstream counterpart on main.
