### PR TITLE
bpf: nat46: remove dead csum_off assignment

### DIFF
--- a/bpf/lib/nat_46x64.h
+++ b/bpf/lib/nat_46x64.h
@@ -341,7 +341,6 @@ static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx,
 		v4.protocol = v6.nexthdr;
 	v4.ttl = v6.hop_limit;
 	v4.tot_len = bpf_htons(bpf_ntohs(v6.payload_len) + sizeof(v4));
-	csum_off = offsetof(struct iphdr, check);
 	csum = csum_diff(NULL, 0, &v4, sizeof(v4), csum);
 	if (ctx_change_proto(ctx, bpf_htons(ETH_P_IP), 0) < 0)
 		return DROP_WRITE_ERROR;


### PR DESCRIPTION
csum_off at nat_46x64.h:344 gets set with offsetof(struct iphdr, check)
but it's overwritten a few lines down by get_csum_offset(v4.protocol)
before it's ever read. checked ipv4_csum_update_by_diff() (the only
thing called in between) and it only takes ctx/l3_off/sum, doesn't
touch csum_off at all.

traced it back with git log -L, it's been dead since the original
nat46 commit (4faedf57ee), just never got cleaned up.

just removes the dead line, no behavior change.

AIL:2 - found and confirmed this myself with cppcheck + git log,
used AI to help write this description up and walk through the
PR steps.
```release-note
NONE
```