### PR TITLE
docs: fix extra closing parenthesis in hive.rst

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -147,7 +147,7 @@ And then put the two together into a simple application:
      	 exampleHive.RegisterFlags(cmd.Flags())
 
          // Add the "hive" sub-command for inspecting the application. 
-         cmd.AddCommand(exampleHive.Command()))
+         cmd.AddCommand(exampleHive.Command())
 
          // Execute the root command.
          cmd.Execute()


### PR DESCRIPTION
This PR fixes the documentation issue in `hive.rst`:

1. **Duplicate closing parenthesis** – In the `main()` function example, `cmd.AddCommand(exampleHive.Command()))` had an extra `)` which would cause a syntax error if compiled. Fixed to `cmd.AddCommand(exampleHive.Command())`.

These changes improve documentation accuracy and readability for new contributors.

@maintainer-s-little-helper release-note/misc