### PR TITLE
fix(route-manager): always set the initial route status to Done

### DIFF
--- a/pkg/datapath/linux/route/reconciler/manager.go
+++ b/pkg/datapath/linux/route/reconciler/manager.go
@@ -4,6 +4,7 @@
 package reconciler
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"slices"
@@ -146,9 +147,8 @@ func (m *DesiredRouteManager) UpsertRoute(route DesiredRoute) error {
 	// By default, any new route we add is not selected and does not have to be reconciled.
 	// The [selectRoutes] method will select the best route for each prefix+table.
 	route.selected = false
-	route.SetStatus(reconciler.StatusDone())
 
-	if _, _, err := m.tbl.Insert(txn, &route); err != nil {
+	if _, _, err := m.tbl.Insert(txn, route.WithStatus(reconciler.StatusDone())); err != nil {
 		return err
 	}
 
@@ -233,17 +233,10 @@ func (m *DesiredRouteManager) selectRoutes(txn statedb.WriteTxn, key DesiredRout
 	// Sort routes by admin distance and name, so that the first one is the
 	// one that is selected.
 	slices.SortStableFunc(routes, func(a, b *DesiredRoute) int {
-		adminDiff := int(a.AdminDistance) - int(b.AdminDistance)
-		if adminDiff == 0 {
-			if a.Owner.name < b.Owner.name {
-				return -1
-			}
-			if a.Owner.name > b.Owner.name {
-				return 1
-			}
-		}
-
-		return adminDiff
+		return cmp.Or(
+			cmp.Compare(a.AdminDistance, b.AdminDistance),
+			cmp.Compare(a.Owner.name, b.Owner.name),
+		)
 	})
 
 	// Mark first route as selected, and all others as not selected.
@@ -253,7 +246,7 @@ func (m *DesiredRouteManager) selectRoutes(txn statedb.WriteTxn, key DesiredRout
 			continue
 		}
 
-		changed := route.SetStatus(reconciler.StatusPending())
+		changed := route.WithStatus(reconciler.StatusPending())
 		changed.selected = selected
 		if _, _, err := m.tbl.Insert(txn, changed); err != nil {
 			return err

--- a/pkg/datapath/linux/route/reconciler/managet_test.go
+++ b/pkg/datapath/linux/route/reconciler/managet_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertRoute(t *testing.T) {
+	db := statedb.New()
+	tbl, err := newDesiredRouteTable(db)
+	require.NoError(t, err)
+	manager := newDesiredRouteManager(db, tbl, nil)
+
+	defaultPriority := uint32(1)
+	defaultPrefix := netip.MustParsePrefix("10.0.0.1/32")
+	newDesiredRouteWithOwner := func(owner *RouteOwner) DesiredRoute {
+		return DesiredRoute{
+			Owner:         owner,
+			Prefix:        defaultPrefix,
+			AdminDistance: AdminDistanceDefault,
+			Table:         TableMain,
+			Priority:      defaultPriority,
+		}
+	}
+
+	assertRoute := func(key DesiredRouteKey, selected bool, statusKind reconciler.StatusKind) {
+		t.Helper()
+		stored, _, found := tbl.Get(db.ReadTxn(), DesiredRouteIndex.Query(key))
+		require.True(t, found)
+		require.Equal(t, selected, stored.selected)
+		require.Equal(t, statusKind, stored.GetStatus().Kind)
+		require.Equal(t, AdminDistanceDefault, stored.AdminDistance)
+		require.Equal(t, TableMain, stored.Table)
+		require.Equal(t, defaultPriority, stored.Priority)
+		require.Equal(t, defaultPrefix, stored.Prefix)
+	}
+
+	// We create 3 owners, and they will all try to insert the same route.
+	// We want to test the selection logic and the status updates of the routes.
+	owner1, err := manager.RegisterOwner("owner1")
+	require.NoError(t, err)
+	owner2, err := manager.RegisterOwner("owner2")
+	require.NoError(t, err)
+	owner3, err := manager.RegisterOwner("owner3")
+	require.NoError(t, err)
+
+	// Insert a route with owner2 first.
+	owner2Route := newDesiredRouteWithOwner(owner2)
+	require.NoError(t, manager.UpsertRoute(owner2Route))
+	// After the upsert the route should be selected and be in pending state waiting for reconciliation.
+	assertRoute(owner2Route.GetFullKey(), true, reconciler.StatusKindPending)
+
+	// Now we insert a route with owner1.
+	owner1Route := newDesiredRouteWithOwner(owner1)
+	require.NoError(t, manager.UpsertRoute(owner1Route))
+	// After the upsert the route with owner1 should be selected because owner1 comes first in lexicographical order.
+	assertRoute(owner1Route.GetFullKey(), true, reconciler.StatusKindPending)
+	assertRoute(owner2Route.GetFullKey(), false, reconciler.StatusKindPending)
+
+	// Now we insert a route with owner3.
+	owner3Route := newDesiredRouteWithOwner(owner3)
+	require.NoError(t, manager.UpsertRoute(owner3Route))
+
+	// The other 2 routes should remain untouched
+	assertRoute(owner1Route.GetFullKey(), true, reconciler.StatusKindPending)
+	assertRoute(owner2Route.GetFullKey(), false, reconciler.StatusKindPending)
+	// After the upsert the route with owner3 should not be selected because owner1 comes first in lexicographical order.
+	// And the status should be Done since its not selected.
+	assertRoute(owner3Route.GetFullKey(), false, reconciler.StatusKindDone)
+}

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -45,7 +45,7 @@ func registerReconciler(
 		params,
 		tbl,
 		(*DesiredRoute).Clone,
-		(*DesiredRoute).SetStatus,
+		(*DesiredRoute).WithStatus,
 		(*DesiredRoute).GetStatus,
 		ops,
 		ops,

--- a/pkg/datapath/linux/route/reconciler/refresher.go
+++ b/pkg/datapath/linux/route/reconciler/refresher.go
@@ -71,7 +71,7 @@ func desiredRouteRefresher(
 							continue
 						}
 
-						desiredRoutes.Insert(txn, desiredRoute.SetStatus(reconciler.StatusRefreshing()))
+						desiredRoutes.Insert(txn, desiredRoute.WithStatus(reconciler.StatusRefreshing()))
 					}
 				}
 
@@ -85,7 +85,7 @@ func desiredRouteRefresher(
 					// that were using this device.
 					for dr := range desiredRoutes.All(txn) {
 						if dr.Device != nil && int(dr.Device.Index) == deviceChange.Object.Index {
-							desiredRoutes.Insert(txn, dr.SetStatus(reconciler.StatusRefreshing()))
+							desiredRoutes.Insert(txn, dr.WithStatus(reconciler.StatusRefreshing()))
 						}
 					}
 				}

--- a/pkg/datapath/linux/route/reconciler/table.go
+++ b/pkg/datapath/linux/route/reconciler/table.go
@@ -268,7 +268,7 @@ func (dr *DesiredRoute) GetStatus() reconciler.Status {
 	return dr.status
 }
 
-func (dr *DesiredRoute) SetStatus(s reconciler.Status) *DesiredRoute {
+func (dr *DesiredRoute) WithStatus(s reconciler.Status) *DesiredRoute {
 	ndr := dr.Clone()
 	ndr.status = s
 	return ndr


### PR DESCRIPTION
If we don't set the status of the route, it'll appear as `""` in the table output (e.g. cilium shell -- db/show desired-routes) which might be confusing. The status will be updated to `Pending` only if `selectRoutes` selects the
route to be reconciled.
I added a test to assert the logic

This PR was prepared with AIL:0
