### PR TITLE
Revert 48442 - disable local accounts on AKS clusters

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -65,6 +65,5 @@ runs:
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
-          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }} \
-          --disable-local-accounts
+          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
 


### PR DESCRIPTION
[Conformance AKS (ci-aks)](https://github.com/cilium/cilium/actions/runs/34087337895) is currently broken, caused by https://github.com/cilium/cilium/pull/48442, more specifically https://github.com/cilium/cilium/commit/120e44d936b324b59ae48120a0b89c1667cbbd2c
