### PR TITLE
bpf: convert HOST_NETNS_COOKIE to runtime config

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -26,10 +26,6 @@
 #define SYS_REJECT	0
 #define SYS_PROCEED	1
 
-#ifndef HOST_NETNS_COOKIE
-# define HOST_NETNS_COOKIE   get_netns_cookie(NULL)
-#endif
-
 static __always_inline __maybe_unused bool is_v4_loopback(__be32 daddr)
 {
 	/* Check for 127.0.0.0/8 range, RFC3330. */
@@ -84,10 +80,15 @@ static __always_inline __maybe_unused bool
 ctx_in_hostns(void *ctx __maybe_unused, __net_cookie *cookie)
 {
 	__net_cookie own_cookie = get_netns_cookie(ctx);
+	__net_cookie host_cookie = CONFIG(host_netns_cookie);
 
 	if (cookie)
 		*cookie = own_cookie;
-	return own_cookie == HOST_NETNS_COOKIE ||
+
+	if (!host_cookie)
+		host_cookie = get_netns_cookie(NULL);
+
+	return own_cookie == host_cookie ||
 	       task_in_extended_hostns();
 }
 

--- a/bpf/include/bpf/config/sock.h
+++ b/bpf/include/bpf/config/sock.h
@@ -14,3 +14,6 @@ DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 
 DECLARE_CONFIG(__u32, mke_host,
 	       "Cgroup class ID identifying MKE containers treated as host-networked")
+
+DECLARE_CONFIG(__u64, host_netns_cookie,
+	       "Cookie identifying the network namespace treated as the host namespace")

--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -15,16 +15,18 @@
 #define DST_PORT 6000
 #define DST_PORT_HOSTNS 6001
 #define BACKEND_PORT 7000
-
-/* Hardcode the host netns cookie to 0 */
-#define HOST_NETNS_COOKIE 0
+#define HOST_NETNS_COOKIE 42
 
 /* Replace the get_netns_cookie with a version that returns
- * the HOST_NETNS_COOKIE when destination is DST_PORT_HOSTNS
+ * the host_netns_cookie when destination is DST_PORT_HOSTNS
  */
 static __always_inline
 int my_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 {
+	/* ctx_in_hostns() may call this with NULL for its runtime-config fallback. */
+	if (!addr)
+		return HOST_NETNS_COOKIE;
+
 	return addr->user_port == DST_PORT_HOSTNS ? HOST_NETNS_COOKIE : 1;
 }
 
@@ -32,6 +34,8 @@ int my_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 
 #include "bpf_sock.c"
 #include "lib/common.h"
+
+ASSIGN_CONFIG(__u64, host_netns_cookie, HOST_NETNS_COOKIE)
 
 #define SVC_KEY_VALUE(_port, _proto, _beslot, _beid, _scope) { \
 	.key = { \

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -14,7 +14,7 @@
 #define BACKEND_PORT 7000
 #define NETNS_COOKIE 5000
 #define NETNS_COOKIE2 5001
-#define HOST_NETNS_COOKIE 0
+#define HOST_NETNS_COOKIE 42
 #define DST_PORT 6000
 #define V6_BACKEND1 v6_pod_one
 #define V6_SVC_ONE v6_node_one
@@ -28,7 +28,13 @@
 static __always_inline
 int test_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 {
-	struct bpf_sock *sk = addr->sk;
+	struct bpf_sock *sk;
+
+	/* ctx_in_hostns() may call this with NULL for its runtime-config fallback. */
+	if (!addr)
+		return HOST_NETNS_COOKIE;
+
+	sk = addr->sk;
 
 	if (!sk)
 		return 0;
@@ -45,6 +51,8 @@ int test_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
 #include "bpf_sock.c"
 
 ASSIGN_CONFIG(bool, enable_lrp, true)
+
+ASSIGN_CONFIG(__u64, host_netns_cookie, HOST_NETNS_COOKIE)
 
 #include "lib/common.h"
 #include "lib/ipcache.h"

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -16,8 +16,15 @@
 
 #define ENABLE_NODEPORT 1
 
-/* Hardcode the host netns cookie to 0 */
-#define HOST_NETNS_COOKIE 0
+#define HOST_NETNS_COOKIE 42
+
+static __always_inline
+__net_cookie test_get_netns_cookie(__maybe_unused void *ctx)
+{
+	return HOST_NETNS_COOKIE;
+}
+
+#define get_netns_cookie(ctx) test_get_netns_cookie(ctx)
 
 #include "bpf_sock.c"
 #include "lib/common.h"
@@ -26,6 +33,9 @@
 
 /* Set port ranges to have deterministic source port selection */
 #include "nodeport_defaults.h"
+
+/* Hardcode the host netns cookie to 42 */
+ASSIGN_CONFIG(__u64, host_netns_cookie, HOST_NETNS_COOKIE)
 
 enum {
 	NODEPORT_LOOKUP = 0,

--- a/pkg/datapath/config/sock_config.go
+++ b/pkg/datapath/config/sock_config.go
@@ -20,6 +20,8 @@ type BPFSock struct {
 	EnableLRP bool `config:"enable_lrp"`
 	// Enable routes when service has 0 endpoints.
 	EnableNoServiceEndpointsRoutable bool `config:"enable_no_service_endpoints_routable"`
+	// Cookie identifying the network namespace treated as the host namespace.
+	HostNetNSCookie uint64 `config:"host_netns_cookie"`
 	// Cgroup class ID identifying MKE containers treated as host-networked.
 	MKEHost uint32 `config:"mke_host"`
 	// Port number used for the overlay network.
@@ -31,5 +33,5 @@ type BPFSock struct {
 }
 
 func NewBPFSock(node Node) *BPFSock {
-	return &BPFSock{false, false, false, false, false, 0x0, 0x0, 0x0, node}
+	return &BPFSock{false, false, false, false, false, 0x0, 0x0, 0x0, 0x0, node}
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/vtep"
-	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -241,19 +240,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		}
 		if option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing {
 			cDefinesMap["TRACE_SOCK_NOTIFY"] = "1"
-		}
-
-		if cookie, err := netns.GetNetNSCookie(); err == nil {
-			// When running in nested environments (e.g. Kind), cilium-agent does
-			// not run in the host netns. So, in such cases the cookie comparison
-			// based on bpf_get_netns_cookie(NULL) for checking whether a socket
-			// belongs to a host netns does not work.
-			//
-			// To fix this, we derive the cookie of the netns in which cilium-agent
-			// runs via getsockopt(...SO_NETNS_COOKIE...) and then use it in the
-			// check above. This is based on an assumption that cilium-agent
-			// always runs with "hostNetwork: true".
-			cDefinesMap["HOST_NETNS_COOKIE"] = fmt.Sprintf("%d", cookie)
 		}
 	}
 

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/maps/registry"
+	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -100,6 +101,19 @@ func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 
 	if option.Config.EnableMKE && lnc.KPRConfig.KubeProxyReplacement {
 		cfg.MKEHost = option.HostExtensionMKE
+	}
+
+	if cookie, err := netns.GetNetNSCookie(); err == nil {
+		// When running in nested environments (e.g. Kind), cilium-agent does
+		// not run in the host netns. So, in such cases the cookie comparison
+		// based on bpf_get_netns_cookie(NULL) for checking whether a socket
+		// belongs to a host netns does not work.
+		//
+		// To fix this, we derive the cookie of the netns in which cilium-agent
+		// runs via getsockopt(...SO_NETNS_COOKIE...) and then use it in
+		// ctx_in_hostns(). This is based on an assumption that cilium-agent
+		// always runs with "hostNetwork: true".
+		cfg.HostNetNSCookie = cookie
 	}
 
 	coll, commit, cleanup, err := collLoader.Load(ctx, logger, spec, &bpf.CollectionOptions{


### PR DESCRIPTION
Declare the host network namespace cookie as socket-specific runtime configuration and populate it when loading the socket LB programs.

Use the configured cookie when determining whether a socket belongs to the host namespace, while preserving the initial-network-namespace fallback when the cookie cannot be retrieved.

Related: https://github.com/cilium/cilium/issues/38370