### PR TITLE
loadbalancer: release orphaned HostPort frontends before upserting

### DIFF
--- a/pkg/loadbalancer/reflectors/hostport_test.go
+++ b/pkg/loadbalancer/reflectors/hostport_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflectors
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type hostPortTestParams struct {
+	cell.In
+
+	DB     *statedb.DB
+	Writer *writer.Writer
+}
+
+func hostPortFixture(t testing.TB) (p hostPortTestParams) {
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+
+	h := hive.New(
+		loadbalancer.ConfigCell,
+		node.LocalNodeStoreTestCell,
+		writer.Cell,
+		cell.Provide(
+			func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
+			func() *option.DaemonConfig { return &option.DaemonConfig{} },
+			tables.NewNodeAddressTable,
+			statedb.RWTable[tables.NodeAddress].ToTable,
+			source.NewSources,
+			func() kpr.KPRConfig { return kpr.KPRConfig{} },
+		),
+		cell.Invoke(func(p_ hostPortTestParams) { p = p_ }),
+	)
+
+	require.NoError(t, h.Start(log, context.TODO()))
+	t.Cleanup(func() { h.Stop(log, context.TODO()) })
+	return p
+}
+
+func hostPortPod(uid string) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+			UID:       types.UID(uid),
+		},
+		Spec: slim_corev1.PodSpec{
+			Containers: []slim_corev1.Container{{
+				Name: "my-app",
+				Ports: []slim_corev1.ContainerPort{{
+					ContainerPort: 80,
+					HostPort:      4444,
+					Protocol:      slim_corev1.ProtocolTCP,
+				}},
+			}},
+		},
+		Status: slim_corev1.PodStatus{
+			Phase:  slim_corev1.PodRunning,
+			PodIP:  "10.244.1.113",
+			PodIPs: []slim_corev1.PodIP{{IP: "10.244.1.113"}},
+			HostIP: "172.19.0.3",
+		},
+	}
+}
+
+// A pod recreated under the same name gets a new UID, and the UID is part of
+// the synthesized HostPort service name. The replacement must take over the
+// frontend the previous pod's service owned.
+func TestUpsertHostPort_PodRecreatedWithSameName(t *testing.T) {
+	p := hostPortFixture(t)
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	extConfig := loadbalancer.ExternalConfig{EnableIPv4: true, EnableIPv6: true, KubeProxyReplacement: true}
+	netnsCookie := func() bool { return true }
+
+	wtxn := p.Writer.WriteTxn()
+	require.NoError(t, upsertHostPort(netnsCookie, loadbalancer.DefaultConfig, extConfig, log, wtxn, p.Writer, hostPortPod("11111111-2e9b-4c61-8454-ae81344876d8")))
+	wtxn.Commit()
+
+	wtxn = p.Writer.WriteTxn()
+	err := upsertHostPort(netnsCookie, loadbalancer.DefaultConfig, extConfig, log, wtxn, p.Writer, hostPortPod("22222222-2e9b-4c61-8454-ae81344876d8"))
+	wtxn.Commit()
+	require.NoError(t, err, "the recreated pod must take over the HostPort")
+
+	txn := p.DB.ReadTxn()
+	var names []string
+	for svc := range p.Writer.Services().All(txn) {
+		names = append(names, svc.Name.String())
+	}
+	require.Len(t, names, 1, "the previous pod's service must be gone, got %v", names)
+	require.Contains(t, names[0], "22222222", "the frontend must be owned by the new pod's service")
+}

--- a/pkg/loadbalancer/reflectors/hostport_test.go
+++ b/pkg/loadbalancer/reflectors/hostport_test.go
@@ -6,6 +6,7 @@ package reflectors
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -108,4 +109,62 @@ func TestUpsertHostPort_PodRecreatedWithSameName(t *testing.T) {
 	}
 	require.Len(t, names, 1, "the previous pod's service must be gone, got %v", names)
 	require.Contains(t, names[0], "22222222", "the frontend must be owned by the new pod's service")
