### PR TITLE
gha/net-perf-gke: move off us-east5

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -67,10 +67,6 @@ env:
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a
-  # Additional zones to fall back to if the primary zone is out of capacity
-  # (GCE STOCKOUT). All within the same region as gcp_zone to keep perf results
-  # comparable.
-  gcp_fallback_zones: us-east5-b us-east5-c
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 582.0.0
 
@@ -254,13 +250,28 @@ jobs:
         run: |
           gcloud info
 
+      - name: Determine fallback zones
+        id: fallback-zones
+        env:
+          ZONE: ${{ env.gcp_zone }}
+        run: |
+          # The other zones of the same region, so that a zone which is out of
+          # capacity does not fail the whole job. Same region only, to keep the
+          # perf results comparable.
+          region="${ZONE%-?}"
+          zones=$(gcloud compute zones list --filter="status=UP" --format='value(name)' \
+            | grep "^${region}-" | grep -v "^${ZONE}$" | tr '\n' ' ')
+          echo "Fallback zones for ${ZONE}: ${zones}"
+          echo "zones=${zones}" >> $GITHUB_OUTPUT
+          echo "candidates=${ZONE} ${zones}" >> $GITHUB_OUTPUT
+
       - name: Create GKE cluster
         id: create-cluster
         uses: ./.github/actions/setup-gke-cluster
         with:
           cluster-name: ${{ env.clusterName }}-${{ matrix.index }}
           zone: ${{ env.gcp_zone }}
-          fallback-zones: ${{ env.gcp_fallback_zones }}
+          fallback-zones: ${{ steps.fallback-zones.outputs.zones }}
           node-taints: ${{ steps.vars.outputs.node_taints }}
           labels: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}"
 
@@ -349,7 +360,7 @@ jobs:
           # Every zone the cluster could have been created in, not just the one
           # it ended up in: a creation attempt that was abandoned because it was
           # too slow keeps provisioning on the GKE side.
-          ZONES: ${{ env.gcp_zone }} ${{ env.gcp_fallback_zones }}
+          ZONES: ${{ steps.fallback-zones.outputs.candidates || env.gcp_zone }}
         run: |
           for zone in ${ZONES}; do
             while [ "$(gcloud container operations list --zone "${zone}" --filter="status=RUNNING AND targetLink~${CLUSTER}" --format="value(name)")" ];do

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -66,7 +66,10 @@ env:
   clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
-  gcp_zone: us-east5-a
+  # Any zone of this region, see "Determine fallback zones" below. us-central1
+  # is the oldest and largest US region, which is the only lever we have on
+  # capacity since GCE does not report it.
+  gcp_zone: us-central1-a
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 582.0.0
 


### PR DESCRIPTION
The perf run keeps failing because us-east5 has no n2-standard-2 machines left. Every region-wide exhaustion we have measured is in that region: the runs of 2026-07-14, 07-22 and 08-06, and again https://github.com/cilium/cilium/actions/runs/33824489004 on 09-04, where all three zones were asked for 4 nodes each and all three refused. That is two whole runs lost out of the twenty six since 2026-08-01, so about one perf night a fortnight produces no data at all.

Falling back to another zone cannot help when the whole region is empty, and GCE offers no way to ask whether a zone can serve a machine shape before requesting it, so the only lever left is which region we ask. us-east5 was never chosen for its capacity, it came with the workflow in January 2024 and was never revisited. us-central1 is the oldest and largest US region and absorbs a 28 machine ask more easily.

The fallback zones stop being a hand-kept list on the way. conformance-gke already asks gcloud for the other zones of the region, so net-perf does the same and the region is named in one place.

The perf numbers move with the region, so the trend has a step here and comparisons across it are not meaningful.

This PR was prepared with AIL:3. I personally checked the logs of the failing run 33824489004.