### PR TITLE
hubble-relay: Add serve extensions

### DIFF
--- a/hubble-relay/cmd/option.go
+++ b/hubble-relay/cmd/option.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import "github.com/cilium/cilium/hubble-relay/cmd/serve"
+
+// cmdOptions collects the optional integrations used while constructing the
+// root command. Keeping serve extensions here lets downstream binaries compose
+// Relay without changing the default command behavior.
+type cmdOptions struct {
+	// serveExtensions preserves the caller-supplied order used for flag
+	// registration, configuration, server options, and reverse cleanup.
+	serveExtensions []serve.Extension
+}
+
+// Option configures the Hubble Relay command before its subcommands are built.
+type Option func(*cmdOptions)
+
+// WithServeExtensions adds extensions to the serve command. Extensions are
+// registered and configured in the supplied order; resources returned by them
+// are released in reverse order by the serve command.
+func WithServeExtensions(extensions ...serve.Extension) Option {
+	return func(opts *cmdOptions) {
+		opts.serveExtensions = append(opts.serveExtensions, extensions...)
+	}
+}

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -26,7 +26,12 @@ const (
 )
 
 // New creates a new hubble-relay command.
-func New() *cobra.Command {
+func New(options ...Option) *cobra.Command {
+	opts := new(cmdOptions)
+	for _, option := range options {
+		option(opts)
+	}
+
 	vp := newViper()
 
 	rootCmd := &cobra.Command{
@@ -66,7 +71,7 @@ func New() *cobra.Command {
 
 	rootCmd.AddCommand(
 		completion.New(),
-		serve.New(vp),
+		serve.New(vp, opts.serveExtensions...),
 		version.New(),
 	)
 	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")

--- a/hubble-relay/cmd/root_test.go
+++ b/hubble-relay/cmd/root_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hubble/relay/server"
+)
+
+// testServeExtension verifies that root-command options reach the serve command.
+type testServeExtension struct{}
+
+// Name implements the serve.Extension interface.
+func (testServeExtension) Name() string {
+	return "test"
+}
+
+// RegisterFlags implements the serve.Extension interface. It adds a
+// recognizable flag for the root-command propagation test.
+func (testServeExtension) RegisterFlags(flags *pflag.FlagSet) {
+	flags.Bool("downstream-feature", false, "enable a downstream feature")
+}
+
+// Configure implements the serve.Extension interface without changing the
+// Relay server.
+func (testServeExtension) Configure(context.Context, *slog.Logger, *viper.Viper) ([]server.Option, io.Closer, error) {
+	return nil, nil, nil
+}
+
+func TestWithServeExtensions(t *testing.T) {
+	root := New(WithServeExtensions(testServeExtension{}))
+	serveCmd, _, err := root.Find([]string{"serve"})
+	require.NoError(t, err)
+	require.NotNil(t, serveCmd)
+
+	flag := serveCmd.Flags().Lookup("downstream-feature")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}

--- a/hubble-relay/cmd/serve/extension.go
+++ b/hubble-relay/cmd/serve/extension.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/pkg/hubble/relay/server"
+)
+
+// Extension adds downstream configuration and server options to the Hubble
+// Relay serve command.
+//
+// Extensions are trusted code linked into a downstream-owned Relay binary.
+// They register flags and are configured in the order supplied to [New]. Relay
+// serve flags are registered before extension flags, and every extension
+// receives the same mutable flag set. Extensions may inspect or modify flags
+// registered earlier. Flag registration failures, including duplicate names or
+// shorthands, follow pflag's behavior and may panic. The flag set is borrowed
+// for the duration of [Extension.RegisterFlags] and must not be retained or
+// accessed after that method returns.
+//
+// Configuration happens after Cobra parses the command and the root command
+// initializes logging, but before Relay derives its server options or starts its
+// servers. Each extension receives the same mutable Viper instance. Changes made
+// before [Extension.Configure] returns are visible to later extensions and to
+// configuration reads performed by Relay; they do not affect flag parsing or
+// logging that has already occurred. In particular, values written with
+// [viper.Viper.Set] take precedence over flags, environment variables,
+// configuration files, and defaults.
+//
+// Relay does not rerun earlier extensions after a later extension changes the
+// configuration. Callers must therefore order extensions so later mutations do
+// not invalidate configuration or resources already accepted by an earlier
+// extension.
+//
+// Viper is not safe for concurrent reads and writes. Extensions must finish
+// accessing it before Configure returns and copy any values needed by runtime
+// resources. Relay does not roll back Viper mutations if an extension fails.
+//
+// Extension server options are appended after the options constructed by the
+// serve command, preserving extension and within-extension order. Option
+// composition depends on the option: scalar setters typically replace earlier
+// values, while interceptor options append to an interceptor chain. The
+// package-level [server.DefaultOptions] are applied by [server.New] after every
+// option passed by the serve command, including extension options.
+//
+// Relay owns every non-nil closer returned by a successful
+// [Extension.Configure]. If configuration fails, the failing extension must
+// release its resources before returning. Later extensions are not configured,
+// and Relay rolls back the resources returned by earlier extensions. During
+// rollback and normal shutdown, Relay first cancels the shared extension context
+// and then calls closers in reverse configuration order.
+type Extension interface {
+	// Name returns the stable name used to identify the extension in errors and
+	// logs. It must be unique among the extensions supplied to New.
+	Name() string
+
+	// RegisterFlags adds extension-specific flags during command construction.
+	// Relay calls it once for each extension in the order supplied to New and
+	// before binding the completed shared flag set to Viper. Lifecycle resources
+	// should be created by Configure, where they can be returned for cleanup.
+	RegisterFlags(flags *pflag.FlagSet)
+
+	// Configure creates extension resources and server options after command
+	// parsing and logging initialization. Relay passes the same derived context
+	// and Viper instance to every extension, then reads the resulting serve
+	// configuration after every extension succeeds. It cancels the context before
+	// invoking any returned closer. Relay applies returned options in slice order.
+	// If Configure returns an error, the extension must release any resources it
+	// created before returning.
+	Configure(ctx context.Context, log *slog.Logger, vp *viper.Viper) ([]server.Option, io.Closer, error)
+}
+
+// configuredCloser associates a resource with the extension that owns it so
+// cleanup errors can identify which extension failed.
+type configuredCloser struct {
+	// extensionName identifies the extension that owns closer.
+	extensionName string
+	// closer releases the resources created by that extension.
+	closer io.Closer
+}
+
+// configuredExtensions contains the server options and resources produced by
+// one successful configuration pass. The caller consumes serverOptions when
+// constructing Relay and must call Close once when that Relay run ends.
+type configuredExtensions struct {
+	// serverOptions preserves extension and within-extension ordering.
+	serverOptions []server.Option
+	// closers preserves configuration order for reverse-order cleanup.
+	closers []configuredCloser
+	// cancel stops the context shared by all configured extensions.
+	cancel context.CancelFunc
+}
+
+// configureExtensions derives a shared lifecycle context and configures each
+// extension sequentially against vp. Mutations to vp are therefore visible to
+// later extensions and the serve command. If any extension fails, the function
+// cancels the shared context, closes resources returned by previously configured
+// extensions in reverse order, and joins cleanup failures with the configuration
+// error. The failing extension is responsible for its own cleanup. On success,
+// the caller owns the returned value and must close it exactly once.
+func configureExtensions(ctx context.Context, log *slog.Logger, vp *viper.Viper, extensions []Extension) (*configuredExtensions, error) {
+	extensionCtx, cancel := context.WithCancel(ctx)
+	configured := &configuredExtensions{cancel: cancel}
+	for _, extension := range extensions {
+		name := extension.Name()
+		serverOptions, closer, err := extension.Configure(extensionCtx, log, vp)
+		if err != nil {
+			configureErr := fmt.Errorf("configure serve extension %q: %w", name, err)
+			if closeErr := configured.Close(); closeErr != nil {
+				return nil, errors.Join(configureErr, closeErr)
+			}
+			return nil, configureErr
+		}
+		if closer != nil {
+			configured.closers = append(configured.closers, configuredCloser{
+				extensionName: name,
+				closer:        closer,
+			})
+		}
+		configured.serverOptions = append(configured.serverOptions, serverOptions...)
+	}
+	return configured, nil
+}
+
+// Close cancels the context shared by the extensions, then closes every
+// extension resource in reverse configuration order. It attempts every close
+// and joins any failures, annotating each one with the extension's name.
+func (c *configuredExtensions) Close() error {
+	c.cancel()
+	var errs error
+	for _, closer := range slices.Backward(c.closers) {
+		if err := closer.closer.Close(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("close serve extension %q: %w", closer.extensionName, err))
+		}
+	}
+	return errs
+}

--- a/hubble-relay/cmd/serve/extension_test.go
+++ b/hubble-relay/cmd/serve/extension_test.go
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package serve
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/cilium/cilium/pkg/hubble/build"
+	"github.com/cilium/cilium/pkg/hubble/relay/defaults"
+	"github.com/cilium/cilium/pkg/hubble/relay/server"
+	"github.com/cilium/cilium/pkg/safeio"
+)
+
+// testExtension records each lifecycle stage and returns the configured server
+// options, closer, or error so tests can exercise extension orchestration.
+var _ Extension = (*testExtension)(nil)
+
+type testExtension struct {
+	name          string
+	serverOptions []server.Option
+	closer        io.Closer
+	err           error
+	calls         *[]string
+	configured    chan<- struct{}
+	config        *viper.Viper
+	configure     func(*viper.Viper)
+}
+
+// Name implements [Extension].
+func (e *testExtension) Name() string {
+	return e.name
+}
+
+// RegisterFlags implements [Extension]. It records flag-registration order and
+// adds a flag named after the extension.
+func (e *testExtension) RegisterFlags(flags *pflag.FlagSet) {
+	*e.calls = append(*e.calls, "flags:"+e.name)
+	flags.String(e.name, "", "test extension flag")
+}
+
+// Configure implements [Extension]. It records configuration order, captures
+// and optionally modifies the shared configuration, and passes the serve
+// context to testCloser for cancellation checks.
+func (e *testExtension) Configure(ctx context.Context, _ *slog.Logger, vp *viper.Viper) ([]server.Option, io.Closer, error) {
+	*e.calls = append(*e.calls, "configure:"+e.name)
+	e.config = vp
+	if e.configure != nil {
+		e.configure(vp)
+	}
+	if closer, ok := e.closer.(*testCloser); ok {
+		closer.ctx = ctx
+	}
+	if e.configured != nil {
+		close(e.configured)
+	}
+	return e.serverOptions, e.closer, e.err
+}
+
+// testCloser records cleanup order and can require the serve context to be
+// canceled before cleanup starts.
+type testCloser struct {
+	name            string
+	err             error
+	calls           *[]string
+	ctx             context.Context
+	requireCanceled bool
+}
+
+// Close implements [io.Closer]. It records the cleanup call and reports an
+// error when its configured cancellation or error condition is not satisfied.
+func (c *testCloser) Close() error {
+	*c.calls = append(*c.calls, "close:"+c.name)
+	if c.requireCanceled && !errors.Is(c.ctx.Err(), context.Canceled) {
+		return errors.New("context was not canceled")
+	}
+	return c.err
+}
+
+func TestNewRegistersExtensionFlags(t *testing.T) {
+	var calls []string
+	extension := &testExtension{name: "downstream-mode", calls: &calls}
+	vp := viper.New()
+
+	cmd := New(vp, extension)
+	require.NoError(t, cmd.Flags().Set("downstream-mode", "enabled"))
+
+	assert.Equal(t, "enabled", vp.GetString("downstream-mode"))
+	assert.Equal(t, []string{"flags:downstream-mode"}, calls)
+}
+
+func TestConfigureExtensions(t *testing.T) {
+	var calls []string
+	first := &testExtension{
+		name:          "first",
+		serverOptions: []server.Option{server.WithInsecureClient()},
+		closer:        &testCloser{name: "first", calls: &calls, requireCanceled: true},
+		calls:         &calls,
+		configure: func(vp *viper.Viper) {
+			assert.Equal(t, "initial", vp.GetString("shared-setting"))
+			vp.Set("shared-setting", "first")
+		},
+	}
+	extensions := []Extension{
+		first,
+		&testExtension{
+			name: "second",
+			serverOptions: []server.Option{
+				server.WithInsecureClient(),
+				server.WithInsecureServer(),
+			},
+			closer: &testCloser{name: "second", calls: &calls, requireCanceled: true},
+			calls:  &calls,
+			configure: func(vp *viper.Viper) {
+				assert.Equal(t, "first", vp.GetString("shared-setting"))
+				vp.Set("shared-setting", "second")
+			},
+		},
+	}
+
+	vp := viper.New()
+	vp.Set("shared-setting", "initial")
+	configured, err := configureExtensions(t.Context(), slog.New(slog.DiscardHandler), vp, extensions)
+	require.NoError(t, err)
+	assert.Len(t, configured.serverOptions, 3)
+	assert.Equal(t, []string{"configure:first", "configure:second"}, calls)
+	assert.Same(t, vp, first.config)
+	assert.Equal(t, "second", vp.GetString("shared-setting"))
+
+	require.NoError(t, configured.Close())
+	assert.Equal(t, []string{
+		"configure:first",
+		"configure:second",
+		"close:second",
+		"close:first",
+	}, calls)
+}
+
+func TestConfigureExtensionsClosesSuccessfulExtensionsOnError(t *testing.T) {
+	var calls []string
+	extensions := []Extension{
+		&testExtension{
+			name:   "first",
+			closer: &testCloser{name: "first", err: errors.New("close failed"), calls: &calls, requireCanceled: true},
+			calls:  &calls,
+		},
+		&testExtension{
+			name:  "second",
+			err:   errors.New("configure failed"),
+			calls: &calls,
+		},
+	}
+
+	configured, err := configureExtensions(t.Context(), slog.New(slog.DiscardHandler), viper.New(), extensions)
+	require.Error(t, err)
+	assert.Nil(t, configured)
+	assert.ErrorContains(t, err, `configure serve extension "second": configure failed`)
+	assert.ErrorContains(t, err, `close serve extension "first": close failed`)
+	assert.Equal(t, []string{"configure:first", "configure:second", "close:first"}, calls)
+}
+
+func TestRunServeClosesExtensionsOnStartupError(t *testing.T) {
+	var calls []string
+	extension := &testExtension{
+		name:   "startup-error",
+		closer: &testCloser{name: "startup-error", calls: &calls, requireCanceled: true},
+		calls:  &calls,
+	}
+	vp := viper.New()
+	New(vp, extension)
+	vp.Set(keyGops, false)
+	vp.Set(keyTLSClientDisabled, true)
+	vp.Set(keyTLSRelayServerCertFile, "/missing/server.crt")
+	vp.Set(keyTLSRelayServerKeyFile, "/missing/server.key")
+
+	err := runServe(t.Context(), vp, []Extension{extension})
+	require.Error(t, err)
+	assert.Equal(t, []string{
+		"flags:startup-error",
+		"configure:startup-error",
+		"close:startup-error",
+	}, calls)
+}
+
+func TestRunServeExtensionLifecycleAndInterceptorOrder(t *testing.T) {
+	// reserveAddress asks the kernel for an unused local address, then releases it
+	// so runServe can bind the same address during the test.
+	reserveAddress := func() string {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		address := listener.Addr().String()
+		require.NoError(t, listener.Close())
+		return address
+	}
+	listenAddress := reserveAddress()
+	metricsListenAddress := reserveAddress()
+
+	var calls []string
+	configured := make(chan struct{})
+	extensionHeader := metadata.Pairs(defaults.GRPCMetadataRelayVersionKey, "extension")
+	extension := &testExtension{
+		name:       "lifecycle",
+		closer:     &testCloser{name: "lifecycle", calls: &calls, requireCanceled: true},
+		calls:      &calls,
+		configured: configured,
+		configure: func(vp *viper.Viper) {
+			// These replace the unusable values set below. Connecting to both
+			// listeners proves Relay reads serve configuration after Configure.
+			vp.Set(keyListenAddress, listenAddress)
+			vp.Set(keyMetricsListenAddress, metricsListenAddress)
+		},
+		serverOptions: []server.Option{
+			server.WithGRPCUnaryInterceptor(func(ctx context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (any, error) {
+				grpc.SetHeader(ctx, extensionHeader)
+				return nil, status.Error(codes.PermissionDenied, "denied by extension")
+			}),
+			server.WithGRPCStreamInterceptor(func(_ any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
+				stream.SetHeader(extensionHeader)
+				return status.Error(codes.PermissionDenied, "denied by extension")
+			}),
+		},
+	}
+	vp := viper.New()
+	New(vp, extension)
+	vp.Set(keyGops, false)
+	vp.Set(keyTLSClientDisabled, true)
+	vp.Set(keyTLSServerDisabled, true)
+	vp.Set(keyListenAddress, "127.0.0.1:0")
+	vp.Set(keyHealthListenAddress, "127.0.0.1:0")
+	vp.Set(keyMetricsListenAddress, "")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runServe(ctx, vp, []Extension{extension})
+	}()
+
+	select {
+	case <-configured:
+	case <-time.After(time.Second):
+		t.Fatal("extension was not configured")
+	}
+
+	conn, err := grpc.NewClient(listenAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := healthpb.NewHealthClient(conn)
+	rpcCtx, rpcCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer rpcCancel()
+
+	var unaryHeader metadata.MD
+	_, err = client.Check(
+		rpcCtx,
+		&healthpb.HealthCheckRequest{},
+		grpc.Header(&unaryHeader),
+		grpc.WaitForReady(true),
+	)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, []string{"extension", build.RelayVersion.SemVer()}, unaryHeader.Get(defaults.GRPCMetadataRelayVersionKey))
+
+	stream, err := client.Watch(rpcCtx, &healthpb.HealthCheckRequest{}, grpc.WaitForReady(true))
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	streamHeader, err := stream.Header()
+	require.NoError(t, err)
+	assert.Equal(t, []string{build.RelayVersion.SemVer(), "extension"}, streamHeader.Get(defaults.GRPCMetadataRelayVersionKey))
+
+	httpClient := &http.Client{Timeout: time.Second}
+	require.Eventually(t, func() bool {
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+metricsListenAddress+"/metrics", nil)
+		if err != nil {
+			return false
+		}
+		response, err := httpClient.Do(request)
+		if err != nil {
+			return false
+		}
+		body, err := safeio.ReadAllLimit(response.Body, safeio.MB)
+		_ = response.Body.Close()
+		if err != nil {
+			return false
+		}
+		metrics := string(body)
+		return strings.Contains(metrics, `grpc_server_handled_total{grpc_code="PermissionDenied",grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"} 1`) &&
+			strings.Contains(metrics, `grpc_server_handled_total{grpc_code="PermissionDenied",grpc_method="Watch",grpc_service="grpc.health.v1.Health",grpc_type="server_stream"} 1`)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve command did not stop")
+	}
+	assert.Equal(t, []string{
+		"flags:lifecycle",
+		"configure:lifecycle",
+		"close:lifecycle",
+	}, calls)
+}

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"os/signal"
 
 	"github.com/google/gops/agent"
