### PR TITLE
helm: unconditionally enable kvstoremesh with clustermesh-apiserver

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -139,7 +139,7 @@ jobs:
             ipFamily: 'dual'
             encryption: 'wireguard'
             kube-proxy: 'none'
-            mode: 'clustermesh'
+            mode: 'kvstoremesh'
             tls-auto-method: cronJob
             cm-auth-mode-1: 'migration'
             cm-auth-mode-2: 'migration'
@@ -171,7 +171,7 @@ jobs:
             ipFamily: 'ipv6'
             encryption: 'disabled'
             kube-proxy: 'none'
-            mode: 'clustermesh'
+            mode: 'kvstoremesh'
             tls-auto-method: certmanager
             cm-auth-mode-1: 'legacy'
             cm-auth-mode-2: 'migration'
@@ -229,7 +229,7 @@ jobs:
             ipFamily: 'dual'
             encryption: 'ipsec'
             kube-proxy: 'iptables'
-            mode: 'clustermesh'
+            mode: 'kvstoremesh'
             tls-auto-method: certmanager
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster-strict'
@@ -323,7 +323,6 @@ jobs:
             --helm-set=hubble.tls.auto.certManagerIssuerRef.name=cilium \
             --helm-set=clustermesh.useAPIServer=${{ matrix.mode != 'external' }} \
             --helm-set=clustermesh.config.enabled=true \
-            --helm-set=clustermesh.apiserver.kvstoremesh.enabled=${{ matrix.mode == 'kvstoremesh' }} \
             --helm-set=clustermesh.maxConnectedClusters=${{ matrix.maxConnectedClusters }} \
             --helm-set=clustermesh.enableEndpointSliceSynchronization=true \
             --helm-set=clustermesh.apiserver.tls.auto.method=${{ matrix.tls-auto-method }} \

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -350,8 +350,8 @@ jobs:
             printf "      port: 2379\n"
           done >> values-clustermesh-config.yaml
 
-          # * We enable KVStoreMesh only at this point to leverage the bootstrap QPS
-          #   and speed-up the overall bootstrap process.
+          # * We enable the ClusterMesh API server only at this point to leverage
+          #   the bootstrap QPS and speed-up the overall bootstrap process.
           # * Increase the KVStoreMesh QPS to match the ones of the cmapisrv-mock,
           #   as not a problem considering the limited number of watchers.
           # * Store etcd data directly in memory, for improved performance.
@@ -360,7 +360,6 @@ jobs:
             --chart-directory=untrusted/install/kubernetes/cilium \
             --set clustermesh.useAPIServer=true \
             --set clustermesh.apiserver.etcd.storageMedium=Memory \
-            --set clustermesh.apiserver.kvstoremesh.enabled=true \
             --set clustermesh.apiserver.kvstoremesh.extraArgs[0]=--kvstore-opt=etcd.qps=1000 \
             --set clustermesh.apiserver.nodeSelector.node-role\\.kubernetes\\.io/control-plane= \
             --set clustermesh.apiserver.tolerations[0].key=node-role.kubernetes.io/control-plane \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -603,44 +603,6 @@ jobs:
           kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
           kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
 
-      - name: Disable kvstoremesh on cluster1
-        if: ${{ !matrix.external-kvstore }}
-        env:
-          KVSTORE_ID: 1
-        run: |
-          cilium --context ${{ env.contextName1 }} upgrade --reset-values \
-            ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
-            ${{ steps.vars.outputs.cilium_install_defaults }} \
-            ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
-            --set clustermesh.apiserver.kvstoremesh.enabled=false \
-            --nodes-without-cilium
-
-      - name: Wait for cluster mesh status to be ready
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
-          cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
-          cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
-
-      - name: Restart clustermesh-apiserver and ensure client can connect to new Service
-        if: ${{ !matrix.external-kvstore }}
-        run: |
-          echo "Restarting clustermesh-apiserver deployments"
-          kubectl --context ${{ env.contextName2 }} -n kube-system rollout restart deployment -l k8s-app=clustermesh-apiserver
-          kubectl --context ${{ env.contextName2 }} -n kube-system rollout status deployment -l k8s-app=clustermesh-apiserver
-
-          echo "Deploying a global Service to test failover"
-          kubectl --context ${{ env.contextName1 }} apply -f echo-failover.yaml
-          kubectl --context ${{ env.contextName2 }} apply -f echo-failover.yaml
-
-          echo "Testing client connection to global Service"
-          kubectl --context ${{ env.contextName1 }} -n ${{ steps.cilium-cli.outputs.namespace }} exec deploy/client -i -- curl -s -v --connect-timeout 2 --max-time 5 --retry-max-time 60 --retry-all-errors --retry 10 --output /dev/null --fail echo-other-node-failover
-
-          # Clean up the service so that it can be re-deployed in subsequent steps
-          kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
-          kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
-
       - name: Gather additional troubleshooting information
         run: |
           kubectl --context ${{ env.contextName1 }} get po -n ${{ steps.cilium-cli.outputs.namespace }} -o wide -l 'kind in (test-conn-disrupt, test-conn-disrupt-ns-traffic)'
