### PR TITLE
[WIP] Support RevDNAT of ICMP Error using Global-Func

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1020,6 +1020,54 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx
 			    scope, ct_entry_types, ct_state, monitor);
 }
 
+/**
+ * ct_lazy_lookup4_icmp_error - CT lookup for an ICMP error packet whose inner
+ * tuple identifies an existing IPv4 connection.
+ *
+ * Unlike ct_lazy_lookup4(), this function:
+ *  - does not read TCP flags from l4_off (l4_off points to the outer ICMP
+ *    header, not the inner TCP header, so reading flags would yield garbage
+ *    and could corrupt CT entry state), and
+ *  - does not refresh the CT entry timeout (ICMP error packets are error
+ *    notifications, not data traffic, matching Linux nf_conntrack behaviour).
+ */
+static __always_inline int
+ct_lazy_lookup4_icmp_error(const void *map, struct ipv4_ct_tuple *tuple,
+			   const struct __ctx_buff *ctx,
+			   fraginfo_t fraginfo __maybe_unused,
+			   int l4_off __maybe_unused, enum ct_dir dir,
+			   enum ct_scope scope, __u32 ct_entry_types,
+			   struct ct_state *ct_state, __u32 *monitor)
+{
+	struct ct_entry *entry;
+
+	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry || !ct_entry_matches_types(entry, ct_entry_types, ct_state))
+		goto ct_new;
+
+	cilium_dbg(ctx, DBG_CT_MATCH, entry->lifetime, entry->rev_nat_index);
+
+	if (CONFIG(enable_conntrack_accounting)) {
+		__sync_fetch_and_add(&entry->packets, 1);
+		__sync_fetch_and_add(&entry->bytes, ctx_full_len(ctx));
+	}
+
+	if (ct_state)
+		ct_lookup_fill_state(ct_state, entry, dir);
+
+	cilium_dbg(ctx, DBG_CT_VERDICT, CT_REPLY,
+		   ct_state ? ct_state->rev_nat_index : 0);
+	*monitor = TRACE_PAYLOAD_LEN;
+	return CT_REPLY;
+
+ct_new:
+	cilium_dbg(ctx, DBG_CT_VERDICT, CT_NEW, 0);
+	*monitor = TRACE_PAYLOAD_LEN;
+	return CT_NEW;
+}
+
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1794,6 +1794,286 @@ lb4_extract_tuple(const struct __ctx_buff *ctx, const struct iphdr *ip4, fraginf
 	}
 }
 