@@ -59,13 +58,13 @@ const (
 )
 
 // New creates a new serve command.
-func New(vp *viper.Viper) *cobra.Command {
+func New(vp *viper.Viper, extensions ...Extension) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run the gRPC proxy server",
 		Long:  `Run the gRPC proxy server.`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runServe(vp)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServe(cmd.Context(), vp, extensions)
 		},
 	}
 	flags := cmd.Flags()
@@ -189,14 +188,32 @@ func New(vp *viper.Viper) *cobra.Command {
 		false,
 		"Disable TLS for the server and allow clients to connect over plaintext.",
 	)
+	for _, extension := range extensions {
+		extension.RegisterFlags(flags)
+	}
 	vp.BindPFlags(flags)
 
 	return cmd
 }
 
-func runServe(vp *viper.Viper) error {
+// runServe configures and starts Relay, then blocks until the server exits or
+// the supplied context, SIGINT, or SIGTERM requests shutdown. It stops the TLS
+// watchers and gops agent created for this run, closes configured extensions,
+// and joins extension cleanup failures with the error that ended the run.
+func runServe(ctx context.Context, vp *viper.Viper, extensions []Extension) (retErr error) {
+	ctx, stop := signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)
+	defer stop()
+
 	// slogloggercheck: the logger has been initialized with default settings
 	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "hubble-relay")
