### PR TITLE
[v1.18] gha: authenticate release images with OIDC

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -82,6 +82,7 @@ jobs:
         if: ${{ env.PUSH_TO_DOCKER_HUB == 'true' }}
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+          DOCKERHUB_OIDC_EXPIREIN: 2700
         with:
           username: ${{ vars.DOCKERHUB_ORGANIZATION }}
 

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -16,6 +16,7 @@ jobs:
   build-and-push:
     timeout-minutes: 45
     name: Build and Push Images
+    # Also decides the subject of the OIDC token, see the login steps below.
     environment:
       name: release
       deployment: false
@@ -71,19 +72,55 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
+      # Docker Hub trades the OIDC token for an access token on its own
+      # identity endpoint, which the action does for us as long as no password
+      # is given. The connection ID only names the trust configured on the
+      # organization, so it lives in a variable of the release environment
+      # rather than in a secret.
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         if: ${{ env.PUSH_TO_DOCKER_HUB == 'true' }}
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
         with:
-          username: ${{ secrets.DOCKER_HUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_RELEASE_PASSWORD }}
+          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
+
+      # Quay's registry endpoint only accepts credentials or a JWT signed by
+      # Quay itself, so the GitHub OIDC token cannot be used as the registry
+      # password directly. Trade it for a short lived robot token first.
+      #
+      # Because the job references an environment, the subject of the token is
+      # repo:cilium@21054566/cilium@48109239:environment:release, the immutable
+      # form that carries the owner and repository ids. That is the identity
+      # federated with the robot account on the Quay side, so renaming the
+      # environment breaks the login.
+      - name: Get a ${{ env.REGISTRY }} robot token via OIDC
+        id: registry-token
+        env:
+          ROBOT: ${{ secrets.QUAY_USERNAME_RELEASE_USERNAME }}
+        run: |
+          oidc_token="$(curl -sSf --retry 3 --retry-all-errors \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=quay.io" \
+            | jq -er '.value')"
+          echo "::add-mask::${oidc_token}"
+
+          # Pass the credentials on stdin so that the OIDC token is not visible
+          # in the process list of the runner.
+          robot_token="$(printf 'user = "%s:%s"\n' "${ROBOT}" "${oidc_token}" \
+            | curl -sSf --retry 3 --retry-all-errors -K - \
+              "https://quay.io/oauth2/federation/robot/token" \
+            | jq -er '.token')"
+          echo "::add-mask::${robot_token}"
+
+          echo "token=${robot_token}" >> "$GITHUB_OUTPUT"
 
       - name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME_RELEASE_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD_RELEASE_PASSWORD }}
+          password: ${{ steps.registry-token.outputs.token }}
 
       - name: Getting image tag
         id: tag


### PR DESCRIPTION
Use OIDC to authenticate the release image build to quay.io and Docker Hub on
v1.18, instead of the static passwords for both, and ask Docker Hub for a token
that outlives the image push. Backport of #48062 and #48535, both needed
together since the default Docker Hub token expires before most images finish
pushing.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 48062 48535
```

This PR was prepared with AIL:3.
