### PR TITLE
Fix Component Overview doc link rendering

### DIFF
--- a/Documentation/overview/component-overview.rst
+++ b/Documentation/overview/component-overview.rst
@@ -41,7 +41,7 @@ Debug Client (CLI)
   .. note::
 
      The in-agent Cilium debug CLI client described here should not be confused
-     with the ```cilium`` command line tool for quick-installing, managing and
+     with the ``cilium`` `command line tool for quick-installing, managing and
      troubleshooting Cilium on Kubernetes clusters
      <https://github.com/cilium/cilium-cli>`_. That tool is typically installed
      remote from the cluster, and uses ``kubeconfig`` information to access


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

---

The link to the `cilium-cli` repo is broken in a note about the debug client in the 'Component Overview' documentation page, where monospace backtick quoting and link definition are colliding.

I fixed it by moving the monospace word out of the link title to solve the consecutive quotes issue.

Fix inspired by [this existing example](https://github.com/cilium/cilium/blob/main/Documentation/installation/k8s-install-rke.rst?plain=1#L60) of a similar case, where I presumed that the monospace word was left out of the link to solve this particular issue.

**Visual preview of the fix:**

Before ([source page](https://docs.cilium.io/en/latest/overview/component-overview/)):

<img width="1107" height="499" alt="image" src="https://github.com/user-attachments/assets/7c462572-8566-4b85-8e2e-1d07ce06d90c" />

After (dev build / [Netlify preview](https://deploy-preview-48537--docs-cilium-io.netlify.app/overview/component-overview)):

<img width="1107" height="499" alt="image" src="https://github.com/user-attachments/assets/5505732c-0495-475b-8760-04c5abeb01d0" />


_No AI was used for this PR._

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
