### PR TITLE
k8s/synced: only wait for CiliumPodIPPool CRD in multi-pool IPAM

### DIFF
--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -21,6 +21,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -41,10 +42,21 @@ func CRDResourceName(crd string) string {
 	return "crd:" + crd
 }
 
+// agentNeedsPodIPPoolCRD reports whether the agent consumes the
+// CiliumPodIPPool CRD. It is only read by the multi-pool IPAM allocator (see
+// the ipamOption.IPAMMultiPool case in pkg/ipam/ipam.go), so in every other
+// IPAM mode the agent must not gate its startup on the CRD being registered.
+func agentNeedsPodIPPoolCRD() bool {
+	return option.Config.IPAM == ipamOption.IPAMMultiPool
+}
+
 func agentCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
 	result := []string{
 		CRDResourceName(v2.CIDName),
-		CRDResourceName(v2alpha1.CPIPName),
+	}
+
+	if agentNeedsPodIPPoolCRD() {
+		result = append(result, CRDResourceName(v2alpha1.CPIPName))
 	}
 
 	if !option.Config.DisableCiliumEndpointCRD {
@@ -133,6 +145,13 @@ func AllCiliumCRDResourceNames(bgpCfg bgpConfig.BGPConfig) []string {
 	res = append(res,
 		CRDResourceName(v2.CNCName),
 	)
+	// The operator registers CiliumPodIPPool regardless of the configured IPAM
+	// mode, whereas the agent only waits for it in multi-pool mode. Add it here
+	// when AgentCRDResourceNames left it out, so that the returned list stays
+	// free of duplicates.
+	if !agentNeedsPodIPPoolCRD() {
+		res = append(res, CRDResourceName(v2alpha1.CPIPName))
+	}
 	return res
 }
 

--- a/pkg/k8s/synced/crd_test.go
+++ b/pkg/k8s/synced/crd_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package synced
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestAgentCRDResourceNamesPodIPPool asserts that the agent only blocks its
+// startup on the CiliumPodIPPool CRD in multi-pool IPAM mode, while the
+// operator keeps registering it in every mode.
+func TestAgentCRDResourceNamesPodIPPool(t *testing.T) {
+	cpip := CRDResourceName(v2alpha1.CPIPName)
+
+	for _, ipamMode := range []string{
+		ipamOption.IPAMKubernetes,
+		ipamOption.IPAMCRD,
+		ipamOption.IPAMENI,
+		ipamOption.IPAMAzure,
+		ipamOption.IPAMClusterPool,
+		ipamOption.IPAMAlibabaCloud,
+		ipamOption.IPAMDelegatedPlugin,
+		ipamOption.IPAMMultiPool,
+	} {
+		t.Run(ipamMode, func(t *testing.T) {
+			prevIPAM := option.Config.IPAM
+			option.Config.IPAM = ipamMode
+			t.Cleanup(func() { option.Config.IPAM = prevIPAM })
+
+			agent := AgentCRDResourceNames(bgpConfig.DefaultConfig)
+			if ipamMode == ipamOption.IPAMMultiPool {
+				assert.Contains(t, agent, cpip,
+					"multi-pool IPAM reads CiliumPodIPPool, so the agent must wait for the CRD")
+			} else {
+				assert.NotContains(t, agent, cpip,
+					"CiliumPodIPPool is unused in %s IPAM mode, so the agent must not wait for the CRD", ipamMode)
+			}
+
+			// The operator creates its CRDs from this list, so CiliumPodIPPool
+			// has to appear exactly once regardless of the IPAM mode.
+			all := AllCiliumCRDResourceNames(bgpConfig.DefaultConfig)
+			assert.Equal(t, 1, countOccurrences(all, cpip),
+				"CiliumPodIPPool must be listed exactly once in %v", all)
+		})
+	}
+}
+
+func countOccurrences(haystack []string, needle string) int {
+	var n int
+	for _, s := range haystack {
+		if s == needle {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
`cilium-agent` gates its startup on the `ciliumpodippools.cilium.io` CRD being registered, regardless of the configured IPAM mode. When that CRD is absent the agent never becomes Ready and loops on:

```
Still waiting for Cilium Operator to register CRDs
module=agent.infra.k8s-synced-crdsync CRDs=[crd:ciliumpodippools.cilium.io]
```

### Root cause

`agentCRDResourceNames()` in `pkg/k8s/synced/crd.go` lists `CPIPName` in the unconditional seed slice:

```go
result := []string{
	CRDResourceName(v2.CIDName),
	CRDResourceName(v2alpha1.CPIPName),   // <-- unconditional
}
```

Every *other* optional CRD in that function is gated behind the option that enables it (`EnableEgressGateway`, `EnableLocalRedirectPolicy`, `EnableEnvoyConfig`, `bgpCfg.Enable`, ...). `CiliumPodIPPool` is only read by the multi-pool IPAM allocator — `pkg/k8s/watchers/watcher.go` even maps the resource to `{skip, ""}` with the comment `// Handled by multi-pool IPAM allocator`. So in every non-multi-pool mode the agent blocks on a CRD it never reads.

This is normally masked because `cilium-operator` registers all Cilium CRDs on startup. It bites any deployment that manages CRDs out of band: a Helm CRD sub-chart, a GitOps `crds/` directory, a curated bundle covering only enabled features, `operator.skipCRDCreation=true`, or an operator without RBAC to create `customresourcedefinitions`.

### Two corrections to the issue report

- **This is not a v1.19 regression.** The issue attributes it to `bbcc82373c`. The line is byte-identical on `v1.18`, and `git log -S CPIPName -- pkg/k8s/synced/crd.go` returns a single commit: `b7b7fb79e67f` (2023-06-05, v1.14). The behaviour has been present since `CiliumPodIPPool` was introduced.
- **`resource.WithCRDSync(...)` is not the cause.** That option only makes a resource *wait* for CRD sync before starting its informer; it does not add anything to the required-CRD list. The list built here is the sole cause.

### The change

Gate the entry on `--ipam=multi-pool`, matching how every other optional CRD in the function is handled.

`AllCiliumCRDResourceNames()` drives **operator CRD registration** (`pkg/k8s/apis/cilium.io/client/register.go:221`), so `CiliumPodIPPool` is still listed there unconditionally — CRD registration is deliberately left unchanged, and the list stays duplicate-free in multi-pool mode. This mirrors `06a8db7a2246` ("daemon: don't wait for presence of unused CNC CRD"), which made exactly this change for `CiliumNodeConfig`.

### Testing

New table-driven test in `pkg/k8s/synced/crd_test.go` over all eight IPAM modes, asserting the agent waits for the CRD iff multi-pool, and that the operator list contains it exactly once in every mode.

The test was confirmed to **fail on unpatched `main`** for all seven non-multi-pool modes and pass with the fix. `go build ./...`, `go vet`, and `gofmt` are clean; `pkg/k8s/synced/...` and `pkg/k8s/apis/cilium.io/...` pass.

No live-cluster (kind) reproduction was run — the change is pure config-gated list construction.

### Not addressed here

`pkg/ipam/podippool` registers its StateDB reflector unconditionally, so with the CRD absent it will error-loop on the initial List. That is log noise rather than a startup block (`waitForAllPools` is only reached in multi-pool mode), and it seemed better kept as a separate change. Happy to fold it in if reviewers prefer.

Fixes: #48533

```release-note
cilium-agent no longer waits for the CiliumPodIPPool CRD to be registered unless multi-pool IPAM is enabled, so a missing ciliumpodippools.cilium.io CRD no longer blocks agent startup in other IPAM modes.
```

---

> [!IMPORTANT]
> **TODO before marking ready for review — AI disclosure.**
> Per the [Cilium AI Policy], Generative AI use at [AI Influence Level] 2 or higher must be reported, describing how it was used and what human review was applied.
> **@timilsinamadhav: please replace this block with your own disclosure before taking this PR out of draft.**

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
