### PR TITLE
gha: publish the external target hostnames as FQDNs

### DIFF
--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -83,5 +83,6 @@ if [ "${#IPTARGET[@]}" -ge 2 ] && [ "${#IPOTHERTARGET[@]}" -ge 2 ]; then
 	echo "ipv6_external_target=${IPTARGET[1]}" >> $GITHUB_OUTPUT
 	echo "ipv6_other_external_target=${IPOTHERTARGET[1]}" >> $GITHUB_OUTPUT
 fi
-echo "external_target_name=$TARGETNAME" >> $GITHUB_OUTPUT
-echo "other_external_target_name=$OTHERTARGETNAME" >> $GITHUB_OUTPUT
+# Publish FQDNs, so that pod resolvers don't walk their ndots:5 search list.
+echo "external_target_name=$TARGETNAME." >> $GITHUB_OUTPUT
+echo "other_external_target_name=$OTHERTARGETNAME." >> $GITHUB_OUTPUT

--- a/.github/actions/kind-external-targets/action.sh
+++ b/.github/actions/kind-external-targets/action.sh
@@ -34,8 +34,9 @@ retry() {
 TARGETNAME=fake.external.service.cilium
 OTHERTARGETNAME=fake.external.service.other.cilium
 
-echo "external_target_name=$TARGETNAME" >> $GITHUB_OUTPUT
-echo "other_external_target_name=$OTHERTARGETNAME" >> $GITHUB_OUTPUT
+# Publish FQDNs, so that pod resolvers don't walk their ndots:5 search list.
+echo "external_target_name=$TARGETNAME." >> $GITHUB_OUTPUT
+echo "other_external_target_name=$OTHERTARGETNAME." >> $GITHUB_OUTPUT
 
 # Create a private key for the self signed CA
 openssl genrsa 2048 > ca-key.pem


### PR DESCRIPTION
Every pod-to-world curl resolves the external target through the pod resolver,
and kubelet hands every pod ndots:5 plus the node's search list. The two
external-target actions publish those hostnames in relative form, so glibc
tries each search domain before trying the name itself. The last search domain
is the Azure VM's DHCP-supplied private suffix, which the kind node inherits
from Docker, and that probe matches neither the appended cilium:53 hosts block
nor the cluster.local zone: it falls through to ".:53 { forward .
/etc/resolv.conf }" and is answered by Azure Private DNS, whose latency we do
not control.

In the sample I looked at that one probe took 5.2s, and curl's
--connect-timeout 2 also bounds name resolution, so the IPv6 leg of
client-egress-tls-sni-double-wildcard-denied exited 28 without ever opening the
connection whose SNI the test asserts on.

cilium-cli already expects an FQDN here: its --external-target default is
"one.one.one.one." and cli-test-config's is "bing.com.", both with the dot. So
publish the two names with it and leave the remaining use sites bare, since a
dot there would break the certificate SANs and the nginx server_name while
CoreDNS normalises its hosts entries to the zone FQDN anyway.

This PR was prepared with AIL:3. I've reviewed the code.