### PR TITLE
cilium-cli: constrain obsolete service-related log exceptions

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -101,7 +101,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock, failedToRetrieveLock, leaderElectionReadTimeout,
-		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService, gobgpFailedCloseTCP,
+		failedToListCRDs, knownIssueWireguardCollision, gobgpFailedCloseTCP,
 		vendoredLeaderElectionLeaseLockError}
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
@@ -111,7 +111,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		legacyBGPFeature, etcdTimeout, unableRestoreRouterIP,
 		routerIPReallocated, cantFindIdentityInCache, keyAllocFailedFoundMaster,
 		cantRecreateMasterKey, cantUpdateCRDIdentity, cantDeleteFromPolicyMap, failedToListCRDs,
-		hubbleQueueFull, reflectPanic, svcNotFound, gobgpv3Warnings, gobgpNotification, gobgpNoMatchingWithdrawPath,
+		hubbleQueueFull, reflectPanic, gobgpv3Warnings, gobgpNotification, gobgpNoMatchingWithdrawPath,
 		gobgpReceivedNotification, gobgpFailedToSend,
 		endpointMapDeleteFailed, etcdReconnection, failedToRetrieveRemoteClusterCfg, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
@@ -134,6 +134,11 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 
 	if ciliumVersion.LT(semver.MustParse("1.19.0")) {
 		warningLogExceptions = append(warningLogExceptions, kvstoreNodesGCWarn, kvstoreNodesGCWarn2, kvstoreNodesGCWarn3)
+	}
+
+	if ciliumVersion.LT(semver.MustParse("1.21.0")) {
+		errorLogExceptions = append(errorLogExceptions, nilDetailsForService)
+		warningLogExceptions = append(warningLogExceptions, svcNotFound)
 	}
 
 	if ciliumVersion.LT(semver.MustParse("1.21.0")) {


### PR DESCRIPTION
Revive the bits from https://github.com/cilium/cilium/pull/40170 that are still relevant.

Instead of completely removing the log exclusions, simply constrain them to old versions that are not tested in the `main` branch CI. This will avoid silly regressions in CI on old branches - and the code will naturally fade out as we update the minimum version for the CLI over time.

Fixes: #35768