### PR TITLE
Backport 1.19: aws/ipam: Recalculate IP limits when falling back to single IPs

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -424,6 +424,24 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 			"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 			logfields.Node, n.k8sObj.Name,
 		)
+		// If subnet is out of prefixes, re-calculate maximum allocatable IPs
+		limits, limitsAvailable := n.getLimits()
+		if !limitsAvailable {
+			return errors.New(errUnableToDetermineLimits)
+		}
+		n.mutex.RLock()
+		e, ok := n.enis[a.InterfaceID]
+		usePrimary := n.k8sObj.Spec.ENI.UsePrimaryAddress != nil && *n.k8sObj.Spec.ENI.UsePrimaryAddress
+		n.mutex.RUnlock()
+		if !ok {
+			return fmt.Errorf("%s: %s", errENINotFound, a.InterfaceID)
+		}
+		maxAllocatableIPs := limits.IPv4
+		if !usePrimary {
+			maxAllocatableIPs--
+		}
+		maxAllocatableIPs -= len(e.Addresses) - len(e.Prefixes)*(option.ENIPDBlockSizeIPv4-1)
+		a.IPv4.AvailableForAllocation = min(a.IPv4.AvailableForAllocation, maxAllocatableIPs)
 	}
 	assignedIPs, err := n.manager.ec2api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
 	if err != nil {
@@ -543,6 +561,7 @@ func (n *Node) findNextIndex(index int32) int32 {
 // usable for metrics accounting purposes.
 const (
 	errUnableToDetermineLimits   = "unable to determine limits"
+	errENINotFound               = "unable to find ENI"
 	unableToDetermineLimits      = "unableToDetermineLimits"
 	errUnableToGetSecurityGroups = "unable to get security groups"
 	unableToGetSecurityGroups    = "unableToGetSecurityGroups"
@@ -618,6 +637,8 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 				logfields.Node, n.k8sObj.Name,
 			)
+			// If subnet is out of prefixes, re-calculate maximum allocatable IPs
+			toAllocate = min(allocation.IPv4.MaxIPsToAllocate, limits.IPv4-1)
 			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false)
 		}
 		if err != nil {
@@ -777,7 +798,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 		return nil, stats, fmt.Errorf("unable to retrieve ENIs")
 	}
 
-	stats.RemainingAvailableInterfaceCount += limits.Adapters - len(n.enis)
+	stats.RemainingAvailableInterfaceCount += limits.Adapters - enis
 	return available, stats, nil
 }
 


### PR DESCRIPTION
Backport of upstream PR #48193 to v1.19.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
48193
```