### PR TITLE
policy: synthesize defaults for always-enforced endpoints

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -392,9 +392,97 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 	return calculatedPolicy, nil
 }
 
-// computePolicyEnforcementAndRules returns whether policy applies at ingress or ingress
-// for the given security identity, as well as a sorted list of any rules which select
-// the set of labels of the given security identity.
+// policyDirectionSpec describes the policy defaults for one traffic direction.
+//
+// The enforcement state is derived from the rules and policy mode, while this specification
+// contains the direction-specific policy semantics. Keeping the two separate makes it possible
+// to synthesize rules from effective enforcement state, even when there are no explicit rules.
+type policyDirectionSpec struct {
+	ingress        bool
+	allowLocalhost bool
+	allowAllLabels labels.LabelArray
+	denyAllLabels  labels.LabelArray
+}
+
+// policyDirection is the effective policy state for one traffic direction.
+type policyDirection struct {
+	spec        policyDirectionSpec
+	rules       ruleSlice
+	enabled     bool
+	defaultDeny bool
+	passVerdict bool
+}
+
+func newPolicyDirection(spec policyDirectionSpec) policyDirection {
+	return policyDirection{
+		spec:  spec,
+		rules: ruleSlice{},
+	}
+}
+
+func (d *policyDirection) addRule(r *rule) {
+	d.enabled = true
+	d.defaultDeny = d.defaultDeny || r.DefaultDeny
+	d.passVerdict = d.passVerdict || r.Verdict == types.Pass
+	d.rules = append(d.rules, r)
+}
+
+func (d *policyDirection) enableDefaultDeny() {
+	d.enabled = true
+	d.defaultDeny = true
+}
+
+func (d *policyDirection) synthesizeDefaultRules(logger *slog.Logger, subject *identity.Identity) {
+	if !d.enabled {
+		return
+	}
+
+	if d.defaultDeny {
+		if d.spec.allowLocalhost && option.Config.AlwaysAllowLocalhost() && subject.ID != identity.ReservedIdentityHost {
+			d.addDefaultRule(subject, types.HostSelectors, LabelsLocalHostIngress, types.Allow)
+			logger.Debug("Localhost allowed for k8s, synthesizing ingress host-allow rule",
+				logfields.Identity, subject,
+			)
+		}
+		if d.passVerdict {
+			d.addDefaultRule(subject, types.WildcardSelectors, d.spec.denyAllLabels, types.Deny)
+			logger.Debug("Only default-deny policies, synthesizing wildcard-deny rule",
+				logfields.Identity, subject,
+			)
+		}
+		return
+	}
+
+	d.addDefaultRule(subject, types.WildcardSelectors, d.spec.allowAllLabels, types.Allow)
+	logger.Debug("Only default-allow policies, synthesizing wildcard-allow rule",
+		logfields.Identity, subject,
+	)
+}
+
+func (d *policyDirection) addDefaultRule(subject *identity.Identity, peers types.Selectors, lbls labels.LabelArray, verdict types.Verdict) {
+	var priority float64
+	if len(d.rules) > 0 {
+		lastRule := d.rules[len(d.rules)-1]
+		if lastRule.Tier == types.DefaultPolicy {
+			priority = lastRule.Priority + 1
+		}
+	}
+
+	d.rules = append(d.rules, &rule{
+		PolicyEntry: types.PolicyEntry{
+			Tier:     types.DefaultPolicy,
+			Priority: priority,
+			Verdict:  verdict,
+			Ingress:  d.spec.ingress,
+			Subject:  types.NewLabelSelectorFromLabels(subject.LabelArray...),
+			L3:       peers,
+			Labels:   lbls,
+		},
+	})
+}
+
+// computePolicyEnforcementAndRules returns whether policy applies at ingress or egress
+// for the given security identity, as well as sorted rules which select the identity.
 //
 // Must be called with repo mutex held for reading.
 func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity.Identity) (
@@ -417,30 +505,24 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 		return false, false, false, false, nil, nil
 	}
 
