### PR TITLE
cilium-cli: don't register terminal leftover pods as test peers

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1204,11 +1204,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				allTargets["lb-svc"] = fmt.Sprintf("%s.%s.svc.cluster.local.", l7LBServiceName, ct.params.TestNamespace)
 			}
 
-			serverPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", testConnDisruptServerL7TrafficAppLabel)})
+			serverPods, err := listLivePods(ctx, ct.clients.src, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", testConnDisruptServerL7TrafficAppLabel)})
 			if err != nil {
 				return err
 			}
-			for _, serverPod := range serverPods.Items {
+			for _, serverPod := range serverPods {
 				for _, podIPAddr := range serverPod.Status.PodIPs {
 					podIP, err := netip.ParseAddr(podIPAddr.IP)
 					if err != nil {
@@ -1975,12 +1975,12 @@ func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
 		}
 		encodedCert := base64.StdEncoding.EncodeToString(cert)
 
-		clientPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
+		clientPods, err := listLivePods(ctx, ct.client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
 		if err != nil {
 			return fmt.Errorf("unable to list client pods: %w", err)
 		}
 
-		for _, pod := range clientPods.Items {
+		for _, pod := range clientPods {
 			cmd := []string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d >> /etc/ssl/certs/ca-certificates.crt", encodedCert)}
 			_, err := ct.execInPodWithTransportRetry(ctx, ct.client, ct.params.TestNamespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 			if err != nil {
@@ -2200,16 +2200,16 @@ type nodeWithType struct {
 
 func (ct *ConnectivityTest) getBackendNodeAndNonBackendNode(ctx context.Context) ([]nodeWithType, error) {
 	appLabel := fmt.Sprintf("app=%s", testConnDisruptServerNSTrafficAppLabel)
-	podList, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: appLabel})
+	podList, err := listLivePods(ctx, ct.clients.src, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: appLabel})
 	if err != nil {
 		return nil, fmt.Errorf("unable to list pods with lable %s: %w", appLabel, err)
 	}
 
-	if len(podList.Items) == 0 {
+	if len(podList) == 0 {
 		return nil, fmt.Errorf("no pods found with label %s", appLabel)
 	}
 
-	pod := podList.Items[0]
+	pod := podList[0]
 	if pod.Spec.NodeName == "" {
 		return nil, fmt.Errorf("pod %s is not scheduled on any node yet", pod.Name)
 	}
@@ -2283,12 +2283,12 @@ func (ct *ConnectivityTest) getConnDisruptClientEgressGatewayPodIPs(ctx context.
 
 	var podIPs []string
 	for _, appLabel := range appLabels {
-		connDisruptPods, err := ct.K8sClient().ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: appLabel})
+		connDisruptPods, err := listLivePods(ctx, ct.K8sClient(), ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: appLabel})
 		if err != nil {
 			return nil, fmt.Errorf("unable to list pods with lable %s: %w", appLabel, err)
 		}
 
-		for _, connDisruptPod := range connDisruptPods.Items {
+		for _, connDisruptPod := range connDisruptPods {
 			podIPs = append(podIPs, connDisruptPod.Status.PodIP)
 		}
 	}
@@ -2851,6 +2851,16 @@ func (ct *ConnectivityTest) CleanupConnectivityTest(ctx context.Context) error {
 	return nil
 }
 
+// listLivePods lists pods by selector, dropping the terminal leftovers a controller has already superseded.
+func listLivePods(ctx context.Context, client *k8s.Client, namespace string, options metav1.ListOptions) ([]corev1.Pod, error) {
+	pods, err := client.ListPods(ctx, namespace, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8s.LivePods(pods.Items), nil
+}
+
 func (ct *ConnectivityTest) validateDeploymentCommon(ctx context.Context, srcDeployments, dstDeployments []string) error {
 	ct.Debug("Validating Deployments...")
 
@@ -2875,12 +2885,12 @@ func (ct *ConnectivityTest) validateDeploymentPerf(ctx context.Context) error {
 		return err
 	}
 
-	perfPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindPerfName})
+	perfPods, err := listLivePods(ctx, ct.client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindPerfName})
 	if err != nil {
 		return fmt.Errorf("unable to list perf pods: %w", err)
 	}
 
-	for _, perfPod := range perfPods.Items {
+	for _, perfPod := range perfPods {
 		role := perfPodRole(perfPod.GetLabels()[perfPodRoleKey])
 		switch role {
 		case perfPodRoleServer:
@@ -2918,11 +2928,11 @@ func (ct *ConnectivityTest) validateDeploymentPerf(ctx context.Context) error {
 // registerEchoPods registers the echo pods of every cluster as test peers.
 func (ct *ConnectivityTest) registerEchoPods(ctx context.Context) error {
 	for _, client := range ct.clients.clients() {
-		echoPods, err := client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindEchoName})
+		echoPods, err := listLivePods(ctx, client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindEchoName})
 		if err != nil {
 			return fmt.Errorf("unable to list echo pods: %w", err)
 		}
-		for _, echoPod := range echoPods.Items {
+		for _, echoPod := range echoPods {
 			ct.echoPods[echoPod.Name] = Pod{
 				K8sClient: client,
 				Pod:       echoPod.DeepCopy(),
@@ -2942,11 +2952,11 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	if ct.Features[features.LocalRedirectPolicy].Enabled {
-		lrpPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindLrpName})
+		lrpPods, err := listLivePods(ctx, ct.client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindLrpName})
 		if err != nil {
 			return fmt.Errorf("unable to list lrp pods: %w", err)
 		}
-		for _, lrpPod := range lrpPods.Items {
+		for _, lrpPod := range lrpPods {
 			if v, hasLabel := lrpPod.GetLabels()["lrp"]; hasLabel {
 				if v == "backend" {
 					ct.lrpBackendPods[lrpPod.Name] = Pod{
@@ -2970,11 +2980,11 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			if err := WaitForDeployment(ctx, ct, ct.clients.src, ns, ccnpDeploymentName); err != nil {
 				return err
 			}
-			ccnpPods, err := ct.client.ListPods(ctx, ns, metav1.ListOptions{LabelSelector: "kind=" + kindCCNPName})
+			ccnpPods, err := listLivePods(ctx, ct.client, ns, metav1.ListOptions{LabelSelector: "kind=" + kindCCNPName})
 			if err != nil {
 				return fmt.Errorf("unable to list ccnp pods in namespace %s: %w", ns, err)
 			}
-			for _, ccnpPod := range ccnpPods.Items {
+			for _, ccnpPod := range ccnpPods {
 				ct.ccnpTestPods[ns] = Pod{
 					K8sClient: ct.client,
 					Pod:       ccnpPod.DeepCopy(),
@@ -2983,12 +2993,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	clientPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
+	clientPods, err := listLivePods(ctx, ct.client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
 	if err != nil {
 		return fmt.Errorf("unable to list client pods: %w", err)
 	}
 
-	for _, pod := range clientPods.Items {
+	for _, pod := range clientPods {
 		if strings.Contains(pod.Name, clientCPDeployment) {
 			ct.clientCPPods[pod.Name] = Pod{
 				K8sClient: ct.client,
@@ -3002,16 +3012,15 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	sameNodePods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoSameNodeDeploymentName})
+	sameNodePods, err := listLivePods(ctx, ct.clients.src, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoSameNodeDeploymentName})
 	if err != nil {
 		return fmt.Errorf("unable to list same node pods: %w", err)
 	}
-	sameNodePodItems := k8s.LivePods(sameNodePods.Items)
-	if len(sameNodePodItems) != 1 {
-		return fmt.Errorf("unexpected number of same node pods: %d", len(sameNodePodItems))
+	if len(sameNodePods) != 1 {
+		return fmt.Errorf("unexpected number of same node pods: %d", len(sameNodePods))
 	}
 	sameNodePod := Pod{
-		Pod: sameNodePodItems[0].DeepCopy(),
+		Pod: sameNodePods[0].DeepCopy(),
 	}
 
 	for _, cp := range ct.clientPods {
@@ -3022,16 +3031,15 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	if !ct.params.SingleNode || ct.params.MultiCluster != "" {
-		otherNodePods, err := ct.clients.dst.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoOtherNodeDeploymentName})
+		otherNodePods, err := listLivePods(ctx, ct.clients.dst, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoOtherNodeDeploymentName})
 		if err != nil {
 			return fmt.Errorf("unable to list other node pods: %w", err)
 		}
-		otherNodePodItems := k8s.LivePods(otherNodePods.Items)
-		if len(otherNodePodItems) != 1 {
-			return fmt.Errorf("unexpected number of other node pods: %d", len(otherNodePodItems))
+		if len(otherNodePods) != 1 {
+			return fmt.Errorf("unexpected number of other node pods: %d", len(otherNodePods))
 		}
 		otherNodePod := Pod{
-			Pod: otherNodePodItems[0].DeepCopy(),
+			Pod: otherNodePods[0].DeepCopy(),
 		}
 
 		for _, cp := range ct.clientPods {
@@ -3042,12 +3050,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	if ct.Features[features.NodeWithoutCilium].Enabled {
-		echoExternalNodePods, err := ct.clients.dst.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoExternalNodeDeploymentName})
+		echoExternalNodePods, err := listLivePods(ctx, ct.clients.dst, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + echoExternalNodeDeploymentName})
 		if err != nil {
 			return fmt.Errorf("unable to list other node pods: %w", err)
 		}
 
-		for _, pod := range echoExternalNodePods.Items {
+		for _, pod := range echoExternalNodePods {
 			ct.echoExternalPods[pod.Name] = Pod{
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
@@ -3072,11 +3080,11 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.params.SharedTestNamespace, frrDaemonSetNameName); err != nil {
 			return err
 		}
-		frrPods, err := ct.clients.dst.ListPods(ctx, ct.params.SharedTestNamespace, metav1.ListOptions{LabelSelector: "name=" + frrDaemonSetNameName})
+		frrPods, err := listLivePods(ctx, ct.clients.dst, ct.params.SharedTestNamespace, metav1.ListOptions{LabelSelector: "name=" + frrDaemonSetNameName})
 		if err != nil {
 			return fmt.Errorf("unable to list FRR pods: %w", err)
 		}
-		for _, pod := range frrPods.Items {
+		for _, pod := range frrPods {
 			ct.frrPods = append(ct.frrPods, Pod{
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
@@ -3086,11 +3094,11 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 
 	if ct.Features[features.Multicast].Enabled {
 		// socat client pods
-		socatCilentPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatClientDeploymentName})
+		socatCilentPods, err := listLivePods(ctx, ct.clients.src, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatClientDeploymentName})
 		if err != nil {
 			return fmt.Errorf("unable to list socat client pods: %w", err)
 		}
-		for _, pod := range socatCilentPods.Items {
+		for _, pod := range socatCilentPods {
 			ct.socatClientPods = append(ct.socatClientPods, Pod{
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
@@ -3101,11 +3109,11 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, socatServerDaemonsetName); err != nil {
 			return err
 		}
-		socatServerPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatServerDaemonsetName})
+		socatServerPods, err := listLivePods(ctx, ct.clients.src, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatServerDaemonsetName})
 		if err != nil {
 			return fmt.Errorf("unable to list socat server pods: %w", err)
 		}
-		for _, pod := range socatServerPods.Items {
+		for _, pod := range socatServerPods {
 			ct.socatServerPods = append(ct.socatServerPods, Pod{
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
@@ -3243,12 +3251,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 				return err
 			}
 		}
-		hostNetNSPods, err := client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindHostNetNS})
+		hostNetNSPods, err := listLivePods(ctx, client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindHostNetNS})
 		if err != nil {
 			return fmt.Errorf("unable to list host netns pods: %w", err)
 		}
 
-		for _, pod := range hostNetNSPods.Items {
+		for _, pod := range hostNetNSPods {
 			_, ok := ct.nodesWithoutCilium[pod.Spec.NodeName]
 			p := Pod{
 				K8sClient: client,
@@ -3278,12 +3286,12 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	l7LBPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
+	l7LBPods, err := listLivePods(ctx, ct.client, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
 	if err != nil {
 		return fmt.Errorf("unable to list client pods: %w", err)
 	}
 
-	for _, pod := range l7LBPods.Items {
+	for _, pod := range l7LBPods {
 		ct.l7LBClientPods[pod.Name] = Pod{
 			K8sClient: ct.client,
 			Pod:       pod.DeepCopy(),

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2915,6 +2915,26 @@ func (ct *ConnectivityTest) validateDeploymentPerf(ctx context.Context) error {
 	return nil
 }
 
+// registerEchoPods registers the echo pods of every cluster as test peers.
+func (ct *ConnectivityTest) registerEchoPods(ctx context.Context) error {
+	for _, client := range ct.clients.clients() {
+		echoPods, err := client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindEchoName})
+		if err != nil {
+			return fmt.Errorf("unable to list echo pods: %w", err)
+		}
+		for _, echoPod := range echoPods.Items {
+			ct.echoPods[echoPod.Name] = Pod{
+				K8sClient: client,
+				Pod:       echoPod.DeepCopy(),
+				scheme:    "http",
+				port:      8080, // listen port of the echo server inside the container
+			}
+		}
+	}
+
+	return nil
+}
+
 func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	srcDeployments, dstDeployments := ct.deploymentList()
 	if err := ct.validateDeploymentCommon(ctx, srcDeployments, dstDeployments); err != nil {
@@ -3103,19 +3123,8 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			return err
 		}
 	}
-	for _, client := range ct.clients.clients() {
-		echoPods, err := client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindEchoName})
-		if err != nil {
-			return fmt.Errorf("unable to list echo pods: %w", err)
-		}
-		for _, echoPod := range echoPods.Items {
-			ct.echoPods[echoPod.Name] = Pod{
-				K8sClient: client,
-				Pod:       echoPod.DeepCopy(),
-				scheme:    "http",
-				port:      8080, // listen port of the echo server inside the container
-			}
-		}
+	if err := ct.registerEchoPods(ctx); err != nil {
+		return err
 	}
 
 	for _, client := range ct.clients.clients() {

--- a/cilium-cli/connectivity/check/deployment_test.go
+++ b/cilium-cli/connectivity/check/deployment_test.go
@@ -42,9 +42,37 @@ func newFakeConnectivityTest(t *testing.T, objects ...runtime.Object) (*Connecti
 			src: client,
 			dst: client,
 		},
+		echoPods: make(map[string]Pod),
 	}
 
 	return ct, client
+}
+
+func echoPod(name string, phase corev1.PodPhase, reason string, ips ...string) *corev1.Pod {
+	podIPs := make([]corev1.PodIP, 0, len(ips))
+	for _, ip := range ips {
+		podIPs = append(podIPs, corev1.PodIP{IP: ip})
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default-test-namespace",
+			Labels:    map[string]string{"kind": kindEchoName},
+		},
+		Status: corev1.PodStatus{Phase: phase, Reason: reason, PodIPs: podIPs},
+	}
+}
+
+func TestRegisterEchoPodsSkipsSupersededLeftovers(t *testing.T) {
+	ct, _ := newFakeConnectivityTest(t,
+		echoPod("echo-other-node-live", corev1.PodRunning, "", "10.0.0.1"),
+		echoPod("echo-other-node-evicted", corev1.PodFailed, "Evicted"),
+	)
+
+	require.NoError(t, ct.registerEchoPods(context.Background()))
+	require.Len(t, ct.EchoPods(), 1)
+	assert.Contains(t, ct.EchoPods(), "echo-other-node-live")
 }
 
 func TestDeployNamespaceCreatesMissingNamespace(t *testing.T) {


### PR DESCRIPTION
A ReplicaSet never deletes a Failed pod, it only creates a replacement, so a node
under eviction pressure leaves terminal siblings behind and every one of them is
registered as a connectivity test peer. They carry no pod IP, so Pod.Address()
returns the empty string, curl is handed the literal URL http://:8080, and it
exits 3 before a packet leaves the pod. On one AKS leg that was 34 evicted echo
leftovers and 87 identical malformed-URL failures, each dragging a sysdump behind
it, until the 90 minute job budget was gone:

https://github.com/cilium/cilium/actions/runs/33943419941/job/101245152804

The listings are first funnelled through one helper, which also lifts the inline
echo peer loop out of validateDeployment, and that helper then filters through
k8s.LivePods, which the echo count assertions in the same function already use.
ListPods itself is untouched, so sysdump and status still see the dead pods, and a
pod whose container ran and crashed has an empty Status.Reason and is still
registered, so a genuinely broken deployment still fails.

This PR was prepared with AIL:3. I personally checked the diff.
