### PR TITLE
bpf: egressgw: have ipv6_ct_reverse_tuple_*() return a pointer

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -575,16 +575,16 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 	ct_flip_tuple_dir6(tuple);
 }
 
-static __always_inline union v6addr
+static __always_inline const union v6addr *
 ipv6_ct_reverse_tuple_saddr(const struct ipv6_ct_tuple *rtuple)
 {
-	return rtuple->daddr;
+	return &rtuple->daddr;
 }
 
-static __always_inline union v6addr
+static __always_inline const union v6addr *
 ipv6_ct_reverse_tuple_daddr(const struct ipv6_ct_tuple *rtuple)
 {
-	return rtuple->saddr;
+	return &rtuple->saddr;
 }
 
 static __always_inline int

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -307,12 +307,12 @@ egress_gw_request_needs_redirect_v6(struct ipv6_ct_tuple *rtuple __maybe_unused,
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
 	const struct egress_gw_policy_entry6 *egress_gw_policy;
-	union v6addr saddr, daddr;
+	const union v6addr *saddr, *daddr;
 
 	saddr = ipv6_ct_reverse_tuple_saddr(rtuple);
 	daddr = ipv6_ct_reverse_tuple_daddr(rtuple);
 
-	egress_gw_policy = lookup_ip6_egress_gw_policy(&saddr, &daddr);
+	egress_gw_policy = lookup_ip6_egress_gw_policy(saddr, daddr);
 	if (!egress_gw_policy)
 		return CTX_ACT_OK;
 


### PR DESCRIPTION
We don't need stack variables here.