### PR TITLE
docs: remove outdated tip about disabling hubble before enabling UI

### DIFF
--- a/Documentation/observability/hubble/hubble-ui.rst
+++ b/Documentation/observability/hubble/hubble-ui.rst
@@ -30,10 +30,7 @@ Enable the Hubble UI by running the following command:
 
 .. tabs::
 
-    .. group-tab:: Cilium CLI 
-
-        If Hubble is already enabled with ``cilium hubble enable``, you must first temporarily disable Hubble with ``cilium hubble disable``.
-        This is because the Hubble UI cannot be added at runtime.
+    .. group-tab:: Cilium CLI
 
         .. code-block:: shell-session
 


### PR DESCRIPTION
The suggestion stems from back then when Cilium CLI implemented commands by manually creating resources instead of relying on Helm. The current CLI can enable the UI without requiring to disable hubble first.

The behaviour can be tested leveraging the following sequence of commands (note: to be issued on a cluster with cilium already installed):
```bash
$ cilium hubble disable # <- let's start from stratch
$ cilium hubble enable
$ cilium hubble enable --ui # <- this should fail according to the documentation
$ cilium hubble ui
```