@@ -772,7 +734,7 @@ jobs:
           json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2 - stress-test"
 
 
-      - name: Downgrade Cilium in cluster1 to ${{ steps.vars.outputs.downgrade_version }} and enable kvstoremesh again
+      - name: Downgrade Cilium in cluster1 to ${{ steps.vars.outputs.downgrade_version }}
         env:
           KVSTORE_ID: 1
         run: |

--- a/Documentation/cmdref/cilium_clustermesh_enable.md
+++ b/Documentation/cmdref/cilium_clustermesh_enable.md
@@ -11,7 +11,7 @@ cilium clustermesh enable [flags]
 ### Options
 
 ```
-      --enable-kvstoremesh    Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore
+      --enable-kvstoremesh    Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore. KVStoreMesh is unconditionally enabled starting from Cilium v1.21 (default true)
   -h, --help                  help for enable
       --service-type string   Type of Kubernetes service to expose control plane { LoadBalancer | NodePort }
 ```

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -676,10 +676,6 @@
      - Clustermesh API server image.
      - object
      - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}``
-   * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.enabled`
-     - Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance (deprecated - KVStoreMesh will always be enabled once the option is removed).
-     - bool
-     - ``true``
    * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.etcdQPS`
      - Rate limit for the kvstoremesh container while syncing resources from all remote clusters to the local etcd.
      - int

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -36,8 +36,8 @@ Automatic Verification
     DNS resolution, network connectivity, TLS authentication, etcd authorization
     and more, and reports the output in a user friendly format.
 
-    When KVStoreMesh is enabled, the output of the troubleshoot command refers
-    to the connections from the agents to the local cache, and it is expected to
+    Normally, the output of the troubleshoot command refers to the connections from
+    the agents to the local cache managed by KVStoreMesh, and it is expected to
     be the same for all the clusters they are connected to. Run the troubleshoot
     command inside the clustermesh-apiserver to investigate KVStoreMesh connectivity
     issues towards the ClusterMesh control plane in remote clusters:
@@ -80,11 +80,10 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
         ClusterMesh:   1/1 remote clusters ready
            k8s-c2: ready, 3 nodes, 25 endpoints, 8 identities, 10 services, 0 endpoint slices, 0 MCS-API service exports, 0 reconnections (last: never)
            └  etcd: 1/1 connected, leases=0, lock lease-ID=7c028201b53de662, has-quorum=true: https://k8s-c2.mesh.cilium.io:2379 - 3.5.4 (Leader)
-           └  remote configuration: expected=true, retrieved=true, cluster-id=3, kvstoremesh=false, sync-canaries=true, service-exports=disabled, endpoint-slice-export-mode=services-only
+           └  remote configuration: expected=true, retrieved=true, cluster-id=3, kvstoremesh=true, sync-canaries=true, service-exports=disabled, endpoint-slice-export-mode=services-only
            └  synchronization status: nodes=true, endpoints=true, identities=true, services=true
 
-    When KVStoreMesh is enabled, additionally check its status and validate that
-    it is correctly connected to all remote clusters:
+ #. Check the KVStoreMesh status and validate that it is correctly connected to all remote clusters:
 
     .. code-block:: shell-session
 
@@ -131,17 +130,12 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
 
     If the connection fails, check the following:
 
-    * When KVStoreMesh is disabled, validate that the ``cilium-host-aliases``
-      section in the ``cilium-clustermesh`` secret maps each remote cluster
-      to the IP of the LoadBalancer that makes the remote control plane
-      available; When KVStoreMesh is enabled, validate the
-      ``cilium-host-aliases`` section in the ``cilium-kvstoremesh`` secret.
+    * Validate that the ``cilium-host-aliases`` section in the ``cilium-kvstoremesh``
+      secret maps each remote cluster to the IP of the LoadBalancer that makes the
+      remote control plane available.
 
     * Validate that a local node in the source cluster can reach the IPs
-      specified in the ``cilium-host-aliases`` section. When KVStoreMesh
-      is disabled, those aliases are configured in the ``cilium-clustermesh``
-      secret. When KVStoreMesh is enabled, they are configured in the
-      ``cilium-kvstoremesh`` secret.
+      specified in the ``cilium-host-aliases`` section.
 
       .. code-block:: yaml
 
