### PR TITLE
cilium-cli: create the node-pinned conn-disrupt pods first

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1145,6 +1145,57 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	// Deploy test-conn-disrupt actors (only in the first
 	// test namespace in case of tests concurrent run)
 	if ct.params.ConnDisruptTestSetup && ct.params.TestNamespaceIndex == 0 {
+		// The only node-pinned pods here, so admit them before the unpinned ones.
+		if ct.ShouldRunConnDisruptEgressGateway() {
+			gatewayNode, nonGatewayNode, err := ct.getGatewayAndNonGatewayNodes()
+			if err != nil {
+				return err
+			}
+			cegp := newConnDisruptCEGP(ct.params.TestNamespace, gatewayNode)
+			ct.Logf("✨ [%s] Deploying %s CiliumEgressGatewayPolicy...", ct.K8sClient().ClusterName(), cegp.Name)
+			_, err = ct.K8sClient().ApplyGeneric(ctx, cegp)
+			if err != nil {
+				return fmt.Errorf("unable to create CiliumEgressGatewayPolicy %s: %w", cegp.Name, err)
+			}
+
+			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerEgressGatewayDeploymentName, KindTestConnDisruptEgressGateway, 1,
+				testConnDisruptEgressGatewayServiceName, testConnDisruptServerEgressGatewayAppLabel, true, newConnDisruptCNPForEgressGateway, ""); err != nil {
+				return err
+			}
+
+			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
+				testConnDisruptClientEgressGatewayOnGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
+				1, false, map[string]string{"kubernetes.io/hostname": gatewayNode}, ""); err != nil {
+				return err
+			}
+			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
+				testConnDisruptClientEgressGatewayOnNonGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
+				1, false, map[string]string{"kubernetes.io/hostname": nonGatewayNode}, ""); err != nil {
+				return err
+			}
+			for _, clientDeploy := range []string{testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName} {
+				err := WaitForDeployment(ctx, ct, ct.clients.dst, ct.params.TestNamespace, clientDeploy)
+				if err != nil {
+					ct.Failf("%s deployment is not ready: %s", clientDeploy, err)
+				}
+			}
+
+			testPods := append(
+				slices.Collect(maps.Values(ct.ClientPods())),
+				slices.Collect(maps.Values(ct.EchoPods()))...)
+
+			if err := WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods,
+				func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {
+					return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
+				}, func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {
+					return nil, nil
+				}); err != nil {
+				ct.Fail(err)
+			}
+		} else {
+			ct.Info("Skipping conn-disrupt-test for Egress Gateway")
+		}
+
 		if ct.params.IncludeConnDisruptTest {
 			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerDeploymentName, KindTestConnDisrupt, 3,
 				testConnDisruptServiceName, "test-conn-disrupt-server", false, newConnDisruptCNP, ""); err != nil {
@@ -1236,56 +1287,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			}
 		} else {
 			ct.Info("Skipping conn-disrupt-test for L7 traffic")
-		}
-
-		if ct.ShouldRunConnDisruptEgressGateway() {
-			gatewayNode, nonGatewayNode, err := ct.getGatewayAndNonGatewayNodes()
-			if err != nil {
-				return err
-			}
-			cegp := newConnDisruptCEGP(ct.params.TestNamespace, gatewayNode)
-			ct.Logf("✨ [%s] Deploying %s CiliumEgressGatewayPolicy...", ct.K8sClient().ClusterName(), cegp.Name)
-			_, err = ct.K8sClient().ApplyGeneric(ctx, cegp)
-			if err != nil {
-				return fmt.Errorf("unable to create CiliumEgressGatewayPolicy %s: %w", cegp.Name, err)
-			}
-
-			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerEgressGatewayDeploymentName, KindTestConnDisruptEgressGateway, 1,
-				testConnDisruptEgressGatewayServiceName, testConnDisruptServerEgressGatewayAppLabel, true, newConnDisruptCNPForEgressGateway, ""); err != nil {
-				return err
-			}
-
-			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
-				testConnDisruptClientEgressGatewayOnGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-				1, false, map[string]string{"kubernetes.io/hostname": gatewayNode}, ""); err != nil {
-				return err
-			}
-			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
-				testConnDisruptClientEgressGatewayOnNonGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-				1, false, map[string]string{"kubernetes.io/hostname": nonGatewayNode}, ""); err != nil {
-				return err
-			}
-			for _, clientDeploy := range []string{testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName} {
-				err := WaitForDeployment(ctx, ct, ct.clients.dst, ct.params.TestNamespace, clientDeploy)
-				if err != nil {
-					ct.Failf("%s deployment is not ready: %s", clientDeploy, err)
-				}
-			}
-
-			testPods := append(
-				slices.Collect(maps.Values(ct.ClientPods())),
-				slices.Collect(maps.Values(ct.EchoPods()))...)
-
-			if err := WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods,
-				func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {
-					return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
-				}, func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {
-					return nil, nil
-				}); err != nil {
-				ct.Fail(err)
-			}
-		} else {
-			ct.Info("Skipping conn-disrupt-test for Egress Gateway")
 		}
 	}
 

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -89,10 +89,10 @@ func pollExecProbe(parentCtx context.Context, readiness time.Duration, probe fun
 func WaitForDeployment(ctx context.Context, log Logger, client *k8s.Client, namespace string, name string) error {
 	log.Logf("⌛ [%s] Waiting for deployment %s/%s to become ready...", client.ClusterName(), namespace, name)
 
-	ctx, cancel := context.WithTimeout(ctx, LongTimeout)
+	deadline, cancel := context.WithTimeout(ctx, LongTimeout)
 	defer cancel()
 	for {
-		err := client.CheckDeploymentStatus(ctx, namespace, name)
+		err := client.CheckDeploymentStatus(deadline, namespace, name)
 		if err == nil {
 			return nil
 		}
@@ -101,11 +101,48 @@ func WaitForDeployment(ctx context.Context, log Logger, client *k8s.Client, name
 
 		select {
 		case <-time.After(PollInterval):
-		case <-ctx.Done():
+		case <-deadline.Done():
+			// The parent context, not the expired one, so the diagnostic can still be fetched.
+			if reason := unschedulablePods(ctx, client, namespace, name); reason != "" {
+				return fmt.Errorf("timeout reached waiting for deployment %s/%s to become ready (last error: %w, unschedulable: %s)",
+					namespace, name, err, reason)
+			}
 			return fmt.Errorf("timeout reached waiting for deployment %s/%s to become ready (last error: %w)",
 				namespace, name, err)
 		}
 	}
+}
+
+// unschedulablePods reports the PodScheduled condition of the deployment's pods
+// that the scheduler could not place, so that a readiness timeout names the
+// admission failure instead of only counting the missing replicas.
+func unschedulablePods(ctx context.Context, client *k8s.Client, namespace, name string) string {
+	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
+	defer cancel()
+
+	deploy, err := client.GetDeployment(ctx, namespace, name, metav1.GetOptions{})
+	if err != nil || deploy == nil || deploy.Spec.Selector == nil {
+		return ""
+	}
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return ""
+	}
+	pods, err := client.ListPods(ctx, namespace, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return ""
+	}
+
+	var reasons []string
+	for _, pod := range pods.Items {
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodScheduled && cond.Status != corev1.ConditionTrue {
+				reasons = append(reasons, fmt.Sprintf("%s: %s: %s", pod.Name, cond.Reason, cond.Message))
+			}
+		}
+	}
+
+	return strings.Join(reasons, "; ")
 }
 
 // WaitForDaemonSet waits until the specified daemonset becomes ready.


### PR DESCRIPTION
The EGW conn-disrupt pods are pinned to a specific node, so they have to be
created first. Otherwise the setup's unpinned pods can take the room on those
nodes and the pinned ones have nowhere left to go, which fails the setup with
"only 0 of 1 replicas are available" as seen in the following URL:

https://github.com/cilium/cilium/actions/runs/33944156161/job/101247182630

That message counts the missing replicas without saying why they never came up, so
WaitForDeployment now reports the PodScheduled condition of the pods it gave up on
and the scheduler's reason reaches the job log instead of only the sysdump.

This PR was prepared with AIL:3. I personally checked the diff.