+/**
+ * Extract CT tuple from the embedded original packet inside an ICMPv4 error.
+ *
+ * Fills @tuple with the reverse-direction representation of the original packet
+ * (saddr/daddr swapped, ports swapped) so callers can use it directly for a
+ * SCOPE_REVERSE CT lookup.
+ *
+ * Returns:
+ *   - CTX_ACT_OK on success
+ *   - DROP_UNSUPP_SERVICE_PROTO if not an ICMP error or inner proto unsupported
+ *   - Negative error code on parse failure
+ *
+ * TODO: no IPv6 counterpart yet. When adding one, target ICMPV6_PKT_TOOBIG
+ * only (the v6 equivalent of ICMPv4 Frag Needed): snat_v6_rev_nat_handle_icmp_pkt_toobig()
+ * is the only ICMPv6 error type with existing RevSNAT support to build RevDNAT on top of.
+ */
+static __always_inline int
+lb4_extract_icmp4_error_tuple(struct __ctx_buff *ctx,
+			      const struct iphdr *ip4,
+			      int l4_off,
+			      struct ipv4_ct_tuple *tuple,
+			      int *inner_l3_off)
+{
+	struct icmphdr icmph;
+	struct iphdr inner_ip4;
+	fraginfo_t fraginfo;
+	__u32 inner_offset;
+	__u32 inner_l4_off;
+	__u64 ctx_len = ctx_full_len(ctx);
+	bool has_inner_l4 = false;
+
+	/* Outer packet must not be fragmented. */
+	fraginfo = ipfrag_encode_ipv4(ip4);
+	if (ipfrag_is_fragment(fraginfo))
+		return DROP_UNSUPP_SERVICE_PROTO;
+
+	/* Only ICMP error types embed the original packet we need to extract. */
+	if ((__u64)l4_off + sizeof(icmph) > ctx_len)
+		return DROP_INVALID;
+	if (ctx_load_bytes(ctx, l4_off, &icmph, sizeof(icmph)) < 0)
+		return DROP_INVALID;
+
+	switch (icmph.type) {
+	case ICMP_DEST_UNREACH:
+		if (icmph.code > NR_ICMP_UNREACH)
+			return DROP_UNSUPP_SERVICE_PROTO;
+		break;
+	case ICMP_TIME_EXCEEDED:
+		break;
+	default:
+		return DROP_UNSUPP_SERVICE_PROTO;
+	}
+
+	/* Load the original packet embedded in the ICMP error payload. */
+	inner_offset = (__u32)(l4_off + sizeof(struct icmphdr));
+	if (inner_l3_off)
+		*inner_l3_off = (int)inner_offset;
+
+	if ((__u64)inner_offset + sizeof(inner_ip4) > ctx_len)
+		return DROP_INVALID;
+
+	if (ctx_load_bytes(ctx, inner_offset, &inner_ip4, sizeof(inner_ip4)) < 0)
+		return DROP_INVALID;
+
+	if (inner_ip4.ihl < 5)
+		return DROP_INVALID;
+
+	/* The inner L4 header may be truncated in the ICMP payload. */
+	inner_l4_off = inner_offset + ipv4_hdrlen(&inner_ip4);
+	if ((__u64)inner_l4_off + sizeof(__be32) <= ctx_len)
+		has_inner_l4 = true;
+
+	/* Embedded packet's direction is reversed, so saddr/daddr are swapped. */
+	tuple->nexthdr = inner_ip4.protocol;
+	tuple->saddr = inner_ip4.daddr;
+	tuple->daddr = inner_ip4.saddr;
+	tuple->sport = 0;
+	tuple->dport = 0;
+	tuple->flags = 0;
+
+	/* Service traffic is always TCP/UDP/SCTP, so fill in ports from the inner L4 header. */
+	switch (tuple->nexthdr) {
+	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+	case IPPROTO_SCTP:
+#endif  /* ENABLE_SCTP */
+	{
+		struct ipv4_frag_l4ports inner_ports;
+
+		if (!has_inner_l4 ||
+		    l4_load_ports(ctx, (int)inner_l4_off, (__be16 *)&inner_ports) < 0)
+			return DROP_INVALID;
+
+		tuple->dport = inner_ports.sport;
+		tuple->sport = inner_ports.dport;
+		ipv4_ct_tuple_swap_ports(tuple);
+		break;
+	}
+	default:
+		return DROP_UNSUPP_SERVICE_PROTO;
+	}
+
+	return CTX_ACT_OK;
+}
+
+/* lb4_icmp4_error_calc_outer_l4_csum_diff - outer ICMP (L4) csum contribution of
+ * rewriting the embedded inner packet's daddr/dport. Does not touch ctx.
+ *
+ * Edits paired with a matching checksum update cancel out and need no outer
+ * accounting; only the unpaired one does, which is what this computes.
+ */
+static __always_inline void
+lb4_icmp4_error_calc_outer_l4_csum_diff(__be32 old_daddr, __be32 new_daddr,
+					__be16 old_port, __be16 new_port,
+					bool icmp_has_inner_l4_csum,
+					__wsum *outer_l4_csum_diff)
+{
+	*outer_l4_csum_diff = 0;
+
+	if (icmp_has_inner_l4_csum) {
+		/* The inner L4 checksum's pseudo-header update for daddr is the
+		 * only unpaired change; dport and the inner IP update cancel out.
+		 */
+		if (old_daddr != new_daddr)
+			*outer_l4_csum_diff = csum_diff(&new_daddr, sizeof(new_daddr),
+							&old_daddr, sizeof(old_daddr), 0);
+	} else {
+		/* No inner L4 checksum to pair dport's change against, so it
+		 * leaks into the outer checksum directly.
+		 */
+		if (old_port != new_port) {
+			__be32 old_port32 = (__be32)old_port;
+			__be32 new_port32 = (__be32)new_port;
+
+			*outer_l4_csum_diff = csum_diff(&old_port32, sizeof(old_port32),
+							&new_port32, sizeof(new_port32), 0);
+		}
+	}
+}
+
+/* lb4_icmp4_error_rewrite_headers - rewrite the L3 address at addr_off (if changed)
+ * and the L4 port at port_off (if changed), amending checksums for both plus any
+ * extra L4 checksum diff the caller already worked out (for folding in an ICMP
+ * error's outer checksum update; see lb4_icmp4_error_calc_outer_l4_csum_diff()).
+ *
+ * Shared by lb4_rev_nat_icmp4_error() for both the embedded inner packet and the
+ * outer ICMP/IP headers.
+ */
+static __always_inline int
+lb4_icmp4_error_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr,
+				int l3_off, __u16 addr_off, __be32 old_addr, __be32 new_addr,
+				int l4_off, int port_off, __be16 old_port, __be16 new_port,
+				__wsum l4_csum_diff_from_inner)
+{
+	__wsum l3_sum = 0;
+	int err;
+
+	if (old_addr == new_addr && old_port == new_port && !l4_csum_diff_from_inner)
+		return 0;
+
+	if (old_addr != new_addr) {
+		err = ipv4_l3_rewrite_addr(ctx, l3_off, addr_off, old_addr, new_addr, &l3_sum);
+		if (err < 0)
+			return err;
+	}
+
+	return l4_rewrite_port_and_csum(ctx, nexthdr, l4_off, port_off,
+					old_port, new_port, l3_sum,
+					l4_csum_diff_from_inner);
+}
+
+/* lb4_rev_nat_icmp4_error - reverse NAT an ICMPv4 error sent back by a backend.
+ * Rewrites the backend's address/port back to the service's in both the embedded
+ * inner packet and the outer ICMP/IP headers, keeping all checksums consistent.
+ */
+static __always_inline int
+lb4_rev_nat_icmp4_error(struct __ctx_buff *ctx,
+			int outer_l3_off,
+			int inner_l3_off,
+			const struct lb4_reverse_nat *nat,
+			const struct iphdr *outer_ip4)
+{
+	struct iphdr inner_ip4;
+	__wsum outer_l4_csum_diff;
+	__u64 ctx_len = ctx_full_len(ctx);
+	int outer_l4_off;
+	int inner_l4_off;
+	int outer_hdr_len;
+	bool icmp_has_inner_l4_csum;
+	int port_off = -1;
+	__be16 old_port = 0;
+	__be16 new_port = 0;
+	__be32 outer_saddr;
+	__u8 outer_proto;
+	int ret;
+
+	if (!nat)
+		return 0;
+
+	if (!outer_ip4)
+		return DROP_INVALID;
+
+	outer_proto = outer_ip4->protocol;
+	if (outer_proto != IPPROTO_ICMP)
+		return DROP_UNSUPP_SERVICE_PROTO;
+
+	outer_hdr_len = ipv4_hdrlen(outer_ip4);
+	outer_l4_off = outer_l3_off + outer_hdr_len;
+	if ((__u64)outer_l4_off + sizeof(struct icmphdr) > ctx_len)
+		return DROP_INVALID;
+
+	outer_saddr = outer_ip4->saddr;
+
+	/* Load the original packet embedded in the ICMP error payload. */
+	if (ctx_load_bytes(ctx, inner_l3_off, &inner_ip4, sizeof(inner_ip4)) < 0)
+		return DROP_INVALID;
+
+	if (inner_ip4.ihl < 5)
+		return DROP_INVALID;
+
+	inner_l4_off = inner_l3_off + ipv4_hdrlen(&inner_ip4);
+
+	/* Check whether the inner L4 checksum field is present in the ICMP payload. */
+	icmp_has_inner_l4_csum = true;
+	if (inner_ip4.protocol == IPPROTO_TCP) {
+		__u32 total_inner_len = (__u32)(ctx_len - inner_l3_off);
+
+		if (total_inner_len < ipv4_hdrlen(&inner_ip4) + TCP_CSUM_OFF + sizeof(__u16))
+			icmp_has_inner_l4_csum = false;
+	}
+
+	/* Find and load the inner dport, if the protocol carries one. */
+	if (nat->port) {
+		switch (inner_ip4.protocol) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+			port_off = TCP_DPORT_OFF;
+			break;
+		default:
+			break;
+		}
+
+		if (port_off >= 0) {
+			if (l4_load_port(ctx, inner_l4_off + port_off, &old_port) < 0)
+				return DROP_INVALID;
+
+			new_port = nat->port;
+		}
+	}
+
+	/* Work out the outer ICMP csum impact before rewriting anything. */
+	lb4_icmp4_error_calc_outer_l4_csum_diff(inner_ip4.daddr, nat->address,
+						old_port, new_port,
+						icmp_has_inner_l4_csum,
+						&outer_l4_csum_diff);
+
+	/* Rewrite the embedded packet's daddr/dport to the backend's. */
+	ret = lb4_icmp4_error_rewrite_headers(ctx, inner_ip4.protocol,
+					      inner_l3_off, IPV4_DADDR_OFF,
+					      inner_ip4.daddr, nat->address,
+					      inner_l4_off, port_off, old_port, new_port, 0);
+	/* Failing to update the inner L4 checksum is not fatal if the ICMP
+	 * error truncated the embedded packet before the checksum field.
+	 */
+	if (!icmp_has_inner_l4_csum && ret == DROP_CSUM_L4)
+		ret = 0;
+	if (ret < 0)
+		return ret;
+
+	/* Rewrite the outer IP source to the service address too, folding in the
+	 * inner rewrite's impact on the outer ICMP (L4) checksum.
+	 */
+	return lb4_icmp4_error_rewrite_headers(ctx, IPPROTO_ICMP,
+					       outer_l3_off, IPV4_SADDR_OFF,
+					       outer_saddr, nat->address,
+					       outer_l4_off, 0, 0, 0,
+					       outer_l4_csum_diff);
+}
+
 static __always_inline
 bool lb4_src_range_ok(const struct lb4_service *svc __maybe_unused,
 		      __u32 saddr __maybe_unused)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -39,9 +39,9 @@ DECLARE_CONFIG(union v6addr, nat_ipv6_masquerade, "Masquerade address for IPv6 t
 DECLARE_CONFIG(bool, enable_remote_node_masquerade, "Masquerade traffic to remote nodes")
 DECLARE_CONFIG(__u16, ephemeral_min, "Ephemeral port range minimum")
 
-/* We only need to SNAT ICMPv4 traffic if BPF masquerading or inter-cluster
- * SNAT are enabled. If they are disabled, we only SNAT replies from service
- * backends and we do not currently support ICMP replies from service backends.
+/* We only need to SNAT ICMPv4 echo/echoreply traffic if BPF masquerading or
+ * inter-cluster SNAT are enabled. If they are disabled, we only SNAT replies
+ * from service backends.
  */
 #if defined(ENABLE_MASQUERADE_IPV4) || defined(ENABLE_INTER_CLUSTER_SNAT)
 # define ENABLE_SNAT_ICMPV4 1
@@ -1040,7 +1040,6 @@ nat_icmp_v4:
 			     port_off, outer_csum_diff, trace, ext_err);
 }
 
