### PR TITLE
[backport]gateway-api: nodeSelector label with hostNetwork enabled

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
@@ -284,6 +285,10 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	cecTranslator := translation.NewCECTranslator(cfg)
 
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, cfg)
+	var nodeLabelSelector v1.LabelSelector
+	if cfg.HostNetworkConfig.NodeLabelSelector != nil {
+		nodeLabelSelector = v1.LabelSelector{MatchLabels: cfg.HostNetworkConfig.NodeLabelSelector.MatchLabels}
+	}
 
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,
@@ -292,6 +297,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		defaultControllerName,
 		installedOptionalKinds,
 		cfg.HostNetworkConfig.Enabled,
+		nodeLabelSelector,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
 	}
@@ -446,12 +452,13 @@ func registerReconcilers(
 	controllerName string,
 	installedOptionalCRDs []schema.GroupVersionKind,
 	hostNetworkEnabled bool,
+	hostNetworkLabel v1.LabelSelector,
 ) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger, controllerName),
-		newGatewayReconciler(mgr, translator, logger, controllerName, hostNetworkEnabled),
+		newGatewayReconciler(mgr, translator, logger, controllerName, hostNetworkEnabled, hostNetworkLabel),
 		newGammaReconciler(mgr, translator, logger, controllerName),
 		newGatewayClassConfigReconciler(mgr, logger),
 		newEndpointSliceReconciler(mgr, logger),

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -43,9 +44,10 @@ type gatewayReconciler struct {
 	logger             *slog.Logger
 	controllerName     string
 	hostNetworkEnabled bool
+	hostNetworkLabel   metav1.LabelSelector
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, hostNetworkEnabled bool) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, hostNetworkEnabled bool, hostNetworkLabel metav1.LabelSelector) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
@@ -55,6 +57,7 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 		logger:             scopedLog,
 		controllerName:     controllerName,
 		hostNetworkEnabled: hostNetworkEnabled,
+		hostNetworkLabel:   hostNetworkLabel,
 	}
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1105,11 +1105,17 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 		// NodePort service gets as many Node
 		// IP addresses as we can fit into Status
 		nodes := &corev1.NodeList{}
-		if err := r.Client.List(ctx, nodes); err != nil {
-			return fmt.Errorf("unable to list nodes")
-		}
 
 		ips := make([]netip.Addr, 0)
+		selector, err := metav1.LabelSelectorAsSelector(&r.hostNetworkLabel)
+		if err != nil {
+			return fmt.Errorf("unable to get node selector label")
+		}
+		if err := r.Client.List(ctx, nodes, &client.ListOptions{
+			LabelSelector: selector,
+		}); err != nil {
+			return fmt.Errorf("unable to list nodes")
+		}
 		for _, node := range nodes.Items {
 			if len(node.Status.Addresses) == 0 {
 				continue

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -35,6 +35,7 @@ import (
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/shortener"
 )
 
@@ -109,6 +110,7 @@ func Test_Conformance(t *testing.T) {
 		skipCEC              bool
 		wantErr              bool
 		hostNetwork          bool
+		nodeLabelSelector    metav1.LabelSelector
 	}{
 		{
 			name: "gateway-http-listener-isolation",
@@ -334,12 +336,18 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
+		// hostNetwork mode tests
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-no-l4-listeners", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-mixed-routes", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-tcp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-udp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-nodelabel", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled-nodeselector", Namespace: "gateway-conformance-infra"}, wantErr: false, skipCEC: true}}, hostNetwork: true,
+			nodeLabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"role": "gateway",
+			}}},
+
 		// ListenerSet tests
 		{name: "listenerset-default-not-allowed", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "default-not-allowed", Namespace: "gateway-conformance-infra"}},
@@ -439,6 +447,7 @@ func Test_Conformance(t *testing.T) {
 			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet)
 
 			c := clientBuilder.Build()
