### PR TITLE
fix(hostPort): self-heal frontend conflict on pod recreate

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1419,7 +1419,7 @@ data:
 {{- end }}
 
 {{- if ne .Values.operator.unmanagedPodWatcher.selector nil }}
-  pod-restart-selector: {{ .Values.operator.unmanagedPodWatcher.selector }}
+  pod-restart-selector: {{ .Values.operator.unmanagedPodWatcher.selector | quote }}
 {{- end }}
 
 {{- if .Values.dnsProxy }}

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -54,7 +54,7 @@ func EnqueueRequestForBackendService(c client.Client, scheme *runtime.Scheme, lo
 		if err := c.List(ctx, tlsrList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceTLSRouteIndex, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
-			scopedLog.Error("Failed to get related HTTPRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get related TLSRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -678,7 +678,32 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 
 	for serviceName, svc := range servicesForThisPod {
 		err := writer.UpsertServiceAndFrontends(wtxn, &svc.service, svc.fes.UnsortedList()...)
-		if err != nil {
+		if errors.Is(err, loadbalancer.ErrFrontendConflict) {
+			// A pod recreated with a stable name (StatefulSet, static pod)
+			// keeps its name but changes its UID, which mints a NEW HostPort
+			// service name (<prefix>:host-port:<port>:<uid>) claiming the same
+			// frontend the OLD (deleted pod's) service still owns. The upsert
+			// fails with ErrFrontendConflict and previously returned early,
+			// skipping the orphan prune below — so the conflict retried
+			// forever and never self-healed. Break the deadlock by pruning the
+			// stale orphan services under this pod's prefix (anything not in
+			// updatedServices is a leftover from a changed/unset hostPort or a
+			// deleted pod), which releases their frontends, then retry.
+			for p := range writer.Services().Prefix(wtxn, loadbalancer.ServiceByName(serviceNamePrefix)) {
+				if updatedServices.Has(p.Name) {
+					continue
+				}
+				if err := writer.DeleteBackendsOfService(wtxn, p.Name, source.Kubernetes); err != nil {
+					return fmt.Errorf("DeleteBackendsOfService: %w", err)
+				}
+				if _, err := writer.DeleteServiceAndFrontends(wtxn, p.Name); err != nil {
+					return fmt.Errorf("DeleteServiceAndFrontends: %w", err)
+				}
+			}
+			if err := writer.UpsertServiceAndFrontends(wtxn, &svc.service, svc.fes.UnsortedList()...); err != nil {
+				return fmt.Errorf("UpsertServiceAndFrontends: %w", err)
+			}
+		} else if err != nil {
 			return fmt.Errorf("UpsertServiceAndFrontends: %w", err)
 		}
 

--- a/pkg/loadbalancer/tests/testdata/hostport-uid-recreate.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport-uid-recreate.txtar
@@ -1,0 +1,130 @@
+#! --lb-test-fault-probability=0.0
+# A pod that keeps its NAME across recreation and changes only its UID. The
+# synthesized HostPort service name embeds the UID, so the replacement pod mints
+# a NEW service name claiming the SAME frontend the OLD one still owns.
+#
+# The delete and the re-add are issued back to back with no settling assertion
+# between them: statedb change iterators coalesce per-key revisions, so the
+# reflector observes only the latest revision and never sees the deletion as a
+# separate event.
+
+db/insert node-addresses addrv4.yaml
+hive start
+
+k8s/add pod.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+k8s/delete pod.yaml
+k8s/add pod2.yaml
+
+db/cmp services services2.table
+db/cmp frontends frontends2.table
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- services.table --
+Name                                                                  Source
+default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8    k8s
+
+-- services2.table --
+Name                                                                  Source
+default/my-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8    k8s
+
+-- frontends.table --
+Address           Type      Status  ServiceName                                                         Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8  10.244.1.113:80/TCP
+
+-- frontends2.table --
+Address           Type      Status  ServiceName                                                         Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8  10.244.1.200:80/TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-07-10T16:20:42Z"
+  labels:
+    run: my-app
+  name: my-app
+  namespace: default
+  resourceVersion: "100491"
+  uid: 11111111-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: my-app
+    ports:
+    - containerPort: 80
+      hostPort: 4444
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: testnode
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.1.113
+  podIPs:
+  - ip: 10.244.1.113
+
+-- pod2.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-07-10T16:20:42Z"
+  labels:
+    run: my-app
+  name: my-app
+  namespace: default
+  resourceVersion: "100492"
+  uid: 22222222-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: my-app
+    ports:
+    - containerPort: 80
+      hostPort: 4444
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: testnode
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.1.200
+  podIPs:
+  - ip: 10.244.1.200


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #48455 line.
- [x] All commits are signed off. See the section [Developer Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models in accordance with the [Cilium AI Policy]. This PR was prepared with AIL:3. I personally checked the txtar reproduction (fails without fix, passes with it), the existing hostport.txtar regression guard, and go vet on the touched package.
- [x] Thanks for contributing!

When a pod is recreated with a stable name (StatefulSet, static pod) but a different UID, upsertHostPort mints a new HostPort service whose frontend conflicts with the old deleted pod service that still owns it. UpsertServiceAndFrontends fails with ErrFrontendConflict and the old code returned early, skipping the orphan-prune loop, so the conflict retried forever and never self-healed.

This change catches ErrFrontendConflict, prunes stale orphan services under the pod prefix (releasing the conflicting frontend), then retries the upsert once. The normal no-conflict path is unchanged.

Testing: new txtar fixture hostport-uid-recreate.txtar models statedb coalescing of delete plus re-add with a new UID and asserts the new service appears. Verified it fails without the fix and passes with it. Existing hostport.txtar still passes. Full pkg/loadbalancer suite shows no new failures.

Fixes: #48455

```release-note
Fix hostPort frontend ownership never being released when a pod is recreated with the same name, which permanently broke that hostPort.
```

[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md