### PR TITLE
policy: synthesize default localhost ingress rule when policyEnforcementMode=always (#48444)

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -487,38 +487,47 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 	// Insert a wildcard rule if there are any ingress rules
 	if len(rulesIngress) > 0 {
 		if !hasIngressDefaultDeny {
-			rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyIngress, types.Allow)
+			rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyIngress, types.Allow, true)
 			p.logger.Debug("Only default-allow policies, synthesizing ingress wildcard-allow rule",
 				logfields.Identity, securityIdentity,
 			)
 		} else {
 			// insert localhost allow for k8s if the policy subject is not the host
 			if option.Config.AlwaysAllowLocalhost() && securityIdentity.ID != identity.ReservedIdentityHost {
-				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.HostSelectors, LabelsLocalHostIngress, types.Allow)
+				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.HostSelectors, LabelsLocalHostIngress, types.Allow, true)
 				p.logger.Debug("Localhost allowed for k8s, synthesizing ingress host-allow rule",
 					logfields.Identity, securityIdentity,
 				)
 			}
 			if hasIngressPassVerdict {
 				// Explicit default deny is only needed for PASS verdict compatibility
-				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyIngress, types.Deny)
+				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyIngress, types.Deny, true)
 				p.logger.Debug("Only default-deny policies, synthesizing ingress wildcard-deny rule",
 					logfields.Identity, securityIdentity,
 				)
 			}
+		}
+	} else if hasIngress && hasIngressDefaultDeny {
+		// When policy enforcement is enabled (e.g. AlwaysEnforce or reserved:init) but no ingress policy rules select the endpoint,
+		// synthesize the host allow rule if AlwaysAllowLocalhost is enabled.
+		if option.Config.AlwaysAllowLocalhost() && securityIdentity.ID != identity.ReservedIdentityHost {
+			rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.HostSelectors, LabelsLocalHostIngress, types.Allow, true)
+			p.logger.Debug("Localhost allowed for k8s, synthesizing ingress host-allow rule",
+				logfields.Identity, securityIdentity,
+			)
 		}
 	}
 
 	// Same for egress -- synthesize a wildcard rule
 	if len(rulesEgress) > 0 {
 		if !hasEgressDefaultDeny {
-			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyEgress, types.Allow)
+			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyEgress, types.Allow, false)
 			p.logger.Debug("Only default-allow policies, synthesizing egress wildcard-allow rule",
 				logfields.Identity, securityIdentity,
 			)
 		} else if hasEgressPassVerdict {
 			// Explicit default deny is only needed for PASS verdict compatibility
-			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyEgress, types.Deny)
+			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyEgress, types.Deny, false)
 			p.logger.Debug("Only default-deny policies, synthesizing egress wildcard-deny rule",
 				logfields.Identity, securityIdentity,
 			)
@@ -530,13 +539,14 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 
 // addDefaultRule appends a default policy tier wildcard rule that only selects the given subject
 // identity.
