### PR TITLE
bpf: lxc: move `lb4_ctx_restore_state()` comment to the correct place

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -108,6 +108,11 @@ struct {
 } cilium_nodeport_nat_buffer __section_maps_btf;
 
 #ifdef ENABLE_IPV4
+/* lb4_ctx_restore_state() restores per packet load balancing state from the
+ * previous tail call.
+ * tuple->flags does not need to be restored, as it will be reinitialized from
+ * the packet.
+ */
 static __always_inline void
 lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 		      __u16 *proxy_port, __u32 *cluster_id __maybe_unused,
@@ -144,11 +149,6 @@ lb4_ctx_store_state(struct __ctx_buff *ctx, const struct ct_state *state,
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, cluster_id);
 }
 
-/* lb4_ctx_restore_state() restores per packet load balancing state from the
- * previous tail call.
- * tuple->flags does not need to be restored, as it will be reinitialized from
- * the packet.
- */
 static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *ip4,
 						       __s8 *ext_err)
 {


### PR DESCRIPTION
When the function was moved in the referenced commit its comment ended up in the wrong place above `__per_packet_lb_svc_xlate_4()`. Move it above `lb4_ctx_restore_state()`.

Fixes: 64e171e9e52b ("bpf: lb: move lb*_ctx_store_state() helpers to bpf_lxc")