### PR TITLE
bpf: fix pod to ClusterIP timeouts when kube-proxy-replacement=false

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -325,9 +325,13 @@ ct_entry_matches_types(const struct ct_entry *entry __maybe_unused,
 		return true;
 
 	/* Only match CT entries that were created for the expected service: */
-	if ((ct_entry_types & CT_ENTRY_SVC) &&
-	    entry->rev_nat_index == state->rev_nat_index)
-		return true;
+	if ((ct_entry_types & CT_ENTRY_SVC) && entry->rev_nat_index) {
+		if (!state || !state->rev_nat_index)
+			return true;
+
+		if (entry->rev_nat_index == state->rev_nat_index)
+			return true;
+	}
 
 #ifdef ENABLE_NODEPORT
 	if ((ct_entry_types & CT_ENTRY_NODEPORT) &&

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -966,7 +966,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, fraginfo,
 			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT, &ct_state, &monitor);
+			      CT_ENTRY_NODEPORT | CT_ENTRY_SVC, &ct_state, &monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;
@@ -2220,7 +2220,7 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
 			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT, &ct_state, &monitor);
+			      CT_ENTRY_NODEPORT | CT_ENTRY_SVC, &ct_state, &monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -215,7 +215,7 @@ skip_fib:
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, fraginfo,
 			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
+			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR | CT_ENTRY_SVC,
 			      NULL, &monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
@@ -536,7 +536,7 @@ skip_fib:
 	/* Cache is_fragment in advance, nodeport_fib_lookup_and_redirect may invalidate ip4. */
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, fraginfo,
 			      l4_off, CT_INGRESS, SCOPE_REVERSE,
-			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
+			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR | CT_ENTRY_SVC,
 			      &ct_state, &monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -235,6 +235,29 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		assert(rev_nat_index == 42);
 	});
 
+	TEST("ct_entry_matches_types", {
+		struct ct_entry entry = {};
+		struct ct_state state = {};
+
+		entry.rev_nat_index = 76;
+
+		/* Wildcard lookup (state = NULL or state->rev_nat_index = 0) with CT_ENTRY_SVC */
+		assert(ct_entry_matches_types(&entry, CT_ENTRY_SVC, NULL));
+		assert(ct_entry_matches_types(&entry, CT_ENTRY_SVC, &state));
+
+		/* Specific lookup with matching rev_nat_index */
+		state.rev_nat_index = 76;
+		assert(ct_entry_matches_types(&entry, CT_ENTRY_SVC, &state));
+
+		/* Specific lookup with non-matching rev_nat_index */
+		state.rev_nat_index = 99;
+		assert(!ct_entry_matches_types(&entry, CT_ENTRY_SVC, &state));
+
+		/* Combination mask CT_ENTRY_NODEPORT | CT_ENTRY_DSR | CT_ENTRY_SVC */
+		state.rev_nat_index = 0;
+		assert(ct_entry_matches_types(&entry, CT_ENTRY_NODEPORT | CT_ENTRY_DSR | CT_ENTRY_SVC, NULL));
+	});
+
 	test_finish();
 }
 


### PR DESCRIPTION
<!-- Fill in the sections below -->

### Description

Fixes intermittent TCP connection timeouts from pods to ClusterIP services (such as `kube-apiserver`) when running native routing with `kube-proxy-replacement=false` and `enable-bpf-masquerade=true`.

#### Root Cause
Pod traffic to an out-of-cluster ClusterIP backend creates a conntrack entry with `CT_ENTRY_SVC` (`entry->rev_nat_index = <id>`, `entry->node_port = 0`). When return packets arrive on `from-netdev`:
1. `nodeport_rev_dnat_ipv4/6` invoked `ct_lazy_lookup` using `CT_ENTRY_NODEPORT`, ignoring `CT_ENTRY_SVC`.
2. `ct_entry_matches_types()` in `bpf/lib/conntrack.h` required `entry->rev_nat_index == state->rev_nat_index` for `CT_ENTRY_SVC`, which failed wildcard lookups (`state->rev_nat_index == 0`).

As a result, RevDNAT did not restore the source IP from the backend IP to the ClusterIP, causing the pod's TCP stack to reject reply packets with intermittent timeouts.

#### Fix
1. Update `ct_entry_matches_types()` in `bpf/lib/conntrack.h` to allow wildcard matching for `CT_ENTRY_SVC` entries when `!state || !state->rev_nat_index`.
2. Include `CT_ENTRY_SVC` in Reverse DNAT lookup masks in `bpf/lib/nodeport.h` and `bpf/lib/nodeport_egress.h`.
3. Add a unit test in `bpf/tests/conntrack_test.c` asserting wildcard `CT_ENTRY_SVC` matching.

### Fixes
Fixes #48459

### How Has This Been Tested?

- [x] **eBPF Unit Tests**: Ran `go test -v ./bpf/tests/bpftest` with added `ct_entry_matches_types` test cases.
- [x] **Go Package Tests**: Ran `go test ./pkg/loadbalancer/...` and `go test ./pkg/datapath/...` (all PASSED).
- [x] **Verifier & Instruction Count**: Confirmed `ct_entry_matches_types` inlines with constant propagation (adds only 2 instructions on RevDNAT path, pruned elsewhere).

### Release Note

```release-note
Fix intermittent pod to ClusterIP timeouts on native-routing clusters when kube-proxy-replacement=false and enable-bpf-masquerade=true.
