### PR TITLE
gha/lint-ariane-config: let Renovate manage the Go version

### DIFF
--- a/.github/workflows/lint-ariane-config.yaml
+++ b/.github/workflows/lint-ariane-config.yaml
@@ -76,7 +76,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.26.0
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.27.0
           cache: false
 
       - name: Install Ariane linter


### PR DESCRIPTION
Renovate finds the go-version pins in the workflows through the
"# renovate: datasource=golang-version depName=go" comment placed above each
one. The Install Go step in lint-ariane-config.yaml has no such comment, so
Renovate never updates it. The pin has stayed at 1.26.0 since the workflow was
added, while every other pin on main is now at 1.27.0, so the Ariane lint job
installs an older toolchain than the rest of CI.

Add the comment and set the pin to 1.27.0.

Fixes: a3be31d0f743 ("ci: lint Ariane config")

This PR was prepared with AIL:3. I personally checked the other
go-version pins under .github/workflows.
