### PR TITLE
Revert 48441 - disable local accounts on AKS clusters

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -74,8 +74,7 @@ runs:
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
-          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }} \
-          --disable-local-accounts
+          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
 
     - name: Get cluster credentials
       shell: bash


### PR DESCRIPTION
[Conformance AKS (ci-aks)](https://github.com/cilium/cilium/actions/runs/34093143722), [Conformance KPR AKS (ci-kpr-aks)](https://github.com/cilium/cilium/actions/runs/34072096667) and [Conformance IPsec (ci-ipsec)](https://github.com/cilium/cilium/actions/runs/34072093665) are currently broken, caused by https://github.com/cilium/cilium/pull/48441, more specifically https://github.com/cilium/cilium/commit/b581ca3a5cf0633661eec09e327af62640c27792
