### PR TITLE
Revert 48265 - disable local accounts on AKS clusters

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -74,8 +74,7 @@ runs:
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
-          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }} \
-          --disable-local-accounts
+          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
 
     - name: Get cluster credentials
       shell: bash


### PR DESCRIPTION
[Conformance AKS (ci-aks)](https://github.com/cilium/cilium/actions/runs/34069437791), [Conformance KPR AKS (ci-kpr-aks)](https://github.com/cilium/cilium/actions/runs/34081597411) and [Conformance IPsec (ci-ipsec)](https://github.com/cilium/cilium/actions/runs/34082273071) are currently broken, caused by https://github.com/cilium/cilium/pull/48265, more specifically https://github.com/cilium/cilium/commit/4ee9cba37b52a2cfa71980606a82586a8982eb82
