### PR TITLE
gha: raise the Docker Hub OIDC token lifetime for release builds

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -79,6 +79,7 @@ jobs:
         if: ${{ env.PUSH_TO_DOCKER_HUB == 'true' }}
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+          DOCKERHUB_OIDC_EXPIREIN: 2700
         with:
           username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 


### PR DESCRIPTION
Without DOCKERHUB_OIDC_EXPIREIN the Docker Hub OIDC access token lives for the
default 300 seconds, and every release image but hubble-relay takes longer than
that to reach its push, so auth.docker.io rejects the expired token as "401
Unauthorized: incorrect username or password":
https://github.com/cilium/cilium/actions/runs/34142638221

Ask for 2700 seconds to match timeout-minutes.

This PR was prepared with AIL:2. I personally checked the login-action source at
dbcb813823bd, where the default is 300 and the maximum is 3600.
