### PR TITLE
gha: Greet first-time issue reporters, not just PR authors

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -15,9 +15,9 @@ jobs:
   greet:
     # Only enforce on drive-by / first-time contributors.
     # Regulars (MEMBER, COLLABORATOR, OWNER, CONTRIBUTOR) are skipped entirely.
+    # The association lives under `pull_request` for PRs and `issue` for issues.
     if: >
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-      github.event.pull_request.author_association == 'FIRST_TIMER' ||
-      github.event.pull_request.author_association == 'NONE'
+      contains(fromJSON('["FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "NONE"]'),
+      github.event.pull_request.author_association || github.event.issue.author_association)
     uses: cilium/cilium/.github/workflows/reusable-greetings.yml@main
     secrets: inherit


### PR DESCRIPTION
The `greet` job only reads `github.event.pull_request.author_association`, which
is null on an `issues` event, so none of the three comparisons match and the job
is skipped for every issue. That is why only PR authors ever get greeted.

Read the association from whichever payload the event carries instead.

Fixes: #48264

```release-note
Fix the GitHub greeter so that it also welcomes first-time issue reporters.
```

This PR was prepared with AIL:3. I checked the workflow condition myself and
confirmed the `pull_request` object is absent from the `issues` event payload.
