### PR TITLE
sockets: preserve unconnected UDP sockets

### DIFF
--- a/pkg/datapath/sockets/sockets.go
+++ b/pkg/datapath/sockets/sockets.go
@@ -243,7 +243,7 @@ func newBPFSocketDestroyer(logger *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Ma
 }
 
 // Destroy destroys sockets matching the passed filter parameters using a BPF
-// socket iterator and the cil_sock_udp_destroy program.
+// socket iterator and the cil_sock_*_destroy program.
 //
 // Supported families in the filter: syscall.AF_INET, syscall.AF_INET6
 // Supported protocols in the filter: unix.IPPROTO_UDP, unix.IPPROTO_TCP
@@ -253,6 +253,16 @@ func (sd *bpfSocketDestroyer) Destroy(logger *slog.Logger, f SocketFilter) error
 	}
 	if f.Protocol != unix.IPPROTO_UDP && f.Protocol != unix.IPPROTO_TCP {
 		return fmt.Errorf("unsupported protocol for socket destroy: %d", f.Protocol)
+	}
+
+	// A UDP reverse-NAT entry is also created for an unconnected socket after
+	// sendto(). The BPF iterator only has the socket cookie and reverse-NAT
+	// entry available, so it cannot distinguish that socket from a connected
+	// socket. bpf_sock_destroy() would abort both, while the netlink path also
+	// matches the socket's destination and therefore leaves unconnected sockets
+	// alone.
+	if f.Protocol == unix.IPPROTO_UDP {
+		return (&netlinkSocketDestroyer{}).Destroy(logger, f)
 	}
 
 	sd.destroyMu.Lock()

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -84,6 +84,22 @@ func TestSocketReqSerialize(t *testing.T) {
 	}
 }
 
+func TestSocketFilterMatchSocket(t *testing.T) {
+	filter := SocketFilter{
+		DestIp:   netip.MustParseAddr("10.0.0.2"),
+		DestPort: 53,
+	}
+
+	assert.False(t, filter.MatchSocket(netlink.SocketID{
+		Destination:     net.ParseIP("0.0.0.0"),
+		DestinationPort: 0,
+	}))
+	assert.True(t, filter.MatchSocket(netlink.SocketID{
+		Destination:     net.ParseIP("10.0.0.2"),
+		DestinationPort: 53,
+	}))
+}
+
 func TestSocketDeserialize(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -613,6 +629,49 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrivilegedBPFSocketDestroyerLeavesUnconnectedUDP(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	log := hivetest.Logger(t)
+	bpf.CheckOrMountFS(log, "")
+
+	sockDestroyer := newTestBPFSocketDestroyer(t)
+	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer server.Close()
+	client, err := net.ListenUDP("udp4", nil)
+	require.NoError(t, err)
+	defer client.Close()
+
+	sysConn, ok := interface{}(client).(syscall.Conn)
+	require.True(t, ok)
+	rawConn, err := sysConn.SyscallConn()
+	require.NoError(t, err)
+	var cookie uint64
+	rawConn.Control(func(fd uintptr) {
+		cookie, err = unix.GetsockoptUint64(int(fd), unix.SOL_SOCKET, unix.SO_COOKIE)
+	})
+	require.NoError(t, err)
+	require.NoError(t, sockDestroyer.PrepareAddress(cookie, server.LocalAddr().String()))
+
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	require.NoError(t, sockDestroyer.Destroy(log, SocketFilter{
+		DestIp:   netip.MustParseAddr(serverAddr.IP.String()),
+		DestPort: uint16(serverAddr.Port),
+		Family:   unix.AF_INET,
+		Protocol: unix.IPPROTO_UDP,
+		States:   StateFilterUDP,
+	}))
+
+	payload := []byte("still open")
+	_, err = client.WriteToUDP(payload, serverAddr)
+	require.NoError(t, err)
+	require.NoError(t, server.SetReadDeadline(time.Now().Add(time.Second)))
+	received := make([]byte, len(payload))
+	n, _, err := server.ReadFromUDP(received)
+	require.NoError(t, err)
+	require.Equal(t, payload, received[:n])
 }
 
 func BenchmarkDestroyers(b *testing.B) {


### PR DESCRIPTION
## Description of change

The BPF socket iterator matches reverse-NAT entries, which are also created for unconnected UDP sockets after `sendto()`. Use the existing netlink destination match for UDP socket termination so only connected sockets are destroyed, while retaining the BPF path for TCP.

Fixes: #48564

```release-note
sockets: preserve unconnected UDP sockets during backend termination
```

## Validation

- Linux-targeted package compile: `GOOS=linux GOARCH=amd64 go test -c ./pkg/datapath/sockets`
- `git diff --check`
- Added a privileged regression test that sends through an unconnected UDP socket after termination and verifies the reply is received.
- Native Windows execution is blocked by the existing `pkg/loadbalancer/reflectors/cell.go:39:31: undefined: unix.ENOPROTOOPT` build failure; this package requires Linux for runtime tests.

This PR was prepared with AIL:3. I personally checked the socket termination path, regression test, and validation results.

- [x] For first time contributors, read the submitting-a-pull-request guide
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off.
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models in accordance with the Cilium AI Policy.