+
+	configuredExtensions, err := configureExtensions(ctx, logger, vp, extensions)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, configuredExtensions.Close())
+	}()
 
 	opts := []server.Option{
 		server.WithLocalClusterName(vp.GetString(keyClusterName)),
@@ -238,6 +255,7 @@ func runServe(vp *viper.Viper) error {
 		if err != nil {
 			return err
 		}
+		defer tlsClientConfig.Stop()
 		opts = append(opts, server.WithClientTLS(tlsClientConfig))
 	}
 
@@ -256,8 +274,10 @@ func runServe(vp *viper.Viper) error {
 		if err != nil {
 			return err
 		}
+		defer tlsServerConfig.Stop()
 		opts = append(opts, server.WithServerTLS(tlsServerConfig))
 	}
+	opts = append(opts, configuredExtensions.serverOptions...)
 
 	if vp.GetBool(keyPprof) {
 		pprof.Enable(logger, vp.GetString(keyPprofAddress), vp.GetInt(keyPprofPort))
@@ -271,29 +291,24 @@ func runServe(vp *viper.Viper) error {
 		}); err != nil {
 			return fmt.Errorf("failed to start gops agent: %w", err)
 		}
+		defer agent.Close()
 	}
 	srv, err := server.New(opts...)
 	if err != nil {
 		return fmt.Errorf("cannot create hubble-relay server: %w", err)
 	}