@@ -164,9 +158,10 @@ State Propagation
 
  #. Run ``cilium-dbg node list`` in one of the Cilium pods and validate that it
     lists both local nodes and nodes from remote clusters. If remote nodes are
-    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
-    are correctly connected to the given remote cluster. Additionally, verify
-    that the initial nodes synchronization from all clusters has completed.
+    not present, validate that Cilium agents are correctly connected to the
+    local KVStoreMesh instance, and KVStoreMesh to the given remote cluster.
+    Additionally, verify that the initial nodes synchronization from all clusters
+    has completed.
 
  #. Validate the connectivity health matrix across clusters by running
     ``cilium-health status`` inside any Cilium pod. It will list the status of
@@ -178,16 +173,18 @@ State Propagation
     identity list`` in one of the Cilium pods. It must list identities from all
     clusters. You can determine what cluster an identity belongs to by looking
     at the label ``io.cilium.k8s.policy.cluster``. If remote identities are
-    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
-    are correctly connected to the given remote cluster. Additionally, verify
-    that the initial identities synchronization from all clusters has completed.
+    not present, validate that Cilium agents are correctly connected to the
+    local KVStoreMesh instance, and KVStoreMesh to the given remote cluster.
+    Additionally, verify that the initial identities synchronization from all
+    clusters has completed.
 
  #. Validate that the IP cache is synchronized correctly by running ``cilium-dbg
     bpf ipcache list`` or ``cilium-dbg map get cilium_ipcache``. The output must
     contain pod IPs from local and remote clusters. If remote IP addresses are
-    not present, validate that Cilium agents (or KVStoreMesh, if enabled)
-    are correctly connected to the given remote cluster. Additionally, verify
-    that the initial IPs synchronization from all clusters has completed.
+    not present, validate that Cilium agents are correctly connected to the
+    local KVStoreMesh instance, and KVStoreMesh to the given remote cluster.
+    Additionally, verify that the initial IPs synchronization from all clusters
+    has completed.
 
  #. When using global services, ensure that global services are configured with
     endpoints from all clusters. Run ``cilium-dbg shell -- db/show backends``
@@ -223,13 +220,11 @@ The following checks apply regardless of the certificate management method:
      containers in the clustermesh-apiserver deployment, to authenticate against the
      sidecar etcd instance. Not applicable if an external etcd cluster is used.
 
-   * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, or
-     the kvstoremesh container in the clustermesh-apiserver deployment when
-     KVStoreMesh is enabled, to authenticate against remote etcd instances.
+   * ``clustermesh-apiserver-remote-cert``, which is used by the kvstoremesh container
+     in the clustermesh-apiserver deployment to authenticate against remote etcd instances.
 
    * ``clustermesh-apiserver-local-cert``, which is used by Cilium agents to
-     authenticate against the local etcd instance. Only applicable if KVStoreMesh
-     is enabled.
+     authenticate against the local etcd instance.
 
 The following checks depend on the specific method used to provision the
 certificates:

--- a/Documentation/operations/upgrade-next.inc
+++ b/Documentation/operations/upgrade-next.inc
@@ -85,6 +85,9 @@ from Cilium.
   you passed ``--aws-use-primary-address`` directly on the operator, set
   ``eni.nodeSpec.usePrimaryAddress=true`` (equivalently, the
   ``--eni-use-primary-address`` agent flag) instead to retain the same behavior.
+* The previously deprecated ``clustermesh.apiserver.kvstoremesh.enabled`` helm
+  value has been removed, and KVStoreMesh is now unconditionally enabled when the
+  clustermesh-apiserver is enabled.
 
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -120,7 +120,6 @@ kind-connect-clustermesh: check_deps kind-clustermesh-ready
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh1 --wait
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh2 --wait
 
-ENABLE_KVSTOREMESH ?= true
 $(eval $(call KIND_ENV,kind-install-cilium-clustermesh))
 kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a local Cilium version into the clustermesh clusters and enable clustermesh.
 	@echo "  INSTALL cilium on clustermesh1 cluster"
@@ -131,7 +130,6 @@ kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a 
 		--set=image.override=$(LOCAL_AGENT_IMAGE) \
 		--set=operator.image.override=$(LOCAL_OPERATOR_IMAGE) \
 		--set=clustermesh.apiserver.image.override=$(LOCAL_CLUSTERMESH_IMAGE) \
