### PR TITLE
workflows: disable local accounts on AKS clusters

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -65,5 +65,6 @@ runs:
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
-          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
+          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }} \
+          --disable-local-accounts
 


### PR DESCRIPTION
[ note: this is a custom backport of #48265 ]

Local accounts are enabled by default on AKS clusters and can be useful but are technically an un-auditable backdoor. This PR disables them by default, since CI persons with the proper privileges may re-enable them ad-hoc if needed to troubleshoot a CI issue.

Doc: https://learn.microsoft.com/en-us/azure/aks/local-accounts