### PR TITLE
bpf: lxc: switch cilium_nodeport_nat_buffer to auxvar

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -101,12 +101,7 @@ struct nodeport_nat_info {
 	__be16 nat_port;
 };
 
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, __u32);
-	__type(value, struct nodeport_nat_info);
-	__uint(max_entries, 1);
-} cilium_nodeport_nat_buffer __section_maps_btf;
+DEFINE_AUX(struct nodeport_nat_info, nodeport_nat_info);
 
 #ifdef ENABLE_IPV4
 /* lb4_ctx_restore_state() restores per packet load balancing state from the
@@ -179,27 +174,26 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 	svc = lb4_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 
 #if defined(ENABLE_NODEPORT)
-	if (!svc) {
-		struct ipv4_ct_tuple tmp = tuple;
+	{
+		struct nodeport_nat_info *nat_info = AUX(nodeport_nat_info);
 
-		/* look up with SCOPE_FORWARD: */
-		__ipv4_ct_tuple_reverse(&tmp);
+		if (!svc) {
+			struct ipv4_ct_tuple tmp = tuple;
 
-		/* If a CT_EGRESS entry exists, it indicates the connection was
-		 * established via the legacy path. Preserve this behavior (skip
-		 * wildcard lookup) to maintain consistency for existing flows.
-		 * Wildcard lookup is applied only for new connections.
-		 */
-		if (!ct_has_egress_entry4(get_ct_map4(&tmp), &tmp)) {
-			svc = lb4_lookup_wildcard_service(&key);
-			if (svc) {
-				struct nodeport_nat_info nat_info = {};
-				__u32 zero = 0;
+			/* look up with SCOPE_FORWARD: */
+			__ipv4_ct_tuple_reverse(&tmp);
 
-				nat_info.nat_addr.p4 = tuple.daddr;
-				nat_info.nat_port = tuple.sport;
-				map_update_elem(&cilium_nodeport_nat_buffer,
-						&zero, &nat_info, 0);
+			/* If a CT_EGRESS entry exists, it indicates the connection was
+			 * established via the legacy path. Preserve this behavior (skip
+			 * wildcard lookup) to maintain consistency for existing flows.
+			 * Wildcard lookup is applied only for new connections.
+			 */
+			if (!ct_has_egress_entry4(get_ct_map4(&tmp), &tmp)) {
+				svc = lb4_lookup_wildcard_service(&key);
+				if (svc) {
+					nat_info->nat_addr.p4 = tuple.daddr;
+					nat_info->nat_port = tuple.sport;
+				}
 			}
 		}
 	}
@@ -357,27 +351,26 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 	svc = lb6_lookup_service(&key, is_defined(ENABLE_NODEPORT));
 
 #if defined(ENABLE_NODEPORT)
-	if (!svc) {
-		struct ipv6_ct_tuple tmp = tuple;
+	{
+		struct nodeport_nat_info *nat_info = AUX(nodeport_nat_info);
 
-		/* look up with SCOPE_FORWARD: */
-		__ipv6_ct_tuple_reverse(&tmp);
+		if (!svc) {
+			struct ipv6_ct_tuple tmp = tuple;
 
-		/* If a CT_EGRESS entry exists, it indicates the connection was
-		 * established via the legacy path. Preserve this behavior (skip
-		 * wildcard lookup) to maintain consistency for existing flows.
-		 * Wildcard lookup is applied only for new connections.
-		 */
-		if (!ct_has_egress_entry6(get_ct_map6(&tmp), &tmp)) {
-			svc = lb6_lookup_wildcard_service(&key);
-			if (svc) {
-				struct nodeport_nat_info nat_info = {};
-				__u32 zero = 0;
+			/* look up with SCOPE_FORWARD: */
+			__ipv6_ct_tuple_reverse(&tmp);
 
-				ipv6_addr_copy(&nat_info.nat_addr, &tuple.daddr);
-				nat_info.nat_port = tuple.sport;
-				map_update_elem(&cilium_nodeport_nat_buffer,
-						&zero, &nat_info, 0);
+			/* If a CT_EGRESS entry exists, it indicates the connection was
+			 * established via the legacy path. Preserve this behavior (skip
+			 * wildcard lookup) to maintain consistency for existing flows.
+			 * Wildcard lookup is applied only for new connections.
+			 */
+			if (!ct_has_egress_entry6(get_ct_map6(&tmp), &tmp)) {
+				svc = lb6_lookup_wildcard_service(&key);
+				if (svc) {
+					ipv6_addr_copy(&nat_info->nat_addr, &tuple.daddr);
+					nat_info->nat_port = tuple.sport;
+				}
 			}
 		}
 	}
@@ -824,9 +817,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	struct nodeport_nat_info *nat_info __maybe_unused;
 	bool __maybe_unused skip_tunnel = false;
-	__u32 __maybe_unused zero = 0;
 	bool hairpin_flow = false;
 	enum ct_status ct_status;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
@@ -872,13 +863,11 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	hairpin_flow = ct_state_new.loopback;
 
 #if defined(ENABLE_NODEPORT)
-	nat_info = map_lookup_elem(&cilium_nodeport_nat_buffer, &zero);
-	if (nat_info) {
+	{
+		struct nodeport_nat_info *nat_info = AUX_REUSE(nodeport_nat_info);
+
 		ipv6_addr_copy(&ct_state_new.nat_addr, &nat_info->nat_addr);
 		ct_state_new.nat_port = nat_info->nat_port;
-
-		memset(&nat_info->nat_addr, 0, sizeof(nat_info->nat_addr));
-		nat_info->nat_port = 0;
 	}
 #endif /* ENABLE_NODEPORT */
 #endif /* ENABLE_PER_PACKET_LB */
@@ -1387,7 +1376,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	struct nodeport_nat_info *nat_info __maybe_unused;
 	bool __maybe_unused skip_tunnel = false;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
 	__u8 policy_match_type = POLICY_MATCH_NONE;
@@ -1400,7 +1388,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	bool from_l7lb = false;
 	__u32 cluster_id = 0;
 	void *ct_map, *ct_related_map = NULL;
-	__u32 __maybe_unused zero = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -1411,13 +1398,11 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	hairpin_flow = ct_state_new.loopback;
 
 #if defined(ENABLE_NODEPORT)
-	nat_info = map_lookup_elem(&cilium_nodeport_nat_buffer, &zero);
-	if (nat_info) {
+	{
+		struct nodeport_nat_info *nat_info = AUX_REUSE(nodeport_nat_info);
+
 		ipv6_addr_copy(&ct_state_new.nat_addr, &nat_info->nat_addr);
 		ct_state_new.nat_port = nat_info->nat_port;
-
-		memset(&nat_info->nat_addr, 0, sizeof(nat_info->nat_addr));
-		nat_info->nat_port = 0;
 	}
 #endif /* ENABLE_NODEPORT */
 #endif /* ENABLE_PER_PACKET_LB */


### PR DESCRIPTION
In combination with https://github.com/cilium/cilium/pull/48300 this also automatically clears the NAT state when we first populate it.

Slightly switch around the access pattern, so that the SVC lookup always re-initializes this NAT state. And the consumer doesn't have to clear it after usage.