### PR TITLE
k8s,loadbalancer: reject LRPs with empty redirectBackend.toPorts array

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -149,6 +149,7 @@ spec:
                       - port
                       - protocol
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - localEndpointSelector

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -151,6 +151,7 @@ type RedirectBackend struct {
 	// When multiple ports are specified, the ports must be named.
 	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	ToPorts []PortInfo `json:"toPorts"`
 }
 

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -278,12 +278,17 @@ func getSanitizedLocalRedirectPolicy(cfg Config, log *slog.Logger, name, namespa
 	}
 
 	// Parse backend config
-	bePorts = make([]bePortInfo, len(redirectTo.ToPorts))
-	if len(redirectTo.ToPorts) > 1 {
+	numBePorts := len(redirectTo.ToPorts)
+	if numBePorts == 0 {
+		return nil, fmt.Errorf("backend must specify at least one port")
+	}
+	if numBePorts > 1 {
 		// We check for backend named ports if either frontend/backend have
 		// multiple ports.
 		checkNamedPort = true
 	}
+
+	bePorts = make([]bePortInfo, len(redirectTo.ToPorts))
 	for i, portInfo := range redirectTo.ToPorts {
 		p, pName, proto, err := portInfo.SanitizePortInfo(checkNamedPort)
 		if err != nil {

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy_test.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func TestParseLRPRejectsEmptyBackendPorts(t *testing.T) {
+	lrp := &v2.CiliumLocalRedirectPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo",
+			Namespace: "default",
+		},
+		Spec: v2.CiliumLocalRedirectPolicySpec{
+			RedirectFrontend: v2.RedirectFrontend{
+				AddressMatcher: &v2.Frontend{
+					IP: "169.254.169.254",
+					ToPorts: []v2.PortInfo{{
+						Port:     "80",
+						Protocol: api.ProtoTCP,
+					}},
+				},
+			},
+			RedirectBackend: v2.RedirectBackend{},
+		},
+	}
+
+	_, err := parseLRP(DefaultConfig, nil, lrp)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Cilium LocalRedirectPolicy CRD requires spec.redirectBackend.toPorts to be specified, but it doesn't enforce a minimum number of elements. This means you can apply a CLRP with an empty redirectBackend.toPorts array, leading to a panic in the agent, because the size of the array isn't validated before access.

This commit makes two changes to fix this issue:

 1. The CRD is updated to include a minimum number of elements. Such a configuration will now be rejected.

 2. The LRP parser now checks the length of the redirectBackend.toPorts array. If the length is zero, an LRP will fail to parse.

Fixes: #48482 

```release-note
Fix panic in agent when CiliumLocalRedirectPolicy `redirectBackend.toPorts` is declared as an empty array. The agent will now reject such a policy.
```

AIL:0