### PR TITLE
MAINTAINERS: Add Jordan Rife

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,6 +28,7 @@ to learn how to level up through the project.
  * [Hemanth Malla] (Microsoft)
  * [Jarno Rajahalme] (Isovalent)
  * [Joe Stringer] (Isovalent)
+ * [Jordan Rife] (Google)
  * [John Fastabend] (Isovalent)
  * [Julian Wiedmann] (Isovalent)
  * [Jussi Mäki] (Isovalent)
@@ -110,6 +111,7 @@ project.
 [Ilya Dmitrichenko]: https://github.com/errordeveloper
 [Jarno Rajahalme]: https://github.com/jrajahalme
 [Joe Stringer]: https://github.com/joestringer
+[Jordan Rife]: https://github.com/jrife
 [John Fastabend]: https://github.com/jrfastab
 [Julian Wiedmann]: https://github.com/julianwiedmann
 [Jussi Mäki]: https://github.com/joamaki


### PR DESCRIPTION
The voting period for granting to commit access to Jordan Rife initiated
at 2026-08-31 is now closed with the following results:

YES: 22
NO: 0
ABSTAIN: 1

With the Company Block Vote Limit applied:
YES: 6 Isovalent + 1 DataDog + 1 CoreWeave + 1 Ledger + 1 Hedgehog = 10 votes
NO: 0 votes
