### PR TITLE
fix: disable auto-direct-node-routing in hybrid mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1052,8 +1052,9 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 		logging.Fatal(logger, "Option "+option.EnableRemoteNodeMasquerade+" requires BPF masquerade to be enabled ("+option.EnableBPFMasquerade+")")
 	}
 
-	if !option.Config.RequiresNativeRouting() && option.Config.EnableAutoDirectRouting {
-		logging.Fatal(logger, fmt.Sprintf("%s requires native or hybrid routing mode.", option.EnableAutoDirectRoutingName))
+	if option.Config.TunnelingEnabled() &&
+		option.Config.EnableAutoDirectRouting {
+		logging.Fatal(logger, fmt.Sprintf("%s requires native routing mode.", option.EnableAutoDirectRoutingName))
 	}
 
 	initClockSourceOption(logger)


### PR DESCRIPTION
When hybrid routing is enabled, the `auto-direct-node-routing` feature is completely ignored, and routes are not created for nodes. For this reason, this PR disables it until it is supported.

## Reason of the failure

* If `RoutingMode == RoutingModeHybrid` -->  `EnableEncapsulation=true` https://github.com/cilium/cilium/blob/e31fcdb45424acf822950591e4bc39092492c312/pkg/datapath/orchestrator/localnodeconfig.go#L189
* with `RoutingModeHybrid` we don't disable the `auto-direct-node-routes` feature as you can see here https://github.com/cilium/cilium/blob/d99f1ccc4fa5b7ba58f48c01c4c88703bbfb286c/daemon/cmd/daemon_main.go#L1056
* But this means that we never enter this `if` https://github.com/cilium/cilium/blob/e31fcdb45424acf822950591e4bc39092492c312/pkg/datapath/linux/node.go#L832 because `n.enableEncapsulation(newNode)` will always be true.

## Repro

populate this config in `contrib/testing/kind-custom.yaml`

```yaml
ipv4:
  enabled: true
ipv6:
  enabled: true
ipv4NativeRoutingCIDR: 10.244.0.0/16
ipv6NativeRoutingCIDR: fd00:10:244::/56
ipam:
  mode: kubernetes

routingMode: hybrid
autoDirectNodeRoutes: true

kubeProxyReplacement: true
bpf:
  masquerade: true
```

```bash
make kind-down && make kind && make kind-image-fast && make kind-install-cilium-fast
# when the cluster is ready, enter one of the nodes
docker exec -it kind-worker bash
# get the routing table
ip r show
```

```txt
default via 172.19.0.1 dev eth0 
10.244.0.0/24 via 10.244.1.24 dev cilium_host proto kernel src 10.244.1.24 mtu 1450 
10.244.1.0/24 via 10.244.1.24 dev cilium_host proto kernel src 10.244.1.24 
10.244.1.24 dev cilium_host proto kernel scope link 
172.19.0.0/16 dev eth0 proto kernel scope link src 172.19.0.2 
```


As you can see we miss the route that should be created by the ADNR component 
```txt
10.244.0.0/24 via 172.19.0.3 dev eth0 proto kernel 
```

If you repeat the experiment changing `routingMode: hybrid` to `routingMode: native`  you will see the route is correctly created.

```txt
default via 172.19.0.1 dev eth0 
10.244.0.0/24 via 172.19.0.3 dev eth0 proto kernel    // <--------------------------
10.244.0.0/24 via 10.244.1.24 dev cilium_host proto kernel src 10.244.1.24 mtu 1450 
10.244.1.0/24 via 10.244.1.24 dev cilium_host proto kernel src 10.244.1.24 
10.244.1.24 dev cilium_host proto kernel scope link 
172.19.0.0/16 dev eth0 proto kernel scope link src 172.19.0.2 
```





[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