-#ifdef ENABLE_SNAT_ICMPV4
 static __always_inline __maybe_unused int
 snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 				  __u64 inner_l3_off,
@@ -1145,7 +1144,6 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 		ret = 0;
 	return ret;
 }
-#endif /* ENABLE_SNAT_ICMPV4 */
 
 static __always_inline __maybe_unused int
 snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
@@ -1190,7 +1188,6 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 			return NAT_PUNT_TO_STACK;
 
 		break;
-#ifdef ENABLE_SNAT_ICMPV4
 	case IPPROTO_ICMP: {
 		struct icmphdr icmphdr __align_stack_8;
 		__u64 inner_l3_off;
@@ -1206,11 +1203,13 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 			return DROP_INVALID;
 
 		switch (icmphdr.type) {
+#ifdef ENABLE_SNAT_ICMPV4
 		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
 			tuple.sport = 0;
 			port_off = offsetof(struct icmphdr, un.echo.id);
 			break;
+#endif /* ENABLE_SNAT_ICMPV4 */
 		case ICMP_DEST_UNREACH:
 			if (icmphdr.code > NR_ICMP_UNREACH)
 				return NAT_PUNT_TO_STACK;
@@ -1239,7 +1238,6 @@ rev_nat_icmp_v4:
 		}
 		break;
 	}