-		--set=clustermesh.apiserver.kvstoremesh.enabled=$(ENABLE_KVSTOREMESH)
 
 	@echo "  INSTALL cilium on clustermesh2 cluster"
 	-$(CILIUM_CLI) --context=kind-clustermesh2 uninstall >/dev/null
@@ -143,7 +141,6 @@ kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a 
 		--set=image.override=$(LOCAL_AGENT_IMAGE) \
 		--set=operator.image.override=$(LOCAL_OPERATOR_IMAGE) \
 		--set=clustermesh.apiserver.image.override=$(LOCAL_CLUSTERMESH_IMAGE) \
-		--set=clustermesh.apiserver.kvstoremesh.enabled=$(ENABLE_KVSTOREMESH)
 
 	$(MAKE) kind-connect-clustermesh
 
@@ -155,7 +152,6 @@ kind-install-cilium-clustermesh-fast: check_deps kind-clustermesh-ready kind-loa
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--values=$(ROOT_DIR)/contrib/testing/kind-clustermesh1.yaml \
 		--values=$(ROOT_DIR)/contrib/testing/kind-fast.yaml \
-		--set=clustermesh.apiserver.kvstoremesh.enabled=$(ENABLE_KVSTOREMESH)
 
 	@echo "  INSTALL cilium on clustermesh2 cluster"
 	-$(CILIUM_CLI) --context=kind-clustermesh2 uninstall >/dev/null
@@ -165,7 +161,6 @@ kind-install-cilium-clustermesh-fast: check_deps kind-clustermesh-ready kind-loa
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--values=$(ROOT_DIR)/contrib/testing/kind-clustermesh2.yaml \
 		--values=$(ROOT_DIR)/contrib/testing/kind-fast.yaml \