+	shutdownDone := make(chan struct{})
 	go func() {
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, unix.SIGINT, unix.SIGTERM)
-		<-sigs
+		defer close(shutdownDone)
+		<-ctx.Done()
 		srv.Stop()
-		if tlsServerConfig != nil {
-			tlsServerConfig.Stop()
-		}
-		if tlsClientConfig != nil {
-			tlsClientConfig.Stop()
-		}
-		if gopsEnabled {
-			agent.Close()
-		}
 	}()
 
-	if err := srv.Serve(); !errors.Is(err, http.ErrServerClosed) {
-		return err
+	serveErr := srv.Serve()
+	stop()
+	<-shutdownDone
+	if !errors.Is(serveErr, http.ErrServerClosed) && !errors.Is(serveErr, grpc.ErrServerStopped) {
+		return serveErr
 	}
 	return nil
 }

--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -4,6 +4,25 @@ to modify or extend the default chart behaviors.
 */}}
 
 {{/*
+Allow packagers to add configuration to hubble-relay.
+*/}}
+{{- define "hubble-relay.config.extra" }}
+{{- end }}
+
+{{/*
+Allow packagers to change the primary hubble-relay port name.
+*/}}
+{{- define "hubble-relay.port.name" -}}
+grpc
+{{- end }}
+
+{{/*
+Allow packagers to add volume mounts to hubble-relay.
+*/}}
+{{- define "hubble-relay.volumeMounts.extra" }}
+{{- end }}
+
+{{/*
 Allow packagers to add extra volumes to cilium-agent.
 */}}
 {{- define "cilium-agent.volumes.extra" }}
