### PR TITLE
Revert 48443 - disable local accounts on AKS clusters

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -261,8 +261,7 @@ jobs:
             --node-count 2 \
             --ip-families ipv4,ipv6 \
             ${{ env.cost_reduction }} \
-            --generate-ssh-keys \
-            --disable-local-accounts
+            --generate-ssh-keys
 
       - name: Get cluster credentials
         run: |


### PR DESCRIPTION
Conformance AKS (ci-aks) is broken on main, v1.20 and v1.19 by the same change, caused here by https://github.com/cilium/cilium/pull/48443, more specifically https://github.com/cilium/cilium/commit/bb60bf3bb370034a69706ee8b4fa8e6a881c0f04
