### PR TITLE
build: fix go format

### DIFF
--- a/pkg/datapath/loader/sock.go
+++ b/pkg/datapath/loader/sock.go
@@ -8,11 +8,11 @@ import (
 	"log/slog"
 	"net/netip"
 
+	"github.com/cilium/ebpf"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	bpfgen "github.com/cilium/cilium/pkg/datapath/bpf"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
-
-	"github.com/cilium/ebpf"
 )
 
 const (
@@ -68,7 +68,6 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 		},
 		MapReplacements: mapReplacements,
 	})
-
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading collection: %w", err)
 	}
@@ -78,17 +77,17 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 	}
 
 	return &bpfgen.SockTermPrograms{
-		CilSockUdpDestroyV4: coll.Programs[v4UDPProgName],
-		CilSockTcpDestroyV4: coll.Programs[v4TCPProgName],
-		CilSockUdpDestroyV6: coll.Programs[v6UDPProgName],
-		CilSockTcpDestroyV6: coll.Programs[v6TCPProgName],
-	}, func(af uint8, addr netip.Addr, port uint16) error {
-		var value bpfgen.SockTermSockTermFilter
-		value.AddressFamily = af
-		value.Port = port
-		a16 := addr.As16()
-		copy(value.Address.Addr6.Addr[:], a16[:])
+			CilSockUdpDestroyV4: coll.Programs[v4UDPProgName],
+			CilSockTcpDestroyV4: coll.Programs[v4TCPProgName],
+			CilSockUdpDestroyV6: coll.Programs[v6UDPProgName],
+			CilSockTcpDestroyV6: coll.Programs[v6TCPProgName],
+		}, func(af uint8, addr netip.Addr, port uint16) error {
+			var value bpfgen.SockTermSockTermFilter
+			value.AddressFamily = af
+			value.Port = port
+			a16 := addr.As16()
+			copy(value.Address.Addr6.Addr[:], a16[:])
 
-		return coll.Variables[filterVarName].Set(&value)
-	}, nil
+			return coll.Variables[filterVarName].Set(&value)
+		}, nil
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -617,15 +617,15 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 				}
 			}
 			return &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns,
-					Name:      podName,
-					UID:       k8sTypes.UID(uid),
-				},
-			}, &K8sMetadata{
-				IdentityLabels: lbls,
-				NamedPorts:     namedPorts,
-			}, nil
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ns,
+						Name:      podName,
+						UID:       k8sTypes.UID(uid),
+					},
+				}, &K8sMetadata{
+					IdentityLabels: lbls,
+					NamedPorts:     namedPorts,
+				}, nil
 		}
 	}
 	resolvePodMetadata := func(t *testing.T, e *Endpoint, restored bool, namedPorts ciliumTypes.NamedPortMap) {

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -102,12 +102,12 @@ func newMultiPoolAllocators(ctx context.Context, p MultiPoolAllocatorParams) (Al
 	}
 
 	return &multiPoolAllocator{
-		manager: mgr,
-		family:  IPv4,
-	}, &multiPoolAllocator{
-		manager: mgr,
-		family:  IPv6,
-	}, nil
+			manager: mgr,
+			family:  IPv4,
+		}, &multiPoolAllocator{
+			manager: mgr,
+			family:  IPv6,
+		}, nil
 }
 
 func (c *multiPoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {


### PR DESCRIPTION
Local `make precheck` fails with formatting errors in the following files:

- pkg/datapath/loader/sock.go
- pkg/endpoint/endpoint_test.go
- pkg/ipam/multipool.go

This commit fixes the formatting issues.

Note: not sure why this doesn't fail in ci :/ seems like this has been introduced by https://github.com/cilium/cilium/pull/48322 (cc @aanm )

edit: go 1.27 update... :facepalm: 