### PR TITLE
workflows: disable local accounts on AKS clusters

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -261,7 +261,8 @@ jobs:
             --node-count 2 \
             --ip-families ipv4,ipv6 \
             ${{ env.cost_reduction }} \
-            --generate-ssh-keys
+            --generate-ssh-keys \
+            --disable-local-accounts
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
[ note: this is a custom backport of #48265 ]

Local accounts are enabled by default on AKS clusters and can be useful but are technically an un-auditable backdoor. This PR disables them by default, since CI persons with the proper privileges may re-enable them ad-hoc if needed to troubleshoot a CI issue.

Doc: https://learn.microsoft.com/en-us/azure/aks/local-accounts