-	rulesIngress = []*rule{}
-	rulesEgress = []*rule{}
-
-	var hasIngressPassVerdict, hasEgressPassVerdict bool
+	ingress := newPolicyDirection(policyDirectionSpec{
+		ingress:        true,
+		allowLocalhost: true,
+		allowAllLabels: LabelsAllowAnyIngress,
+		denyAllLabels:  LabelsDenyAnyIngress,
+	})
+	egress := newPolicyDirection(policyDirectionSpec{
+		allowAllLabels: LabelsAllowAnyEgress,
+		denyAllLabels:  LabelsDenyAnyEgress,
+	})
 
 	processKey := func(rKey ruleKey) {
 		r := p.rules[rKey]
 		if r.matchesSubject(securityIdentity) {
 			if r.Ingress {
-				if r.DefaultDeny {
-					hasIngressDefaultDeny = true
-				}
-				if r.Verdict == types.Pass {
-					hasIngressPassVerdict = true
-				}
-				rulesIngress = append(rulesIngress, r)
+				ingress.addRule(r)
 			} else {
-				if r.DefaultDeny {
-					hasEgressDefaultDeny = true
-				}
-				if r.Verdict == types.Pass {
-					hasEgressPassVerdict = true
-				}
-				rulesEgress = append(rulesEgress, r)
+				egress.addRule(r)
 			}
 		}
 	}
@@ -459,13 +541,15 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 	// If no rules enable default-deny, then all traffic is allowed except that
 	// explicitly denied by a Deny rule.
 	//
-	// There are three possible cases _per direction_:
+	// There are three possible cases for explicit rules _per direction_:
 	// 1: No rules are present,
 	// 2: At least one default-deny rule is present. Then, policy is enabled
 	// 3: Only non-default-deny rules are present. Then, policy is enabled, but we must
 	//    insert an additional allow-all rule. We must do this, even if all traffic is
 	//    allowed, because rules may have additional effects such as enabling L7 proxy.
 	//    The wildcard rule is inserted to the last tier and priority.
+	// The daemon policy mode may also enable a direction without any explicit rules. The effective
+	// direction state below is what determines which defaults must be synthesized.
 	namespace, _ := lbls.LookupLabel(&podNamespaceLabel)
 	if namespace != "" {
 		for rKey := range p.rulesByNamespace[namespace] {
@@ -474,88 +558,24 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 	}
 
 	// sort rules (in place) by priority
-	rulesIngress.sort()
-	rulesEgress.sort()
-
-	hasIngress = len(rulesIngress) > 0
-	hasEgress = len(rulesEgress) > 0
+	ingress.rules.sort()
+	egress.rules.sort()
 
 	// If policy enforcement is enabled for the daemon, then it has to be
 	// enabled for the endpoint.
 	// If the endpoint has the reserved:init label, i.e. if it has not yet
 	// received any labels, always enforce policy (default deny).
 	if policyMode == option.AlwaysEnforce || lbls.Has(labels.IDNameInit) {
-		hasIngress = true
-		hasEgress = true
-		hasIngressDefaultDeny = true
-		hasEgressDefaultDeny = true
+		ingress.enableDefaultDeny()
+		egress.enableDefaultDeny()
 	}
 
-	// Insert a wildcard rule if there are any ingress rules
-	if len(rulesIngress) > 0 {
-		if !hasIngressDefaultDeny {
-			rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyIngress, types.Allow)
-			p.logger.Debug("Only default-allow policies, synthesizing ingress wildcard-allow rule",
-				logfields.Identity, securityIdentity,
-			)
-		} else {
-			// insert localhost allow for k8s if the policy subject is not the host
-			if option.Config.AlwaysAllowLocalhost() && securityIdentity.ID != identity.ReservedIdentityHost {
-				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.HostSelectors, LabelsLocalHostIngress, types.Allow)
-				p.logger.Debug("Localhost allowed for k8s, synthesizing ingress host-allow rule",
-					logfields.Identity, securityIdentity,
-				)
-			}
-			if hasIngressPassVerdict {
-				// Explicit default deny is only needed for PASS verdict compatibility
-				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyIngress, types.Deny)
-				p.logger.Debug("Only default-deny policies, synthesizing ingress wildcard-deny rule",
-					logfields.Identity, securityIdentity,
-				)
-			}
-		}
-	}
+	ingress.synthesizeDefaultRules(p.logger, securityIdentity)
+	egress.synthesizeDefaultRules(p.logger, securityIdentity)
 