-#endif /* ENABLE_SNAT_ICMPV4 */
 	default:
 		return NAT_PUNT_TO_STACK;
 	};

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2172,7 +2172,7 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		},
 	};
 	const struct remote_endpoint_info *info __maybe_unused = NULL;
-	int ifindex = 0, ret, l3_off = ETH_HLEN, l4_off;
+	int ifindex = 0, ret, l3_off = ETH_HLEN, l4_off, inner_l3_off = 0;
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
@@ -2184,6 +2184,7 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	fraginfo_t fraginfo;
 	const __u32 *vrf_id __maybe_unused = NULL;
 	__u32 monitor = 0;
+	bool is_icmp_error = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -2194,10 +2195,17 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
 	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
+		if (ret == DROP_UNSUPP_SERVICE_PROTO) {
+			ret = lb4_extract_icmp4_error_tuple(ctx, ip4, l4_off,
+							    &tuple, &inner_l3_off);
+			if (ret == CTX_ACT_OK)
+				is_icmp_error = true;
+		}
 		if (ret == DROP_UNSUPP_SERVICE_PROTO || ret == DROP_UNKNOWN_L4)
 			goto skip_revdnat;
 
-		return ret;
+		if (ret < 0)
+			return ret;
 	}
 
 #if defined(ENABLE_SRV6) && defined(IS_BPF_LXC)
