### PR TITLE
bpf: fix ICMP reply generation failure handling to preserve drop notification and metrics

### DIFF
--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -39,8 +39,11 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	/* Trim down to sample size (IPv4 header + 8 bytes datagram) */
-	if (full_len < sizeof(struct ethhdr))
+	if (ipv4_hdrlen(ip4) < sizeof(struct iphdr) ||
+	    (void *)ip4 + ipv4_hdrlen(ip4) > data_end)
+		return DROP_INVALID;
+
+	if (full_len < sizeof(struct ethhdr) + ipv4_hdrlen(ip4))
 		return DROP_INVALID;
 
 	sample_len = ipv4_hdrlen(ip4) + ICMP_PACKET_MAX_SAMPLE_SIZE;
@@ -50,34 +53,35 @@ int generate_icmp4_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		sample_len = full_len - sizeof(struct ethhdr);
 	}
 
-	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
-
-	data = ctx_data(ctx);
-	data_end = ctx_data_end(ctx);
-
-	/* Calculate the checksum of the ICMP sample */
-	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, (int)sample_len);
-
-	/* We need to insert a IPv4 and ICMP header before the original packet.
-	 * Make that room.
+	/* Adjust headroom first. If headroom extension fails (e.g. alloc failure),
+	 * ctx remains untouched so drop notifications and metrics remain valid.
 	 */
-
 	ret = ctx_adjust_hroom(ctx, sizeof(*ip4) + sizeof(*icmphdr),
 			       BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET);
 	if (ret < 0)
 		return DROP_INVALID;
 
-	/* changing size invalidates pointers, so we need to re-fetch them. */
+	/* Adjust tailroom to sample size if packet needs trimming. */
+	if (new_len < full_len) {
+		ret = ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
+		if (ret < 0)
+			return DROP_INVALID;
+	}
+
+	/* Changing size invalidates pointers, so we re-fetch them once. */
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 
-	/* Bound check all headers at once. */
+	/* Bound check all headers and sample payload for the BPF verifier. */
 	ethhdr = data;
 	ip4 = (void *)ethhdr + sizeof(*ethhdr);
 	icmphdr = (void *)ip4 + sizeof(*ip4);
 	inner_ip4 = (void *)icmphdr + sizeof(*icmphdr);
-	if ((void *)inner_ip4 + sizeof(*inner_ip4) > data_end)
+	if ((void *)inner_ip4 + sample_len > data_end)
 		return DROP_INVALID;
+
+	/* Calculate the checksum of the ICMP sample */
+	csum = icmp_wsum_accumulate((void *)inner_ip4, data_end, (int)sample_len);
 
 	/* Write reversed eth header, ready for egress */
 	eth_flip_addrs(ethhdr);

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -606,8 +606,11 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 	int i;
 	int ret;
 
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
 	/* Trim down to sample size */
-	if (full_len < sizeof(struct ethhdr))
+	if (full_len < sizeof(struct ethhdr) + sizeof(struct ipv6hdr))
 		return DROP_INVALID;
 
 	sample_len = ICMPV6_PACKET_MAX_SAMPLE_SIZE;
@@ -617,34 +620,35 @@ int generate_icmp6_reply(struct __ctx_buff *ctx, __u8 icmp_type, __u8 icmp_code,
 		sample_len = full_len - sizeof(struct ethhdr);
 	}
 
-	ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
-
-	data = ctx_data(ctx);
-	data_end = ctx_data_end(ctx);
-
-	/* Calculate the unfolded checksum of the ICMPv6 sample */
-	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, (int)sample_len);
-
-	/* We need to insert a IPv6 and ICMPv6 header before the original packet.
-	 * Make that room.
+	/* Adjust headroom first. If headroom extension fails (e.g. alloc failure),
+	 * ctx remains untouched so drop notifications and metrics remain valid.
 	 */
-
 	ret = ctx_adjust_hroom(ctx, sizeof(*ip6) + sizeof(*icmphdr),
 			       BPF_ADJ_ROOM_MAC, BPF_F_ADJ_ROOM_NO_CSUM_RESET);
 	if (ret < 0)
 		return DROP_INVALID;
 
-	/* changing size invalidates pointers, so we need to re-fetch them. */
+	/* Adjust tailroom to sample size if packet needs trimming. */
+	if (new_len < full_len) {
+		ret = ctx_adjust_troom(ctx, (__s32)(new_len - full_len));
+		if (ret < 0)
+			return DROP_INVALID;
+	}
+
+	/* Changing size invalidates pointers, so we re-fetch them once. */
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 
-	/* Bound check all headers at once. */
+	/* Bound check all headers and sample payload for the BPF verifier. */
 	ethhdr = data;
 	ip6 = (void *)ethhdr + sizeof(*ethhdr);
 	icmphdr = (void *)ip6 + sizeof(*ip6);
 	inner_ip6 = (void *)icmphdr + sizeof(*icmphdr);
-	if ((void *)inner_ip6 + sizeof(*inner_ip6) > data_end)
+	if ((void *)inner_ip6 + sample_len > data_end)
 		return DROP_INVALID;
+
+	/* Calculate the unfolded checksum of the ICMPv6 sample */
+	csum = icmp_wsum_accumulate((void *)inner_ip6, data_end, (int)sample_len);
 
 	/* Write reversed eth header, ready for egress */
 	eth_flip_addrs(ethhdr);


### PR DESCRIPTION
### Problem
When `generate_icmp4_reply()` or `generate_icmp6_reply()` fails (due to malformed/short headers, headroom allocation failure, or bounds check failure), `ctx` was being mutated before validation was complete.

The caller falls through to `send_drop_notify_error()`, which then reads from the mutated/truncated `ctx`, resulting in:
- Inaccurate `drop_bytes_total` metrics (since `ctx_full_len(ctx)` returns the modified buffer size).
- Corrupted packet payloads in drop notification perf events sent to Hubble and monitor.

Additionally, `generate_icmp6_reply()` lacked early `revalidate_data` header checking before buffer modifications.

### Solution
1. **Upfront Validation**: Perform complete input header validation (`revalidate_data`, `ipv4_hdrlen`, minimum frame length) **before** calling any buffer room adjustment helpers. If validation fails, exit with `DROP_INVALID` leaving `ctx` 100% untouched.
2. **Headroom First**: Expand headroom (`ctx_adjust_hroom`) first. If memory allocation fails, no buffer modifications have occurred.
3. **Guarded Tailroom**: Only invoke `ctx_adjust_troom` when `new_len < full_len`.
4. **Verifier Bounds Safety**: Check `(void *)inner_ip4 + sample_len > data_end` (and `inner_ip6 + sample_len`) after room adjustment to guarantee bounds safety for `icmp_wsum_accumulate` and avoid out-of-bounds verifier rejections.
5. **No Pseudo-Rollbacks**: Avoid calling non-transactional helper rollbacks after a helper failure, keeping verifier instruction count and state complexity low.

Fixes: #48486

### Testing
- Validated upfront header checks and sample bounds checks.
- Verified clean C structure and verifier safety across IPv4 and IPv6 datapath paths.

```release-note
Fix ICMP reply generation to preserve drop notification and metrics on failure.
```
