### PR TITLE
helm: Allow configuring IP families of the hubble-peer Service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2268,6 +2268,14 @@
      - The cluster domain to use to query the Hubble Peer service. It should be the local cluster.
      - string
      - ``"cluster.local"``
+   * - :spelling:ignore:`hubble.peerService.ipFamilies`
+     - IP families of the Peer service, for example ``[IPv6]``. Hubble Relay reaches the agents through this service, so its IP family must match the address family of the agents' node addresses. This is needed in dual-stack clusters where the agents announce IPv6 addresses but the cluster's primary IP family is IPv4. If unset, the Kubernetes default is used.
+     - list
+     - ``nil``
+   * - :spelling:ignore:`hubble.peerService.ipFamilyPolicy`
+     - IP family policy of the Peer service. If unset, the Kubernetes default is used.
+     - string
+     - ``nil``
    * - :spelling:ignore:`hubble.peerService.targetPort`
      - Target Port for the Peer service, must match the hubble.listenAddress' port.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -617,6 +617,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.tls.server.mtls.name | string | `nil` | Name of the ConfigMap containing the CA to validate client certificates against. If mTLS is enabled and this is unspecified, it will default to the same CA used for Hubble metrics server certificates. |
 | hubble.networkPolicyCorrelation | object | `{"enabled":true}` | Enables network policy correlation of Hubble flows, i.e. populating `egress_allowed_by`, `ingress_denied_by` fields with policy information. |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
+| hubble.peerService.ipFamilies | list | `nil` | IP families of the Peer service, for example `[IPv6]`. Hubble Relay reaches the agents through this service, so its IP family must match the address family of the agents' node addresses. This is needed in dual-stack clusters where the agents announce IPv6 addresses but the cluster's primary IP family is IPv4. If unset, the Kubernetes default is used. |
+| hubble.peerService.ipFamilyPolicy | string | `nil` | IP family policy of the Peer service. If unset, the Kubernetes default is used. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. Deprecated: use top-level preferIpv6 instead. |
 | hubble.redact | object | `{"enabled":false,"http":{"headers":{"allow":[],"deny":[]},"urlQuery":false,"userInfo":true}}` | Enables redacting sensitive information present in Layer 7 flows. |

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -30,4 +30,11 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.hubble.peerService.targetPort }}
   internalTrafficPolicy: Local
+  {{- if .Values.hubble.peerService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.hubble.peerService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.hubble.peerService.ipFamilies }}
+  ipFamilies:
+    {{- toYaml .Values.hubble.peerService.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3427,6 +3427,26 @@
             "clusterDomain": {
               "type": "string"
             },
+            "ipFamilies": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "ipFamilyPolicy": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "enum": [
+                    "SingleStack",
+                    "PreferDualStack",
+                    "RequireDualStack"
+                  ]
+                }
+              ]
+            },
             "targetPort": {
               "type": "integer"
             }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1689,6 +1689,24 @@ hubble:
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.
     clusterDomain: cluster.local
+    # @schema
+    # type: [null, array]
+    # @schema
+    # -- (list) IP families of the Peer service, for example `[IPv6]`. Hubble
+    # Relay reaches the agents through this service, so its IP family must match
+    # the address family of the agents' node addresses. This is needed in
+    # dual-stack clusters where the agents announce IPv6 addresses but the
+    # cluster's primary IP family is IPv4. If unset, the Kubernetes default is
+    # used.
+    ipFamilies: ~
+    # @schema
+    # anyOf:
+    # - type: [null]
+    # - enum: [SingleStack, PreferDualStack, RequireDualStack]
+    # @schema
+    # -- (string) IP family policy of the Peer service. If unset, the Kubernetes
+    # default is used.
+    ipFamilyPolicy: ~
   # -- TLS configuration for Hubble
   tls:
     # -- Enable mutual TLS for listenAddress. Setting this value to false is

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1706,6 +1706,24 @@ hubble:
     # -- The cluster domain to use to query the Hubble Peer service. It should
     # be the local cluster.
     clusterDomain: cluster.local
+    # @schema
+    # type: [null, array]
+    # @schema
+    # -- (list) IP families of the Peer service, for example `[IPv6]`. Hubble
+    # Relay reaches the agents through this service, so its IP family must match
+    # the address family of the agents' node addresses. This is needed in
+    # dual-stack clusters where the agents announce IPv6 addresses but the
+    # cluster's primary IP family is IPv4. If unset, the Kubernetes default is
+    # used.
+    ipFamilies: ~
+    # @schema
+    # anyOf:
+    # - type: [null]
+    # - enum: [SingleStack, PreferDualStack, RequireDualStack]
+    # @schema
+    # -- (string) IP family policy of the Peer service. If unset, the Kubernetes
+    # default is used.
+    ipFamilyPolicy: ~
   # -- TLS configuration for Hubble
   tls:
     # -- Enable mutual TLS for listenAddress. Setting this value to false is


