### PR TITLE
bpf: recreate CT entry for mismatching from_l7lb

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1023,7 +1023,10 @@ ct_recreate6:
 
 		/* See comment in handle_ipv4_from_lxc(). */
 		ct_state_new.proxy_redirect = proxy_port > 0;
-		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
+		ct_state_new.from_l7lb = from_l7lb;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect ||
+			     (ct_state->syn &&
+			      ct_state->from_l7lb != ct_state_new.from_l7lb)))
 			goto ct_recreate6;
 		break;
 
@@ -1606,11 +1609,18 @@ ct_recreate4:
 		 * suddenly comes into the scope of an L7 policy. Recreating the entry
 		 * updates the proxy_redirect flag properly.
 		 *
+		 * A new SYN may reuse a tuple with different L7 LB provenance. Recreate
+		 * the entry so the new connection takes ownership of the tuple, but do
+		 * not allow later packets from the old connection to take it back.
+		 *
 		 * if the packet hits a closing stale entry, ct_lookup returns CT_NEW and
 		 * caller recreates the entry.
 		 */
 		ct_state_new.proxy_redirect = proxy_port > 0;
-		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
+		ct_state_new.from_l7lb = from_l7lb;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect ||
+			     (ct_state->syn &&
+			      ct_state->from_l7lb != ct_state_new.from_l7lb)))
 			goto ct_recreate4;
 		break;
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -682,12 +682,13 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
-
-		if (ct_state && dir == CT_SERVICE && tcp_is_syn(tcp_flags))
-			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}
+
+	/* ct_state may be reused; always set to reflect the current packet. */
+	if (ct_state)
+		ct_state->syn = tcp_is_syn(tcp_flags);
 
 	cilium_dbg3(ctx, DBG_CT_LOOKUP6_1, (__u32)tuple->saddr.p4, (__u32)tuple->daddr.p4,
 		    (bpf_ntohs(tuple->sport) << 16) | bpf_ntohs(tuple->dport));
@@ -942,12 +943,13 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
-
-		if (ct_state && dir == CT_SERVICE && tcp_is_syn(tcp_flags))
-			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}
+
+	/* ct_state may be reused; always set to reflect the current packet. */
+	if (ct_state)
+		ct_state->syn = tcp_is_syn(tcp_flags);
 
 #ifndef QUIET_CT
 	cilium_dbg3(ctx, DBG_CT_LOOKUP4_1, tuple->saddr, tuple->daddr,

--- a/bpf/tests/l7_lb_local_backend.h
+++ b/bpf/tests/l7_lb_local_backend.h
@@ -16,6 +16,7 @@
 #define CLIENT_IP		v4_pod_one
 #define CLIENT_IP6		v6_pod_one
 #define CLIENT_PORT		tcp_src_one
+#define REUSED_CLIENT_PORT	tcp_src_two
 
 #define BACKEND_IP		v4_svc_one
 #define BACKEND_IP6		v6_svc_one
@@ -200,4 +201,200 @@ int l7_lb_local_backend_v6_check(const struct __ctx_buff *ctx)
 #endif
 
 	test_finish();
+}
+
+static __always_inline int
+l7_lb_ct_pktgen(struct __ctx_buff *ctx, bool ipv6, bool fin)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	if (ipv6)
+		l4 = pktgen__push_ipv6_tcp_packet(&builder,
+						  (__u8 *)mac_one, (__u8 *)mac_host,
+						  (__u8 *)CLIENT_IP6, (__u8 *)BACKEND_IP6,
+						  REUSED_CLIENT_PORT, BACKEND_PORT);
+	else
+		l4 = pktgen__push_ipv4_tcp_packet(&builder,
+						  (__u8 *)mac_one, (__u8 *)mac_host,
+						  CLIENT_IP, BACKEND_IP,
+						  REUSED_CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	if (fin) {
+		l4->syn = 0;
+		l4->fin = 1;
+	}
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+static __always_inline int
+l7_lb_ct_check(void *map, const void *tuple, bool from_l7lb)
+{
+	struct ct_entry *entry;
+
+	test_init();
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		test_fatal("no CT entry found");
+
+	assert(entry->from_l7lb == from_l7lb);
+
+	test_finish();
+}
+
+static __always_inline int
+l7_lb_ct_v4_check(bool from_l7lb)
+{
+	struct ipv4_ct_tuple tuple = {
+		.daddr = CLIENT_IP,
+		.saddr = BACKEND_IP,
+		.dport = BACKEND_PORT,
+		.sport = REUSED_CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	return l7_lb_ct_check(get_ct_map4(&tuple), &tuple, from_l7lb);
+}
+
+static __always_inline int
+l7_lb_ct_v6_check(bool from_l7lb)
+{
+	struct ipv6_ct_tuple tuple = {
+		.daddr = *(union v6addr *)CLIENT_IP6,
+		.saddr = *(union v6addr *)BACKEND_IP6,
+		.dport = BACKEND_PORT,
+		.sport = REUSED_CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	return l7_lb_ct_check(get_ct_map6(&tuple), &tuple, from_l7lb);
+}
+
+static __always_inline int
+l7_lb_ct_setup(struct __ctx_buff *ctx, bool from_proxy)
+{
+	policy_add_egress_allow_all_entry();
+	if (from_proxy)
+		return tail_call_egress_policy(ctx, CLIENT_EP_ID);
+	return pod_send_packet(ctx);
+}
+
+/* A direct SYN reusing an Envoy upstream tuple must take ownership of its CT
+ * entry. Later packets from the old Envoy connection must not take it back.
+ */
+PKTGEN("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, false);
+}
+
+SETUP("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(true);
+}
+
+PKTGEN("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, false);
+}
+
+SETUP("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, false);
+}
+
+CHECK("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, true);
+}
+
+SETUP("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, false);
+}
+
+SETUP("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(true);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, false);
+}
+
+SETUP("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, false);
+}
+
+CHECK("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, true);
+}
+
+SETUP("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(false);
 }


### PR DESCRIPTION
An Envoy L7 LB upstream connection transparently reuses the source pod's IP address and port. If the pod then accesses the same backend through a non-L7 service while reusing that source port, both connections can produce the same conntrack tuple.

The direct SYN consequently finds the live CT entry created for the Envoy upstream connection. Both connections have `proxy_redirect` cleared, because neither packet is being redirected at this point, so the existing `proxy_redirect` mismatch check does not detect the stale entry. However, the Envoy entry has `from_l7lb` set, causing replies for the direct connection to be routed to Envoy instead of the pod.

For a SYN matching an established entry, recreate the entry when its `from_l7lb` value differs from the current packet. Restrict this check to SYN packets so that delayed packets from the displaced connection cannot take ownership of the tuple back.

Since the original change, SYN reporting was moved into `__ct_lookup{4,6}` and limited to `CT_SERVICE` lookups. Extend it to all CT directions so the `CT_EGRESS` path can identify the new SYN. Assign the actual `tcp_is_syn()` result rather than only setting the bit, as the per-CPU CT state buffer is reused and must not retain SYN state for a subsequent non-SYN packet.

Add IPv4 and IPv6 tests covering an Envoy SYN followed by a direct SYN and a delayed Envoy FIN.

AIL: 3 (tests fully written by Codex, human reviewed before submission)