+			nodeLabel := &slim_meta_v1.LabelSelector{MatchLabels: tt.nodeLabelSelector.MatchLabels}
 			gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 				ServiceConfig: translation.ServiceConfig{
 					ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
@@ -447,7 +456,8 @@ func Test_Conformance(t *testing.T) {
 					UseRemoteAddress: true,
 				},
 				HostNetworkConfig: translation.HostNetworkConfig{
-					Enabled: tt.hostNetwork,
+					Enabled:           tt.hostNetwork,
+					NodeLabelSelector: nodeLabel,
 				},
 			})
 
@@ -457,6 +467,7 @@ func Test_Conformance(t *testing.T) {
 				logger:             logger,
 				controllerName:     defaultControllerName,
 				hostNetworkEnabled: tt.hostNetwork,
+				hostNetworkLabel:   tt.nodeLabelSelector,
 			}
 
 			// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/status_gateway_address.go
+++ b/operator/pkg/gateway-api/status_gateway_address.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/shortener"
+)
+
+type GatewayAddressStatusManager struct {
+	client           client.Client
+	logger           *slog.Logger
+	hostNetworkLabel []metav1.LabelSelector
+}
+
+func NewGatewayAddressStatusManager(client client.Client, logger *slog.Logger, hostNetworkLabel ...metav1.LabelSelector) *GatewayAddressStatusManager {
+	return &GatewayAddressStatusManager{
+		client:           client,
+		logger:           logger,
+		hostNetworkLabel: hostNetworkLabel,
+	}
+}
+
+// ValidateStaticAddresses validates spec.addresses before resource
+// reconciliation continues. It only checks the requested static address shape;
+// it does not look at assigned Service status. Invalid addresses are surfaced
+// through Gateway conditions and reported as not valid.
+func (m *GatewayAddressStatusManager) ValidateStaticAddresses(gw *gatewayv1.Gateway) bool {
+	if len(gw.Spec.Addresses) == 0 {
+		return true
+	}
+	for _, address := range gw.Spec.Addresses {
+		if address.Type != nil && *address.Type != gatewayv1.IPAddressType {
+			setGatewayAccepted(gw, false, "Unsupported Gateway address, address type is not supported", gatewayv1.GatewayReasonUnsupportedAddress)
+			setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready", gatewayv1.GatewayReasonListenersNotReady)
+			return false
+		}
+		if address.Value == "" {
+			setGatewayAccepted(gw, false, "Unsupported Gateway address, address value is not set", gatewayv1.GatewayReasonUnsupportedAddress)
+			setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready", gatewayv1.GatewayReasonListenersNotReady)
+			return false
+		}
+		if _, err := netip.ParseAddr(address.Value); err != nil {
+			setGatewayAccepted(gw, false, "Unsupported Gateway address, invalid ip address", gatewayv1.GatewayReasonUnsupportedAddress)
+			setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready", gatewayv1.GatewayReasonListenersNotReady)
+			return false
+		}
+	}
+	return true
+}
+
+// SetAddressStatus reads the managed frontend Service and projects its observed
+// addresses into Gateway status. When at least one usable address is present,
+// it also marks the Gateway and accepted listeners as Programmed.
+func (m *GatewayAddressStatusManager) SetAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {
+	m.logger.InfoContext(ctx, "Checking address status for Gateway", logfields.Resource, client.ObjectKeyFromObject(gw).String())
+	setGatewayProgrammed(gw, metav1.ConditionFalse, "Gateway waiting for address", gatewayv1.GatewayReasonAddressNotAssigned)
+
+	svcList := &corev1.ServiceList{}
+	if err := m.client.List(ctx, svcList, client.MatchingLabels{
+		owningGatewayLabel: shortener.ShortenK8sResourceName(gw.GetName()),
+	}, client.InNamespace(gw.GetNamespace())); err != nil {
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready, failed to load services", gatewayv1.GatewayReasonAddressNotAssigned)
+		return fmt.Errorf("failed to load services: %w", err)
+	}
+
+	if len(svcList.Items) == 0 {
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready, failed to load services: no service found", gatewayv1.GatewayReasonAddressNotAssigned)
+		return fmt.Errorf("failed to load services: no service found")
+	}
+	svc := svcList.Items[0]
+
+	var addresses []gatewayv1.GatewayStatusAddress
+	// Check the svc type
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeNodePort:
+		// NodePort service gets as many Node
+		// IP addresses as we can fit into Status
+		nodes := &corev1.NodeList{}
+
+		ips := make([]netip.Addr, 0)
+		// for every label that is present, determine if there are any nodes with those labels and
+		// add them to the list of ips
+		for _, s := range m.hostNetworkLabel {
+			selector, err := metav1.LabelSelectorAsSelector(&s)
+			if err != nil {
+				return fmt.Errorf("unable to get node selector label")
+			}
+			if err := m.client.List(ctx, nodes, &client.ListOptions{
+				LabelSelector: selector,
+			}); err != nil {
+				return fmt.Errorf("unable to list nodes")
+			}
+			for _, node := range nodes.Items {
+				if len(node.Status.Addresses) == 0 {
+					continue
+				}
+				nodeAddress := node.Status.Addresses[0]
+				ip, err := netip.ParseAddr(nodeAddress.Address)
+				if err != nil {
+					// the first address is not an IP address (e.g. a hostname),
+					// skip the node instead of reporting an invalid address.
+					continue
+				}
+				ips = append(ips, ip.Unmap())
+			}
+		}
+
+		// sort the addresses for consistent ip addresses assigned
+		slices.SortFunc(ips, netip.Addr.Compare)
+
+		// allows for only a max of 16 addresses
+		if len(ips) > 16 {
+			ips = ips[:16]
+		}
+		for _, ipAddress := range ips {
+			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+				Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
+				Value: ipAddress.String(),
+			})
+		}
+	case corev1.ServiceTypeLoadBalancer:
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			// Potential loadbalancer service isn't ready yet. No need to report as an error, because
+			// reconciliation should be triggered when the loadbalancer services gets updated.
+			return nil
+		}
+		for _, s := range svc.Status.LoadBalancer.Ingress {
+			if len(s.IP) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
+					Value: s.IP,
+				})
+			}
+			if len(s.Hostname) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.HostnameAddressType),
+					Value: s.Hostname,
+				})
+			}
+		}
+	default:
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready, failed to load services: invalid service type for gateway", gatewayv1.GatewayReasonAddressNotAssigned)
+		return fmt.Errorf("failed to load services: invalid service type for gateway")
+	}
+
+	if len(addresses) > 0 {
+		m.logger.InfoContext(ctx, "At least one valid address, marking gateway programmed", logfields.Resource, client.ObjectKeyFromObject(gw).String())
+		setGatewayProgrammed(gw, metav1.ConditionTrue, "Gateway Programmed", gatewayv1.GatewayReasonProgrammed)
+		for i := range gw.Status.Listeners {
+			l := &gw.Status.Listeners[i]
+			// Is Listener Accepted?
+			accepted := false
+
+			for _, cond := range l.Conditions {
+				if cond.Type == string(gatewayv1.GatewayConditionAccepted) &&
+					cond.Status == metav1.ConditionTrue {
+					accepted = true
+					break
+				}
+			}
+			if accepted {
+				l.Conditions = helpers.MergeConditions(l.Conditions, metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionProgrammed),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(gatewayv1.ListenerReasonProgrammed),
+					Message:            "Listener Programmed",
+					ObservedGeneration: gw.Generation,
+					LastTransitionTime: metav1.Now(),
+				})
+			}
+		}
+	}
+
+	gw.Status.Addresses = addresses
+	return nil
+}
+
+// SetStaticAddressStatus compares requested static addresses with the assigned
+// load balancer ingress addresses. It is a post-reconcile check for whether
+// the requested static addresses were actually satisfied.
+func (m *GatewayAddressStatusManager) SetStaticAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {
+	if len(gw.Spec.Addresses) == 0 {
+		return nil
+	}
+	svcList := &corev1.ServiceList{}
+	if err := m.client.List(ctx, svcList, client.MatchingLabels{
+		owningGatewayLabel: shortener.ShortenK8sResourceName(gw.GetName()),
+	}, client.InNamespace(gw.GetNamespace())); err != nil {
+		return fmt.Errorf("failed to load services: %w", err)
+	}
+
+	if len(svcList.Items) == 0 {
+		return fmt.Errorf("failed to load services: no service found")
+	}
+
+	svc := svcList.Items[0]
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		// Potential loadbalancer service isn't ready yet. No need to report as an error, because
+		// reconciliation should be triggered when the loadbalancer services gets updated.
+		return nil
+	}
+
+	// Compare parsed addresses because the same IP address can have multiple
+	// textual representations.
+	addresses := make(map[netip.Addr]struct{}, len(svc.Status.LoadBalancer.Ingress))
+	for _, addr := range svc.Status.LoadBalancer.Ingress {
+		ip, err := netip.ParseAddr(addr.IP)
+		if err != nil {
+			// Ignore hostname-only ingress entries.
+			continue
+		}
+		addresses[ip] = struct{}{}
+	}
+
+	for _, addr := range gw.Spec.Addresses {
+		ip, err := netip.ParseAddr(addr.Value)
+		if err != nil {
+			setGatewayProgrammed(gw, metav1.ConditionFalse, fmt.Sprintf("StaticAddress %q can't be used", addr.Value), gatewayv1.GatewayReasonAddressNotUsable)
+			return nil
+		}
+		if _, ok := addresses[ip]; !ok {
+			setGatewayProgrammed(gw, metav1.ConditionFalse, fmt.Sprintf("StaticAddress %q can't be used", addr.Value), gatewayv1.GatewayReasonAddressNotUsable)
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
@@ -1,0 +1,84 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled-nodeselector
+    io.cilium.gateway/owning-gateway: hostnetwork-enabled-nodeselector
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+  labels:
+    role: gateway
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker3
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.5
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.4
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/watch-handlers/node.go
+++ b/operator/pkg/gateway-api/watch-handlers/node.go
@@ -25,12 +25,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 		scopedLog := logger.With(
 			logfields.K8sNamespace, ns.GetName(),
 		)
-		nodeList := &corev1.NodeList{}
-		if err := c.List(ctx, nodeList); err != nil {
-			scopedLog.WarnContext(ctx, "Unable to list nodes", logfields.Error, err)
-			return nil
-		}
-
+		// get all the gateways with cilium controller name
 		gateways, err := getAllGatewaysSetForController(ctx, c, controllerName)
 
 		if err != nil {
@@ -40,7 +35,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 
 		reqs := make([]reconcile.Request, 0, len(gateways))
 		svcList := &corev1.ServiceList{}
-		svcMap := make(map[string]struct{})
+		svcMap := make(map[types.UID]struct{})
 
 		// for each gateway, filter for the services owned by the gateway
 		for gw := range gateways {
@@ -54,7 +49,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			// if the service owned by the gateway is a nodeport, add to map of UID
 			for _, svc := range svcList.Items {
 				if svc.Spec.Type == "NodePort" {
-					svcMap[string(svc.GetOwnerReferences()[0].UID)] = struct{}{}
+					svcMap[svc.GetOwnerReferences()[0].UID] = struct{}{}
 				}
 			}
 		}
@@ -80,13 +75,13 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			if err := c.Get(ctx, gatewayNamespaceName, gateway); err != nil {
 				scopedLog.WarnContext(ctx, "Unable to get gateway", logfields.Error, err)
 			}
-			if _, err := svcMap[string(gateway.GetUID())]; err {
-				// there is no nodeport svc for this gateway, no need to reconcile
-				continue
+
+			if _, exist := svcMap[gateway.GetUID()]; exist {
+				// gateway present in svcMap have a nodeport service and should be queued for reconcile
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: gatewayNamespaceName,
+				})
 			}
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: gatewayNamespaceName,
-			})
 		}
 		return reqs
 	})


### PR DESCRIPTION
[ upstream commit 165eefd20b043a11bd5a2cfff0c5c56a48ca7eb0 ]

Allows the use of node labels for when host network is enabled. Add in another test case, and clean up unnecessary code.

<!-- Description of change -->
backport of https://github.com/cilium/cilium/pull/47463 to v1.20

```release-note
gateway-api: node label selector for when hostNetwork is enabled
```
