### PR TITLE
gha/conformance-aks: add a timeout to the cluster create step

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -333,6 +333,7 @@ jobs:
           creds: ${{ secrets.AZURE_PR_SP_CREDS }}
 
       - name: Create AKS cluster
+        timeout-minutes: 20
         uses: ./.github/actions/setup-aks-cluster
         with:
           cluster_name: ${{ env.name }}


### PR DESCRIPTION
az aks create has no timeout of its own, and this step failed to provision a
cluster on the run below, taking the whole 90 minute job with it:

https://github.com/cilium/cilium/actions/runs/34120371682/job/101736916860

Add a 20 minute timeout so it fails sooner.

This PR was prepared with AIL:3. I personally checked this step's recent
durations.
