### PR TITLE
renovate: point the builder Go caches at the shared /tmp

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,8 +136,14 @@
   // ignore the vendor directory. '-modcacherw' has to be repeated because this
   // replaces the value the manager sets itself.
   // See https://github.com/renovatebot/renovate/issues/21010
+  // builder.sh derives the Go caches from 'go env' and bind-mounts them, but
+  // mount-docker-socket means the runner's daemon resolves the mount, and only
+  // /tmp is shared with the Renovate container. Point them at /tmp so the
+  // builder container gets a directory it can write to.
   "customEnvVariables": {
-    "GOFLAGS": "-modcacherw -mod=mod"
+    "GOFLAGS": "-modcacherw -mod=mod",
+    "BUILDER_GOCACHE_DIR": "/tmp/.cache/go/.cache/go-build",
+    "BUILDER_GOMODCACHE_DIR": "/tmp/.cache/go/pkg"
   },
   "assignAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
Renovate runs postUpgradeTasks such as generate-apis through
contrib/scripts/builder.sh, which derives GOCACHE and GOMODCACHE from the go in
its own container and bind-mounts both into the builder image. With
mount-docker-socket the runner's daemon resolves those mounts while the action
shares only /tmp, so /home/ubuntu/.cache/go-build lands on the runner as root
and the builder container cannot write it: it runs under an uid whose primary
group stopped being root, so the script no longer takes its root path. The step
then dies mid-target: in run 34001974055 go-swagger's raw output was already
written and only the goimports pass that formats it was lost, so Renovate
committed 370 files that do not compile. update-cmdref goes the same way.

builder.sh already honours BUILDER_GOCACHE_DIR and BUILDER_GOMODCACHE_DIR and
the rest of CI points them at /tmp/.cache/go, so the same two values here are
enough. Renovate reads this file from the default branch for every base branch
it visits.

https://github.com/cilium/cilium/actions/runs/34001974055

This PR was prepared with AIL:3. I personally checked the diff.
