### PR TITLE
docs: remove stale crypto hash kernel requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -163,7 +163,6 @@ linked, either choice is valid.
         CONFIG_NET_SCH_INGRESS=y
         CONFIG_DEBUG_INFO_BTF=y
         CONFIG_CRYPTO_SHA1=y
-        CONFIG_CRYPTO_USER_API_HASH=y
         CONFIG_CGROUPS=y
         CONFIG_CGROUP_BPF=y
         CONFIG_PERF_EVENTS=y


### PR DESCRIPTION
The system requirements page lists `CONFIG_CRYPTO_USER_API_HASH` as a base
kernel requirement, but the current Cilium source has no use of the kernel's
user-space hash API. The option is present only in this documentation line,
which was carried forward from the older requirements page.

Remove the stale requirement so users do not enable an unrelated kernel option
for Cilium. This is a documentation-only change; the remaining crypto option
(`CONFIG_CRYPTO_SHA1`) is unchanged.

Validation:

- `git diff --check`
- searched the current tree (excluding `vendor/` and `.git/`) for
  `CRYPTO_USER_API_HASH`, `crypto_user`, and `AF_ALG`; no implementation use was found

This PR was prepared with AIL:3. I used an LLM to help inspect the issue,
trace the documentation line, and draft the patch and description. I personally
verified the current source search, diff, and final documentation change.

Fixes: #48206

```release-note
Remove the stale `CONFIG_CRYPTO_USER_API_HASH` entry from the documented base kernel requirements.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