@@ -82,7 +101,7 @@ disable-server-tls: true
 {{- end }}
 
 {{- define "hubble-relay.service.targetPort" -}}
-grpc
+{{- include "hubble-relay.port.name" . }}
 {{- end }}
 
 {{/*

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -52,4 +52,5 @@ data:
     {{- if .Values.hubble.relay.logOptions.level }}
     log-level: {{ .Values.hubble.relay.logOptions.level }}
     {{- end }}
+    {{- include "hubble-relay.config.extra" . | nindent 4 }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - --debug
           {{- end }}
           ports:
-            - name: grpc
+            - name: {{ include "hubble-relay.port.name" . }}
               containerPort: {{ include "hubble-relay.config.listenPort" . }}
             {{- if .Values.hubble.relay.prometheus.enabled }}
             - name: prometheus
@@ -147,6 +147,7 @@ spec:
           {{- with .Values.hubble.relay.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- include "hubble-relay.volumeMounts.extra" . | nindent 10 }}
           terminationMessagePolicy: FallbackToLogsOnError
         {{- include "hubble-relay.containers.extra" . | nindent 8 }}
       restartPolicy: Always


### PR DESCRIPTION
This PR adds explicit Hubble Relay serve-command extension points for
downstream users that build their own Relay binary or package the Helm chart.
Extensions can register flags, update the shared Viper configuration, append
ordered server options, and return resources that Relay closes during rollback
and shutdown without replacing the OSS command.

Extensions are trusted startup code. They have stable names for errors, run in
the supplied order, share the command's mutable pflag and Viper state, and clean
up their own resources before returning a configuration error. The chart adds
empty hooks for Relay configuration, volume mounts, and the primary port name;
the Service target follows the selected port.

This PR was prepared with AIL:4. Codex drafted the implementation and tests. I
reviewed the extension API, lifecycle behavior, and chart integration and
directed the revisions.

```release-note
Hubble Relay can now be extended by downstream builds with custom startup
configuration and server options.
```
