### PR TITLE
gateway-api: fail Gateway reconcile on GatewayClass lookup errors

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -70,11 +70,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			return controllerruntime.Success()
 		}
-		scopedLog.ErrorContext(ctx, "Unable to get GatewayClass",
-			gatewayClass, gw.Spec.GatewayClassName,
-			logfields.Error, err)
-		// Doing nothing till the GatewayClass is available and matching controller name
-		return controllerruntime.Success()
+		return controllerruntime.Fail(fmt.Errorf("failed to get GatewayClass %q: %w", gw.Spec.GatewayClassName, err))
 	}
 
 	if string(gwc.Spec.ControllerName) != r.controllerName {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -872,6 +873,45 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(gw), actualGateway))
 		})
 	}
+}
+
+func Test_gatewayReconciler_Reconcile_failsOnGatewayClassGetError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("client unavailable")
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(testhelpers.TestScheme(helpers.AllOptionalKinds, helpers.RegisterGatewayAPITypesToScheme)).
+		WithObjects(gw).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*gatewayv1.GatewayClass); ok {
+					return expectedErr
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &gatewayReconciler{
+		client:         c,
+		logger:         hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+		controllerName: defaultControllerName,
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})
+	require.ErrorIs(t, err, expectedErr)
+	require.ErrorContains(t, err, `failed to get GatewayClass "cilium"`)
+	require.Equal(t, ctrl.Result{}, result)
 }
 
 // Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC verifies that a


### PR DESCRIPTION
Only a missing `GatewayClass` is an expected reconciliation state. Other `GatewayClass` lookup failures can be transient or technical client errors, so return them to controller-runtime to trigger normal logging and retry behavior instead of treating reconciliation as successful.