### PR TITLE
ipam: only require PodIPPool CRD for multi-pool

### DIFF
--- a/pkg/ipam/podippool/podippool.go
+++ b/pkg/ipam/podippool/podippool.go
@@ -13,10 +13,12 @@ import (
 	"github.com/cilium/statedb/index"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -131,7 +133,7 @@ func NewTableAndReflector(jg job.Group, db *statedb.DB, cs client.Clientset) (st
 		return nil, err
 	}
 
-	if !cs.IsEnabled() {
+	if !cs.IsEnabled() || option.Config.IPAM != ipamOption.IPAMMultiPool {
 		return pools, nil
 	}
 

--- a/pkg/ipam/podippool/script_test.go
+++ b/pkg/ipam/podippool/script_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/hive"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -36,6 +38,9 @@ func TestScript(t *testing.T) {
 		time.Now = now
 		time.Since = since
 	})
+	originalIPAM := option.Config.IPAM
+	option.Config.IPAM = ipamOption.IPAMMultiPool
+	t.Cleanup(func() { option.Config.IPAM = originalIPAM })
 	t.Setenv("TZ", "")
 	nodeTypes.SetName("testnode")
 

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -21,6 +21,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -44,7 +45,9 @@ func CRDResourceName(crd string) string {
 func agentCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
 	result := []string{
 		CRDResourceName(v2.CIDName),
-		CRDResourceName(v2alpha1.CPIPName),
+	}
+	if option.Config.IPAM == ipamOption.IPAMMultiPool {
+		result = append(result, CRDResourceName(v2alpha1.CPIPName))
 	}
 
 	if !option.Config.DisableCiliumEndpointCRD {
@@ -130,6 +133,11 @@ func GatewayAPIResourceNames() []string {
 // that the cilium operator or testsuite may register.
 func AllCiliumCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
 	res := append(AgentCRDResourceNames(bgpCfg), GatewayAPIResourceNames()...)
+	if option.Config.IPAM != ipamOption.IPAMMultiPool {
+		// The operator registers all Cilium CRDs, including the PodIPPool CRD
+		// that is only consumed by agents in multi-pool IPAM mode.
+		res = append(res, CRDResourceName(v2alpha1.CPIPName))
+	}
 	res = append(res,
 		CRDResourceName(v2.CNCName),
 	)

--- a/pkg/k8s/synced/crd_test.go
+++ b/pkg/k8s/synced/crd_test.go
@@ -15,27 +15,27 @@ import (
 )
 
 func TestAgentCRDResourceNamesIPAMMode(t *testing.T) {
-	originalIPAM := option.Config.IPAM
-	t.Cleanup(func() { option.Config.IPAM = originalIPAM })
-
 	for _, tc := range []struct {
-		name          string
 		ipam          string
 		expectsIPPool bool
 	}{
 		{
-			name:          "multi-pool",
 			ipam:          ipamOption.IPAMMultiPool,
 			expectsIPPool: true,
 		},
-		{
-			name: "other IPAM modes",
-			ipam: ipamOption.IPAMKubernetes,
-		},
+		{ipam: ipamOption.IPAMKubernetes},
+		{ipam: ipamOption.IPAMCRD},
+		{ipam: ipamOption.IPAMENI},
+		{ipam: ipamOption.IPAMAzure},
+		{ipam: ipamOption.IPAMClusterPool},
+		{ipam: ipamOption.IPAMAlibabaCloud},
+		{ipam: ipamOption.IPAMDelegatedPlugin},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.ipam, func(t *testing.T) {
+			originalIPAM := option.Config.IPAM
+			t.Cleanup(func() { option.Config.IPAM = originalIPAM })
 			option.Config.IPAM = tc.ipam
-			names := agentCRDResourceNames(bgpConfig.BGPConfig{})
+			names := agentCRDResourceNames(bgpConfig.DefaultConfig)
 			if tc.expectsIPPool {
 				require.Contains(t, names, CRDResourceName(v2alpha1.CPIPName))
 			} else {
@@ -46,11 +46,29 @@ func TestAgentCRDResourceNamesIPAMMode(t *testing.T) {
 }
 
 func TestAllCiliumCRDResourceNamesIncludesPodIPPool(t *testing.T) {
-	originalIPAM := option.Config.IPAM
-	t.Cleanup(func() { option.Config.IPAM = originalIPAM })
-
-	for _, ipam := range []string{ipamOption.IPAMKubernetes, ipamOption.IPAMMultiPool} {
-		option.Config.IPAM = ipam
-		require.Contains(t, AllCiliumCRDResourceNames(bgpConfig.BGPConfig{}), CRDResourceName(v2alpha1.CPIPName))
+	for _, ipam := range []string{
+		ipamOption.IPAMKubernetes,
+		ipamOption.IPAMCRD,
+		ipamOption.IPAMENI,
+		ipamOption.IPAMAzure,
+		ipamOption.IPAMClusterPool,
+		ipamOption.IPAMAlibabaCloud,
+		ipamOption.IPAMDelegatedPlugin,
+		ipamOption.IPAMMultiPool,
+	} {
+		t.Run(ipam, func(t *testing.T) {
+			originalIPAM := option.Config.IPAM
+			t.Cleanup(func() { option.Config.IPAM = originalIPAM })
+			option.Config.IPAM = ipam
+			names := AllCiliumCRDResourceNames(bgpConfig.DefaultConfig)
+			require.Contains(t, names, CRDResourceName(v2alpha1.CPIPName))
+			n := 0
+			for _, name := range names {
+				if name == CRDResourceName(v2alpha1.CPIPName) {
+					n++
+				}
+			}
+			require.Equal(t, 1, n)
+		})
 	}
 }

--- a/pkg/k8s/synced/crd_test.go
+++ b/pkg/k8s/synced/crd_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package synced
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestAgentCRDResourceNamesIPAMMode(t *testing.T) {
+	originalIPAM := option.Config.IPAM
+	t.Cleanup(func() { option.Config.IPAM = originalIPAM })
+
+	for _, tc := range []struct {
+		name          string
+		ipam          string
+		expectsIPPool bool
+	}{
+		{
+			name:          "multi-pool",
+			ipam:          ipamOption.IPAMMultiPool,
+			expectsIPPool: true,
+		},
+		{
+			name: "other IPAM modes",
+			ipam: ipamOption.IPAMKubernetes,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			option.Config.IPAM = tc.ipam
+			names := agentCRDResourceNames(bgpConfig.BGPConfig{})
+			if tc.expectsIPPool {
+				require.Contains(t, names, CRDResourceName(v2alpha1.CPIPName))
+			} else {
+				require.NotContains(t, names, CRDResourceName(v2alpha1.CPIPName))
+			}
+		})
+	}
+}
+
+func TestAllCiliumCRDResourceNamesIncludesPodIPPool(t *testing.T) {
+	originalIPAM := option.Config.IPAM
+	t.Cleanup(func() { option.Config.IPAM = originalIPAM })
+
+	for _, ipam := range []string{ipamOption.IPAMKubernetes, ipamOption.IPAMMultiPool} {
+		option.Config.IPAM = ipam
+		require.Contains(t, AllCiliumCRDResourceNames(bgpConfig.BGPConfig{}), CRDResourceName(v2alpha1.CPIPName))
+	}
+}


### PR DESCRIPTION
## Description of change

Only wait for the CiliumPodIPPool CRD and start its reflector when the agent uses multi-pool IPAM. The operator still registers the CRD for all installations.

Fixes: #48533

```release-note
ipam: only require the CiliumPodIPPool CRD for multi-pool IPAM
```

## Validation

- `go test ./pkg/k8s/synced`
- `go test ./pkg/ipam/podippool -run '^$'` (compile check)
- The PodIPPool txtar test is blocked on this Windows checkout by the existing CRLF parser issue (`Flags\r` column); it fails before exercising the changed reflector.

This PR was prepared with AIL:3. I personally checked the affected startup/resource paths, the regression test, and the validation results.

- [x] For first time contributors, read the submitting-a-pull-request guide
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off.
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI) in accordance with the Cilium AI Policy.

@maintainer-s-little-helper release-note/bug
