### PR TITLE
docs: use relative domain name for deathstar service instead of FQDN

### DIFF
--- a/Documentation/gettingstarted/demo.rst
+++ b/Documentation/gettingstarted/demo.rst
@@ -18,9 +18,9 @@ From the perspective of the *deathstar* service, only the ships with label ``org
 
 .. code-block:: shell-session
 
-    $ kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 Apply an L3/L4 Policy
@@ -63,14 +63,14 @@ Now if we run the landing requests again, only the *tiefighter* pods with the la
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 This works as expected. Now the same request run from an *xwing* pod will fail:
 
 .. code-block:: shell-session
 
-    $ kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl -s -XPOST deathstar/v1/request-landing
 
 This request will hang, so press Control-C to kill the curl request, or wait for it to time out.
 
@@ -185,7 +185,7 @@ For example, consider that the *deathstar* service exposes some maintenance APIs
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPUT deathstar.default.svc.cluster.local/v1/exhaust-port
+    $ kubectl exec tiefighter -- curl -s -XPUT deathstar/v1/exhaust-port
     Panic: deathstar exploded
 
     goroutine 1 [running]:
@@ -224,7 +224,7 @@ We can now re-run the same test as above, but we will see a different outcome:
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 
@@ -232,7 +232,7 @@ and
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPUT deathstar.default.svc.cluster.local/v1/exhaust-port
+    $ kubectl exec tiefighter -- curl -s -XPUT deathstar/v1/exhaust-port
     Access denied
 
 As this rule builds on the identity-aware rule, traffic from pods without the label
@@ -240,7 +240,7 @@ As this rule builds on the identity-aware rule, traffic from pods without the la
 
 .. code-block:: shell-session
 
-    $ kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl -s -XPOST deathstar/v1/request-landing
 
 
 As you can see, with Cilium L7 security policies, we are able to permit
@@ -385,8 +385,8 @@ It is also possible to monitor the HTTP requests live by using ``cilium-dbg moni
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system cilium-kzgdx -- cilium-dbg monitor -v --type l7
-    <- Response http to 0 ([k8s:class=tiefighter k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default k8s:org=empire]) from 2756 ([k8s:io.cilium.k8s.policy.cluster=default k8s:class=deathstar k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default]), identity 8876->43854, verdict Forwarded POST http://deathstar.default.svc.cluster.local/v1/request-landing => 200
-    <- Request http from 0 ([k8s:class=tiefighter k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default k8s:org=empire]) to 2756 ([k8s:io.cilium.k8s.policy.cluster=default k8s:class=deathstar k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default]), identity 8876->43854, verdict Denied PUT http://deathstar.default.svc.cluster.local/v1/request-landing => 403
+    <- Response http to 0 ([k8s:class=tiefighter k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default k8s:org=empire]) from 2756 ([k8s:io.cilium.k8s.policy.cluster=default k8s:class=deathstar k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default]), identity 8876->43854, verdict Forwarded POST http://deathstar/v1/request-landing => 200
+    <- Request http from 0 ([k8s:class=tiefighter k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default k8s:org=empire]) to 2756 ([k8s:io.cilium.k8s.policy.cluster=default k8s:class=deathstar k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default]), identity 8876->43854, verdict Denied PUT http://deathstar/v1/request-landing => 403
 
 The above output demonstrates a successful response to a POST request followed by a PUT request that is denied by the L7 policy.
 

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -756,9 +756,9 @@ port-forwarding to Hubble Relay, you will need to specify the
 .. code-block:: shell-session
 
     $ hubble observe --tls --tls-ca-cert-files ./hubble-ca.crt --tls-server-name hubble.hubble-relay.cilium.io --pod deathstar --protocol http
