### PR TITLE
loader: bound each base program compile separately

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/renameio/v2"
@@ -258,16 +259,36 @@ func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *regist
 	if xdpConfig.Disabled() {
 		return nil
 	}
-	for _, dev := range devices {
-		// When WG & encrypt-node are on, the devices include cilium_wg0 to attach cil_from_wireguard
-		// so that NodePort's rev-{S,D}NAT translations happens for a reply from the remote node.
-		// So We need to exclude cilium_wg0 not to attach the XDP program when XDP acceleration
-		// is enabled, otherwise we will get "operation not supported" error.
-		if dev == wgTypes.IfaceName {
-			continue
-		}
 
-		if err := compileAndLoadXDPProg(ctx, logger, reg, collLoader, lnc, dev, xdpConfig.Mode()); err != nil {
+	// When WG & encrypt-node are on, the devices include cilium_wg0 to attach cil_from_wireguard
+	// so that NodePort's rev-{S,D}NAT translations happens for a reply from the remote node.
+	// So We need to exclude cilium_wg0 not to attach the XDP program when XDP acceleration
+	// is enabled, otherwise we will get "operation not supported" error.
+	xdpDevs := slices.DeleteFunc(slices.Clone(devices), func(dev string) bool {
+		return dev == wgTypes.IfaceName
+	})
+	if len(xdpDevs) == 0 {
+		return nil
+	}
+
+	objPath, err := compileXDPProg(ctx, logger)
+	if err != nil {
+		// Hoisting the compile out of the loop below moved it out of that loop's
+		// best-effort tolerance, so keep tolerating it here.
+		if option.Config.NodePortAcceleration == option.XDPModeBestEffort {
+			logger.Info("Failed to compile XDP program, ignoring due to best-effort mode",
+				logfields.Error, err,
+			)
+			return nil
+		}
+		return fmt.Errorf("compiling XDP program: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	for _, dev := range xdpDevs {
+		if err := loadXDPProg(ctx, logger, reg, collLoader, lnc, objPath, dev, xdpConfig.Mode()); err != nil {
 			if option.Config.NodePortAcceleration == option.XDPModeBestEffort {
 				logger.Info("Failed to attach XDP program, ignoring due to best-effort mode",
 					logfields.Error, err,

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -408,8 +408,8 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, defaults.ExecTimeout)
-	defer cancel()
+	// Each clang run below bounds itself with defaults.ExecTimeout; everything
+	// else here inherits only cancellation.
 
 	if lnc.KPRConfig.EnableSocketLB {
 		// compile bpf_sock.c and attach/detach progs for socketLB

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -414,7 +414,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 	if lnc.KPRConfig.EnableSocketLB {
 		// compile bpf_sock.c and attach/detach progs for socketLB
 		if err := compileWithOptions(ctx, l.logger, socketProg, socketObj, nil); err != nil {
-			logging.Fatal(l.logger, "failed to compile bpf_sock.c", logfields.Error, err)
+			return fmt.Errorf("failed to compile bpf_sock.c: %w", err)
 		}
 		if err := socketlb.Enable(ctx, l.logger, l.registry, l.bpfCollectionLoader, l.sysctl, lnc); err != nil {
 			return err
@@ -426,12 +426,12 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 	}
 
 	if err := reinitializeXDPLocked(ctx, l.logger, l.registry, l.bpfCollectionLoader, lnc, devices); err != nil {
-		logging.Fatal(l.logger, "Failed to compile XDP program", logfields.Error, err)
+		return fmt.Errorf("failed to reinitialize XDP programs: %w", err)
 	}
 
 	// Compile alignchecker program
 	if err := compileDefault(ctx, l.logger, "bpf_alignchecker.c", defaults.AlignCheckerName); err != nil {
-		logging.Fatal(l.logger, "alignchecker compile failed", logfields.Error, err)
+		return fmt.Errorf("alignchecker compile failed: %w", err)
 	}
 	// Validate alignments of C and Go equivalent structs
 	if err := alignchecker.CheckStructAlignments(defaults.AlignCheckerName); err != nil {

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -158,6 +159,12 @@ func pidFromProcess(proc *os.Process) string {
 //
 // May output assembly or source code after prepocessing.
 func compile(ctx context.Context, logger *slog.Logger, prog *progInfo, dir *directoryInfo) (string, error) {
+	// ExecTimeout is a budget for one command, so spend it on this clang and on
+	// no other: a caller compiling several programs in sequence must not let an
+	// earlier one eat the time the next one needs.
+	ctx, cancel := context.WithTimeout(ctx, defaults.ExecTimeout)
+	defer cancel()
+
 	compileArgs := append(testIncludes,
 		fmt.Sprintf("-I%s", path.Join(dir.Runtime, "globals")),
 		fmt.Sprintf("-I%s", dir.State),
@@ -248,6 +255,19 @@ func compile(ctx context.Context, logger *slog.Logger, prog *progInfo, dir *dire
 	return output.Name(), nil
 }
 
+// logCompilerVersion runs the compiler to log which one is about to be used.
+func logCompilerVersion(ctx context.Context, logger *slog.Logger, msg string) error {
+	ctx, cancel := context.WithTimeout(ctx, defaults.ExecTimeout)
+	defer cancel()
+
+	version, err := exec.CommandContext(ctx, compiler, "--version").CombinedOutput(logger, true)
+	if err != nil {
+		return err
+	}
+	logger.Debug(msg, compiler, string(version))
+	return nil
+}
+
 // compileDatapath invokes the compiler and linker to create all state files for
 // the BPF datapath, with the primary target being the BPF ELF binary.
 //
@@ -258,15 +278,9 @@ func compile(ctx context.Context, logger *slog.Logger, prog *progInfo, dir *dire
 func compileDatapath(ctx context.Context, logger *slog.Logger, dirs *directoryInfo, isHost bool) error {
 	scopedLog := logger.With(logfields.Debug, true)
 
-	versionCmd := exec.CommandContext(ctx, compiler, "--version")
-	compilerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
-	if err != nil {
+	if err := logCompilerVersion(ctx, scopedLog, "Compiling datapath"); err != nil {
 		return err
 	}
-	scopedLog.Debug(
-		"Compiling datapath",
-		compiler, string(compilerVersion),
-	)
 
 	prog := epProg
 	if isHost {
@@ -343,15 +357,9 @@ func compileOverlay(ctx context.Context, logger *slog.Logger) error {
 	}
 	scopedLog := logger.With(logfields.Debug, true)
 
-	versionCmd := exec.CommandContext(ctx, compiler, "--version")
-	compilerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
-	if err != nil {
+	if err := logCompilerVersion(ctx, scopedLog, "Compiling overlay programs"); err != nil {
 		return err
 	}
-	scopedLog.Debug(
-		"Compiling overlay programs",
-		compiler, string(compilerVersion),
-	)
 
 	prog := &progInfo{
 		Source:     overlayProg,
@@ -370,7 +378,7 @@ func compileOverlay(ctx context.Context, logger *slog.Logger) error {
 	return nil
 }
 
-func compileWireguard(ctx context.Context, logger *slog.Logger) (err error) {
+func compileWireguard(ctx context.Context, logger *slog.Logger) error {
 	dirs := &directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
@@ -379,15 +387,10 @@ func compileWireguard(ctx context.Context, logger *slog.Logger) (err error) {
 	}
 	scopedLog := logger.With(logfields.Debug, true)
 
-	versionCmd := exec.CommandContext(ctx, compiler, "--version")
-	compilerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
-	if err != nil {
+	if err := logCompilerVersion(ctx, scopedLog, "Compiling wireguard programs"); err != nil {
 		return err
 	}
-	scopedLog.Debug(
-		"Compiling wireguard programs",
-		compiler, string(compilerVersion),
-	)
+
 	prog := &progInfo{
 		Source:     wireguardProg,
 		Output:     wireguardObj,

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -143,10 +143,9 @@ func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode 
 	}
 }
 
-// compileAndLoadXDPProg compiles bpf_xdp.c for the given XDP device and loads it.
-func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger,
-	reg *registry.MapRegistry, collLoader *bpfCollectionLoader,
-	lnc *config.Config, xdpDev string, xdpMode xdp.Mode) error {
+// compileXDPProg compiles bpf_xdp.c. The object is not specialized per device,
+// so one compile serves every XDP device.
+func compileXDPProg(ctx context.Context, logger *slog.Logger) (string, error) {
 	dirs := &directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
@@ -159,14 +158,13 @@ func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger,
 		OutputType: outputObject,
 	}
 
-	objPath, err := compile(ctx, logger, prog, dirs)
-	if err != nil {
-		return err
-	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
+	return compile(ctx, logger, prog, dirs)
+}
 
+// loadXDPProg loads the object at objPath and attaches it to the given XDP device.
+func loadXDPProg(ctx context.Context, logger *slog.Logger,
+	reg *registry.MapRegistry, collLoader *bpfCollectionLoader,
+	lnc *config.Config, objPath string, xdpDev string, xdpMode xdp.Mode) error {
 	iface, err := safenetlink.LinkByName(xdpDev)
 	if err != nil {
 		return fmt.Errorf("retrieving device %s: %w", xdpDev, err)


### PR DESCRIPTION
defaults.ExecTimeout is documented as a timeout for executing commands and its
other user wraps exactly one invocation, but Reinitialize derives a single 300s
deadline from it and runs everything under that: the bpf_sock.c compile and
socketlb.Enable, the XDP compile and one load per device, bpf_alignchecker.c and
the alignment check, wireguard, overlay and the proxy routing rules. The last
compile only gets whatever the earlier ones left it. One of those earlier
compiles was redundant, because bpf_xdp.c was compiled inside the per-device
loop even though neither the progInfo nor the directoryInfo mentions the device,
so every iteration ran clang with the same argv and wrote the same object.

In run 33862617835 the bpf_sock, two bpf_xdp and bpf_alignchecker compiles spent
231 of the 300 seconds and clang was SIGKILLed 62ms past the deadline on
bpf_overlay.c, which the retry then compiled in 61s. dpInitialized never closed
and every endpoint regeneration on the node queued behind it for four and a half
minutes. Where the deadline lands also decides whether the agent survives it: in
run 33215561782 three agents on one node each ran out of the same 300s, two
killed compiling bpf_alignchecker.c and exiting 255 through logging.Fatal, the
third killed compiling bpf_overlay.c and simply retrying.

So bpf_xdp.c is compiled once and its object handed to a per-device load step,
compile() and the compiler version probe each derive their own ExecTimeout with
the outer context left carrying cancellation, and the three compile failures
that used to be fatal return an error for the orchestrator to retry ten seconds
later. The struct alignment check stays fatal, since a C and Go layout mismatch
is a build-time invariant no retry can change. The magnitude of the timeout is
unchanged, so a genuinely stuck clang is still killed at 300s.

This PR was prepared with AIL:3. I personally checked the compile timestamps in
the run 33862617835 agent log and the exit code 255 on the two killed containers
in the run 33215561782 sysdump.

```release-note
Fix slow or failed datapath reinitialization on a CPU-contended node, where
several sequential BPF program compiles shared one 300s timeout and a compile
that ran out of time could terminate the agent.
```
