### PR TITLE
gha: Retry the Go toolchain download in the LVH VMs

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -268,7 +268,9 @@ jobs:
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
             go install golang.org/dl/go${{ env.go-version }}@latest
-            go${{ env.go-version }} download
+            # dl.google.com resets the transfer mid-download often enough to fail the job.
+            for i in {1..5}; do go${{ env.go-version }} download && break || sleep 5; echo "Retrying the Go toolchain download..."; done
+            go${{ env.go-version }} version
             # renovate: datasource=github-releases depName=mfridman/tparse
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
             # renovate: datasource=github-releases depName=cilium/go-junit-report/v2/cmd/go-junit-report

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -185,7 +185,9 @@ jobs:
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
             CGO_ENABLED=0 GOPROXY=direct GOSUMDB= go install golang.org/dl/go${{ env.go-version }}@latest
-            go${{ env.go-version }} download
+            # dl.google.com resets the transfer mid-download often enough to fail the job.
+            for i in {1..5}; do go${{ env.go-version }} download && break || sleep 5; echo "Retrying the Go toolchain download..."; done
+            go${{ env.go-version }} version
 
             # Free up disk space: remove the pre-installed Go toolchain and
             # build caches, only go${{ env.go-version }} is needed from now on.


### PR DESCRIPTION
The Go toolchain tarball download from dl.google.com can fail mid-transfer
and take the whole step down with it, as it did on the 5.15 leg of
https://github.com/cilium/cilium/actions/runs/33682685428. Add retries for
this.

This PR was prepared with AIL:3. I personally checked the diff.

