### PR TITLE
.github: Remove AIL number from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please ensure your pull request adheres to the following guidelines:
 - [ ] Disclose use of machine learning models (including LLMs and other generative AI)
       in accordance with the [Cilium AI Policy], and indicate the rating using
       [AI Influence Level].
-      Example: "This PR was prepared with AIL:3. I personally checked X."
+      Example: "This PR was prepared with AIL:N. I personally checked X."
 - [ ] Thanks for contributing!
 
 <!-- Description of change -->


### PR DESCRIPTION
The AIL suggestion here influences the default value that contributors
set. Change it to AIL:N to encourage the contributor to self-declare
usage of computer generation tools.