-	// Same for egress -- synthesize a wildcard rule
-	if len(rulesEgress) > 0 {
-		if !hasEgressDefaultDeny {
-			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyEgress, types.Allow)
-			p.logger.Debug("Only default-allow policies, synthesizing egress wildcard-allow rule",
-				logfields.Identity, securityIdentity,
-			)
-		} else if hasEgressPassVerdict {
-			// Explicit default deny is only needed for PASS verdict compatibility
-			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyEgress, types.Deny)
-			p.logger.Debug("Only default-deny policies, synthesizing egress wildcard-deny rule",
-				logfields.Identity, securityIdentity,
-			)
-		}
-	}
-
-	return
-}
-
-// addDefaultRule appends a default policy tier wildcard rule that only selects the given subject
-// identity.
-func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Selectors, lbls labels.LabelArray, verdict types.Verdict) ruleSlice {
-	var priority float64
-	lastRule := rules[len(rules)-1]
-	if lastRule.Tier == types.DefaultPolicy {
-		priority = lastRule.Priority + 1
-	}
-	ingress := lastRule.Ingress
-
-	return append(rules, &rule{
-		PolicyEntry: types.PolicyEntry{
-			Tier:     types.DefaultPolicy,
-			Priority: priority,
-			Verdict:  verdict,
-			Ingress:  ingress,
-			Subject:  types.NewLabelSelectorFromLabels(subject.LabelArray...),
-			L3:       peers,
-			Labels:   lbls,
-		},
-	})
+	return ingress.enabled, egress.enabled,
+		ingress.defaultDeny, egress.defaultDeny,
+		ingress.rules, egress.rules
 }
 
 // ComputeSelectorPolicy resolves the SelectorPolicy for the given identity at

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -247,6 +247,47 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 
 }
 
+func TestAlwaysEnforceLocalhost(t *testing.T) {
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	oldLocalhostOpt := option.Config.UnsafeDaemonConfigOption.AllowLocalhost
+	defer func() { option.Config.UnsafeDaemonConfigOption.AllowLocalhost = oldLocalhostOpt }()
+
+	SetPolicyEnabled(option.AlwaysEnforce)
+	option.Config.UnsafeDaemonConfigOption.AllowLocalhost = option.AllowLocalhostAlways
+
+	td := newTestData(t, hivetest.Logger(t))
+	repo := td.repo
+
+	fooSelectLabel := labels.ParseSelectLabel("foo")
+	fooNumericIdentity := 9001
+	fooIdentity := identity.NewIdentity(identity.NumericIdentity(fooNumericIdentity), labels.Labels{"foo": fooSelectLabel})
+	td.addIdentity(fooIdentity)
+
+	// In AlwaysEnforce mode with no rules added, computePolicyEnforcementAndRules should return hasIngress=true
+	// and synthesize the localhost allow rule.
+	ing, egr, _, _, matchingRulesI, matchingRulesE := repo.computePolicyEnforcementAndRules(fooIdentity)
+	require.True(t, ing, "ingress policy enforcement should apply under AlwaysEnforce")
+	require.True(t, egr, "egress policy enforcement should apply under AlwaysEnforce")
+	require.Len(t, matchingRulesI, 1, "should synthesize localhost allow rule for ingress")
+	require.Equal(t, LabelsLocalHostIngress, matchingRulesI[0].Labels)
+	require.Empty(t, matchingRulesE, "no egress rules synthesized")
+
+	// Resolve policy for fooIdentity and verify that localhost ingress policy is generated.
+	selPolicy, err := repo.ResolvePolicy(fooIdentity)
+	require.NoError(t, err)
+	require.NotNil(t, selPolicy)
+
+	sp := selPolicy.(*selectorPolicy)
+	l4Ingress := sp.L4Policy.Ingress
+	require.Equal(t, 1, l4Ingress.PortRules.Len(), "ingress policy should contain 1 rule for localhost allow")
+	require.Contains(t, l4Ingress.PortRules[types.DefaultPolicy].RangePortMap, portProtoKey{Port: 0, EndPort: 0, Proto: 0})
+	filter := l4Ingress.PortRules[types.DefaultPolicy].RangePortMap[portProtoKey{Port: 0, EndPort: 0, Proto: 0}]
+	require.NotNil(t, filter)
+	require.Contains(t, filter.PerSelectorPolicies, td.cachedSelectorHost, "should contain per-selector policy for host selector")
+}
+
 func TestWildcardL3RulesIngress(t *testing.T) {
 	td := newTestData(t, hivetest.Logger(t))
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a Fixes: #XXX line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a Fixes: <commit-id> tag, then
      please add the commit author[s] as reviewer[s] to this issue.
      Not applicable: this commit references an issue, not another commit.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

<!-- Description of change -->

When policy enforcement is set to always, an endpoint can be enforced in a direction without any explicit rules. Previously, synthesized policy rules were gated by the number of explicit rules, so the implicit localhost allowance was missing from the resolved ingress policy. This could cause kubelet probes from the host to be denied.

This change models effective enforcement state separately from explicit rules and synthesizes direction-specific defaults from that state. The regression test covers an always-enforced endpoint with no explicit policy rules and verifies that the localhost ingress rule is generated.

AI disclosure: This PR was prepared with generative AI assistance (AIL:4).

Fixes: #48444

```release-note
Fix kubelet probes when policy enforcement is always enabled
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request