### PR TITLE
gateway-api: remove stale TODO comments in helper tests

### DIFF
--- a/operator/pkg/gateway-api/helpers/equal_test.go
+++ b/operator/pkg/gateway-api/helpers/equal_test.go
@@ -178,7 +178,6 @@ func TestObjectEqual(t *testing.T) {
 			if tt.wantErr {
 				t.Fatal("ObjectEqual() succeeded unexpectedly")
 			}
-			// TODO: update the condition below to compare got with tt.want.
 			if got != tt.want {
 				t.Errorf("ObjectEqual() = %v, want %v", got, tt.want)
 			}

--- a/operator/pkg/gateway-api/helpers/routes_test.go
+++ b/operator/pkg/gateway-api/helpers/routes_test.go
@@ -112,7 +112,6 @@ func TestIsParentAttachable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsParentAttachable(tt.reconcileParent, tt.route, tt.parents, nil)
-			// TODO: update the condition below to compare got with tt.want.
 			if tt.want != got {
 				t.Errorf("IsParentAttachable() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ x All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->
Removed stale TODO comments in `equal_test.go` and `routes_test.go`.
Both comments ask to compare `got` with `tt.want`, which is already
done on the next line.

AIL:1

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