+}
+
+func hostPortPodPorts(name, uid string, hostPorts ...int32) *slim_corev1.Pod {
+	pod := hostPortPod(uid)
+	pod.Name = name
+	pod.Spec.Containers[0].Ports = nil
+	for i, hp := range hostPorts {
+		pod.Spec.Containers[0].Ports = append(pod.Spec.Containers[0].Ports, slim_corev1.ContainerPort{
+			ContainerPort: int32(80 + i),
+			HostPort:      hp,
+			Protocol:      slim_corev1.ProtocolTCP,
+		})
+	}
+	return pod
+}
+
+func serviceNames(t *testing.T, p hostPortTestParams) []string {
+	t.Helper()
+	txn := p.DB.ReadTxn()
+	var names []string
+	for svc := range p.Writer.Services().All(txn) {
+		names = append(names, svc.Name.String())
+	}
+	slices.Sort(names)
+	return names
+}
+
+// A HostPort wanted by the pod may already be owned by a service that is not
+// one of this pod's orphans. That is a genuine conflict: the reflector must
+// report it without having changed anything, rather than pruning the pod's
+// previous services and applying the ports it happened to process first.
+func TestUpsertHostPort_ConflictWithLiveServiceLeavesStateUnchanged(t *testing.T) {
+	p := hostPortFixture(t)
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	extConfig := loadbalancer.ExternalConfig{EnableIPv4: true, EnableIPv6: true, KubeProxyReplacement: true}
+	netnsCookie := func() bool { return true }
+
+	upsert := func(pod *slim_corev1.Pod) error {
+		wtxn := p.Writer.WriteTxn()
+		err := upsertHostPort(netnsCookie, loadbalancer.DefaultConfig, extConfig, log, wtxn, p.Writer, pod)
+		wtxn.Commit()
+		return err
+	}
+
+	// An unrelated pod holds host port 5555.
+	require.NoError(t, upsert(hostPortPodPorts("other-app", "aaaaaaaa-0000-0000-0000-000000000001", 5555)))
+	// my-app holds host port 4444.
+	require.NoError(t, upsert(hostPortPodPorts("my-app", "11111111-0000-0000-0000-000000000001", 4444)))
+
+	before := serviceNames(t, p)
+	require.Len(t, before, 2)
+
+	// my-app is recreated and now also asks for 5555, which other-app owns.
+	err := upsert(hostPortPodPorts("my-app", "22222222-0000-0000-0000-000000000002", 4444, 5555))
+	require.ErrorIs(t, err, loadbalancer.ErrFrontendConflict)
+
+	require.Equal(t, before, serviceNames(t, p),
+		"nothing may be pruned or inserted when a wanted frontend is owned by a live service")
 }

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -676,19 +676,13 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 		}
 	}
 
-	for serviceName, svc := range servicesForThisPod {
-		err := writer.UpsertServiceAndFrontends(wtxn, &svc.service, svc.fes.UnsortedList()...)
-		if err != nil {
-			return fmt.Errorf("UpsertServiceAndFrontends: %w", err)
-		}
-
-		if err := writer.SetBackends(wtxn, serviceName, source.Kubernetes, svc.bes...); err != nil {
-			return fmt.Errorf("SetBackends: %w", err)
-		}
-	}
-
 	// Find and remove orphaned HostPort services, frontends and backends
 	// if 'HostPort' has changed or has been unset.
+	//
+	// This runs before the upsert below: the service name carries the pod's
+	// UID, so a pod recreated under the same name mints a new service that
+	// claims a frontend the previous pod's service still owns. Releasing the
+	// orphans first lets the replacement take the frontend over.
 	for svc := range writer.Services().Prefix(wtxn, loadbalancer.ServiceByName(serviceNamePrefix)) {
 		if updatedServices.Has(svc.Name) {
 			continue
@@ -702,6 +696,17 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 		_, err = writer.DeleteServiceAndFrontends(wtxn, svc.Name)
 		if err != nil {
 			return fmt.Errorf("DeleteServiceAndFrontends: %w", err)
+		}
+	}
+
+	for serviceName, svc := range servicesForThisPod {
+		err := writer.UpsertServiceAndFrontends(wtxn, &svc.service, svc.fes.UnsortedList()...)
+		if err != nil {
+			return fmt.Errorf("UpsertServiceAndFrontends: %w", err)
+		}
+
+		if err := writer.SetBackends(wtxn, serviceName, source.Kubernetes, svc.bes...); err != nil {
+			return fmt.Errorf("SetBackends: %w", err)
 		}
 	}
 

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -687,15 +687,20 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 	}
 
 	// Check the wanted frontends against the ones already in the table before
