### PR TITLE
node: Properly handle conflicting nodes

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -41,8 +41,7 @@ var LocalNodeStoreCell = cell.Module(
 	"Provides LocalNodeStore for observing and updating local node info",
 
 	cell.ProvidePrivate(NewNodeTable),
-	cell.ProvidePrivate(newNodeCandidateTable),
-	cell.Provide(provideWriter),
+	WriterCell,
 	cell.Provide(NewNodeTableAndLocalNodeStore),
 	cell.Provide(NewClusterSizeDependantInterval),
 )

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -41,6 +41,7 @@ var LocalNodeStoreCell = cell.Module(
 	"Provides LocalNodeStore for observing and updating local node info",
 
 	cell.ProvidePrivate(NewNodeTable),
+	cell.ProvidePrivate(newNodeCandidateTable),
 	cell.Provide(provideWriter),
 	cell.Provide(NewNodeTableAndLocalNodeStore),
 	cell.Provide(NewClusterSizeDependantInterval),
@@ -79,14 +80,15 @@ func NewNodeTableAndLocalNodeStore(params LocalNodeStoreParams) (
 	*LocalNodeStore, NodeGetter, statedb.Table[*Node], error,
 ) {
 	nodeTable := params.Nodes
-	wtxn := params.DB.WriteTxn(nodeTable)
+	wtxn := params.NodeWriter.WriteTxn()
+	defer wtxn.Abort()
 
 	// Register an initializer that'll mark the table initialized once we're done
 	// with [LocalNodeSynchronizer.InitLocalNode].
-	initDone := nodeTable.RegisterInitializer(wtxn, LocalNodeTableInitializerName)
+	initDone := params.NodeWriter.RegisterInitializer(wtxn, LocalNodeTableInitializerName)
 
 	// Insert the skeleton local node.
-	nodeTable.Insert(wtxn,
+	params.NodeWriter.upsertLocal(wtxn, nil,
 		&LocalNode{
 			Node: types.Node{
 				Name:      types.GetName(),
@@ -96,7 +98,7 @@ func NewNodeTableAndLocalNodeStore(params LocalNodeStoreParams) (
 				// we don't need to always check for nil values.
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
-				Source:      source.Unspec,
+				Source:      source.Local,
 			},
 			Local: &LocalNodeInfo{},
 		})
@@ -106,17 +108,13 @@ func NewNodeTableAndLocalNodeStore(params LocalNodeStoreParams) (
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			wtxn := params.DB.WriteTxn(nodeTable)
+			wtxn := params.NodeWriter.WriteTxn()
+			defer wtxn.Abort()
 			n, _, _ := nodeTable.Get(wtxn, LocalNodeQuery)
-			// Delete the initial one as name might change.
-			nodeTable.Delete(wtxn, n)
-
+			orig := n
 			n = n.DeepCopy()
 			err := params.Sync.InitLocalNode(ctx, n)
-			n.Statuses = n.Statuses.Pending(
-				reconcilerNames(s.writer.getRequiredReconcilers(wtxn))...,
-			)
-			nodeTable.Insert(wtxn, n)
+			params.NodeWriter.upsertLocal(wtxn, orig, n)
 			initDone(wtxn)
 			wtxn.Commit()
 
@@ -222,7 +220,7 @@ func (s *LocalNodeStore) Get(ctx context.Context) (LocalNode, error) {
 
 // Update modifies the local node with a mutator.
 func (s *LocalNodeStore) Update(update func(*LocalNode)) {
-	txn := s.db.WriteTxn(s.nodes)
+	txn := s.writer.WriteTxn()
 	defer txn.Abort()
 	ln, _, found := s.nodes.Get(txn, LocalNodeQuery)
 	if !found {
@@ -239,16 +237,7 @@ func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 		// No changes.
 		return
 	}
-	ln.Statuses = orig.Statuses.Pending(
-		reconcilerNames(s.writer.getRequiredReconcilers(txn))...,
-	)
-
-	if orig.Fullname() != ln.Fullname() {
-		// Name or cluster has changed, delete first to remove it from the name index.
-		s.nodes.Delete(txn, orig)
-	}
-
-	s.nodes.Insert(txn, ln)
+	s.writer.upsertLocal(txn, orig, ln)
 	txn.Commit()
 }
 
@@ -265,10 +254,11 @@ func NewTestLocalNodeStore(mockNode LocalNode) *LocalNodeStore {
 	if mockNode.Local == nil {
 		mockNode.Local = &LocalNodeInfo{}
 	}
-	txn := db.WriteTxn(tbl)
-	tbl.Insert(txn, &mockNode)
+	writer := NewWriter(slog.Default(), db, tbl)
+	txn := writer.WriteTxn()
+	writer.upsertLocal(txn, nil, &mockNode)
 	txn.Commit()
-	return &LocalNodeStore{db, tbl, nil, nil}
+	return &LocalNodeStore{db, tbl, nil, writer}
 }
 
 // LocalNodeStoreTestCell is a convenience for tests that provides a no-op

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -5,6 +5,7 @@ package node_test
 
 import (
 	"context"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,8 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	. "github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 type testSynchronizer struct{ identity chan uint32 }
@@ -183,6 +186,59 @@ func TestLocalNodeStoreUpdateMarksStatusesPending(t *testing.T) {
 		reconciler.StatusKindPending,
 		local.Statuses.Get(requiredReconciler).Kind,
 	)
+}
+
+func TestLocalNodeStoreUpdateRestoresConflictingCandidate(t *testing.T) {
+	var (
+		store  *LocalNodeStore
+		db     *statedb.DB
+		nodes  statedb.Table[*Node]
+		writer *Writer
+	)
+	hive := hive.New(
+		LocalNodeStoreTestCell,
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.ClusterInfo{Name: "test"}
+		}),
+		cell.Invoke(func(
+			s *LocalNodeStore,
+			d *statedb.DB,
+			ns statedb.Table[*Node],
+			w *Writer,
+		) {
+			store, db, nodes, writer = s, d, ns, w
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	tlog := hivetest.Logger(t)
+	require.NoError(t, hive.Start(tlog, ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Minute)
+		defer stopCancel()
+		require.NoError(t, hive.Stop(tlog, stopCtx))
+	})
+
+	store.Update(func(n *LocalNode) {
+		n.IPAddresses = []types.Address{{IP: net.ParseIP("10.0.0.1")}}
+	})
+	remote := &types.Node{
+		Name:        "remote",
+		Source:      source.Kubernetes,
+		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+	}
+	txn := writer.WriteTxn()
+	writer.Upsert(txn, remote)
+	txn.Commit()
+	_, _, found := nodes.Get(db.ReadTxn(), NodeByName(remote.Fullname()))
+	require.False(t, found)
+
+	store.Update(func(n *LocalNode) {
+		n.IPAddresses = []types.Address{{IP: net.ParseIP("10.0.0.2")}}
+	})
+	_, _, found = nodes.Get(db.ReadTxn(), NodeByName(remote.Fullname()))
+	require.True(t, found)
 }
 
 func TestWaitForLocalNodeInit(t *testing.T) {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -276,8 +276,7 @@ func New(
 	}
 
 	if writer != nil {
-		nodeTable := writer.Table()
-		wtxn := db.WriteTxn(nodeTable)
+		wtxn := writer.WriteTxn()
 		clusterInitDone := m.writer.RegisterInitializer(
 			wtxn,
 			ClusterNodeTableInitializerName,
@@ -288,12 +287,12 @@ func New(
 		)
 		wtxn.Commit()
 		m.clusterNodeTableInit = sync.OnceFunc(func() {
-			wtxn := db.WriteTxn(nodeTable)
+			wtxn := writer.WriteTxn()
 			clusterInitDone(wtxn)
 			wtxn.Commit()
 		})
 		m.meshNodeTableInit = sync.OnceFunc(func() {
-			wtxn := db.WriteTxn(nodeTable)
+			wtxn := writer.WriteTxn()
 			meshInitDone(wtxn)
 			wtxn.Commit()
 		})
@@ -728,7 +727,8 @@ func (m *manager) upsertToNodeTable(n *nodeTypes.Node) {
 	if n.IsLocal() || m.writer == nil {
 		return
 	}
-	txn := m.db.WriteTxn(m.writer.Table())
+	txn := m.writer.WriteTxn()
+	defer txn.Abort()
 	m.writer.Upsert(txn, n)
 	txn.Commit()
 }
@@ -737,7 +737,8 @@ func (m *manager) deleteFromNodeTable(src source.Source, nodeID nodeTypes.Identi
 	if m.writer == nil {
 		return
 	}
-	txn := m.db.WriteTxn(m.writer.Table())
+	txn := m.writer.WriteTxn()
+	defer txn.Abort()
 	m.writer.Delete(txn, src, nodeID)
 	txn.Commit()
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1292,15 +1292,15 @@ func TestNodeTableMirroring(t *testing.T) {
 	requireNode(t, n2)
 
 	// NodeManager delegates table conflict resolution to node.Writer. For
-	// equal-priority address owners the latest update wins.
+	// equal-priority address owners the node identity breaks the tie.
 	n3 := n2.DeepCopy()
 	n3.Name = "node3"
 	mngr.NodeUpdated(*n3)
 	requireNode(t, n1)
-	requireNoNode(t, n2)
-	requireNode(t, *n3)
+	requireNode(t, n2)
+	requireNoNode(t, *n3)
 
-	// Deleting the displaced node must not delete the current address owner.
+	// Deleting the current winner restores the shadowed address owner.
 	mngr.NodeDeleted(n2)
 	requireNoNode(t, n2)
 	requireNode(t, *n3)

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -60,37 +60,43 @@ func (n *Node) TableHeader() []string {
 		"Name",
 		"Source",
 		"Addresses",
+		"Status",
 	}
 }
 
 // TableRow implements statedb.TableWritable.
 func (n *Node) TableRow() []string {
-	addrs := make([]string, len(n.IPAddresses))
-	for i := range n.IPAddresses {
-		addrs[i] = string(n.IPAddresses[i].Type) + ":" + n.IPAddresses[i].ToString()
+	name := n.Fullname()
+	if n.Local != nil {
+		name += " (local)"
+	}
+	addrs := []string{}
+	for kind, addr := range n.addresses(nil) {
+		addrs = append(addrs, kind+":"+addr.String())
 	}
 	slices.Sort(addrs)
 	return []string{
-		n.Fullname(),
+		name,
 		string(n.Source),
 		strings.Join(addrs, ", "),
+		n.Statuses.String(),
 	}
 }
 
 var _ statedb.TableWritable = &Node{}
 
-// addressClusters returns the normalized, cluster-aware addresses associated
-// with the node. The optional predicate omits configured Cilium internal
-// router addresses that may intentionally be shared by every node.
-func (n *Node) addressClusters(
+// addresses returns the normalized, cluster-aware addresses associated with
+// the node and their kind. The optional predicate omits configured Cilium
+// internal router addresses that may intentionally be shared by every node.
+func (n *Node) addresses(
 	omitStaticLocalRouterIP func(string) bool,
-) iter.Seq[cmtypes.AddrCluster] {
-	return func(yield func(cmtypes.AddrCluster) bool) {
-		yieldAddr := func(addr netip.Addr, clusterID uint32) bool {
+) iter.Seq2[string, cmtypes.AddrCluster] {
+	return func(yield func(string, cmtypes.AddrCluster) bool) {
+		yieldAddr := func(kind string, addr netip.Addr, clusterID uint32) bool {
 			if !addr.IsValid() {
 				return true
 			}
-			return yield(cmtypes.AddrClusterFrom(addr.Unmap(), clusterID))
+			return yield(kind, cmtypes.AddrClusterFrom(addr.Unmap(), clusterID))
 		}
 
 		for _, address := range n.IPAddresses {
@@ -107,18 +113,21 @@ func (n *Node) addressClusters(
 			if address.Type == addressing.NodeCiliumInternalIP {
 				clusterID = n.addressClusterID
 			}
-			if !yieldAddr(addr, clusterID) {
+			if !yieldAddr(string(address.Type), addr, clusterID) {
 				return
 			}
 		}
 
-		for _, addr := range []netip.Addr{
-			n.IPv4HealthIP.Addr,
-			n.IPv6HealthIP.Addr,
-			n.IPv4IngressIP.Addr,
-			n.IPv6IngressIP.Addr,
+		for _, address := range []struct {
+			kind string
+			addr netip.Addr
+		}{
+			{"HealthIP", n.IPv4HealthIP.Addr},
+			{"HealthIP", n.IPv6HealthIP.Addr},
+			{"IngressIP", n.IPv4IngressIP.Addr},
+			{"IngressIP", n.IPv6IngressIP.Addr},
 		} {
-			if !yieldAddr(addr, n.addressClusterID) {
+			if !yieldAddr(address.kind, address.addr, n.addressClusterID) {
 				return
 			}
 		}
@@ -205,7 +214,7 @@ var (
 		Name: "address",
 		FromObject: func(obj *Node) index.KeySet {
 			keys := make([]index.Key, 0, len(obj.IPAddresses)+4)
-			for addr := range obj.addressClusters(nil) {
+			for _, addr := range obj.addresses(nil) {
 				keys = append(keys, nodeAddressKey(addr))
 			}
 			return index.NewKeySet(keys...)

--- a/pkg/node/table_test.go
+++ b/pkg/node/table_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -16,6 +17,39 @@ import (
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
+
+func TestNodeTableRow(t *testing.T) {
+	n := &Node{
+		Node: nodeTypes.Node{
+			Name:   "node-1",
+			Source: "kubernetes",
+			IPAddresses: []nodeTypes.Address{
+				{
+					Type: addressing.NodeInternalIP,
+					IP:   net.ParseIP("192.0.2.1"),
+				},
+			},
+			IPv4HealthIP:  iputil.AddrFrom(netip.MustParseAddr("10.0.0.2")),
+			IPv4IngressIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.3")),
+		},
+		addressClusterID: 42,
+		Local:            &LocalNodeInfo{},
+		Statuses: reconciler.NewStatusSet().Set(
+			"test-reconciler",
+			reconciler.StatusDone(),
+		),
+	}
+
+	require.Equal(t, []string{"Name", "Source", "Addresses", "Status"}, n.TableHeader())
+	row := n.TableRow()
+	require.Len(t, row, 4)
+	require.Equal(t, "node-1 (local)", row[0])
+	require.Equal(t,
+		"HealthIP:10.0.0.2@42, IngressIP:10.0.0.3@42, InternalIP:192.0.2.1",
+		row[2],
+	)
+	require.Contains(t, row[3], "Done: test-reconciler")
+}
 
 func TestNodeAddressIndexClusterIdentity(t *testing.T) {
 	db := statedb.New()

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -420,7 +420,7 @@ func (w *Writer) upsertCandidate(txn *WriteTxn, candidate *nodeCandidate) {
 }
 
 func (w *Writer) prepareCandidate(candidate *nodeCandidate) {
-	for address := range candidate.node.addressClusters(w.isStaticLocalRouterIP) {
+	for _, address := range candidate.node.addresses(w.isStaticLocalRouterIP) {
 		candidate.conflictAddresses = append(candidate.conflictAddresses, address)
 	}
 	slices.SortFunc(candidate.conflictAddresses, func(a, b cmtypes.AddrCluster) int {

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -4,6 +4,7 @@
 package node
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -13,9 +14,11 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/reconciler"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -25,9 +28,10 @@ import (
 
 // Writer provides source-aware write access to the node table.
 type Writer struct {
-	log   *slog.Logger
-	db    *statedb.DB
-	nodes statedb.RWTable[*Node]
+	log        *slog.Logger
+	db         *statedb.DB
+	nodes      statedb.RWTable[*Node]
+	candidates statedb.RWTable[*nodeCandidate]
 
 	isStaticLocalRouterIP  func(string) bool
 	prefixClusterMutatorFn PrefixClusterMutatorFn
@@ -53,24 +57,50 @@ const (
 
 // NewWriter constructs a node table writer.
 func NewWriter(log *slog.Logger, db *statedb.DB, nodes statedb.RWTable[*Node]) *Writer {
-	return &Writer{log: log, db: db, nodes: nodes}
-}
-
-type writerParams struct {
-	cell.In
-
-	Log          *slog.Logger
-	DB           *statedb.DB
-	Nodes        statedb.RWTable[*Node]
-	DaemonConfig *option.DaemonConfig `optional:"true"`
-}
-
-func provideWriter(p writerParams) *Writer {
-	w := NewWriter(p.Log, p.DB, p.Nodes)
-	if p.DaemonConfig != nil {
-		w.isStaticLocalRouterIP = p.DaemonConfig.IsLocalRouterIP
+	candidates, err := newNodeCandidateTable(db)
+	if err != nil {
+		panic(err)
 	}
-	return w
+	return newWriter(log, db, nodes, candidates)
+}
+
+// WriteTxn atomically updates node candidates and the selected node table.
+// The transaction must be committed or aborted. Commit reconciles the
+// conflict-free node table for the affected conflict components.
+type WriteTxn struct {
+	statedb.WriteTxn
+	w      *Writer
+	closed bool
+
+	changes map[nodeCandidateKey]nodeCandidateChange
+}
+
+// WriteTxn opens a transaction for updating node candidates.
+func (w *Writer) WriteTxn() *WriteTxn {
+	return &WriteTxn{
+		WriteTxn: w.db.WriteTxn(w.candidates, w.nodes),
+		w:        w,
+		changes:  map[nodeCandidateKey]nodeCandidateChange{},
+	}
+}
+
+// Abort discards candidate and selected-node changes.
+func (txn *WriteTxn) Abort() {
+	if txn.closed {
+		return
+	}
+	txn.closed = true
+	txn.WriteTxn.Abort()
+}
+
+// Commit derives the selected node table and atomically commits both tables.
+func (txn *WriteTxn) Commit() statedb.ReadTxn {
+	if txn.closed {
+		return nil
+	}
+	txn.w.reconcileChanges(txn)
+	txn.closed = true
+	return txn.WriteTxn.Commit()
 }
 
 // Table returns read-only access to the node table.
@@ -93,8 +123,13 @@ func deriveAddressClusterID(mutator PrefixClusterMutatorFn, n *nodeTypes.Node) u
 
 // RegisterInitializer registers a producer that must finish its initial node
 // listing before the table is considered initialized.
-func (w *Writer) RegisterInitializer(txn statedb.WriteTxn, name string) func(statedb.WriteTxn) {
-	return w.nodes.RegisterInitializer(txn, name)
+func (w *Writer) RegisterInitializer(txn *WriteTxn, name string) func(*WriteTxn) {
+	w.checkTxn(txn)
+	complete := w.nodes.RegisterInitializer(txn, name)
+	return func(txn *WriteTxn) {
+		w.checkTxn(txn)
+		complete(txn)
+	}
 }
 
 // RegisterReconciler adds the named reconciler to the list of required
@@ -302,111 +337,427 @@ func (w *Writer) Refresh(ctx context.Context, reconcilers ...NodeReconciler) err
 	return w.waitUntilReconciled(ctx, rtxn, false, reconcilers)
 }
 
-// Upsert takes ownership of n and inserts or updates it if its source is
-// allowed to overwrite the current owner. The caller must not modify n after
-// calling Upsert. It reports whether the table changed. Conflicting weaker
-// objects are not retained, so their producer must upsert them again if the
-// winning object is later deleted.
-func (w *Writer) Upsert(txn statedb.WriteTxn, n *nodeTypes.Node) bool {
-	reconcilers := reconcilerNames(w.getRequiredReconcilers(txn))
-	obj := &Node{
+// Upsert takes ownership of n and stores it as a candidate. The caller must not
+// modify n after calling Upsert. The conflict-free node table is reconciled
+// when txn is committed.
+func (w *Writer) Upsert(txn *WriteTxn, n *nodeTypes.Node) {
+	w.checkTxn(txn)
+	candidate := &nodeCandidate{node: &Node{
 		Node:             *n,
 		addressClusterID: deriveAddressClusterID(w.prefixClusterMutatorFn, n),
-		Statuses:         reconciler.NewStatusSet().Pending(reconcilers...),
-	}
-
-	old, _, found := w.nodes.Get(txn, NodeByName(obj.Fullname()))
-	if found {
-		if old.Local != nil || !source.AllowOverwrite(old.Source, obj.Source) {
-			w.log.Warn("Ignoring node update from lower priority source",
-				logfields.Node, obj.Fullname(),
-				logfields.Source, old.Source,
-				logfields.NodeOwner, obj.Source,
-			)
-			return false
-		}
-		if old.Node.DeepEqual(&obj.Node) &&
-			old.addressClusterID == obj.addressClusterID {
-			return false
-		}
-	}
-
-	// Resolve all address conflicts before changing the table. This keeps the
-	// operation atomic when an incoming node overlaps multiple existing nodes:
-	// a single stronger owner rejects the update without deleting weaker ones.
-	conflicts := map[string]*Node{}
-	for addrCluster := range obj.addressClusters(w.isStaticLocalRouterIP) {
-		for candidate := range w.nodes.List(txn, NodeByAddress(addrCluster)) {
-			if candidate.Fullname() == obj.Fullname() {
-				continue
-			}
-			if _, found := conflicts[candidate.Fullname()]; found {
-				continue
-			}
-			w.log.Warn("Node address conflicts with another node",
-				logfields.IPAddr, addrCluster,
-				logfields.Node, obj.Fullname(),
-				logfields.Source, obj.Source,
-				logfields.ConflictingResource, candidate.Fullname(),
-				logfields.NodeOwner, candidate.Source,
-			)
-			conflicts[candidate.Fullname()] = candidate
-		}
-	}
-	for _, candidate := range conflicts {
-		if candidate.Local != nil || !source.AllowOverwrite(candidate.Source, obj.Source) {
-			return false
-		}
-	}
-
-	for _, candidate := range conflicts {
-		if _, _, err := w.nodes.Delete(txn, candidate); err != nil {
-			w.log.Error("Failed to delete node with conflicting address",
-				logfields.Error, err,
-				logfields.Node, candidate.Name,
-				logfields.Source, candidate.Source,
-			)
-			return false
-		}
-	}
-
-	if found {
-		obj.Statuses = old.Statuses.Pending(reconcilers...)
-	}
-
-	if _, _, err := w.nodes.Insert(txn, obj); err != nil {
-		w.log.Error("Failed to write node to table",
-			logfields.Error, err,
-			logfields.Node, obj.Name,
-			logfields.Source, obj.Source,
+	}}
+	if old, _, found := w.candidates.Get(
+		txn,
+		nodeCandidateByID(candidate.key().String()),
+	); found && old.node.Local != nil {
+		w.log.Warn("Ignoring remote update to local node",
+			logfields.Node, n.Fullname(),
+			logfields.Source, n.Source,
 		)
-		return false
+		return
 	}
-	return true
+	w.upsertCandidate(txn, candidate)
 }
 
-// Delete removes a remote node if this writer's source still owns it. It
-// reports whether the table changed.
-func (w *Writer) Delete(txn statedb.WriteTxn, src source.Source, identity nodeTypes.Identity) bool {
-	old, _, found := w.nodes.Get(txn, NodeByName(identity.String()))
-	if !found {
-		return false
+// Delete removes a remote node candidate from the given source. The selected
+// node table is reconciled when txn is committed.
+func (w *Writer) Delete(txn *WriteTxn, src source.Source, identity nodeTypes.Identity) {
+	w.checkTxn(txn)
+	key := nodeCandidateKey{identity, src}
+	candidate, _, found := w.candidates.Get(txn, nodeCandidateByID(key.String()))
+	if found && candidate.node.Local == nil {
+		w.deleteCandidate(txn, candidate)
+		return
 	}
-	if old.Local != nil || old.Source != src {
+
+	if active, _, found := w.nodes.Get(txn, NodeByName(identity.String())); found {
 		w.log.Warn("Ignoring node deletion from source that does not own node",
 			logfields.Node, identity.Name,
 			logfields.Source, src,
-			logfields.NodeOwner, old.Source,
+			logfields.NodeOwner, active.Source,
 		)
-		return false
 	}
-	if _, _, err := w.nodes.Delete(txn, old); err != nil {
-		w.log.Error("Failed to delete node from table",
+}
+
+func (w *Writer) checkTxn(txn *WriteTxn) {
+	if txn.w != w {
+		panic("node: write transaction belongs to another Writer")
+	}
+	if txn.closed {
+		panic("node: write transaction is closed")
+	}
+}
+
+func (w *Writer) upsertCandidate(txn *WriteTxn, candidate *nodeCandidate) {
+	w.prepareCandidate(candidate)
+	key := candidate.key()
+	old, _, found := w.candidates.Get(txn, nodeCandidateByID(key.String()))
+	if found && sameCandidate(old, candidate) {
+		return
+	}
+	if _, _, err := w.candidates.Insert(txn, candidate); err != nil {
+		w.log.Error("Failed to write node candidate",
 			logfields.Error, err,
-			logfields.Node, identity.Name,
-			logfields.Source, src,
+			logfields.Node, candidate.node.Fullname(),
+			logfields.Source, candidate.node.Source,
 		)
-		return false
+		return
 	}
-	return true
+	w.recordCandidateChange(txn, key, old, candidate)
+}
+
+func (w *Writer) prepareCandidate(candidate *nodeCandidate) {
+	for address := range candidate.node.addressClusters(w.isStaticLocalRouterIP) {
+		candidate.conflictAddresses = append(candidate.conflictAddresses, address)
+	}
+	slices.SortFunc(candidate.conflictAddresses, func(a, b cmtypes.AddrCluster) int {
+		return a.Compare(b)
+	})
+	candidate.conflictAddresses = slices.Compact(candidate.conflictAddresses)
+}
+
+func sameCandidate(a, b *nodeCandidate) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.node.DeepEqual(b.node) &&
+		a.node.addressClusterID == b.node.addressClusterID
+}
+
+func (w *Writer) recordCandidateChange(
+	txn *WriteTxn,
+	key nodeCandidateKey,
+	old, new *nodeCandidate,
+) {
+	change, found := txn.changes[key]
+	if !found {
+		change.old = old
+	}
+	change.new = new
+	if sameCandidate(change.old, change.new) {
+		delete(txn.changes, key)
+	} else {
+		txn.changes[key] = change
+	}
+}
+
+func (w *Writer) upsertLocal(txn *WriteTxn, old, candidate *Node) {
+	w.checkTxn(txn)
+	if old != nil && (nodeCandidateKey{old.Node.Identity(), old.Source}) !=
+		(nodeCandidateKey{candidate.Node.Identity(), candidate.Source}) {
+		if previous, _, found := w.candidates.Get(
+			txn,
+			nodeCandidateByID((nodeCandidateKey{old.Node.Identity(), old.Source}).String()),
+		); found {
+			w.deleteCandidate(txn, previous)
+		}
+	}
+	candidate.addressClusterID = deriveAddressClusterID(w.prefixClusterMutatorFn, &candidate.Node)
+	w.upsertCandidate(txn, &nodeCandidate{node: candidate})
+}
+
+func (w *Writer) deleteCandidate(txn *WriteTxn, candidate *nodeCandidate) {
+	if _, _, err := w.candidates.Delete(txn, candidate); err != nil {
+		w.log.Error("Failed to delete node candidate",
+			logfields.Error, err,
+			logfields.Node, candidate.node.Fullname(),
+			logfields.Source, candidate.node.Source,
+		)
+		return
+	}
+	w.recordCandidateChange(txn, candidate.key(), candidate, nil)
+}
+
+// affectedCandidates returns the current candidates in every conflict
+// component touched by txn, together with the node names whose selected rows
+// may need updating. Candidates are connected when they have the same node
+// name or share a conflict address.
+//
+// Both the old and new versions of each change seed the traversal. Using the
+// old version is important for deletes and address changes: although it is no
+// longer indexed, its name and addresses lead us to all pieces of the former
+// conflict component.
+func (w *Writer) affectedCandidates(txn *WriteTxn) ([]*nodeCandidate, set.Set[string]) {
+	var (
+		worklist         []*nodeCandidate
+		candidateKeys    set.Set[nodeCandidateKey]
+		affectedNames    set.Set[string]
+		visitedNames     set.Set[string]
+		visitedAddresses set.Set[cmtypes.AddrCluster]
+	)
+
+	addCandidate := func(candidate *nodeCandidate) {
+		key := candidate.key()
+		if candidateKeys.Has(key) {
+			return
+		}
+		candidateKeys.Insert(key)
+		worklist = append(worklist, candidate)
+		affectedNames.Insert(candidate.node.Fullname())
+	}
+	visitConflicts := func(candidate *nodeCandidate) {
+		name := candidate.node.Fullname()
+		affectedNames.Insert(name)
+		if !visitedNames.Has(name) {
+			visitedNames.Insert(name)
+			for other := range w.candidates.List(txn, nodeCandidateByName(name)) {
+				addCandidate(other)
+			}
+		}
+		for _, address := range candidate.conflictAddresses {
+			if visitedAddresses.Has(address) {
+				continue
+			}
+			visitedAddresses.Insert(address)
+			for other := range w.candidates.List(txn, nodeCandidateByAddress(address)) {
+				addCandidate(other)
+			}
+		}
+	}
+
+	for _, change := range txn.changes {
+		if change.old != nil {
+			visitConflicts(change.old)
+		}
+		if change.new != nil {
+			visitConflicts(change.new)
+		}
+	}
+	// worklist is both the result and the traversal queue. Visiting a candidate
+	// can append previously unseen neighbors, so use an index loop whose bound
+	// grows with the slice. A range loop would only visit the elements present
+	// when the loop started.
+	for i := 0; i < len(worklist); i++ {
+		visitConflicts(worklist[i])
+	}
+	slices.SortFunc(worklist, compareCandidatePrecedence)
+	return worklist, affectedNames
+}
+
+func (w *Writer) selectCandidates(
+	txn *WriteTxn,
+	candidates []*nodeCandidate,
+) map[string]*nodeCandidate {
+	selected := make(map[string]*nodeCandidate, len(candidates))
+	addressOwners := map[cmtypes.AddrCluster]*nodeCandidate{}
+	for _, candidate := range candidates {
+		name := candidate.node.Fullname()
+		if owner := selected[name]; owner != nil {
+			if _, updated := txn.changes[candidate.key()]; updated {
+				w.log.Warn("Ignoring lower priority node update",
+					logfields.Node, name,
+					logfields.Source, candidate.node.Source,
+					logfields.NodeOwner, owner.node.Source,
+				)
+			}
+			continue
+		}
+
+		conflict := false
+		for _, address := range candidate.conflictAddresses {
+			if owner := addressOwners[address]; owner != nil {
+				conflict = true
+				if _, updated := txn.changes[candidate.key()]; updated {
+					w.log.Warn("Node address conflicts with another node",
+						logfields.IPAddr, address,
+						logfields.Node, name,
+						logfields.Source, candidate.node.Source,
+						logfields.ConflictingResource, owner.node.Fullname(),
+						logfields.NodeOwner, owner.node.Source,
+					)
+				}
+			}
+		}
+		if conflict {
+			continue
+		}
+
+		selected[name] = candidate
+		for _, address := range candidate.conflictAddresses {
+			addressOwners[address] = candidate
+		}
+	}
+	return selected
+}
+
+func sameDesiredNode(active *Node, candidate *nodeCandidate) bool {
+	return active.DeepEqual(candidate.node) &&
+		active.addressClusterID == candidate.node.addressClusterID
+}
+
+func (w *Writer) reconcileChanges(txn *WriteTxn) {
+	if len(txn.changes) == 0 {
+		return
+	}
+	candidates, affectedNames := w.affectedCandidates(txn)
+	selected := w.selectCandidates(txn, candidates)
+	existing := make(map[string]*Node, affectedNames.Len())
+
+	for name := range affectedNames.Members() {
+		active, _, found := w.nodes.Get(txn, NodeByName(name))
+		if !found {
+			continue
+		}
+		existing[name] = active
+		candidate := selected[name]
+		if candidate != nil && sameDesiredNode(active, candidate) {
+			continue
+		}
+		if _, _, err := w.nodes.Delete(txn, active); err != nil {
+			w.log.Error("Failed to delete node from table",
+				logfields.Error, err,
+				logfields.Node, active.Fullname(),
+				logfields.Source, active.Source,
+			)
+			continue
+		}
+	}
+
+	reconcilers := reconcilerNames(w.getRequiredReconcilers(txn))
+	for name, candidate := range selected {
+		if old := existing[name]; old != nil && sameDesiredNode(old, candidate) {
+			continue
+		}
+		obj := candidate.node.DeepCopy()
+		if old := existing[name]; old != nil {
+			obj.Statuses = old.Statuses.Pending(reconcilers...)
+		} else {
+			obj.Statuses = reconciler.NewStatusSet().Pending(reconcilers...)
+		}
+		if _, _, err := w.nodes.Insert(txn, obj); err != nil {
+			w.log.Error("Failed to write node to table",
+				logfields.Error, err,
+				logfields.Node, obj.Fullname(),
+				logfields.Source, obj.Source,
+			)
+			continue
+		}
+	}
+}
+
+type writerParams struct {
+	cell.In
+
+	Log          *slog.Logger
+	DB           *statedb.DB
+	Nodes        statedb.RWTable[*Node]
+	Candidates   statedb.RWTable[*nodeCandidate]
+	DaemonConfig *option.DaemonConfig `optional:"true"`
+}
+
+func provideWriter(p writerParams) *Writer {
+	w := newWriter(p.Log, p.DB, p.Nodes, p.Candidates)
+	if p.DaemonConfig != nil {
+		w.isStaticLocalRouterIP = p.DaemonConfig.IsLocalRouterIP
+	}
+	return w
+}
+
+func newWriter(
+	log *slog.Logger,
+	db *statedb.DB,
+	nodes statedb.RWTable[*Node],
+	candidates statedb.RWTable[*nodeCandidate],
+) *Writer {
+	return &Writer{
+		log:        log,
+		db:         db,
+		nodes:      nodes,
+		candidates: candidates,
+	}
+}
+
+type nodeCandidateChange struct {
+	old *nodeCandidate
+	new *nodeCandidate
+}
+
+type nodeCandidateKey struct {
+	identity nodeTypes.Identity
+	source   source.Source
+}
+
+type nodeCandidate struct {
+	node *Node
+
+	// conflictAddresses are the normalized addresses used for conflict
+	// detection and by the candidate address index.
+	conflictAddresses []cmtypes.AddrCluster
+}
+
+func (candidate nodeCandidate) key() nodeCandidateKey {
+	return nodeCandidateKey{candidate.node.Node.Identity(), candidate.node.Source}
+}
+
+func (candidate *nodeCandidate) TableHeader() []string {
+	return []string{"Name", "Source"}
+}
+
+func (candidate *nodeCandidate) TableRow() []string {
+	return []string{candidate.node.Fullname(), string(candidate.node.Source)}
+}
+
+const nodeCandidateTableName = "node-candidates"
+
+var (
+	// The primary index uniquely identifies a producer's candidate.
+	nodeCandidateIDIndex = statedb.Index[*nodeCandidate, string]{
+		Name: "id",
+		FromObject: func(candidate *nodeCandidate) index.KeySet {
+			return index.NewKeySet(index.String(candidate.key().String()))
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     true,
+	}
+	nodeCandidateNameIndex = statedb.Index[*nodeCandidate, string]{
+		Name: "name",
+		FromObject: func(candidate *nodeCandidate) index.KeySet {
+			return index.NewKeySet(index.String(candidate.node.Fullname()))
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     false,
+	}
+	nodeCandidateAddressIndex = statedb.Index[*nodeCandidate, cmtypes.AddrCluster]{
+		Name: "address",
+		FromObject: func(candidate *nodeCandidate) index.KeySet {
+			keys := make([]index.Key, 0, len(candidate.conflictAddresses))
+			for _, address := range candidate.conflictAddresses {
+				keys = append(keys, nodeAddressKey(address))
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey:    nodeAddressKey,
+		FromString: nodeAddressKeyString,
+		Unique:     false,
+	}
+	nodeCandidateByID      = nodeCandidateIDIndex.Query
+	nodeCandidateByName    = nodeCandidateNameIndex.Query
+	nodeCandidateByAddress = nodeCandidateAddressIndex.Query
+)
+
+func (key nodeCandidateKey) String() string {
+	return string(key.source) + "\x00" + key.identity.Cluster + "\x00" + key.identity.Name
+}
+
+func compareCandidatePrecedence(a, b *nodeCandidate) int {
+	return cmp.Or(
+		a.node.Source.ComparePriority(b.node.Source),
+		cmp.Compare(a.node.Cluster, b.node.Cluster),
+		cmp.Compare(a.node.Name, b.node.Name),
+		// ComparePriority treats unknown sources equally. Use the source name
+		// as the final tie-breaker to produce a total, deterministic order.
+		cmp.Compare(a.node.Source, b.node.Source),
+	)
+}
+
+func newNodeCandidateTable(db *statedb.DB) (statedb.RWTable[*nodeCandidate], error) {
+	return statedb.NewTable(
+		db,
+		nodeCandidateTableName,
+		nodeCandidateIDIndex,
+		nodeCandidateNameIndex,
+		nodeCandidateAddressIndex,
+	)
 }

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"net/netip"
 	"slices"
+	"strings"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
@@ -32,11 +33,13 @@ type Writer struct {
 	db         *statedb.DB
 	nodes      statedb.RWTable[*Node]
 	candidates statedb.RWTable[*nodeCandidate]
+	health     cell.Health
 
 	isStaticLocalRouterIP  func(string) bool
 	prefixClusterMutatorFn PrefixClusterMutatorFn
 
 	requiredReconcilers []NodeReconciler
+	reportedStatus      string
 }
 
 // PrefixClusterMutatorFn derives cluster-aware addressing options from a
@@ -53,6 +56,15 @@ const (
 	LinuxNodeReconciler NodeReconciler = "linux"
 	// WireGuardNodeReconciler realizes nodes in the WireGuard datapath.
 	WireGuardNodeReconciler NodeReconciler = "wireguard"
+)
+
+// WriterCell provides the node table Writer
+var WriterCell = cell.Module(
+	"node-writer",
+	"Node table writer",
+
+	cell.ProvidePrivate(newNodeCandidateTable),
+	cell.Provide(provideWriter),
 )
 
 // NewWriter constructs a node table writer.
@@ -99,6 +111,7 @@ func (txn *WriteTxn) Commit() statedb.ReadTxn {
 		return nil
 	}
 	txn.w.reconcileChanges(txn)
+	txn.w.reportHealth(txn)
 	txn.closed = true
 	return txn.WriteTxn.Commit()
 }
@@ -642,15 +655,47 @@ type writerParams struct {
 	DB           *statedb.DB
 	Nodes        statedb.RWTable[*Node]
 	Candidates   statedb.RWTable[*nodeCandidate]
+	Health       cell.Health
 	DaemonConfig *option.DaemonConfig `optional:"true"`
 }
 
 func provideWriter(p writerParams) *Writer {
 	w := newWriter(p.Log, p.DB, p.Nodes, p.Candidates)
+	w.health = p.Health
 	if p.DaemonConfig != nil {
 		w.isStaticLocalRouterIP = p.DaemonConfig.IsLocalRouterIP
 	}
 	return w
+}
+
+func (w *Writer) reportHealth(txn statedb.ReadTxn) {
+	if w.health == nil {
+		return
+	}
+	nodeCount := w.nodes.NumObjects(txn)
+	conflictCount := w.candidates.NumObjects(txn) - nodeCount
+	status := fmt.Sprintf("%d nodes (%d conflicts)", nodeCount, conflictCount)
+	if conflictCount > 0 {
+		names := make([]string, 0, conflictCount)
+		for candidate := range w.candidates.All(txn) {
+			active, _, found := w.nodes.Get(txn, NodeByName(candidate.node.Fullname()))
+			if !found || active.Source != candidate.node.Source {
+				names = append(names, candidate.node.Fullname())
+			}
+		}
+		slices.Sort(names)
+		names = slices.Compact(names)
+		status += ": " + strings.Join(names, ", ")
+	}
+	if status == w.reportedStatus {
+		return
+	}
+	w.reportedStatus = status
+	if conflictCount == 0 {
+		w.health.OK(status)
+	} else {
+		w.health.Degraded(status, fmt.Errorf("node conflicts: %d", conflictCount))
+	}
 }
 
 func newWriter(

--- a/pkg/node/writer.go
+++ b/pkg/node/writer.go
@@ -270,12 +270,10 @@ func (w *Writer) waitUntilReconciled(
 			if _, found := targets[node.Fullname()]; found {
 				finished := true
 				if reconcilers == nil {
-					for _, status := range node.Statuses.All() {
-						if status.Kind != reconciler.StatusKindDone &&
-							(requireDone || status.Kind != reconciler.StatusKindError) {
-							finished = false
-							break
-						}
+					if requireDone {
+						finished = node.Statuses.IsDone()
+					} else {
+						finished = !node.Statuses.IsPendingOrRefreshing()
 					}
 				} else {
 					for _, name := range reconcilers {

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -6,10 +6,13 @@ package node
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,20 +28,78 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 )
 
+type writerTest struct {
+	t     *testing.T
+	db    *statedb.DB
+	nodes statedb.RWTable[*Node]
+	w     *Writer
+}
+
+func newWriterTest(t *testing.T) *writerTest {
+	t.Helper()
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	return &writerTest{t, db, nodes, NewWriter(hivetest.Logger(t), db, nodes)}
+}
+
+func (wt *writerTest) upsert(n *types.Node) bool {
+	wt.t.Helper()
+	revision := wt.nodes.Revision(wt.db.ReadTxn())
+	txn := wt.w.WriteTxn()
+	wt.w.Upsert(txn, n)
+	txn.Commit()
+	return wt.nodes.Revision(wt.db.ReadTxn()) != revision
+}
+
+func (wt *writerTest) delete(src source.Source, identity types.Identity) bool {
+	wt.t.Helper()
+	revision := wt.nodes.Revision(wt.db.ReadTxn())
+	txn := wt.w.WriteTxn()
+	wt.w.Delete(txn, src, identity)
+	txn.Commit()
+	return wt.nodes.Revision(wt.db.ReadTxn()) != revision
+}
+
+func (wt *writerTest) requireNode(name string) *Node {
+	wt.t.Helper()
+	n, _, found := wt.nodes.Get(wt.db.ReadTxn(), NodeByName(name))
+	require.True(wt.t, found, name)
+	return n
+}
+
+func (wt *writerTest) requireNoNode(name string) {
+	wt.t.Helper()
+	_, _, found := wt.nodes.Get(wt.db.ReadTxn(), NodeByName(name))
+	require.False(wt.t, found, name)
+}
+
+func testNode(name string, src source.Source, addresses ...string) *types.Node {
+	n := &types.Node{Name: name, Source: src}
+	for _, address := range addresses {
+		n.IPAddresses = append(n.IPAddresses, types.Address{IP: net.ParseIP(address)})
+	}
+	return n
+}
+
 func TestSourceWriter(t *testing.T) {
 	db := statedb.New()
 	nodes, err := NewNodeTable(db)
 	require.NoError(t, err)
 	w := NewWriter(hivetest.Logger(t), db, nodes)
 	upsert := func(n *types.Node) bool {
-		txn := db.WriteTxn(nodes)
-		defer txn.Commit()
-		return w.Upsert(txn, n)
+		revision := nodes.Revision(db.ReadTxn())
+		txn := w.WriteTxn()
+		w.Upsert(txn, n)
+		txn.Commit()
+		return nodes.Revision(db.ReadTxn()) != revision
 	}
 	deleteNode := func(src source.Source, identity types.Identity) bool {
-		txn := db.WriteTxn(nodes)
-		defer txn.Commit()
-		return w.Delete(txn, src, identity)
+		revision := nodes.Revision(db.ReadTxn())
+		txn := w.WriteTxn()
+		w.Delete(txn, src, identity)
+		txn.Commit()
+		return nodes.Revision(db.ReadTxn()) != revision
 	}
 
 	n := &types.Node{Name: "node-1", Source: source.Kubernetes}
@@ -86,6 +147,202 @@ func TestSourceWriter(t *testing.T) {
 	require.False(t, found)
 }
 
+func TestWriterRestoresSourceFallback(t *testing.T) {
+	wt := newWriterTest(t)
+	wt.w.RegisterReconciler("test")
+	requireSource := func(name string, src source.Source) *Node {
+		n := wt.requireNode(name)
+		require.Equal(t, src, n.Source)
+		return n
+	}
+
+	k8s := &types.Node{Name: "node-1", Source: source.Kubernetes}
+	require.True(t, wt.upsert(k8s))
+
+	// Restoring a displaced candidate starts a new reconciliation attempt.
+	txn := wt.db.WriteTxn(wt.nodes)
+	active, _, found := wt.nodes.Get(txn, NodeByName("node-1"))
+	require.True(t, found)
+	updated := active.DeepCopy()
+	updated.Statuses = updated.Statuses.Set("test", reconciler.StatusDone())
+	_, _, err := wt.nodes.Insert(txn, updated)
+	require.NoError(t, err)
+	txn.Commit()
+
+	kvstore := k8s.DeepCopy()
+	kvstore.Source = source.KVStore
+	require.True(t, wt.upsert(kvstore))
+	requireSource("node-1", source.KVStore)
+	require.True(t, wt.delete(source.KVStore, kvstore.Identity()))
+	restored := requireSource("node-1", source.Kubernetes)
+	require.Equal(t, reconciler.StatusKindPending, restored.Statuses.Get("test").Kind)
+
+	// A rejected candidate is also restored after its winner disappears.
+	mesh := k8s.DeepCopy()
+	mesh.Source = source.ClusterMesh
+	require.False(t, wt.upsert(mesh))
+	require.True(t, wt.delete(source.Kubernetes, k8s.Identity()))
+	requireSource("node-1", source.ClusterMesh)
+
+	// Deleting a shadowed candidate prevents it from being restored later.
+	require.True(t, wt.upsert(k8s))
+	require.False(t, wt.delete(source.ClusterMesh, mesh.Identity()))
+	require.True(t, wt.delete(source.Kubernetes, k8s.Identity()))
+	wt.requireNoNode("node-1")
+}
+
+func TestWriterAbortDiscardsCandidates(t *testing.T) {
+	wt := newWriterTest(t)
+
+	winner := &types.Node{Name: "node-1", Source: source.Kubernetes}
+	txn := wt.w.WriteTxn()
+	wt.w.Upsert(txn, winner)
+	txn.Commit()
+
+	shadowed := winner.DeepCopy()
+	shadowed.Source = source.ClusterMesh
+	txn = wt.w.WriteTxn()
+	wt.w.Upsert(txn, shadowed)
+	txn.Abort()
+
+	txn = wt.w.WriteTxn()
+	wt.w.Delete(txn, winner.Source, winner.Identity())
+	txn.Commit()
+	wt.requireNoNode(winner.Fullname())
+}
+
+func TestWriterNetNoOpTransactionDoesNotReconcile(t *testing.T) {
+	wt := newWriterTest(t)
+
+	transient := &types.Node{Name: "transient", Source: source.Kubernetes}
+	revision := wt.nodes.Revision(wt.db.ReadTxn())
+	txn := wt.w.WriteTxn()
+	wt.w.Upsert(txn, transient)
+	wt.w.Delete(txn, transient.Source, transient.Identity())
+	txn.Commit()
+	require.Equal(t, revision, wt.nodes.Revision(wt.db.ReadTxn()))
+	_, _, found := wt.w.candidates.Get(
+		wt.db.ReadTxn(),
+		nodeCandidateByID((nodeCandidateKey{transient.Identity(), transient.Source}).String()),
+	)
+	require.False(t, found)
+
+	original := &types.Node{Name: "node-1", Source: source.Kubernetes}
+	txn = wt.w.WriteTxn()
+	wt.w.Upsert(txn, original)
+	txn.Commit()
+
+	wtxn := wt.db.WriteTxn(wt.nodes)
+	active, _, found := wt.nodes.Get(wtxn, NodeByName(original.Fullname()))
+	require.True(t, found)
+	active = active.DeepCopy()
+	active.Statuses = active.Statuses.Set("test", reconciler.StatusDone())
+	_, _, err := wt.nodes.Insert(wtxn, active)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	revision = wt.nodes.Revision(wt.db.ReadTxn())
+	updated := original.DeepCopy()
+	updated.EncryptionKey = 42
+	txn = wt.w.WriteTxn()
+	wt.w.Upsert(txn, updated)
+	wt.w.Upsert(txn, original)
+	txn.Commit()
+	require.Equal(t, revision, wt.nodes.Revision(wt.db.ReadTxn()))
+	active, _, found = wt.nodes.Get(wt.db.ReadTxn(), NodeByName(original.Fullname()))
+	require.True(t, found)
+	require.Equal(t, reconciler.StatusKindDone, active.Statuses.Get("test").Kind)
+}
+
+func TestWriterIncrementalSelectionMatchesReference(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+
+	sources := []source.Source{
+		source.KubeAPIServer,
+		source.Local,
+		source.KVStore,
+		source.Kubernetes,
+		source.ClusterMesh,
+	}
+	rng := rand.New(rand.NewPCG(1, 2))
+	for iteration := range 500 {
+		txn := w.WriteTxn()
+		for range 1 + rng.IntN(3) {
+			slot := rng.IntN(40)
+			src := sources[slot%len(sources)]
+			name := fmt.Sprintf("node-%02d", slot%16)
+			if rng.IntN(4) == 0 {
+				w.Delete(txn, src, types.Identity{Name: name})
+				continue
+			}
+
+			n := &types.Node{
+				Name:          name,
+				Source:        src,
+				EncryptionKey: uint8(iteration%255 + 1),
+			}
+			for range rng.IntN(4) {
+				address := rng.IntN(24) + 1
+				n.IPAddresses = append(n.IPAddresses, types.Address{
+					Type: addressing.NodeInternalIP,
+					IP:   net.IPv4(10, 0, 0, byte(address)),
+				})
+			}
+			w.Upsert(txn, n)
+		}
+		txn.Commit()
+		requireWriterMatchesReference(t, w, db.ReadTxn())
+	}
+}
+
+// referenceSelectedCandidates intentionally scans the complete candidate
+// table. It is the simple reference implementation for testing incremental
+// conflict-component reconciliation.
+func referenceSelectedCandidates(w *Writer, txn statedb.ReadTxn) map[string]*nodeCandidate {
+	selected := map[string]*nodeCandidate{}
+	addressOwners := map[cmtypes.AddrCluster]*nodeCandidate{}
+	var candidates []*nodeCandidate
+	for candidate := range w.candidates.All(txn) {
+		candidates = append(candidates, candidate)
+	}
+	slices.SortFunc(candidates, compareCandidatePrecedence)
+	for _, candidate := range candidates {
+		name := candidate.node.Fullname()
+		if selected[name] != nil {
+			continue
+		}
+		conflict := false
+		for _, address := range candidate.conflictAddresses {
+			if addressOwners[address] != nil {
+				conflict = true
+				break
+			}
+		}
+		if conflict {
+			continue
+		}
+		selected[name] = candidate
+		for _, address := range candidate.conflictAddresses {
+			addressOwners[address] = candidate
+		}
+	}
+	return selected
+}
+
+func requireWriterMatchesReference(t *testing.T, w *Writer, txn statedb.ReadTxn) {
+	t.Helper()
+	expected := referenceSelectedCandidates(w, txn)
+	require.Equal(t, len(expected), w.nodes.NumObjects(txn))
+	for name, candidate := range expected {
+		actual, _, found := w.nodes.Get(txn, NodeByName(name))
+		require.True(t, found, name)
+		require.True(t, sameDesiredNode(actual, candidate), name)
+	}
+}
+
 func TestWriterReconcilerRegistration(t *testing.T) {
 	db := statedb.New()
 	nodes, err := NewNodeTable(db)
@@ -93,9 +350,11 @@ func TestWriterReconcilerRegistration(t *testing.T) {
 	w := NewWriter(hivetest.Logger(t), db, nodes)
 
 	upsert := func(n *types.Node) bool {
-		txn := db.WriteTxn(nodes)
-		defer txn.Commit()
-		return w.Upsert(txn, n)
+		revision := nodes.Revision(db.ReadTxn())
+		txn := w.WriteTxn()
+		w.Upsert(txn, n)
+		txn.Commit()
+		return nodes.Revision(db.ReadTxn()) != revision
 	}
 	get := func(name string) *Node {
 		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
@@ -225,11 +484,11 @@ func TestWriterWaitUntilReconciled(t *testing.T) {
 		name string,
 	) {
 		t.Helper()
-		txn := db.WriteTxn(nodes)
-		require.True(t, w.Upsert(txn, &types.Node{
+		txn := w.WriteTxn()
+		w.Upsert(txn, &types.Node{
 			Name:   name,
 			Source: source.Kubernetes,
-		}))
+		})
 		txn.Commit()
 	}
 	setStatus := func(
@@ -313,7 +572,7 @@ func TestWriterWaitUntilReconciled(t *testing.T) {
 	})
 }
 
-func TestSourceWriterDoesNotOverwriteLocalNode(t *testing.T) {
+func TestSourceWriterRespectsLocalNodePriority(t *testing.T) {
 	db := statedb.New()
 	nodes, err := NewNodeTable(db)
 	require.NoError(t, err)
@@ -327,132 +586,219 @@ func TestSourceWriterDoesNotOverwriteLocalNode(t *testing.T) {
 		},
 		Local: &LocalNodeInfo{},
 	}
-	txn := db.WriteTxn(nodes)
-	_, _, err = nodes.Insert(txn, local)
-	require.NoError(t, err)
+	txn := w.WriteTxn()
+	w.upsertLocal(txn, nil, local)
 	txn.Commit()
 
-	remote := &types.Node{Name: "local", Source: source.KubeAPIServer}
-	txn = db.WriteTxn(nodes)
-	require.False(t, w.Upsert(txn, remote))
-	require.False(t, w.Delete(txn, source.Local, remote.Identity()))
+	remote := &types.Node{Name: "local", Source: source.Kubernetes}
+	txn = w.WriteTxn()
+	w.Upsert(txn, remote)
+	w.Delete(txn, source.Local, remote.Identity())
 	txn.Commit()
 	got, _, found := nodes.Get(db.ReadTxn(), NodeByName("local"))
 	require.True(t, found)
 	require.NotNil(t, got.Local)
 
-	// The local row also owns its addresses regardless of source priority.
+	// The local row also owns its addresses against lower-priority sources.
 	remote = &types.Node{
 		Name:        "remote",
-		Source:      source.KubeAPIServer,
+		Source:      source.Kubernetes,
 		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
 	}
-	txn = db.WriteTxn(nodes)
-	require.False(t, w.Upsert(txn, remote))
+	txn = w.WriteTxn()
+	w.Upsert(txn, remote)
 	txn.Commit()
 	_, _, found = nodes.Get(db.ReadTxn(), NodeByName("remote"))
 	require.False(t, found)
+
+	// KubeAPIServer has higher source priority than Local. It is not used as a
+	// node-table source in production, but follows the normal ordering here.
+	apiServer := &types.Node{
+		Name:        "api-server",
+		Source:      source.KubeAPIServer,
+		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+	}
+	txn = w.WriteTxn()
+	w.Upsert(txn, apiServer)
+	txn.Commit()
+	_, _, found = nodes.Get(db.ReadTxn(), LocalNodeQuery)
+	require.False(t, found)
+	_, _, found = nodes.Get(db.ReadTxn(), NodeByName("api-server"))
+	require.True(t, found)
 }
 
 func TestWriterAddressConflicts(t *testing.T) {
-	db := statedb.New()
-	nodes, err := NewNodeTable(db)
-	require.NoError(t, err)
-	w := NewWriter(hivetest.Logger(t), db, nodes)
-
-	upsert := func(n *types.Node) bool {
-		txn := db.WriteTxn(nodes)
-		defer txn.Commit()
-		return w.Upsert(txn, n)
+	wt := newWriterTest(t)
+	upsert := wt.upsert
+	deleteNode := func(n *types.Node) bool {
+		return wt.delete(n.Source, n.Identity())
 	}
-	requireNode := func(name string) *Node {
-		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
-		require.True(t, found, name)
-		return n
-	}
-	requireNoNode := func(name string) {
-		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
-		require.False(t, found, name)
-	}
-	newNode := func(name string, src source.Source, addresses ...string) *types.Node {
-		n := &types.Node{Name: name, Source: src}
-		for _, address := range addresses {
-			n.IPAddresses = append(n.IPAddresses, types.Address{IP: net.ParseIP(address)})
-		}
-		return n
-	}
+	requireNode := wt.requireNode
+	requireNoNode := wt.requireNoNode
+	newNode := testNode
 
 	// A stronger source takes the address and removes the weaker node.
-	require.True(t, upsert(newNode("mesh", source.ClusterMesh, "10.0.0.1")))
-	require.True(t, upsert(newNode("k8s", source.Kubernetes, "10.0.0.1")))
+	mesh := newNode("mesh", source.ClusterMesh, "10.0.0.1")
+	k8s := newNode("k8s", source.Kubernetes, "10.0.0.1")
+	require.True(t, upsert(mesh))
+	require.True(t, upsert(k8s))
 	requireNoNode("mesh")
 	require.Equal(t, source.Kubernetes, requireNode("k8s").Source)
 
 	// A weaker source cannot take an address from its current owner.
-	require.False(t, upsert(newNode("weaker", source.ClusterMesh, "10.0.0.1")))
+	weaker := newNode("weaker", source.ClusterMesh, "10.0.0.1")
+	require.False(t, upsert(weaker))
 	requireNoNode("weaker")
 	requireNode("k8s")
 
-	// At equal priority the latest update wins.
-	require.True(t, upsert(newNode("latest", source.Kubernetes, "10.0.0.1")))
-	requireNoNode("k8s")
-	requireNode("latest")
+	// At equal priority the node identity is the deterministic tie-breaker.
+	latest := newNode("latest", source.Kubernetes, "10.0.0.1")
+	require.False(t, upsert(latest))
+	requireNode("k8s")
+	requireNoNode("latest")
+
+	// Fallback respects source priority first and node identity within one
+	// priority. Remove the shadowed Kubernetes candidate before testing the
+	// ClusterMesh candidates.
+	require.False(t, deleteNode(latest))
+	require.True(t, deleteNode(k8s))
+	requireNode("mesh")
+	requireNoNode("weaker")
+	require.True(t, deleteNode(mesh))
+	requireNode("weaker")
 
 	// Health and ingress addresses participate in the same ownership checks.
 	health := newNode("health", source.Kubernetes)
 	health.IPv4HealthIP = iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))
 	require.True(t, upsert(health))
-	require.True(t, upsert(newNode("health-latest", source.Kubernetes, "10.0.0.4")))
-	requireNoNode("health")
-	requireNode("health-latest")
+	require.False(t, upsert(newNode("health-latest", source.Kubernetes, "10.0.0.4")))
+	requireNode("health")
+	requireNoNode("health-latest")
 
 	ingress := newNode("ingress", source.Kubernetes)
 	ingress.IPv4IngressIP = iputil.AddrFrom(netip.MustParseAddr("10.0.0.5"))
 	require.True(t, upsert(ingress))
-	require.True(t, upsert(newNode("ingress-latest", source.Kubernetes, "10.0.0.5")))
-	requireNoNode("ingress")
-	requireNode("ingress-latest")
+	require.False(t, upsert(newNode("ingress-latest", source.Kubernetes, "10.0.0.5")))
+	requireNode("ingress")
+	requireNoNode("ingress-latest")
 
 	// Four-byte IPv4 and IPv4-mapped IPv6 representations are equivalent.
 	mapped := newNode("mapped", source.Kubernetes)
 	mapped.IPAddresses = []types.Address{{IP: net.IP{10, 0, 0, 6}}}
 	require.True(t, upsert(mapped))
-	require.True(t, upsert(newNode("mapped-latest", source.Kubernetes, "10.0.0.6")))
-	requireNoNode("mapped")
-	requireNode("mapped-latest")
+	require.False(t, upsert(newNode("mapped-latest", source.Kubernetes, "10.0.0.6")))
+	requireNode("mapped")
+	requireNoNode("mapped-latest")
 
 	// Check all conflicts before deleting anything. This update could replace
 	// the mesh node, but is rejected because it cannot replace the KVStore node.
 	require.True(t, upsert(newNode("mesh-2", source.ClusterMesh, "10.0.0.2")))
-	require.True(t, upsert(newNode("kvstore", source.KVStore, "10.0.0.3")))
+	kvstore := newNode("kvstore", source.KVStore, "10.0.0.3")
+	require.True(t, upsert(kvstore))
 	require.False(t, upsert(newNode(
 		"mixed", source.Kubernetes, "10.0.0.2", "10.0.0.3",
 	)))
 	requireNode("mesh-2")
 	requireNode("kvstore")
 	requireNoNode("mixed")
+
+	// Removing the blocker restores the mixed candidate, which can then replace
+	// the weaker node that shares its other address.
+	require.True(t, deleteNode(kvstore))
+	requireNoNode("mesh-2")
+	requireNode("mixed")
+}
+
+func TestWriterRestoresFallbackWhenAddressIsReleased(t *testing.T) {
+	wt := newWriterTest(t)
+
+	winner := testNode("winner", source.Kubernetes, "10.0.0.1")
+	fallback := testNode("fallback", source.ClusterMesh, "10.0.0.1")
+	require.True(t, wt.upsert(winner))
+	require.False(t, wt.upsert(fallback))
+
+	winner = testNode("winner", source.Kubernetes, "10.0.0.2")
+	require.True(t, wt.upsert(winner))
+	for _, name := range []string{"winner", "fallback"} {
+		wt.requireNode(name)
+	}
+}
+
+func TestWriterConflictWinnerIndependentOfOrder(t *testing.T) {
+	for _, order := range [][]string{{"z-node", "a-node"}, {"a-node", "z-node"}} {
+		t.Run(strings.Join(order, "-then-"), func(t *testing.T) {
+			wt := newWriterTest(t)
+
+			for _, name := range order {
+				txn := wt.w.WriteTxn()
+				wt.w.Upsert(txn, &types.Node{
+					Name:        name,
+					Source:      source.Kubernetes,
+					IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+				})
+				txn.Commit()
+			}
+
+			wt.requireNode("a-node")
+			wt.requireNoNode("z-node")
+
+			txn := wt.w.WriteTxn()
+			wt.w.Delete(txn, source.Kubernetes, types.Identity{Name: "a-node"})
+			txn.Commit()
+			wt.requireNode("z-node")
+		})
+	}
+}
+
+func TestWriterPreservesLatestShadowedProducerUpdate(t *testing.T) {
+	wt := newWriterTest(t)
+
+	original := testNode("node", source.Kubernetes, "10.0.0.1")
+	blocker := testNode("blocker", source.Local, "10.0.0.2")
+	require.True(t, wt.upsert(original))
+	require.True(t, wt.upsert(blocker))
+
+	updated := testNode("node", source.Kubernetes, "10.0.0.2")
+	updated.EncryptionKey = 42
+	require.True(t, wt.upsert(updated))
+	wt.requireNoNode("node")
+
+	// The old active version is no longer a candidate. Once the blocker is
+	// removed, the latest update from the producer becomes active.
+	require.True(t, wt.upsert(testNode("competitor", source.KVStore, "10.0.0.1")))
+	require.True(t, wt.delete(blocker.Source, blocker.Identity()))
+	got := wt.requireNode("node")
+	require.Equal(t, updated.EncryptionKey, got.EncryptionKey)
+	require.Equal(t, updated.IPAddresses, got.IPAddresses)
+}
+
+func TestWriterRestoresCascadingFallbacks(t *testing.T) {
+	wt := newWriterTest(t)
+
+	active := testNode("active", source.Kubernetes, "10.0.0.1", "10.0.0.2")
+	blocker := testNode("blocker", source.Local, "10.0.0.3")
+	bridge := testNode("bridge", source.KVStore, "10.0.0.1", "10.0.0.3")
+	fallback := testNode("fallback", source.ClusterMesh, "10.0.0.2")
+
+	require.True(t, wt.upsert(active))
+	require.True(t, wt.upsert(blocker))
+	require.False(t, wt.upsert(bridge))
+	require.False(t, wt.upsert(fallback))
+
+	// Restoring bridge displaces active and releases 10.0.0.2. The lower
+	// priority fallback must observe that release later in the same pass.
+	require.True(t, wt.delete(blocker.Source, blocker.Identity()))
+	wt.requireNoNode("active")
+	wt.requireNoNode("blocker")
+	wt.requireNode("bridge")
+	wt.requireNode("fallback")
 }
 
 func TestWriterClusterAwareAddressConflicts(t *testing.T) {
-	db := statedb.New()
-	nodes, err := NewNodeTable(db)
-	require.NoError(t, err)
-	w := NewWriter(hivetest.Logger(t), db, nodes)
-
-	upsert := func(n *types.Node) bool {
-		txn := db.WriteTxn(nodes)
-		defer txn.Commit()
-		return w.Upsert(txn, n)
-	}
-	requireNode := func(name string) *Node {
-		n, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
-		require.True(t, found, name)
-		return n
-	}
-	requireNoNode := func(name string) {
-		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
-		require.False(t, found, name)
-	}
+	wt := newWriterTest(t)
+	upsert := wt.upsert
+	requireNode := wt.requireNode
+	requireNoNode := wt.requireNoNode
 	newNode := func(
 		name, cluster string,
 		addressType addressing.AddressType,
@@ -472,7 +818,7 @@ func TestWriterClusterAwareAddressConflicts(t *testing.T) {
 
 	// The hook is installed during Hive invoke time, before producers write to
 	// the table.
-	w.SetPrefixClusterMutatorFn(func(n *types.Node) []cmtypes.PrefixClusterOpts {
+	wt.w.SetPrefixClusterMutatorFn(func(n *types.Node) []cmtypes.PrefixClusterOpts {
 		clusterIDs := map[string]uint32{"cluster-1": 1, "cluster-2": 2}
 		return []cmtypes.PrefixClusterOpts{cmtypes.WithClusterID(clusterIDs[n.Cluster])}
 	})
@@ -482,13 +828,13 @@ func TestWriterClusterAwareAddressConflicts(t *testing.T) {
 	require.True(t, upsert(newNode(
 		"node-1", "cluster-1", addressing.NodeCiliumInternalIP, "10.0.0.1",
 	)))
-	_, _, found := nodes.Get(
-		db.ReadTxn(),
+	_, _, found := wt.nodes.Get(
+		wt.db.ReadTxn(),
 		NodeByAddress(cmtypes.AddrClusterFrom(netip.MustParseAddr("10.0.0.1"), 0)),
 	)
 	require.False(t, found)
-	_, _, found = nodes.Get(
-		db.ReadTxn(),
+	_, _, found = wt.nodes.Get(
+		wt.db.ReadTxn(),
 		NodeByAddress(cmtypes.AddrClusterFrom(netip.MustParseAddr("10.0.0.1"), 1)),
 	)
 	require.True(t, found)
@@ -512,19 +858,16 @@ func TestWriterClusterAwareAddressConflicts(t *testing.T) {
 	require.True(t, upsert(newNode(
 		"underlay-1", "cluster-1", addressing.NodeInternalIP, "192.0.2.1",
 	)))
-	require.True(t, upsert(newNode(
+	require.False(t, upsert(newNode(
 		"underlay-2", "cluster-2", addressing.NodeInternalIP, "192.0.2.1",
 	)))
-	requireNoNode("cluster-1/underlay-1")
-	requireNode("cluster-2/underlay-2")
+	requireNode("cluster-1/underlay-1")
+	requireNoNode("cluster-2/underlay-2")
 }
 
 func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
-	db := statedb.New()
-	nodes, err := NewNodeTable(db)
-	require.NoError(t, err)
-	w := NewWriter(hivetest.Logger(t), db, nodes)
-	w.isStaticLocalRouterIP = func(ip string) bool {
+	wt := newWriterTest(t)
+	wt.w.isStaticLocalRouterIP = func(ip string) bool {
 		return ip == "169.254.23.0" || ip == "fe80::"
 	}
 
@@ -544,24 +887,22 @@ func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
 		},
 		Local: &LocalNodeInfo{},
 	}
-	txn := db.WriteTxn(nodes)
-	_, _, err = nodes.Insert(txn, local)
-	require.NoError(t, err)
+	txn := wt.w.WriteTxn()
+	wt.w.upsertLocal(txn, nil, local)
 	txn.Commit()
 
 	for _, name := range []string{"remote-1", "remote-2"} {
-		txn = db.WriteTxn(nodes)
-		require.True(t, w.Upsert(txn, &types.Node{
+		txn = wt.w.WriteTxn()
+		wt.w.Upsert(txn, &types.Node{
 			Name:        name,
 			Source:      source.CustomResource,
 			IPAddresses: slices.Clone(routerAddresses),
-		}))
+		})
 		txn.Commit()
 	}
 
 	for _, name := range []string{"local", "remote-1", "remote-2"} {
-		_, _, found := nodes.Get(db.ReadTxn(), NodeByName(name))
-		require.True(t, found, name)
+		wt.requireNode(name)
 	}
 	for _, address := range []netip.Addr{
 		netip.MustParseAddr("169.254.23.0"),
@@ -569,7 +910,7 @@ func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
 	} {
 		var owners []string
 		addrCluster := cmtypes.AddrClusterFrom(address, 0)
-		for n := range nodes.List(db.ReadTxn(), NodeByAddress(addrCluster)) {
+		for n := range wt.nodes.List(wt.db.ReadTxn(), NodeByAddress(addrCluster)) {
 			owners = append(owners, n.Name)
 		}
 		require.ElementsMatch(t, []string{"local", "remote-1", "remote-2"}, owners)
@@ -577,28 +918,28 @@ func TestWriterAllowsSharedLocalRouterIP(t *testing.T) {
 
 	// Matching a local node address alone is not enough: only the configured
 	// Cilium internal router addresses may be shared.
-	txn = db.WriteTxn(nodes)
-	require.False(t, w.Upsert(txn, &types.Node{
+	txn = wt.w.WriteTxn()
+	wt.w.Upsert(txn, &types.Node{
 		Name:   "conflict",
 		Source: source.CustomResource,
 		IPAddresses: []types.Address{{
 			Type: addressing.NodeCiliumInternalIP,
 			IP:   net.ParseIP("10.0.0.1"),
 		}},
-	}))
+	})
 	txn.Commit()
 
 	// The configured address remains conflicting when it is not advertised as
 	// a Cilium internal IP.
-	txn = db.WriteTxn(nodes)
-	require.False(t, w.Upsert(txn, &types.Node{
+	txn = wt.w.WriteTxn()
+	wt.w.Upsert(txn, &types.Node{
 		Name:   "wrong-type",
 		Source: source.CustomResource,
 		IPAddresses: []types.Address{{
 			Type: addressing.NodeInternalIP,
 			IP:   net.ParseIP("169.254.23.0"),
 		}},
-	}))
+	})
 	txn.Commit()
 }
 

--- a/pkg/node/writer_test.go
+++ b/pkg/node/writer_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
@@ -342,6 +343,113 @@ func requireWriterMatchesReference(t *testing.T, w *Writer, txn statedb.ReadTxn)
 		require.True(t, sameDesiredNode(actual, candidate), name)
 	}
 }
+
+func TestWriterReportsShadowedCandidates(t *testing.T) {
+	db := statedb.New()
+	nodes, err := NewNodeTable(db)
+	require.NoError(t, err)
+	w := NewWriter(hivetest.Logger(t), db, nodes)
+	health := &writerHealth{}
+	w.health = health
+
+	winner := &types.Node{Name: "node-1", Source: source.Kubernetes}
+	txn := w.WriteTxn()
+	w.Upsert(txn, winner)
+	txn.Commit()
+	update := health.popUpdate(t)
+	require.Equal(t, cell.StatusOK, update.level)
+	require.Equal(t, "1 nodes (0 conflicts)", update.reason)
+
+	shadowed := winner.DeepCopy()
+	shadowed.Source = source.ClusterMesh
+	txn = w.WriteTxn()
+	w.Upsert(txn, shadowed)
+	txn.Commit()
+
+	update = health.popUpdate(t)
+	require.Equal(t, cell.StatusDegraded, update.level)
+	require.Equal(t, "1 nodes (1 conflicts): node-1", update.reason)
+	require.EqualError(t, update.err, "node conflicts: 1")
+
+	txn = w.WriteTxn()
+	w.Delete(txn, shadowed.Source, shadowed.Identity())
+	txn.Commit()
+
+	update = health.popUpdate(t)
+	require.Equal(t, cell.StatusOK, update.level)
+	require.Equal(t, "1 nodes (0 conflicts)", update.reason)
+
+	addressOwner := &types.Node{
+		Name:        "address-owner",
+		Source:      source.Kubernetes,
+		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+	}
+	txn = w.WriteTxn()
+	w.Upsert(txn, addressOwner)
+	txn.Commit()
+	update = health.popUpdate(t)
+	require.Equal(t, cell.StatusOK, update.level)
+	require.Equal(t, "2 nodes (0 conflicts)", update.reason)
+
+	addressShadowed := &types.Node{
+		Name:        "address-shadowed",
+		Source:      source.ClusterMesh,
+		IPAddresses: []types.Address{{IP: net.ParseIP("10.0.0.1")}},
+	}
+	txn = w.WriteTxn()
+	w.Upsert(txn, addressShadowed)
+	txn.Commit()
+	update = health.popUpdate(t)
+	require.Equal(t, cell.StatusDegraded, update.level)
+	require.Equal(t, "2 nodes (1 conflicts): address-shadowed", update.reason)
+	require.EqualError(t, update.err, "node conflicts: 1")
+
+	aborted := &types.Node{Name: "aborted", Source: source.ClusterMesh}
+	txn = w.WriteTxn()
+	w.Upsert(txn, aborted)
+	txn.Abort()
+	require.Empty(t, health.updates)
+
+	txn = w.WriteTxn()
+	txn.Commit()
+	require.Empty(t, health.updates)
+}
+
+type writerHealthUpdate struct {
+	level  cell.Level
+	reason string
+	err    error
+}
+
+type writerHealth struct {
+	updates []writerHealthUpdate
+}
+
+func (h *writerHealth) popUpdate(t *testing.T) writerHealthUpdate {
+	t.Helper()
+	require.NotEmpty(t, h.updates)
+	update := h.updates[0]
+	h.updates = h.updates[1:]
+	return update
+}
+
+func (h *writerHealth) OK(reason string) {
+	h.updates = append(h.updates, writerHealthUpdate{level: cell.StatusOK, reason: reason})
+}
+
+func (h *writerHealth) Degraded(reason string, err error) {
+	h.updates = append(h.updates, writerHealthUpdate{
+		level:  cell.StatusDegraded,
+		reason: reason,
+		err:    err,
+	})
+}
+
+func (*writerHealth) Stopped(string) {}
+
+func (h *writerHealth) NewScope(string) cell.Health { return h }
+
+func (*writerHealth) Close() {}
 
 func TestWriterReconcilerRegistration(t *testing.T) {
 	db := statedb.New()

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -4,6 +4,7 @@
 package source
 
 import (
+	"cmp"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -90,19 +91,25 @@ var getSourcePriorities = sync.OnceValue(func() map[Source]int {
 	return m
 })
 
+// ComparePriority returns a negative value if s has higher precedence than other,
+// zero if they have equal precedence, and a positive value if s has lower
+// precedence. Unknown sources have lower precedence than all known sources
+// and compare equal to one another.
+func (s Source) ComparePriority(other Source) int {
+	priorities := getSourcePriorities()
+	priority := func(src Source) int {
+		if p, ok := priorities[src]; ok {
+			return p
+		}
+		return len(defaultSources)
+	}
+	return cmp.Compare(priority(s), priority(other))
+}
+
 // AllowOverwrite returns true if new state from a particular source is allowed
 // to overwrite existing state from another source
 func AllowOverwrite(existing, next Source) bool {
-	priorities := getSourcePriorities()
-	pNext, ok := priorities[next]
-	if !ok {
-		pNext = len(defaultSources)
-	}
-	pExisting, ok := priorities[existing]
-	if !ok {
-		pExisting = len(defaultSources)
-	}
-	return pNext <= pExisting
+	return next.ComparePriority(existing) <= 0
 }
 
 var Cell = cell.Module(

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -4,6 +4,7 @@
 package source
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"testing"
@@ -13,6 +14,19 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 )
+
+func TestComparePriority(t *testing.T) {
+	for i, a := range defaultSources {
+		for j, b := range defaultSources {
+			require.Equal(t, cmp.Compare(i, j), a.ComparePriority(b), "%s vs %s", a, b)
+		}
+	}
+
+	unknown := Source("unknown")
+	require.Positive(t, unknown.ComparePriority(Unspec))
+	require.Negative(t, Unspec.ComparePriority(unknown))
+	require.Zero(t, unknown.ComparePriority(Source("also-unknown")))
+}
 
 func TestAllowOverwrite(t *testing.T) {
 	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))


### PR DESCRIPTION
This extends the `node.Writer` to do proper handling of conflicting nodes. All nodes are now inserted into `node-candidates` table and on `node.WriteTxn.Commit` we perform conflict resolution and update the proper `nodes` table. 

Additionally improving the node table output by adding status to it and use of StatusSet in WaitUntilReconciled.

AIL:3