@@ -2218,15 +2226,31 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	else if (ret == CTX_ACT_REDIRECT)
 		goto redirect;
 
-	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
-			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT, &ct_state, &monitor);
+	if (is_icmp_error)
+		ret = ct_lazy_lookup4_icmp_error(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
+						 l4_off, CT_INGRESS, SCOPE_REVERSE,
+						 CT_ENTRY_NODEPORT, &ct_state, &monitor);
+	else
+		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
+				      l4_off, CT_INGRESS, SCOPE_REVERSE,
+				      CT_ENTRY_NODEPORT, &ct_state, &monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;
-		ret = lb4_rev_nat(ctx, l3_off, l4_off,
-				  ct_state.rev_nat_index, 0, 0,
-				  false, &tuple, ipfrag_has_l4_header(fraginfo));
+		if (!is_icmp_error) {
+			ret = lb4_rev_nat(ctx, l3_off, l4_off,
+					  ct_state.rev_nat_index, 0, 0,
+					  false, &tuple, ipfrag_has_l4_header(fraginfo));
+		} else {
+			const struct lb4_reverse_nat *nat;
+
+			nat = lb4_lookup_rev_nat_entry(ctx, ct_state.rev_nat_index);
+			if (!nat)
+				ret = 0;
+			else
+				ret = lb4_rev_nat_icmp4_error(ctx, l3_off, inner_l3_off,
+							      nat, ip4);
+		}
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -2803,6 +2827,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	fraginfo_t fraginfo;
 	struct ipv4_ct_tuple tuple = {};
 	bool is_svc_proto = true;
+	bool is_icmp_error = false;
 	const struct lb4_service *svc;
 	struct lb4_key key = {};
 	int l3_off = ETH_HLEN;
@@ -2814,7 +2839,12 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNSUPP_SERVICE_PROTO) {
+			int inner_l3_off;
+
 			is_svc_proto = false;
+			if (lb4_extract_icmp4_error_tuple(ctx, ip4, l4_off,
+							  &tuple, &inner_l3_off) == CTX_ACT_OK)
+				is_icmp_error = true;
 			goto skip_service_lookup;
 		}
 		if (ret == DROP_UNKNOWN_L4) {
@@ -2889,9 +2919,10 @@ skip_service_lookup:
 	}
 
 	/* Check for RevSNAT. When BPF-Masquerading is off, we only need to
-	 * handle SVC replies:
+	 * handle SVC replies and ICMP errors (so that RevDNAT for the
+	 * embedded SVC reply can still happen):
 	 */
-	if (is_defined(ENABLE_MASQUERADE_IPV4) || is_svc_proto)
+	if (is_defined(ENABLE_MASQUERADE_IPV4) || is_svc_proto || is_icmp_error)
 		return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS, ext_err);
 
 	return CTX_ACT_OK;

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -488,7 +488,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 			   struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
-	int ret, l3_off = ETH_HLEN, l4_off;
+	int ret, l3_off = ETH_HLEN, l4_off, inner_l3_off = 0;
 	struct lb4_reverse_nat nat_info;
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
@@ -496,6 +496,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 	struct iphdr *ip4;
 	fraginfo_t fraginfo;
 	__u32 monitor = 0;
+	bool is_icmp_error = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -506,9 +507,16 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
 	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