-    May  4 13:23:40.501: default/tiefighter:42690 -> default/deathstar-c74d84667-cx5kp:80 http-request FORWARDED (HTTP/1.1 POST http://deathstar.default.svc.cluster.local/v1/request-landing)
-    May  4 13:23:40.502: default/tiefighter:42690 <- default/deathstar-c74d84667-cx5kp:80 http-response FORWARDED (HTTP/1.1 200 0ms (POST http://deathstar.default.svc.cluster.local/v1/request-landing))
-    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port)
+    May  4 13:23:40.501: default/tiefighter:42690 -> default/deathstar-c74d84667-cx5kp:80 http-request FORWARDED (HTTP/1.1 POST http://deathstar/v1/request-landing)
+    May  4 13:23:40.502: default/tiefighter:42690 <- default/deathstar-c74d84667-cx5kp:80 http-response FORWARDED (HTTP/1.1 200 0ms (POST http://deathstar/v1/request-landing))
+    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar/v1/exhaust-port)
 
 To persist these options for the shell session, set the following environment variables:
 

--- a/Documentation/observability/hubble/hubble-cli.rst
+++ b/Documentation/observability/hubble/hubble-cli.rst
@@ -42,14 +42,14 @@ allowed by the policy.
 
 .. code-block:: shell-session
 
-    kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 This next request is accessing an HTTP endpoint which is denied by policy.
 
 .. code-block:: shell-session
 
-    kubectl exec tiefighter -- curl -s -XPUT deathstar.default.svc.cluster.local/v1/exhaust-port
+    kubectl exec tiefighter -- curl -s -XPUT deathstar/v1/exhaust-port
     Access denied
 
 Finally, this last request will hang because the ``xwing`` pod does not have
@@ -58,7 +58,7 @@ request, or wait for it to time out.
 
 .. code-block:: shell-session
 
-    kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    kubectl exec xwing -- curl -s -XPOST deathstar/v1/request-landing
     command terminated with exit code 28
 
 Let's now inspect this traffic using the CLI. The command below filters all
@@ -67,9 +67,9 @@ traffic on the application layer (L7, HTTP) to the ``deathstar`` pod:
 .. code-block:: shell-session
 
     hubble observe --pod deathstar --protocol http
-    May  4 13:23:40.501: default/tiefighter:42690 -> default/deathstar-c74d84667-cx5kp:80 http-request FORWARDED (HTTP/1.1 POST http://deathstar.default.svc.cluster.local/v1/request-landing)
-    May  4 13:23:40.502: default/tiefighter:42690 <- default/deathstar-c74d84667-cx5kp:80 http-response FORWARDED (HTTP/1.1 200 0ms (POST http://deathstar.default.svc.cluster.local/v1/request-landing))
-    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port)
+    May  4 13:23:40.501: default/tiefighter:42690 -> default/deathstar-c74d84667-cx5kp:80 http-request FORWARDED (HTTP/1.1 POST http://deathstar/v1/request-landing)
+    May  4 13:23:40.502: default/tiefighter:42690 <- default/deathstar-c74d84667-cx5kp:80 http-response FORWARDED (HTTP/1.1 200 0ms (POST http://deathstar/v1/request-landing))
+    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar/v1/exhaust-port)
 
 
 
@@ -79,7 +79,7 @@ dropped:
 .. code-block:: shell-session
 
     hubble observe --pod deathstar --verdict DROPPED
-    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar.default.svc.cluster.local/v1/exhaust-port)
+    May  4 13:23:43.791: default/tiefighter:42742 -> default/deathstar-c74d84667-cx5kp:80 http-request DROPPED (HTTP/1.1 PUT http://deathstar/v1/exhaust-port)
     May  4 13:23:47.852: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)
     May  4 13:23:47.852: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)
     May  4 13:23:48.854: default/xwing:42818 <> default/deathstar-c74d84667-cx5kp:80 Policy denied DROPPED (TCP Flags: SYN)

--- a/Documentation/observability/hubble/hubble-ui.rst
+++ b/Documentation/observability/hubble/hubble-ui.rst
@@ -155,9 +155,9 @@ some traffic.
 
 .. code-block:: shell-session
 
-    $ kubectl exec xwing -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 These requests will then be displayed in the UI as service dependencies between

--- a/Documentation/security/policy-creation.rst
+++ b/Documentation/security/policy-creation.rst
@@ -139,7 +139,7 @@ Now let's send some traffic from the tiefighter to the deathstar:
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 We can check the policy verdict from the Cilium Pod:
@@ -187,7 +187,7 @@ Now if we run the landing requests again,
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 we can then observe that the traffic which was previously audited to be dropped
@@ -264,7 +264,7 @@ label ``org=empire`` should succeed:
 
 .. code-block:: shell-session
 
-    $ kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec tiefighter -- curl -s -XPOST deathstar/v1/request-landing
     Ship landed
 
 And we can observe that the traffic was allowed by the policy:
@@ -280,7 +280,7 @@ This works as expected. Now the same request from an *xwing* Pod should fail:
 
 .. code-block:: shell-session
 
-    $ kubectl exec xwing -- curl --connect-timeout 3 -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
+    $ kubectl exec xwing -- curl --connect-timeout 3 -s -XPOST deathstar/v1/request-landing
     command terminated with exit code 28
 
 This curl request should timeout after three seconds, we can observe the policy


### PR DESCRIPTION
Depending on the cluster configuration, what is meant to be a FQDN can be interpreted to be relative to the wrong DNS search path, and being incorrectly resolved. The following is an example of a derived resolver configuration that triggers the wrong behaviour:
```
$ kubectl exec tiefighter -- cat /etc/resolv.conf                                                                                                                                          1m 25s
nameserver 10.96.0.10
search default.svc.cluster.local svc.cluster.local cluster.local foo.com
options ndots:5
```
`deathstar.default.svc.cluster.local` is first interpreted as relative (it contains 4 dots vs the 5 dots required to be considered a FQDN), and the resolver tries to sequentially look-up the following alternatives:
- `deathstar.default.svc.cluster.local.default.svc.cluster.local`
- `deathstar.default.svc.cluster.local.svc.cluster.local`
- `deathstar.default.svc.cluster.local.cluster.local`
- `deathstar.default.svc.cluster.local.foo.com`

Some configurations could wrongly resolve the last one (e.g.: in my local setup, `deathstar.default.svc.cluster.local.foo.com` wrongly resolved to `127.0.0.1`), resulting into the wrong destination for all requests towards the `deathstar` service.

This PR replaces the FQDN with the relative domain name, allowing to correctly handle the aforementioned scenario.