### PR DESCRIPTION
## Problem

In dual-stack clusters whose primary IP family is IPv4 but whose nodes (and therefore the Cilium agents announced through Hubble) use IPv6 addresses, `hubble-relay` goes into `CrashLoopBackOff`: the `hubble-peer` Service is rendered without `ipFamilies`/`ipFamilyPolicy`, so Kubernetes allocates it a SingleStack IPv4 ClusterIP, and Relay cannot reach the agents through it. Editing the Service by hand to `ipFamilies: [IPv6]` fixes it, but the chart offers no way to set this, as reported in #42017.

## Root cause

`install/kubernetes/cilium/templates/hubble/peer-service.yaml:20-32`: the `spec:` block of the `hubble-peer` Service only renders `selector`, `ports` and `internalTrafficPolicy`. There are no values under `hubble.peerService` (`install/kubernetes/cilium/values.yaml.tmpl:1698-1708`) for the IP family of the Service, so it always falls back to the cluster default, regardless of which address family the agents use. `hubble-relay` connects to `hubble-peer.<ns>.svc.<clusterDomain>` (`templates/hubble-relay/configmap.yaml:24`), so a mismatch makes every peer connection fail.

## Fix

Following the direction given by the maintainer in #42017, add two optional values that default to unset, so the default render is unchanged:

```yaml
hubble:
  peerService:
    ipFamilies: ~       # e.g. [IPv6]
    ipFamilyPolicy: ~   # SingleStack | PreferDualStack | RequireDualStack
```

and render them in `templates/hubble/peer-service.yaml` when set. `values.yaml`, `values.schema.json`, the chart `README.md` and `Documentation/helm-values.rst` are regenerated with `make -C install/kubernetes` and `make -C Documentation update-helm-values`; the schema restricts `ipFamilyPolicy` to the three values Kubernetes accepts.

## How tested

The chart has no unit-test harness, so the change was checked by rendering the chart with `helm template` before and after, using a small script that extracts the `hubble-peer` Service and asserts on it.

Before:

```
case 1: ipFamilies=[IPv6], ipFamilyPolicy=SingleStack
  FAIL ipFamilyPolicy missing
  FAIL ipFamilies missing
case 2: ipFamilies=[IPv6,IPv4], ipFamilyPolicy=PreferDualStack
  FAIL ipFamilyPolicy missing
  FAIL ipFamilies missing
case 3: defaults
  PASS default render has no ipFamilies/ipFamilyPolicy
case 4: values.schema.json accepts the new values
  PASS lint
case 5: values.schema.json rejects a bad ipFamilyPolicy
  FAIL schema accepts ipFamilyPolicy=Bogus
RESULT: FAIL
```

After:

```
case 1: ipFamilies=[IPv6], ipFamilyPolicy=SingleStack
  PASS ipFamilyPolicy rendered
  PASS ipFamilies rendered
case 2: ipFamilies=[IPv6,IPv4], ipFamilyPolicy=PreferDualStack
  PASS ipFamilyPolicy rendered
  PASS both ipFamilies rendered
case 3: defaults
  PASS default render has no ipFamilies/ipFamilyPolicy
case 4: values.schema.json accepts the new values
  PASS lint
case 5: values.schema.json rejects a bad ipFamilyPolicy
  PASS schema rejects Bogus
RESULT: PASS
```

Rendered Service with `--set hubble.peerService.ipFamilies={IPv6} --set hubble.peerService.ipFamilyPolicy=SingleStack`:

```yaml
spec:
  selector:
    k8s-app: cilium
  ports:
  - name: peer-service
    port: 443
    protocol: TCP
    targetPort: 4244
  internalTrafficPolicy: Local
  ipFamilyPolicy: SingleStack
  ipFamilies:
    - IPv6
```

- `helm template` with default values produces the same output before and after (only the randomly generated TLS material differs).
- `make -C install/kubernetes` (check-values-yaml, schema, docs, lint) passes and leaves the tree clean.
- `make -C Documentation update-helm-values` regenerated `helm-values.rst` with the two new entries.

## Links

- Issue: https://github.com/cilium/cilium/issues/42017
- Kubernetes dual-stack Services: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services

Fixes: #42017

```release-note
helm: Add hubble.peerService.ipFamilies and hubble.peerService.ipFamilyPolicy to configure the IP families of the hubble-peer Service, so Hubble Relay can reach agents whose node addresses are IPv6 in a dual-stack cluster.
```

This PR was prepared with AIL:4: the code, generated files and test script were produced by an AI agent; a human reviewed the diff, re-ran the checks and takes responsibility for the change. This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