+		if (ret == DROP_UNSUPP_SERVICE_PROTO) {
+			ret = lb4_extract_icmp4_error_tuple(ctx, ip4, l4_off,
+							    &tuple, &inner_l3_off);
+			if (ret == CTX_ACT_OK)
+				is_icmp_error = true;
+		}
 		if (ret == DROP_UNSUPP_SERVICE_PROTO || ret == DROP_UNKNOWN_L4)
 			return CTX_ACT_OK;
-		return ret;
+		if (ret < 0)
+			return ret;
 	}
 
 	if (!nodeport_rev_dnat_get_info_ipv4(ctx, &tuple, &nat_info))
@@ -534,10 +542,16 @@ skip_fib:
 #endif
 
 	/* Cache is_fragment in advance, nodeport_fib_lookup_and_redirect may invalidate ip4. */
-	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
-			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
-			      &ct_state, &monitor);
+	if (is_icmp_error)
+		ret = ct_lazy_lookup4_icmp_error(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
+						 l4_off, CT_INGRESS, SCOPE_REVERSE,
+						 CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
+						 &ct_state, &monitor);
+	else
+		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
+				      l4_off, CT_INGRESS, SCOPE_REVERSE,
+				      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
+				      &ct_state, &monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a
 	 * CT entry exists:
@@ -545,9 +559,18 @@ skip_fib:
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;
-
-		ret = __lb4_rev_nat(ctx, l3_off, l4_off, &tuple,
-				    &nat_info, false, ipfrag_has_l4_header(fraginfo));
+		if (!is_icmp_error) {
+			ret = __lb4_rev_nat(ctx, l3_off, l4_off, &tuple,
+					    &nat_info, false, ipfrag_has_l4_header(fraginfo));
+		} else {
+			/* nodeport_fib_lookup_and_redirect() above may have
+			 * invalidated ip4; re-fetch it before dereferencing.
+			 */
+			if (!revalidate_data(ctx, &data, &data_end, &ip4))
+				return DROP_INVALID;
+			ret = lb4_rev_nat_icmp4_error(ctx, l3_off, inner_l3_off,
+						      &nat_info, ip4);
+		}
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -198,3 +198,46 @@ icmp4_err_frag_needed_after_revnat = (
     IP(src=v4_node_one, dst=v4_pod_two, flags="DF") /
     TCP(sport=3030, dport=80)  # original port restored
 )
+
+
+# NodePort LB4 RevDNAT ICMP error scenario:
+# Backend (mac_five, v4_pod_two) sends ICMP Frag Needed to LB (host_mac_addr, v4_node_one)
+# complaining about the SNATed request (LB_IP:NODEPORT_PORT_MIN_NAT -> backend).
+nodeport_lb4_icmp_error_before = (
+    Ether(src=mac_five, dst=host_mac_addr) /
+    IP(src=v4_pod_two, dst=v4_node_one, ttl=64) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_node_one, dst=v4_pod_two, ttl=64, flags="DF") /
+    TCP(sport=32768, dport=8080, seq=tcp_default_seq, flags="S")
+)
+
+
+# After RevDNAT: ICMP error should target the original client (v4_ext_one:111 -> v4_svc_two:80).
+nodeport_lb4_icmp_error_after = (
+    Ether(src=mac_five, dst=host_mac_addr) /
+    IP(src=v4_svc_two, dst=v4_ext_one, ttl=63) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_ext_one, dst=v4_svc_two, ttl=64, flags="DF") /
+    TCP(sport=111, dport=tcp_svc_one, seq=tcp_default_seq, flags="S")
+)
+
+
+# DSR backend node ICMP error RevDNAT scenario:
+# Backend node (mac_three, v4_pod_one) sends ICMP Frag Needed to client (mac_one, v4_ext_one),
+# referencing the original request (v4_ext_one:111 -> v4_pod_one:8080).
+dsr_backend_icmp4_err_before = (
+    Ether(src=mac_three, dst=mac_one) /
+    IP(src=v4_pod_one, dst=v4_ext_one, ttl=64) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=64, flags="DF") /
+    TCP(sport=111, dport=8080, seq=tcp_default_seq, flags="S")
+)
+
+# After RevDNAT: outer src BACKEND_IP -> FRONTEND_IP, inner dst BACKEND_IP:8080 -> FRONTEND_IP:80.
+dsr_backend_icmp4_err_after = (
+    Ether(src=mac_three, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one, ttl=64) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_ext_one, dst=v4_svc_one, ttl=64, flags="DF") /
+    TCP(sport=111, dport=tcp_svc_one, seq=tcp_default_seq, flags="S")
+)

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -4,6 +4,7 @@
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
+#include "scapy.h"
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
@@ -26,6 +27,14 @@
 #define SVC_EGRESS_IFACE	26
 
 #define BACKEND_EP_ID		127
