### PR TITLE
k8s: fall back to websocket when spdy port forward fails

### DIFF
--- a/pkg/k8s/portforward/portforward.go
+++ b/pkg/k8s/portforward/portforward.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -67,18 +69,39 @@ type PortForwardResult struct {
 	ForwardedPorts []ForwardedPort
 }
 
+// createDialer builds a dialer that tries WebSocket and falls back to SPDY,
+// since some proxies in front of the kube-apiserver do not support SPDY.
+func createDialer(config *rest.Config, url *url.URL) (httpstream.Dialer, error) {
+	dialerWebsocket, errWebsocket := portforward.NewSPDYOverWebsocketDialer(url, config)
+
+	roundTripper, upgrader, errSPDY := spdy.RoundTripperFor(config)
+	dialerSPDY := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, url)
+
+	if errSPDY != nil && errWebsocket == nil {
+		return dialerWebsocket, nil
+	}
+	if errWebsocket != nil && errSPDY == nil {
+		return dialerSPDY, nil
+	}
+	if errSPDY != nil && errWebsocket != nil {
+		return nil, fmt.Errorf("error while creating k8s dialer: (websocket) %w, (spdy) %w", errWebsocket, errSPDY)
+	}
+
+	return portforward.NewFallbackDialer(dialerSPDY, dialerWebsocket, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	}), nil
+}
+
 // PortForward executes in a goroutine a port forward command.
 // To stop the port-forwarding, use the context by cancelling it.
 func (pf *PortForwarder) PortForward(ctx context.Context, p PortForwardParameters) (*PortForwardResult, error) {
 	req := pf.clientset.CoreV1().RESTClient().Post().Namespace(p.Namespace).
 		Resource("pods").Name(p.Pod).SubResource(strings.ToLower("PortForward"))
 
-	roundTripper, upgrader, err := spdy.RoundTripperFor(pf.config)
+	dialer, err := createDialer(pf.config, req.URL())
 	if err != nil {
 		return nil, err
 	}
-
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
 	if len(p.Addresses) == 0 {
 		p.Addresses = []string{"localhost"}

--- a/pkg/k8s/portforward/portforward_test.go
+++ b/pkg/k8s/portforward/portforward_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package portforward
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestCreateDialer(t *testing.T) {
+	config := &rest.Config{Host: "https://localhost:6443"}
+	u, err := url.Parse("https://localhost:6443/api/v1/namespaces/default/pods/foo/portforward")
+	require.NoError(t, err)
+
+	dialer, err := createDialer(config, u)
+	require.NoError(t, err)
+	require.NotNil(t, dialer)
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read Submitting a pull request
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section Developer's Certificate of Origin
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

PortForward only tried SPDY, which many proxies in front of the kube-apiserver do not support since it was deprecated in 2015. This means `cilium hubble port-forward` and similar commands can fail with an upgrade error behind such a proxy.

This mirrors createDialer in cilium-cli/k8s/client.go, which already tries websocket and falls back to SPDY. Added a unit test for the new createDialer helper.

Fixes: cilium/cilium-cli#3258

```release-note
Fix port forwarding failing behind proxies that do not support SPDY by falling back to websocket.
```