### PR TITLE
gh: lint-bpf-checks: clean up disk when running BPF tests

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -142,6 +142,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
This job seems to be running out of disk space sometimes. Might be related to the recent increase in parallel execution.