### PR TITLE
policy, hubble: provide attribution for default denies

### DIFF
--- a/cilium-cli/connectivity/builder/all_ingress_deny.go
+++ b/cilium-cli/connectivity/builder/all_ingress_deny.go
@@ -34,6 +34,6 @@ func (t allIngressDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
 					return check.ResultOK, check.ResultNone
 				}
 			}
-			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
+			return check.ResultDrop, check.ResultDefaultDenyIngressDropWithPolicy(ct, "all-ingress-deny")
 		})
 }

--- a/cilium-cli/connectivity/builder/all_ingress_deny_knp.go
+++ b/cilium-cli/connectivity/builder/all_ingress_deny_knp.go
@@ -41,6 +41,6 @@ func (t allIngressDenyKnp) build(ct *check.ConnectivityTest, _ map[string]string
 					return check.ResultOK, check.ResultNone
 				}
 			}
-			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
+			return check.ResultDrop, check.ResultDefaultDenyIngressDropWithPolicy(ct, "all-ingress-deny")
 		})
 }

--- a/cilium-cli/connectivity/builder/client_ingress.go
+++ b/cilium-cli/connectivity/builder/client_ingress.go
@@ -24,6 +24,6 @@ func (t clientIngress) build(ct *check.ConnectivityTest, _ map[string]string) {
 			if a.Source().HasLabel("other", "client") {
 				return check.ResultOK, check.ResultOK
 			}
-			return check.ResultOK, check.ResultDefaultDenyIngressDrop
+			return check.ResultOK, check.ResultDefaultDenyIngressDropWithPolicy(ct, "client-ingress-from-client2")
 		})
 }

--- a/cilium-cli/connectivity/builder/client_ingress_knp.go
+++ b/cilium-cli/connectivity/builder/client_ingress_knp.go
@@ -24,6 +24,6 @@ func (t clientIngressKnp) build(ct *check.ConnectivityTest, _ map[string]string)
 			if a.Source().HasLabel("other", "client") {
 				return check.ResultOK, check.ResultOK
 			}
-			return check.ResultOK, check.ResultDefaultDenyIngressDrop
+			return check.ResultOK, check.ResultDefaultDenyIngressDropWithPolicy(ct, "client-ingress-from-client2")
 		})
 }

--- a/cilium-cli/connectivity/builder/echo_ingress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7_named_port.go
@@ -36,6 +36,6 @@ func (t echoIngressL7NamedPort) build(ct *check.ConnectivityTest, _ map[string]s
 				}
 				return egress, check.ResultNone
 			}
-			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
+			return check.ResultDrop, check.ResultDefaultDenyIngressDropWithPolicy(ct, "echo-ingress-l7-http-named-port")
 		})
 }

--- a/cilium-cli/connectivity/check/result.go
+++ b/cilium-cli/connectivity/check/result.go
@@ -12,6 +12,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type Result struct {
@@ -211,6 +212,39 @@ var (
 		ExitCode: ExitCurlHTTPError,
 	}
 )