-	// changing anything. A frontend held by a service that is not one of the
-	// orphans above belongs to some other pod, and taking it would be wrong.
-	// The transaction is committed whether or not this function succeeds, so
-	// bailing out after a prune or an upsert would leave the pod's services
-	// half applied.
+	// changing anything, and note the orphans that are holding one. A frontend
+	// held by a service that is not one of the orphans belongs to some other
+	// pod, and taking it would be wrong. The transaction is committed whether
+	// or not this function succeeds, so bailing out after a prune or an upsert
+	// would leave the pod's services half applied.
+	reclaimedServices := sets.New[loadbalancer.ServiceName]()
 	for _, svc := range servicesForThisPod {
 		for fe := range svc.fes {
 			existing, _, found := writer.Frontends().Get(wtxn, loadbalancer.FrontendByAddress(fe.Address))
-			if !found || existing.ServiceName.Equal(fe.ServiceName) || orphanedServices.Has(existing.ServiceName) {
+			if !found || existing.ServiceName.Equal(fe.ServiceName) {
+				continue
+			}
+			if orphanedServices.Has(existing.ServiceName) {
+				reclaimedServices.Insert(existing.ServiceName)
 				continue
 			}
 			return fmt.Errorf("%w: %s wanted by %s is owned by %s",
@@ -704,15 +709,13 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 		}
 	}
 
-	// Release the orphans first, so that a frontend one of them still owns is
-	// free for the service replacing it.
-	for name := range orphanedServices {
-		if err := writer.DeleteBackendsOfService(wtxn, name, source.Kubernetes); err != nil {
-			return fmt.Errorf("DeleteBackendsOfService: %w", err)
-		}
-
-		if _, err := writer.DeleteServiceAndFrontends(wtxn, name); err != nil {
-			return fmt.Errorf("DeleteServiceAndFrontends: %w", err)
+	// Release just the orphans whose frontends are being taken over, so the
+	// upsert below can claim them. The rest are left until afterwards: deleting
+	// a service drops its backends, and recreating them for the new service
+	// would churn their IDs in the datapath maps for no reason.
+	for name := range reclaimedServices {
+		if err := deleteHostPortService(wtxn, writer, name); err != nil {
+			return err
 		}
 	}
 
@@ -725,6 +728,31 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 		if err := writer.SetBackends(wtxn, serviceName, source.Kubernetes, svc.bes...); err != nil {
 			return fmt.Errorf("SetBackends: %w", err)
 		}
+	}
+
+	// Remove the orphans left over: a HostPort that changed or was unset, or a
+	// previous incarnation of the pod whose frontends nothing reclaimed.
+	for name := range orphanedServices {
+		if reclaimedServices.Has(name) {
+			continue
+		}
+		if err := deleteHostPortService(wtxn, writer, name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteHostPortService removes a synthesized HostPort service along with its
+// frontends and backends.
+func deleteHostPortService(wtxn writer.WriteTxn, writer *writer.Writer, name loadbalancer.ServiceName) error {
+	if err := writer.DeleteBackendsOfService(wtxn, name, source.Kubernetes); err != nil {
+		return fmt.Errorf("DeleteBackendsOfService: %w", err)
+	}
+
+	if _, err := writer.DeleteServiceAndFrontends(wtxn, name); err != nil {
+		return fmt.Errorf("DeleteServiceAndFrontends: %w", err)
 	}
 
 	return nil

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -676,25 +676,42 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 		}
 	}
 
-	// Find and remove orphaned HostPort services, frontends and backends
-	// if 'HostPort' has changed or has been unset.
-	//
-	// This runs before the upsert below: the service name carries the pod's
-	// UID, so a pod recreated under the same name mints a new service that
-	// claims a frontend the previous pod's service still owns. Releasing the
-	// orphans first lets the replacement take the frontend over.
+	// The pod's services from a previous revision: same pod, but a HostPort
+	// that has changed or been unset, or a different pod UID after the pod was
+	// recreated under the same name. Their frontends are the pod's to reclaim.
+	orphanedServices := sets.New[loadbalancer.ServiceName]()
 	for svc := range writer.Services().Prefix(wtxn, loadbalancer.ServiceByName(serviceNamePrefix)) {
-		if updatedServices.Has(svc.Name) {
-			continue
+		if !updatedServices.Has(svc.Name) {
+			orphanedServices.Insert(svc.Name)
 		}
+	}
 
-		err := writer.DeleteBackendsOfService(wtxn, svc.Name, source.Kubernetes)
-		if err != nil {
+	// Check the wanted frontends against the ones already in the table before
+	// changing anything. A frontend held by a service that is not one of the
+	// orphans above belongs to some other pod, and taking it would be wrong.
+	// The transaction is committed whether or not this function succeeds, so
+	// bailing out after a prune or an upsert would leave the pod's services
+	// half applied.
+	for _, svc := range servicesForThisPod {
+		for fe := range svc.fes {
+			existing, _, found := writer.Frontends().Get(wtxn, loadbalancer.FrontendByAddress(fe.Address))
+			if !found || existing.ServiceName.Equal(fe.ServiceName) || orphanedServices.Has(existing.ServiceName) {
+				continue
+			}
+			return fmt.Errorf("%w: %s wanted by %s is owned by %s",
+				loadbalancer.ErrFrontendConflict,
+				fe.Address.StringWithProtocol(), fe.ServiceName, existing.ServiceName)
+		}
+	}
+
+	// Release the orphans first, so that a frontend one of them still owns is
+	// free for the service replacing it.
+	for name := range orphanedServices {
+		if err := writer.DeleteBackendsOfService(wtxn, name, source.Kubernetes); err != nil {
 			return fmt.Errorf("DeleteBackendsOfService: %w", err)
 		}
 
-		_, err = writer.DeleteServiceAndFrontends(wtxn, svc.Name)
-		if err != nil {
+		if _, err := writer.DeleteServiceAndFrontends(wtxn, name); err != nil {
 			return fmt.Errorf("DeleteServiceAndFrontends: %w", err)
 		}
 	}

--- a/pkg/loadbalancer/tests/testdata/hostport-recreate.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport-recreate.txtar
@@ -1,0 +1,184 @@
+#! --lb-test-fault-probability=0.0
+# A pod recreated under the same name gets a new UID. The UID is part of the
+# synthesized HostPort service name, so the replacement asks for a frontend the
+# previous pod's service still owns.
+
+# Add a node address that we'll use as the host port frontend.
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
+
+# Start the test application
+hive start
+
+# Add a pod with 'hostPort'.
+k8s/add pod.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# The pod is recreated under the same name with a new UID and the same
+# hostPort. The delete and the add land in the same reflector buffer, which
+# coalesces them into the add, so the replacement is processed while the
+# previous pod's service still owns the frontend.
+k8s/delete pod.yaml
+k8s/add pod-recreated.yaml
+db/cmp services services2.table
+db/cmp frontends frontends2.table
+db/cmp backends backends2.table
+
+# The host port is still programmed for the new service, with the frontend and
+# backend IDs unchanged: only the service that was holding the frontend went
+# away, so nothing in the datapath had to be renumbered.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps2.expected lbmaps.actual
+
+# Cleanup
+k8s/delete pod-recreated.yaml
+
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    test
+
+-- services.table --
+Name                                                               Source
+default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8 k8s
+
+-- services2.table --
+Name                                                               Source
+default/my-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 k8s
+
+-- frontends.table --
+Address           Type      Status  ServiceName                                                        Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8 10.244.1.113:80/TCP
+
+-- frontends2.table --
+Address           Type      Status  ServiceName                                                        Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.113:80/TCP
+
+-- backends.table --
+Service                                                            Address
+default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8 10.244.1.113:80/TCP
+
+-- backends2.table --
+Service                                                            Address
+default/my-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.113:80/TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.113:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:4444
+REV: ID=2 ADDR=1.1.1.1:4444
+SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort
+-- lbmaps2.expected --
+BE: ID=1 ADDR=10.244.1.113:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:4444
+REV: ID=2 ADDR=1.1.1.1:4444
+SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-07-10T16:20:42Z"
+  labels:
+    run: my-app
+  name: my-app
+  namespace: default
+  resourceVersion: "100491"
+  uid: 11111111-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: my-app
+    ports:
+    - containerPort: 80
+      hostPort: 4444
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: testnode
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.1.113
+  podIPs:
+  - ip: 10.244.1.113
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+
+-- pod-recreated.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-07-10T16:25:11Z"
+  labels:
+    run: my-app
+  name: my-app
+  namespace: default
+  resourceVersion: "100492"
+  uid: 22222222-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: my-app
+    ports:
+    - containerPort: 80
+      hostPort: 4444
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: testnode
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.1.113
+  podIPs:
+  - ip: 10.244.1.113
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:25:11Z"


### PR DESCRIPTION
The synthesized HostPort service name ends in the pod UID, so a pod recreated
under the same name produces a *new* service name that claims a frontend the
previous pod's service still owns. `upsertHostPort` upserts before pruning and
returns on error, so the prune that would have released the frontend is never
reached:

```
UpsertServiceAndFrontends: frontend already owned by another service:
0.0.0.0:25/TCP is owned by <ns>/<pod>:host-port:25:<UID of the deleted pod>
```

The agent repeats that every ~500ms and the hostPort black-holes until it is
restarted. Pruning first lets the replacement take the frontend over; both run
in the same write transaction, so there is no window where the port is unclaimed.

Note the caller commits the transaction regardless of the error, which is why the
stale state persisted instead of being retried into a good one.

Added `TestUpsertHostPort_PodRecreatedWithSameName`, which fails on main with the
error above and passes with this change.

Fixes: #48455

```release-note
Fix HostPort becoming permanently unusable when a pod is recreated with the same name
```
