### PR TITLE
MAINTAINERS: Add Rastislav Szabo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -48,6 +48,7 @@ to learn how to level up through the project.
  * [Nirmoy Das] (AMD)
  * [Paul Chaignon] (Isovalent)
  * [Quentin Monnet] (Hedgehog)
+ * [Rastislav Szabo] (Isovalent)
  * [Robin Hahling] (Isovalent)
  * [Sebastian Wicki] (Isovalent)
  * [Simone Magnani] (Isovalent)
@@ -132,6 +133,7 @@ project.
 [Nirmoy Das]: https://github.com/nirmoy
 [Paul Chaignon]: https://github.com/pchaigno
 [Quentin Monnet]: https://github.com/qmonnet
+[Rastislav Szabo]: https://github.com/rastislavs
 [Ray Bejjani]: https://github.com/raybejjani
 [Robin Hahling]: https://github.com/rolinh
 [Sebastian Wicki]: https://github.com/gandro


### PR DESCRIPTION
The voting period for granting to commit access to Rastislav Szabo initiated at 2026-08-27 is now closed with the following results:

YES: 24 NO: 0 ABSTAIN: 0

With the Company Block Vote Limit applied:

YES: 6 Isovalent + 1 Ledger + 1 DataDog + 1 Hedgehog = 9 votes
NO: 0 votes