### PR TITLE
gha/conformance-multi-pool: use the local fake external targets

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -171,14 +171,6 @@ jobs:
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          hubble: false
-          include-unsafe-tests: true
-          test-concurrency: 5
-
       - name: Set up job variables
         id: vars
         run: |
@@ -244,18 +236,7 @@ jobs:
           CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=true"
           KIND_SVC_CIDR="10.243.0.0/16,fd00:10:243::/112"
 
-          CONNECTIVITY_TEST_DEFAULTS=" ${{ steps.e2e_config.outputs.test_flags }} \
-            --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
-            --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
-            --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \
-            --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
-            --deployment-pod-annotations='{ \
-                \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
-                \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
-            }'"
-
           echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ROUTES} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_MULTIPOOL_IPAM}" >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
           echo kind_svc_cidr=${KIND_SVC_CIDR} >> $GITHUB_OUTPUT
 
@@ -337,6 +318,29 @@ jobs:
 
           kubectl patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+
+      - name: Set up connectivity test variables
+        id: conn_vars
+        run: |
+          CONNECTIVITY_TEST_DEFAULTS=" ${{ steps.e2e_config.outputs.test_flags }} \
+            --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
+            --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
+            --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \
+            --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
+            --deployment-pod-annotations='{ \
+                \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
+                \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
+            }'"
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+
       - name: Create the IPSec secret
         if: matrix.encryption == 'ipsec'
         run: |
@@ -360,7 +364,7 @@ jobs:
       - name: Run connectivity test
         id: run-tests
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.conn_vars.outputs.connectivity_test_defaults }}
 
       - name: Collect Pod and Pool IPs
         id: ips

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -247,6 +247,10 @@ jobs:
             KUBEPROXYMODE=none \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-multi-pool.yaml
 
+      - name: Add external docker network
+        uses: ./.github/actions/kind-external-network
+        id: external_network
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -318,6 +322,18 @@ jobs:
 
           kubectl patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
 
+      # This must run after the step above, which replaces the whole CoreDNS
+      # ConfigMap and would drop the server block appended here.
+      - name: Add external targets to kind cluster
+        uses: ./.github/actions/kind-external-targets
+        id: external_targets
+        with:
+          kind_network: ${{ steps.external_network.outputs.kind_network }}
+          ipv4_external_target: ${{ steps.external_network.outputs.ipv4_external_target }}
+          ipv4_other_external_target: ${{ steps.external_network.outputs.ipv4_other_external_target }}
+          ipv6_external_target: ${{ steps.external_network.outputs.ipv6_external_target }}
+          ipv6_other_external_target: ${{ steps.external_network.outputs.ipv6_other_external_target }}
+
       - name: Get connectivity test flags
         id: e2e_config
         uses: ./.github/actions/cli-test-config
@@ -325,6 +341,16 @@ jobs:
           hubble: false
           include-unsafe-tests: true
           test-concurrency: 5
+          external-cidr: ${{ steps.external_network.outputs.ipv4_external_cidr }}
+          external-cidrv6: ${{ steps.external_network.outputs.ipv6_external_cidr }}
+          external-ip: ${{ steps.external_network.outputs.ipv4_external_target }}
+          external-ipv6: ${{ steps.external_network.outputs.ipv6_external_target }}
+          external-other-ip: ${{ steps.external_network.outputs.ipv4_other_external_target }}
+          external-other-ipv6: ${{ steps.external_network.outputs.ipv6_other_external_target }}
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
 
       - name: Set up connectivity test variables
         id: conn_vars


### PR DESCRIPTION
ci-multi-pool resolves its external targets over public DNS, so the SNI-deny
assertions rest on a working path from the runner to 8.8.4.4. One lost datagram
there and curl's 2s connect deadline expires before the deny is ever reached, so
the test reports exit 28 where it expected 35:

https://github.com/cilium/cilium/actions/runs/34118701289/job/101731550755

Wire the workflow onto the fake external targets the repo already has, the same
move #48250 is making for ci-clustermesh. That needs the flags assembled after
the kind cluster exists rather than before it, so the step moves past cluster
creation and CONNECTIVITY_TEST_DEFAULTS gets a step of its own, with no flag or
behaviour change of its own. The external docker network is then created before
the cluster, the target containers and their CoreDNS entries go in after the
nameserver patch that replaces the whole ConfigMap and would otherwise drop them,
and the resulting addresses, CIDRs and CA reach the test through cli-test-config.
The names resolve inside the cluster, so the assertion no longer depends on the
runner reaching the internet.

This PR was prepared with AIL:3. I personally checked the failing run's
cilium-envoy and DNS-proxy logs.