-		--set=clustermesh.apiserver.kvstoremesh.enabled=$(ENABLE_KVSTOREMESH)
 
 	$(MAKE) kind-image-fast
 	$(MAKE) kind-connect-clustermesh

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -95,7 +95,8 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore")
+	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", true,
+		"Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore. KVStoreMesh is unconditionally enabled starting from Cilium v1.21")
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort }")
 
 	return cmd

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -219,7 +219,6 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.healthPort | int | `9880` | TCP port for the clustermesh-apiserver health API. |
 | clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}` | Clustermesh API server image. |
-| clustermesh.apiserver.kvstoremesh.enabled | bool | `true` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance (deprecated - KVStoreMesh will always be enabled once the option is removed). |
 | clustermesh.apiserver.kvstoremesh.etcdQPS | int | `100` | Rate limit for the kvstoremesh container while syncing resources from all remote clusters to the local etcd. |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -296,7 +296,6 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -392,7 +391,6 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- end }}
       volumes:
       {{- if (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
       {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
@@ -452,8 +450,7 @@ spec:
         emptyDir:
           medium: {{ ternary "Memory" "" (eq .Values.clustermesh.apiserver.etcd.storageMedium "Memory") | quote }}
       {{- end }}
-      {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-        # To read the kvstoremesh configuration and TLS certificates
+      # To read the kvstoremesh configuration and TLS certificates
       {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
       - name: kvstoremesh-secrets
         projected:
@@ -495,7 +492,6 @@ spec:
             path: etcd-config.yaml
           name: cilium-config
         name: etcd-config
-      {{- end }}
       {{- end }}
       {{- with .Values.clustermesh.apiserver.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -1,7 +1,6 @@
-{{- $kvstoreMetricsEnabled := and .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled -}}
 {{- if and
   .Values.clustermesh.useAPIServer
-  (or .Values.clustermesh.apiserver.metrics.enabled $kvstoreMetricsEnabled .Values.clustermesh.apiserver.metrics.etcd.enabled) }}
+  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,7 +32,7 @@ spec:
     targetPort: apiserv-metrics
     {{- end }}
   {{- end }}
-  {{- if $kvstoreMetricsEnabled }}
+  {{- if .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled }}
   - name: kvmesh-metrics
     port: {{ .Values.clustermesh.apiserver.metrics.kvstoremesh.port }}
     protocol: TCP

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -1,7 +1,6 @@
-{{- $kvstoreMetricsEnabled := and .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled -}}
 {{- if and
   .Values.clustermesh.useAPIServer
-  (or .Values.clustermesh.apiserver.metrics.enabled $kvstoreMetricsEnabled .Values.clustermesh.apiserver.metrics.etcd.enabled)
+  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled)
   .Values.clustermesh.apiserver.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -54,7 +53,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if $kvstoreMetricsEnabled }}
+  {{- if .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled }}
   - port: kvmesh-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.interval | quote }}
     {{- if .Values.clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.scrapeTimeout }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -70,7 +70,7 @@ spec:
                   - client auth
                   validity: {{ $certValidityStr }}
                 {{- end }}
-                {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+                {{- if .Values.clustermesh.useAPIServer }}
                 - name: clustermesh-apiserver-local-cert
                   namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.local-common-name" . | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -60,7 +60,6 @@ spec:
                   - key encipherment
                   - client auth
                   validity: {{ $certValidityStr }}
-                {{- if .Values.clustermesh.useAPIServer }}
                 - name: clustermesh-apiserver-remote-cert
                   namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.remote-common-name" . | quote }}
@@ -69,8 +68,6 @@ spec:
                   - key encipherment
                   - client auth
                   validity: {{ $certValidityStr }}
-                {{- end }}
-                {{- if .Values.clustermesh.useAPIServer }}
                 - name: clustermesh-apiserver-local-cert
                   namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.local-common-name" . | quote }}
@@ -79,7 +76,6 @@ spec:
                   - key encipherment
                   - client auth
                   validity: {{ $certValidityStr }}
-                {{- end }}
           {{- with .Values.certgen.extraVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := include "clustermesh-apiserver-generate-certs.local-common-name" . -}}
 {{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 
 data:
-  {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+  {{- $kvstoremesh := .Values.clustermesh.useAPIServer }}
   {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:%d" (include "cilium.namespace" .) (int .Values.clustermesh.apiserver.service.port)) "" $kvstoremesh }}
   {{- $local_etcd := and $kvstoremesh (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
   {{- range (include "clustermesh-clusters" . | fromJson) }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -175,6 +175,10 @@
 {{- end -}}
 
 {{- if .Values.clustermesh.useAPIServer }}
+  {{- if eq (dig "clustermesh" "apiserver" "kvstoremesh" "enabled" "true" .Values.AsMap | toString) "false" }}
+    {{ fail "KVStoreMesh is now unconditionally enabled together with the clustermesh-apiserver, and cannot be disabled. For details please refer to https://docs.cilium.io/en/v1.21/operations/upgrade/#helm-options" }}
+  {{- end }}
+
   {{- if eq "true" (include "identityAllocationCRD" .) }}
     {{/* CRDs are used */}}
     {{- if and .Values.disableEndpointCRD }}
@@ -182,17 +186,14 @@
     {{- end }}
   {{- else }}
     {{/* kvstore is used */}}
-    {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-      {{ fail (printf "The kvstoremesh container cannot be disabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstores through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
+    {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
+      {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s and kvstore mode internal. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstores through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
     {{- end}}
   {{- end }}
 {{- end }}
 {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
   {{- if not .Values.clustermesh.useAPIServer }}
     {{- fail "kvstoremesh.kvstoreMode=external can only be used with clustermesh.useAPIServer=true" }}
-  {{- end }}
-  {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-    {{- fail "kvstoremesh.kvstoreMode=external can only be used with kvstoremesh.enabled=true" }}
   {{- end }}
   {{- if ne (toString .Values.clustermesh.apiserver.replicas) "1"  }}
     {{- fail "Only single clustermesh-apiserver replica is allowed when kvstoreMode=external" }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1080,9 +1080,6 @@
             },
             "kvstoremesh": {
               "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
                 "etcdQPS": {
                   "type": "integer"
                 },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3967,9 +3967,6 @@ clustermesh:
       # the memory limits of the container.
       storageMedium: Disk
     kvstoremesh:
-      # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
-      # from the remote clusters in the local etcd instance (deprecated - KVStoreMesh will always be enabled once the option is removed).
-      enabled: true
       # -- TCP port for the KVStoreMesh health API.
       healthPort: 9881
       # -- Configuration for the KVStoreMesh readiness probe.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -4005,10 +4005,6 @@ clustermesh:
       storageMedium: Disk
 
     kvstoremesh:
-      # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
-      # from the remote clusters in the local etcd instance (deprecated - KVStoreMesh will always be enabled once the option is removed).
-      enabled: true
-
       # -- TCP port for the KVStoreMesh health API.
       healthPort: 9881
       # -- Configuration for the KVStoreMesh readiness probe.


### PR DESCRIPTION
The kvstoremesh.enabled helm option got deprecated by 9a390abb3e0a ("clustermesh: deprecate kvstoremesh.enabled helm option"). It is now time to remove it, and unconditionally enable KVStoreMesh when the clustermesh-apiserver is enabled, to simplify a bit the overall set of configurations.

AIL: 1

<!-- Description of change -->

```release-note
KVStoreMesh is now unconditionally enabled when the clustermesh-apiserver is enabled.
```

