### PR TITLE
gateway-api: avoid logging missing GatewayClass as error

### DIFF
--- a/operator/pkg/gateway-api/helpers/gateway.go
+++ b/operator/pkg/gateway-api/helpers/gateway.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -31,6 +32,9 @@ func GatewayHasMatchingControllerFn(ctx context.Context, c client.Client, contro
 		gwc := &gatewayv1.GatewayClass{}
 		key := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
 		if err := c.Get(ctx, key, gwc); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false
+			}
 			scopedLog.ErrorContext(ctx, "Unable to get GatewayClass", logfields.Error, err)
 			return false
 		}

--- a/operator/pkg/gateway-api/watch-handlers/helpers.go
+++ b/operator/pkg/gateway-api/watch-handlers/helpers.go
@@ -33,6 +33,9 @@ func hasMatchingController(ctx context.Context, c client.Client, controllerName 
 		gwc := &gatewayv1.GatewayClass{}
 		key := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
 		if err := c.Get(ctx, key, gwc); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false
+			}
 			scopedLog.ErrorContext(ctx, "Unable to get GatewayClass", logfields.Error, err)
 			return false
 		}


### PR DESCRIPTION
Gateway predicates and watch handlers can observe Gateways whose referenced GatewayClass does not exist. Return false without logging for that case, since the invalid reference should be reported through Gateway status instead of operator error logs.

Keep error logging for other GatewayClass lookup failures so API, RBAC, or client errors remain visible.