### PR TITLE
renovate: drop the cooldown for the Go toolchain

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -156,6 +156,14 @@
       "minimumReleaseAgeBehaviour": "timestamp-optional",
     },
     {
+      // No cooldown for the Go toolchain. It is pinned twice, as the golang
+      // image and as the workflow go-version, and the rule above already exempts
+      // the image half, so a fresh Go patch would otherwise land in one half of
+      // the 'base-images' group and not the other.
+      "matchPackageNames": ["docker.io/library/golang", "go"],
+      "minimumReleaseAge": "0 days",
+    },
+    {
       // Do not pin or update digests for self-referenced cilium/cilium GitHub
       // Actions and reusable workflows (e.g.,
       // cilium/cilium/.github/actions/set-commit-status@<sha> # main or


### PR DESCRIPTION
The Go toolchain version is pinned in two places: the golang image in the
Dockerfiles, tracked through the docker datasource, and the go-version pins in
the workflows, tracked through golang-version. renovate.json5 puts both in the
base-images group so they move together.

A cooldown rule holds back every release younger than five days, and the rule
after it switches that cooldown off for the whole docker datasource, so only
the image half escapes it. The two halves then disagree whenever a Go patch is
fresh. PR #48327 arrived with golang:1.26.8 in the Dockerfiles, a day after it
was pushed, next to twenty workflow pins still on 1.26.7.

Drop the cooldown for both halves instead. A Go patch is what CI should build
with as soon as it exists, and waiting on one half of the pair only splits the
group.

Fixes: c2b823c9aca9 ("renovate: restore updates of docker images")

This PR was prepared with AIL:3. I personally checked the
renovate-config-validator run for the edited file against the same run on
main.