+
+func ResultDefaultDenyIngressDropWithPolicy(ct *ConnectivityTest, policyName string) Result {
+	dropFunc := func(flow *flowpb.Flow) bool {
+		reason := flow.GetDropReasonDesc()
+		// Cilium v1.21 reports all policies that caused a default deny.
+		// For v1.20 and earlier, just determine the reason
+		if !versioncheck.MustCompile(">=1.21.0")(ct.CiliumVersion) {
+			return reason == flowpb.DropReason_POLICY_DENIED
+		}
+
+		// Starting in v1.20 (but untested), PASS verdicts will be either DENY or DENIED
+		// This is because a baseline deny entry is created.
+		if reason != flowpb.DropReason_POLICY_DENIED && reason != flowpb.DropReason_POLICY_DENY {
+			return false
+		}
+
+		// Ensure that the policies responsible for the drop include the name in question
+		for _, pol := range flow.GetIngressDeniedBy() {
+			if pol.Name == policyName {
+				ct.Debugf("Found flow with deny attributed to policy  %s", pol.Name)
+				return true
+			}
+		}
+		return false
+	}
+
+	return Result{
+		Drop:           true,
+		IngressDrop:    true,
+		DropReasonFunc: dropFunc,
+		ExitCode:       ExitAnyError,
+	}
+}
 
 func (e ExitCode) String() string {
 	switch e {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1386,14 +1386,14 @@ func (e *Endpoint) UpdateBandwidthPolicy(bandwidthEgress, bandwidthIngress, prio
 // datapath's L3-vs-L4 precedence (via EndpointPolicy.Lookup), so port-range entries and the
 // various matchType-equivalent stored shapes (L3L4, L4Only, L3Proto, ProtoOnly, L3Only, All)
 // resolve through a single LPM walk without per-matchType key adjustments on the caller side.
-func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
+func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key, deny bool) (
 	info policyTypes.PolicyCorrelationInfo,
 	ok bool,
 ) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
-	_, ruleMeta, found := e.realizedPolicy.Lookup(key)
+	ruleMeta, found := e.realizedPolicy.Attribute(key, deny)
 	if !found {
 		return info, false
 	}

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -79,5 +79,5 @@ type EndpointInfo interface {
 	GetK8sPodUID() string
 	GetLabels() labels.Labels
 	GetPod() *slim_corev1.Pod
-	GetPolicyCorrelationInfoForKey(key policyTypes.Key) (policyTypes.PolicyCorrelationInfo, bool)
+	GetPolicyCorrelationInfoForKey(key policyTypes.Key, deny bool) (policyTypes.PolicyCorrelationInfo, bool)
 }

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1372,7 +1372,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.True(t, ok)
 	info, ok := ep.GetPolicyCorrelationInfoForKey(
 		policy.KeyForDirection(directionFromProto(f.GetTrafficDirection())).
-			WithIdentity(identity.NumericIdentity(f.GetDestination().GetIdentity())))
+			WithIdentity(identity.NumericIdentity(f.GetDestination().GetIdentity())), false)
 	assert.True(t, ok)
 	lbls := labels.LabelArrayListFromString(info.RuleLabels)
 	assert.Equal(t, lbls, policyLabel)

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -471,7 +471,7 @@ func (e *FakeEndpointInfo) GetPod() *slim_corev1.Pod {
 	return e.Pod
 }
 
-func (e *FakeEndpointInfo) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
+func (e *FakeEndpointInfo) GetPolicyCorrelationInfoForKey(key policyTypes.Key, deny bool) (
 	info policyTypes.PolicyCorrelationInfo,
 	ok bool,
 ) {

--- a/pkg/labels/arraylist.go
+++ b/pkg/labels/arraylist.go
@@ -226,6 +226,13 @@ func writeRemainder(str string, start, end int, sb *strings.Builder) {
 
 // merge 'b' to 'a' assuming both are sorted
 func MergeSortedLabelArrayListStrings(la, lb LabelArrayListString) LabelArrayListString {
+	if la == "" {
+		return lb
+	}
+	if lb == "" {
+		return la
+	}
+
 	var sb strings.Builder
 	var aStart, aEnd, bStart, bEnd int
 	a := string(la)

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -67,6 +67,7 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 
 	info, ok := epInfo.GetPolicyCorrelationInfoForKey(
 		policy.KeyForDirection(direction).WithIdentity(remoteIdentity).WithPortProto(proto, dport),
+		(denied || audited),
 	)
 	if !ok {
 		logger.Debug(

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1505,6 +1505,10 @@ type L4DirectionPolicy struct {
 
 	// features tracks properties of PortRules to skip code when features are not used
 	features policyFeatures
+
+	// defaultDenyRules tracks all rules that contribute to
+	// default deny.
+	defaultDenyRules ruleOrigin
 }
 
 // newL4DirectionPolicy creates a new L4DirectionPolicy with slices initialized for one tier for

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -367,7 +367,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	if ingressEnabled {
 		policyCtx.PolicyTrace("resolving ingress policy")
-		newL4IngressPolicy, err := rulesIngress.resolveL4Policy(&policyCtx)
+		newL4IngressPolicy, err := rulesIngress.resolveL4Policy(&policyCtx, true)
 		if err != nil {
 			return nil, err
 		}
@@ -376,7 +376,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	if egressEnabled {
 		policyCtx.PolicyTrace("resolving egress policy")
-		newL4EgressPolicy, err := rulesEgress.resolveL4Policy(&policyCtx)
+		newL4EgressPolicy, err := rulesEgress.resolveL4Policy(&policyCtx, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -324,6 +324,29 @@ func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, RuleMeta, bool) {
 	return entry.MapStateEntry, entry.derivedFromRules.Value(), found
 }
 
+// Attribute functions like Lookup, but also returns the rules responsible
+// for setting the endpoint in to default deny state if relevant.
+func (p *EndpointPolicy) Attribute(key Key, deny bool) (RuleMeta, bool) {
+	_, ruleMeta, found := p.Lookup(key)
+	if !found {
+		// If this was denied, and not found, then it was a default deny.
+		// Substitute in the full set of policies
+		if deny {
+			if key.IsIngress() {
+				ruleMeta = p.SelectorPolicy.L4Policy.Ingress.defaultDenyRules.Value()
+			} else {
+				ruleMeta = p.SelectorPolicy.L4Policy.Egress.defaultDenyRules.Value()
+			}
+		} else {
+			// unlikely, but somehow traffic was allowed and we didn't find the
+			// corresponding mapstate entry. Maybe skew as a new policy was being
+			// applied to BPF.
+			return ruleMeta, false
+		}
+	}
+	return ruleMeta, true
+}
+
 // CopyMapStateFrom copies the policy map entries from m.
 func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
 	for key, entry := range m {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/cilium/cilium/pkg/container/set"
@@ -113,10 +114,11 @@ func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) 
 	return tierBasePriorities, tierPriorityLevels, nil
 }
 
-func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPolicy, error) {
+func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext, ingress bool) (L4DirectionPolicy, error) {
 	state := traceState{}
 	result := L4DirectionPolicy{
-		PortRules: L4PolicyMaps{makeL4PolicyMap()},
+		PortRules:        L4PolicyMaps{makeL4PolicyMap()},
+		defaultDenyRules: NilRuleOrigin,
 	}
 
 	if len(rules) == 0 {
@@ -141,6 +143,7 @@ func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPoli
 	increment := types.Priority(1) // default increment
 	tier := types.Tier(0)
 	lastPrio := rules[0].Priority
+	numDefaultDeny := 0 // attribute default deny to the first rule, but count the number of rules
 	for _, r := range rules {
 		if r.Tier != tier {
 			tier = r.Tier
@@ -172,6 +175,26 @@ func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPoli
 		if r.Verdict == types.Pass && tier < lastTier {
 			increment = types.Priority(tierPassPriorities[tier]) + 1
 		}
+
+		if r.DefaultDeny {
+			if numDefaultDeny == 0 {
+				// Attribute any default-deny flows to the first rule.
+				result.defaultDenyRules = r.origin()
+			}
+			numDefaultDeny++
+		}
+	}
+
+	// Tag the default-deny attribution with the standard default-deny label, along with
+	// some information indicating that the attribution may have been truncated.
+	if numDefaultDeny > 0 {
+		desc := "egress"
+		lbls := LabelsDenyAnyEgress
+		if ingress {
+			desc = "ingress"
+			lbls = LabelsDenyAnyIngress
+		}
+		result.defaultDenyRules = result.defaultDenyRules.Merge(makeSingleRuleOrigin(lbls, fmt.Sprintf("%s default deny from %d rules", desc, numDefaultDeny)))
 	}
 
 	state.trace(len(rules), policyCtx)


### PR DESCRIPTION
This was inspired by a conversation with @derailed.

Kubernetes' (and Cilium's) network policy default deny semantics are confusing, to say the least. Specifically, every pod is default-allow until the first policy selects that pod. Then it is switched to default-deny. This is calculated per direction, too.

This all can make it quite difficult to determine *why* a given bit of traffic was dropped.

This change adds policy attribution / correlation for denies as well. Specifically, it uses the same ruleOrigin mechanism used for explicit entries. This gathers the set of policies that contributed to a given direction's default posture.

To make it clear that this was a default deny, a marker label (already sometimes used with PASS verdicts) is always returned from the Hubble flow.

The effect is that denies are now attributed to the policies that caused them. This results in a hubble flow like this:

```jsonc
{
    // ...
    "egress_denied_by": [
      {
        "name": "client-allow-cidr",
        "namespace": "foo",
        "labels": [
          "k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
          "k8s:io.cilium.k8s.policy.name=client-allow-cidr",
          "k8s:io.cilium.k8s.policy.namespace=foo",
          "k8s:io.cilium.k8s.policy.uid=60fd759e-1c30-4cbe-b6e6-84df5f6d7139"
        ],
        "revision": "2",
        "kind": "CiliumNetworkPolicy"
      },
      {
        "labels": [
          "reserved:io.cilium.policy.derived-from=deny-any-egress"
        ],
        "revision": "2"
      }
    ],
    "policy_log": [
      "egress default deny from 1 rules"
    ]
}
```

In the event that policy mode "always" is configured, all endpoints are always in default-deny. So the flow looks like this, regardless of the presence or absence of rules:

```jsonc
{
    // ...
    "egress_denied_by": [
      {
        "labels": [
          "reserved:io.cilium.policy.derived-from=deny-any-egress"
        ],
        "revision": "2"
      }
    ],
    "policy_log": [
      "egress default deny from PolicyEnforcement mode 'always'"
    ]
}
```

```release-note
Hubble flows now report the reason for a default-deny drop. This is typically the first policy that causes a Pod to be in default-deny state.
```