-func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Selectors, lbls labels.LabelArray, verdict types.Verdict) ruleSlice {
+func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Selectors, lbls labels.LabelArray, verdict types.Verdict, ingress bool) ruleSlice {
 	var priority float64
-	lastRule := rules[len(rules)-1]
-	if lastRule.Tier == types.DefaultPolicy {
-		priority = lastRule.Priority + 1
+	if len(rules) > 0 {
+		lastRule := rules[len(rules)-1]
+		if lastRule.Tier == types.DefaultPolicy {
+			priority = lastRule.Priority + 1
+		}
 	}
-	ingress := lastRule.Ingress
 
 	return append(rules, &rule{
 		PolicyEntry: types.PolicyEntry{

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -247,6 +247,47 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 
 }
 
+func TestAlwaysEnforceLocalhost(t *testing.T) {
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	oldLocalhostOpt := option.Config.UnsafeDaemonConfigOption.AllowLocalhost
+	defer func() { option.Config.UnsafeDaemonConfigOption.AllowLocalhost = oldLocalhostOpt }()
+
+	SetPolicyEnabled(option.AlwaysEnforce)
+	option.Config.UnsafeDaemonConfigOption.AllowLocalhost = option.AllowLocalhostAlways
+
+	td := newTestData(t, hivetest.Logger(t))
+	repo := td.repo
+
+	fooSelectLabel := labels.ParseSelectLabel("foo")
+	fooNumericIdentity := 9001
+	fooIdentity := identity.NewIdentity(identity.NumericIdentity(fooNumericIdentity), labels.Labels{"foo": fooSelectLabel})
+	td.addIdentity(fooIdentity)
+
+	// In AlwaysEnforce mode with no rules added, computePolicyEnforcementAndRules should return hasIngress=true
+	// and synthesize the localhost allow rule.
+	ing, egr, _, _, matchingRulesI, matchingRulesE := repo.computePolicyEnforcementAndRules(fooIdentity)
+	require.True(t, ing, "ingress policy enforcement should apply under AlwaysEnforce")
+	require.True(t, egr, "egress policy enforcement should apply under AlwaysEnforce")
+	require.Len(t, matchingRulesI, 1, "should synthesize localhost allow rule for ingress")
+	require.Equal(t, LabelsLocalHostIngress, matchingRulesI[0].Labels)
+	require.Empty(t, matchingRulesE, "no egress rules synthesized")
+
+	// Resolve policy for fooIdentity and verify that localhost ingress policy is generated
+	selPolicy, err := repo.ResolvePolicy(fooIdentity)
+	require.NoError(t, err)
+	require.NotNil(t, selPolicy)
+
+	sp := selPolicy.(*selectorPolicy)
+	l4Ingress := sp.L4Policy.Ingress
+	require.Equal(t, 1, l4Ingress.PortRules.Len(), "ingress policy should contain 1 rule for localhost allow")
+	require.Contains(t, l4Ingress.PortRules[types.DefaultPolicy].RangePortMap, portProtoKey{Port: 0, EndPort: 0, Proto: 0})
+	filter := l4Ingress.PortRules[types.DefaultPolicy].RangePortMap[portProtoKey{Port: 0, EndPort: 0, Proto: 0}]
+	require.NotNil(t, filter)
+	require.Contains(t, filter.PerSelectorPolicies, td.cachedSelectorHost, "should contain per-selector policy for host selector")
+}
+
 func TestWildcardL3RulesIngress(t *testing.T) {
 	td := newTestData(t, hivetest.Logger(t))
 


### PR DESCRIPTION
<!-- Please ensure your pull request adheres to the following guidelines: -->
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/latest/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/latest/contributing/development/contributing_guide/#dev-coo)

Fixes: #48444

### Problem
Starting with Cilium v1.20.0 (PR #44590), kubelet HTTP health probes originating from `reserved:host` are denied for pods when `policyEnforcementMode=always` (or endpoints with `reserved:init`) and no user ingress policies select the pod.

Adding any ingress policy (including an `ingressDeny: [{}]` policy) caused kubelet probes to succeed, because PR #44590 moved default rule synthesis (including the `LabelsLocalHostIngress` rule) inside `if len(rulesIngress) > 0`.

When `policyEnforcementMode=always` is enabled:
- Ingress policy enforcement is active (`hasIngress = true` and `hasIngressDefaultDeny = true`).
- If no user policies select the pod for ingress, `len(rulesIngress) == 0`.
- The `if len(rulesIngress) > 0` condition evaluated to `false`, skipping synthesis of `LabelsLocalHostIngress`.
- The endpoint BPF policy map enforced default deny for ingress without an entry for `reserved:host`, dropping local kubelet probes.

### Solution
- Updated `computePolicyEnforcementAndRules` in `pkg/policy/repository.go` so that when policy enforcement is active (`hasIngress && hasIngressDefaultDeny`) but `len(rulesIngress) == 0`, `LabelsLocalHostIngress` is synthesized if `option.Config.AlwaysAllowLocalhost()` is enabled.
- Updated `addDefaultRule` to take an `ingress bool` parameter to handle `len(rules) == 0` safely.
- Added unit test `TestAlwaysEnforceLocalhost` in `pkg/policy/repository_test.go` to verify localhost ingress rule synthesis under `option.AlwaysEnforce`.

### AI Influence Level
This PR was prepared with AIL:3. Code logic and unit tests were thoroughly verified using unit tests.

```release-note
Fix kubelet health probes denied from reserved:host when policyEnforcementMode=always and no ingress policies exist on the endpoint.
```