### PR TITLE
gha/conformance-aks: give the nodes a 64 GiB OS disk

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -104,7 +104,7 @@ concurrency:
 
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
-  cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 64
   test_concurrency: 5
 
 jobs:


### PR DESCRIPTION
The AKS node image ships a pre-pulled image cache sized for the 128 GB OS disk
AKS creates by default, and the tests use none of it. conformance-aks asks for
30 GiB to keep the bill down, so that dead cache alone leaves the
nodes-without-cilium 67 and 83 per cent full while they run nothing but the
kube-system addons. From the run's sysdump, node names shortened:

    NAME        NODEFS USED  NODEFS CAPACITY  NODEFS(%)  DISKPRESSURE
    vmss000000      19288Mi          28691Mi        67%  False
    vmss000001      23799Mi          28691Mi        83%  False
    vmss000002      19811Mi          28691Mi        69%  False
    vmss000003       8440Mi          28691Mi        29%  False

vmss000003 reads 29 per cent because it is the node that ran out. What cilium
install pulls crossed kubelet's hard ephemeral-storage eviction threshold there
at 16:25:26, "EvictionThresholdMet ... Attempting to reclaim ephemeral-storage",
and the disk-pressure NoSchedule taint it then held for the whole five minute
transition period left every client3 pod unschedulable long enough for
cilium-test-4 to miss the connectivity test's deadline:

    0/4 nodes are available: 1 node(s) didn't match pod anti-affinity rules,
    3 node(s) had untolerated taint(s)

Those taints are cilium.io/no-schedule on the two nodes-without-cilium and
node.kubernetes.io/disk-pressure on vmss000003, which the agent's node watch
sees added at 16:25:29 and gone at 16:30:36, the instant the pods went
Scheduled. The remaining node is vmss000002, where client already ran.

https://github.com/cilium/cilium/actions/runs/33776101877

This PR was prepared with AIL:3. I personally checked the node capacity
figures in the run's sysdump.