+
+static const __u8 dsr_backend_icmp4_err_before_buf[] = {
+	SCAPY_BUF_BYTES(dsr_backend_icmp4_err_before)
+};
+
+static const __u8 dsr_backend_icmp4_err_after_buf[] = {
+	SCAPY_BUF_BYTES(dsr_backend_icmp4_err_after)
+};
 
 static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *node_mac = mac_three;
@@ -377,6 +386,87 @@ CHECK(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
+}
+
+/* Test that the backend node RevDNATs an ICMP error reported by the DSR backend.
+ * The ICMP Frag Needed references the original request (CLIENT_IP -> BACKEND_IP).
+ * After RevDNAT the outer src should be FRONTEND_IP and the embedded tuple should
+ * show client->service addresses/ports.
+ */
+PKTGEN("tc", "tc_nodeport_dsr_backend_icmp_error_revdnat")
+int nodeport_dsr_backend_icmp_error_revdnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder, dsr_backend_icmp4_err_before_buf,
+			sizeof(dsr_backend_icmp4_err_before_buf));
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_backend_icmp_error_revdnat")
+int nodeport_dsr_backend_icmp_error_revdnat_setup(struct __ctx_buff *ctx)
+{
+	/* Initialized in original-direction order; __ipv4_ct_tuple_reverse()
+	 * converts to reply-direction addrs / original-direction ports
+	 * (per ipv4_ct_tuple definition).
+	 */
+	struct ipv4_ct_tuple ct_tuple = {
+		.saddr = CLIENT_IP,
+		.daddr = BACKEND_IP,
+		.sport = BACKEND_PORT,
+		.dport = CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+	/* DSR: RevDNAT target is in the CT entry (nat_addr/nat_port),
+	 * not the LB table.
+	 */
+	struct ct_state ct_state_entry = {
+		.dsr_internal = 1,
+		.nat_addr = { .p4 = FRONTEND_IP },
+		.nat_port = FRONTEND_PORT,
+	};
+
+	/* Insert a reply-direction CT entry so the backend's ICMP error
+	 * is recognized.
+	 */
+	__ipv4_ct_tuple_reverse(&ct_tuple);
+	if (ct_create4(get_ct_map4(&ct_tuple), NULL, &ct_tuple, ctx,
+		       CT_EGRESS, &ct_state_entry, NULL) < 0)
+		return TEST_ERROR;
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_dsr_backend_icmp_error_revdnat")
+int nodeport_dsr_backend_icmp_error_revdnat_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) + sizeof(struct ethhdr) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("dsr_backend_icmp4_err_after",
+			   "Ether",
+			   ctx,
+			   sizeof(__u32),
+			   dsr_backend_icmp4_err_after_buf,
+			   sizeof(dsr_backend_icmp4_err_after_buf));
+
+	test_finish();
 }
 
 /* Same scenario as above, but for a different CLIENT_IP_2. Here replies

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -4,6 +4,7 @@
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
+#include "scapy.h"
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
@@ -37,6 +38,14 @@ static volatile const __u8 *lb_mac = mac_host;
 static volatile const __u8 *node_mac = mac_three;
 static volatile const __u8 *local_backend_mac = mac_four;
 static volatile const __u8 *remote_backend_mac = mac_five;
+
+static const __u8 nodeport_icmp4_err_before_buf[] = {
+	SCAPY_BUF_BYTES(nodeport_lb4_icmp_error_before)
+};
+
+static const __u8 nodeport_icmp4_err_after_buf[] = {
+	SCAPY_BUF_BYTES(nodeport_lb4_icmp_error_after)
+};
 
 __section_entry
 int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
@@ -150,6 +159,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+#include "lib/nat.h"
 
 ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
@@ -885,6 +895,122 @@ CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
+}
+
+/* Test that the LB RevDNATs an ICMP error reported by the remote backend.
+ * The test feeds the LB with an ICMP Frag Needed referencing the NATed
+ * request (LB_IP:NODEPORT_PORT_MIN_NAT -> backend). After RevDNAT the outer
+ * packet should target the original client and the embedded tuple should
+ * show client->service addresses/ports.
+ */
+PKTGEN("tc", "tc_nodeport_nat_fwd_icmp_error_revnat")
+int nodeport_nat_fwd_icmp_error_revnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder, nodeport_icmp4_err_before_buf,
+			sizeof(nodeport_icmp4_err_before_buf));
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_nat_fwd_icmp_error_revnat")
+int nodeport_nat_fwd_icmp_error_revnat_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+	__u32 key = 0;
+	struct mock_settings settings_value = {
+		.nat_source_port = __bpf_htons(NODEPORT_PORT_MIN_NAT),
+		.fail_fib = false,
+	};
+	struct ipv4_ct_tuple tuple = {
+		.saddr = BACKEND_IP_REMOTE,
+		.daddr = LB_IP,
+		.sport = BACKEND_PORT,
+		.dport = __bpf_htons(NODEPORT_PORT_MIN_NAT),
+		.nexthdr = IPPROTO_TCP,
+		.flags = NAT_DIR_INGRESS,
+	};
+	struct ipv4_nat_entry entry = {
+		.to_daddr = CLIENT_IP,
+		.to_dport = CLIENT_PORT,
+	};
+	/* Initialized in original-direction order; __ipv4_ct_tuple_reverse()
+	 * converts to reply-direction addrs / original-direction ports
+	 * (per ipv4_ct_tuple definition).
+	 */
+	struct ipv4_ct_tuple ct_tuple = {
+		.saddr = CLIENT_IP,
+		.daddr = BACKEND_IP_REMOTE,
+		.sport = BACKEND_PORT,
+		.dport = CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_state ct_state_entry = {
+		.node_port = 1,
+		.rev_nat_index = revnat_id,
+		.src_sec_id = WORLD_IPV4_ID,
+	};
+
+	/* LB service + backend for RevDNAT: maps rev_nat_index -> FRONTEND_IP_REMOTE:FRONTEND_PORT. */
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP_REMOTE, 0, 112233, 0, 0);
+
+	/* Mock FIB settings and SNAT entry for RevSNAT: rewrites outer dst LB_IP -> CLIENT_IP
+	 * and inner src LB_IP:NODEPORT_PORT_MIN_NAT -> CLIENT_IP:CLIENT_PORT.
+	 */
+	map_update_elem(&settings_map, &key, &settings_value, BPF_ANY);
+	map_update_elem(&cilium_snat_v4_external, &tuple, &entry, BPF_ANY);
+
+	/* CT entry (TUPLE_F_OUT) for RevDNAT: after RevSNAT the CT lookup finds this entry,
+	 * reads rev_nat_index, and rewrites outer src BACKEND -> FRONTEND and inner dst.
+	 */
+	__ipv4_ct_tuple_reverse(&ct_tuple);
+	if (ct_create4(get_ct_map4(&ct_tuple), NULL, &ct_tuple, ctx,
+		       CT_EGRESS, &ct_state_entry, NULL) < 0)
+		return TEST_ERROR;
+
+	/* Related CT entry for the outer ICMP packet itself. */
+	ct_tuple.flags |= TUPLE_F_RELATED;
+	if (ct_create4(get_ct_map4(&ct_tuple), NULL, &ct_tuple, ctx,
+		       CT_EGRESS, &ct_state_entry, NULL) < 0)
+		return TEST_ERROR;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_nat_fwd_icmp_error_revnat")
+int nodeport_nat_fwd_icmp_error_revnat_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) + sizeof(struct ethhdr) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	ASSERT_CTX_BUF_OFF("tc_nodeport_lb4_icmp_error_after",
+			   "Ether",
+			   ctx,
+			   sizeof(__u32),
+			   nodeport_icmp4_err_after_buf,
+			   sizeof(nodeport_icmp4_err_after_buf));
+
+	test_finish();
 }
 
 /* The following three tests are checking the scenario where a Rev NAT entry gets


### PR DESCRIPTION
This PR implements this RFE.(https://github.com/cilium/cilium/issues/32029)

Backends can return ICMP errors for DNATed traffic; reverse-translate them back to the service address before forwarding to the client.