### PR TITLE
bpf: narrow variable declaration scopes

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -155,7 +155,6 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	int ret, zero __maybe_unused = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	const struct endpoint_info *ep;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -193,7 +192,8 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
 	    !from_host && identity_is_cluster(secctx) &&
 	    !identity_is_remote_node(secctx)) {
-		ep = lookup_ip6_endpoint(ip6);
+		const struct endpoint_info *ep = lookup_ip6_endpoint(ip6);
+
 		if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 			return DROP_UNENCRYPTED_TRAFFIC;
 	}
@@ -274,7 +274,6 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr *dst;
-	int l3_off = ETH_HLEN;
 	const struct remote_endpoint_info *info = NULL;
 	const struct endpoint_info *ep;
 	int ret __maybe_unused;
@@ -353,6 +352,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* Lookup IPv6 address in list of local endpoints */
 	ep = lookup_ip6_endpoint(ip6);
 	if (ep) {
+		int l3_off = ETH_HLEN;
+
 		/* Let through packets to the node-ip so they are
 		 * processed by the local ip stack.
 		 */
@@ -619,7 +620,6 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	bool __maybe_unused is_host_id = false;
 	void *data, *data_end;
 	struct iphdr *ip4;
-	const struct endpoint_info *ep;
 	int zero __maybe_unused = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -647,7 +647,8 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
 	    !from_host && identity_is_cluster(secctx) &&
 	    !identity_is_remote_node(secctx)) {
-		ep = lookup_ip4_endpoint(ip4);
+		const struct endpoint_info *ep = lookup_ip4_endpoint(ip4);
+
 		if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 			return DROP_UNENCRYPTED_TRAFFIC;
 	}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -547,8 +547,6 @@ snat_v4_calc_icmp_error_csum_diff(__be32 old_addr, __be32 new_addr,
 				  __be16 old_port, __be16 new_port,
 				  bool inner_has_l4_csum)
 {
-	__be32 old_port32 = (__be32)old_port;
-	__be32 new_port32 = (__be32)new_port;
 	__wsum sum = 0;
 
 	if (inner_has_l4_csum) {
@@ -564,8 +562,12 @@ snat_v4_calc_icmp_error_csum_diff(__be32 old_addr, __be32 new_addr,
 		 * If the inner L4 header does not include the L4 checksum,
 		 * only the port is modified within the inner L4 header.
 		 */
-		if (old_port != new_port)
+		if (old_port != new_port) {
+			__be32 old_port32 = (__be32)old_port;
+			__be32 new_port32 = (__be32)new_port;
+
 			sum = csum_diff(&old_port32, 4, &new_port32, 4, 0);
+		}
 	}
 
 	return sum;


### PR DESCRIPTION
Move these variable declarations into the conditional blocks where they are used.

Note that `l3_off` in `bpf_host.c` is already declared in the corresponding place in `handle_ipv4`. Thus the asymmetry between the diff for IPv4 and IPv6.
