### PR TITLE
bpf/analyze: no-op unreachable BPF functions

### DIFF
--- a/pkg/bpf/analyze/blocks.go
+++ b/pkg/bpf/analyze/blocks.go
@@ -6,10 +6,12 @@ package analyze
 import (
 	"errors"
 	"fmt"
+	"iter"
 	"slices"
 	"strings"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
 )
 
 // leaderKey is used to store the leader metadata in an instruction's metadata.
@@ -213,6 +215,18 @@ func (b *Block) leader(insns asm.Instructions) *leader {
 	return getLeaderMeta(&insns[b.start])
 }
 
+func (b *Block) first(insns asm.Instructions) *asm.Instruction {
+	if len(insns) == 0 {
+		return nil
+	}
+
+	if b.start >= len(insns) {
+		return nil
+	}
+
+	return &insns[b.start]
+}
+
 func (b *Block) last(insns asm.Instructions) *asm.Instruction {
 	if len(insns) == 0 {
 		return nil
@@ -259,6 +273,21 @@ func (b *Block) iterateGlobal(blocks Blocks, insns asm.Instructions) *BlockItera
 // the last instruction in the block.
 func (b *Block) backtrack(insns asm.Instructions) *Backtracker {
 	return newBacktracker(b, insns)
+}
+
+// Func returns the BTF function metadata associated with the block, if any. If
+// the block is not the start of a function, it returns nil.
+func (b *Block) Func(insns asm.Instructions) *btf.Func {
+	if b.sym == "" {
+		return nil
+	}
+
+	first := b.first(insns)
+	if first == nil {
+		return nil
+	}
+
+	return btf.FuncMetadata(first)
 }
 
 func (b *Block) String() string {
@@ -330,29 +359,19 @@ func (b *Block) Dump(insns asm.Instructions) string {
 	return sb.String()
 }
 
-// BlockIterator is an iterator over the instructions in a block or a list of
-// blocks.
-//
-// It can be configured to iterate locally within a block or globally across
-// multiple blocks. When iterating globally, it will roll over to the next or
-// previous block when reaching the end or start of the current block,
-// respectively.
-//
-// The iterator tracks the raw instruction offset of the current instruction
-// when iterating forwards, but not when iterating backwards since that would
-// require summing up instruction sizes from the start of the block. Raw offsets
-// are only used for dumping instructions in forward order.
+// BlockIterator is a linear (meaning ignoring control flow) forward iterator over
+// one or more blocks and the instructions represented by those blocks.
 type BlockIterator struct {
-	blocks Blocks
-	block  *Block
+	// blockIdx is the position of block within blocks. blocks may be a window
+	// of a larger block list, so this doesn't always equal block.id.
+	blockIdx int
+	block    *Block
+	blocks   Blocks
 
-	insns asm.Instructions
-
-	ins   *asm.Instruction
-	index int
-
-	// offset is zero when backtracking to predecessors or when iterating
-	// backwards from the end of a block (e.g. with a new iterator).
+	// index is the index of ins within insns.
+	index  int
+	ins    *asm.Instruction
+	insns  asm.Instructions
 	offset asm.RawInstructionOffset
 }
 
@@ -364,25 +383,28 @@ func (i *BlockIterator) Index() int {
 	return i.index
 }
 
+// Offset returns the raw instruction offset of the instruction within the
+// program.
 func (i *BlockIterator) Offset() asm.RawInstructionOffset {
 	return i.offset
 }
 
-// nextBlock pulls the next block by identifier, if it exists. Otherwise,
-// returns false.
+// NextBlock pulls the next block in the iterator's block list, if it exists.
+// Otherwise, returns false.
 //
 // Positions the iterator at the start of the next block. Offset is updated to
 // the raw offset of the first instruction in the next block.
-func (i *BlockIterator) nextBlock() bool {
+func (i *BlockIterator) NextBlock() bool {
 	if i.block == nil {
 		return false
 	}
 
-	if i.block.id+1 >= i.blocks.count() {
+	if i.blockIdx+1 >= len(i.blocks) {
 		return false
 	}
 
-	i.block = i.blocks[i.block.id+1]
+	i.blockIdx++
+	i.block = i.blocks[i.blockIdx]
 	i.index = i.block.start
 	i.offset = i.block.raw
 	i.ins = &i.insns[i.index]
@@ -407,7 +429,7 @@ func (i *BlockIterator) Next() bool {
 	if i.index+1 > i.block.end {
 		// Roll over to the next block if iterating globally and there is a next
 		// block. False if iterating locally or there's no next block.
-		return i.nextBlock()
+		return i.NextBlock()
 	}
 
 	i.index++
@@ -420,8 +442,8 @@ func (i *BlockIterator) Next() bool {
 // Backtrack returns a Backtracker starting at the current instruction of the
 // BlockIterator.
 //
-// [Backtracker.Instruction] will return the same instruction as the current
-// instruction of the BlockIterator.
+// The first call to [Backtracker.Instruction] will return the same instruction
+// as the current instruction of the BlockIterator.
 //
 // [Backtracker.Previous] will return the instruction preceding the current one,
 // if any.
@@ -593,6 +615,70 @@ func (bl Blocks) iterate(insns asm.Instructions) *BlockIterator {
 		return nil
 	}
 	return bl.first().iterateGlobal(bl, insns)
+}
+
+// Name returns the symbol name of the first block, e.g. the function name if
+// the Blocks make up the start of a function.
+func (bl Blocks) Name() string {
+	if len(bl) == 0 {
+		return ""
+	}
+	return bl.first().sym
+}
+
+// Func returns the BTF function metadata associated with the first block, if
+// any.
+func (bl Blocks) Func(insns asm.Instructions) *btf.Func {
+	if len(bl) == 0 {
+		return nil
+	}
+	return bl.first().Func(insns)
+}
+
+// Instructions yields pointers to the blocks' instructions in order, keyed by
+// an index relative to the first block's first instruction. For a function's
+// Blocks, index 0 is the entry instruction, carrying its symbol and BTF
+// metadata.
+func (bl Blocks) Instructions(insns asm.Instructions) iter.Seq2[int, *asm.Instruction] {
+	return func(yield func(int, *asm.Instruction) bool) {
+		iter := bl.iterate(insns)
+		if iter == nil {
+			return
+		}
+
+		i := 0
+		for iter.Next() {
+			if !yield(i, iter.Instruction()) {
+				return
+			}
+			i++
+		}
+	}
+}
+
+// funcs yields the functions in the block list as subslices. The first block
+// starts the first function, subsequent functions start at blocks carrying BTF
+// func metadata. Blocks with a symbol but no BTF func metadata (e.g. jump
+// labels) don't start a new function.
+func (bl Blocks) funcs(insns asm.Instructions) iter.Seq[Blocks] {
+	return func(yield func(Blocks) bool) {
+		iter := bl.iterate(insns)
+		if iter == nil {
+			return
+		}
+
+		start := 0
+		for iter.NextBlock() {
+			if iter.block.Func(insns) == nil {
+				continue
+			}
+			if !yield(bl[start:iter.blockIdx]) {
+				return
+			}
+			start = iter.blockIdx
+		}
+		yield(bl[start:])
+	}
 }
 
 func (bl Blocks) String() string {

--- a/pkg/bpf/analyze/blocks.go
+++ b/pkg/bpf/analyze/blocks.go
@@ -244,22 +244,13 @@ func (b *Block) iterateLocal(insns asm.Instructions) *BlockIterator {
 		insns:  insns,
 		index:  b.start,
 		offset: b.raw,
-		local:  true,
 	}
 }
 
 func (b *Block) iterateGlobal(blocks Blocks, insns asm.Instructions) *BlockIterator {
-	if b.start < 0 || b.end < 0 || b.start >= len(insns) || b.end >= len(insns) {
-		return nil
-	}
-	return &BlockIterator{
-		blocks: blocks,
-		block:  b,
-		insns:  insns,
-		index:  b.start,
-		offset: b.raw,
-		local:  false,
-	}
+	i := b.iterateLocal(insns)
+	i.blocks = blocks
+	return i
 }
 
 // backtrack returns a Backtracker starting at the end of the block.
@@ -363,8 +354,6 @@ type BlockIterator struct {
 	// offset is zero when backtracking to predecessors or when iterating
 	// backwards from the end of a block (e.g. with a new iterator).
 	offset asm.RawInstructionOffset
-
-	local bool
 }
 
 func (i *BlockIterator) Instruction() *asm.Instruction {
@@ -416,13 +405,9 @@ func (i *BlockIterator) Next() bool {
 	}
 
 	if i.index+1 > i.block.end {
-		if !i.local {
-			// Iterating globally, roll over to the next block if it exists.
-			return i.nextBlock()
-		}
-
-		// Iterating locally, stop here.
-		return false
+		// Roll over to the next block if iterating globally and there is a next
+		// block. False if iterating locally or there's no next block.
+		return i.nextBlock()
 	}
 
 	i.index++

--- a/pkg/bpf/analyze/blocks.go
+++ b/pkg/bpf/analyze/blocks.go
@@ -248,23 +248,17 @@ func (b *Block) edge(insns asm.Instructions) *edge {
 	return getEdgeMeta(last)
 }
 
-func (b *Block) iterateLocal(insns asm.Instructions) *BlockIterator {
+func (b *Block) iterate(insns asm.Instructions) *Iterator {
 	if b.start < 0 || b.end < 0 || b.start >= len(insns) || b.end >= len(insns) {
 		return nil
 	}
 
-	return &BlockIterator{
-		block:  b,
-		insns:  insns,
-		index:  b.start,
-		offset: b.raw,
+	return &Iterator{
+		block:   b,
+		insns:   insns,
+		insnIdx: b.start,
+		offset:  b.raw,
 	}
-}
-
-func (b *Block) iterateGlobal(blocks Blocks, insns asm.Instructions) *BlockIterator {
-	i := b.iterateLocal(insns)
-	i.blocks = blocks
-	return i
 }
 
 // backtrack returns a Backtracker starting at the end of the block.
@@ -314,8 +308,8 @@ func (b *Block) Dump(insns asm.Instructions) string {
 
 	if len(insns) != 0 {
 		sb.WriteString("Instructions:\n")
-		i := b.iterateLocal(insns)
-		for i.Next() {
+		i := b.iterate(insns)
+		for i.NextInstruction() {
 			ins := i.Instruction()
 			if ins.Symbol() != "" {
 				fmt.Fprintf(&sb, "\t%s:\n", ins.Symbol())
@@ -326,7 +320,7 @@ func (b *Block) Dump(insns asm.Instructions) string {
 					fmt.Fprintf(&sb, "\t%*s; %s\n", 4, " ", line)
 				}
 			}
-			fmt.Fprintf(&sb, "\t%*d: %v\n", 4, i.Offset(), ins)
+			fmt.Fprintf(&sb, "\t%*d: %v\n", 4, i.RawInstructionOffset(), ins)
 		}
 		sb.WriteString("\n")
 	} else {
@@ -359,33 +353,36 @@ func (b *Block) Dump(insns asm.Instructions) string {
 	return sb.String()
 }
 
-// BlockIterator is a linear (meaning ignoring control flow) forward iterator over
+// Iterator is a linear (meaning ignoring control flow) forward iterator over
 // one or more blocks and the instructions represented by those blocks.
-type BlockIterator struct {
+type Iterator struct {
 	// blockIdx is the position of block within blocks. blocks may be a window
 	// of a larger block list, so this doesn't always equal block.id.
 	blockIdx int
 	block    *Block
 	blocks   Blocks
 
-	// index is the index of ins within insns.
-	index  int
-	ins    *asm.Instruction
-	insns  asm.Instructions
-	offset asm.RawInstructionOffset
+	// insnIdx is the index of ins within insns.
+	insnIdx int
+	ins     *asm.Instruction
+	insns   asm.Instructions
+	offset  asm.RawInstructionOffset
 }
 
-func (i *BlockIterator) Instruction() *asm.Instruction {
+// Instruction returns the current instruction pointed to by the Iterator.
+func (i *Iterator) Instruction() *asm.Instruction {
 	return i.ins
 }
 
-func (i *BlockIterator) Index() int {
-	return i.index
+// InstructionIndex returns the index of the current instruction within the
+// iterated Blocks.
+func (i *Iterator) InstructionIndex() int {
+	return i.insnIdx
 }
 
-// Offset returns the raw instruction offset of the instruction within the
-// program.
-func (i *BlockIterator) Offset() asm.RawInstructionOffset {
+// RawInstructionOffset returns the raw instruction offset of the instruction
+// within the program.
+func (i *Iterator) RawInstructionOffset() asm.RawInstructionOffset {
 	return i.offset
 }
 
@@ -394,7 +391,7 @@ func (i *BlockIterator) Offset() asm.RawInstructionOffset {
 //
 // Positions the iterator at the start of the next block. Offset is updated to
 // the raw offset of the first instruction in the next block.
-func (i *BlockIterator) NextBlock() bool {
+func (i *Iterator) NextBlock() bool {
 	if i.block == nil {
 		return false
 	}
@@ -405,36 +402,36 @@ func (i *BlockIterator) NextBlock() bool {
 
 	i.blockIdx++
 	i.block = i.blocks[i.blockIdx]
-	i.index = i.block.start
+	i.insnIdx = i.block.start
 	i.offset = i.block.raw
-	i.ins = &i.insns[i.index]
+	i.ins = &i.insns[i.insnIdx]
 
 	return true
 }
 
-// Next advances the iterator to the next instruction in the block. If the end
+// NextInstruction advances the iterator to the next instruction in the block. If the end
 // of the block is reached, it will either stop (if iterating locally) or roll
 // over to the next block (if iterating globally).
-func (i *BlockIterator) Next() bool {
-	if i.block == nil || i.index < i.block.start || i.index > i.block.end {
+func (i *Iterator) NextInstruction() bool {
+	if i.block == nil || i.insnIdx < i.block.start || i.insnIdx > i.block.end {
 		return false
 	}
 
-	// First call to Next with this iterator, pull the first insn and return.
+	// On the first call, pull the first insn and return.
 	if i.ins == nil {
-		i.ins = &i.insns[i.index]
+		i.ins = &i.insns[i.insnIdx]
 		return true
 	}
 
-	if i.index+1 > i.block.end {
+	if i.insnIdx+1 > i.block.end {
 		// Roll over to the next block if iterating globally and there is a next
 		// block. False if iterating locally or there's no next block.
 		return i.NextBlock()
 	}
 
-	i.index++
+	i.insnIdx++
 	i.offset += asm.RawInstructionOffset(i.ins.Size() / asm.InstructionSize)
-	i.ins = &i.insns[i.index]
+	i.ins = &i.insns[i.insnIdx]
 
 	return true
 }
@@ -447,8 +444,8 @@ func (i *BlockIterator) Next() bool {
 //
 // [Backtracker.Previous] will return the instruction preceding the current one,
 // if any.
-func (i *BlockIterator) Backtrack() *Backtracker {
-	return newBacktracker(i.block, i.insns).Seek(i.index)
+func (i *Iterator) Backtrack() *Backtracker {
+	return newBacktracker(i.block, i.insns).Seek(i.insnIdx)
 }
 
 // Backtracker is an iterator that walks backwards through a Block's
@@ -610,11 +607,18 @@ func (bl Blocks) first() *Block {
 	return bl[0]
 }
 
-func (bl Blocks) iterate(insns asm.Instructions) *BlockIterator {
+func (bl Blocks) iterate(insns asm.Instructions) *Iterator {
 	if len(bl) == 0 {
 		return nil
 	}
-	return bl.first().iterateGlobal(bl, insns)
+
+	i := bl.first().iterate(insns)
+	if i == nil {
+		return nil
+	}
+	i.blocks = bl
+
+	return i
 }
 
 // Name returns the symbol name of the first block, e.g. the function name if
@@ -647,7 +651,7 @@ func (bl Blocks) Instructions(insns asm.Instructions) iter.Seq2[int, *asm.Instru
 		}
 
 		i := 0
-		for iter.Next() {
+		for iter.NextInstruction() {
 			if !yield(i, iter.Instruction()) {
 				return
 			}

--- a/pkg/bpf/analyze/blocks_test.go
+++ b/pkg/bpf/analyze/blocks_test.go
@@ -189,13 +189,13 @@ func TestBlocksIterateLocal(t *testing.T) {
 
 	assert.EqualValues(t, 100, bl.count())
 
-	iter := bl.first().iterateLocal(insns)
+	iter := bl.first().iterate(insns)
 
 	// Iterate over the first block only. Next should return false after the first
 	// block is done and stay at index 0.
-	assert.True(t, iter.Next())
-	assert.False(t, iter.Next())
-	assert.Equal(t, 0, iter.index)
+	assert.True(t, iter.NextInstruction())
+	assert.False(t, iter.NextInstruction())
+	assert.Equal(t, 0, iter.insnIdx)
 }
 
 func TestBlocksIterateGlobal(t *testing.T) {
@@ -208,19 +208,19 @@ func TestBlocksIterateGlobal(t *testing.T) {
 
 	iter := bl.iterate(insns)
 	i := 0
-	for ; iter.Next(); i++ {
+	for ; iter.NextInstruction(); i++ {
 		if iter.ins.OpCode.JumpOp() == asm.Exit {
 			continue
 		}
 
 		// The Constant fields of the branching instructions are set to their insn
 		// index. Make sure the iterator index matches.
-		assert.EqualValues(t, iter.index, iter.ins.Constant)
+		assert.EqualValues(t, iter.insnIdx, iter.ins.Constant)
 	}
 
 	// We should have seen all instructions.
 	assert.Equal(t, 100, i)
-	assert.Equal(t, 99, iter.index)
+	assert.Equal(t, 99, iter.insnIdx)
 }
 
 func TestBlocksIterateOffset(t *testing.T) {
@@ -242,27 +242,27 @@ func TestBlocksIterateOffset(t *testing.T) {
 
 	iter := bl.iterate(insns)
 
-	assert.True(t, iter.Next()) // Pull MovImm
-	assert.Equal(t, 0, iter.index)
+	assert.True(t, iter.NextInstruction()) // Pull MovImm
+	assert.Equal(t, 0, iter.insnIdx)
 	assert.Equal(t, asm.RawInstructionOffset(0), iter.offset)
 
-	assert.True(t, iter.Next()) // Pull LoadImm
-	assert.Equal(t, 1, iter.index)
+	assert.True(t, iter.NextInstruction()) // Pull LoadImm
+	assert.Equal(t, 1, iter.insnIdx)
 	assert.Equal(t, asm.RawInstructionOffset(1), iter.offset)
 
-	assert.True(t, iter.Next()) // Pull JEq
-	assert.Equal(t, 2, iter.index)
+	assert.True(t, iter.NextInstruction()) // Pull JEq
+	assert.Equal(t, 2, iter.insnIdx)
 	assert.Equal(t, asm.RawInstructionOffset(3), iter.offset) // Advance 2 raw insns due to LoadImm
 
-	assert.True(t, iter.Next()) // Pull LoadImm
-	assert.Equal(t, 3, iter.index)
+	assert.True(t, iter.NextInstruction()) // Pull LoadImm
+	assert.Equal(t, 3, iter.insnIdx)
 	assert.Equal(t, asm.RawInstructionOffset(4), iter.offset)
 
-	assert.True(t, iter.Next()) // Pull Return
-	assert.Equal(t, 4, iter.index)
+	assert.True(t, iter.NextInstruction()) // Pull Return
+	assert.Equal(t, 4, iter.insnIdx)
 	assert.Equal(t, asm.RawInstructionOffset(6), iter.offset) // Advance 2 raw insns due to LoadImm
 
-	assert.False(t, iter.Next())
+	assert.False(t, iter.NextInstruction())
 }
 
 func TestBacktracker(t *testing.T) {

--- a/pkg/bpf/analyze/reachability.go
+++ b/pkg/bpf/analyze/reachability.go
@@ -83,21 +83,6 @@ type Reachable struct {
 	j Bitmap
 }
 
-func (r *Reachable) isLive(id uint64) bool {
-	if id >= r.blocks.count() {
-		return false
-	}
-	return r.l.Get(id)
-}
-
-func (r *Reachable) countAll() uint64 {
-	return r.blocks.count()
-}
-
-func (r *Reachable) countLive() uint64 {
-	return r.l.Popcount()
-}
-
 // Reachability determines whether or not each Block in blocks is reachable
 // given the variables.
 //
@@ -164,13 +149,13 @@ func Reachability(blocks Blocks, insns asm.Instructions, variables map[string]*e
 	return r, nil
 }
 
-// Iterate returns an iterator that wraps an internal BlockIterator. The
+// Instructions iterates instructions by wrapping an internal BlockIterator. The
 // internal iterator is yielded along with a bool indicating whether the current
 // instruction is reachable.
 //
-// The BlockIterator itself is yielded so it can be cloned to start a
-// backtracking session.
-func (r *Reachable) Iterate() iter.Seq2[*BlockIterator, bool] {
+// The BlockIterator itself is yielded so it can be used to start a backtracking
+// session.
+func (r *Reachable) Instructions() iter.Seq2[*BlockIterator, bool] {
 	return func(yield func(*BlockIterator, bool) bool) {
 		iter := r.blocks.iterate(r.insns)
 		for iter.Next() {

--- a/pkg/bpf/analyze/reachability.go
+++ b/pkg/bpf/analyze/reachability.go
@@ -137,16 +137,35 @@ func Reachability(blocks Blocks, insns asm.Instructions, variables map[string]*e
 		return nil, fmt.Errorf("predicting blocks: %w", err)
 	}
 
-	// Always visit bpf2bpf callees since they are always reachable, on pre-6.8 kernels
-	for _, block := range blocks {
-		for _, called := range block.calls {
-			if err := r.visitBlock(called, vars); err != nil {
-				return nil, fmt.Errorf("predicting blocks: %w", err)
+	return r, nil
+}
+
+// Blocks returns an iterator over the blocks in the program, yielding each
+// block along with a boolean indicating whether the block is reachable.
+func (r *Reachable) Blocks() iter.Seq2[*Block, bool] {
+	return func(yield func(*Block, bool) bool) {
+		iter := r.blocks.iterate(r.insns)
+		for iter.NextBlock() {
+			live := r.l.Get(iter.block.id)
+			if !yield(iter.block, live) {
+				return
 			}
 		}
 	}
+}
 
-	return r, nil
+// Funcs returns an iterator over the functions in the program, yielding each
+// function's Blocks along with a boolean indicating whether the function is
+// reachable. A function is reachable if and only if its first block is, since
+// functions are only entered through calls to their entry blocks.
+func (r *Reachable) Funcs() iter.Seq2[Blocks, bool] {
+	return func(yield func(Blocks, bool) bool) {
+		for f := range r.blocks.funcs(r.insns) {
+			if !yield(f, r.l.Get(f.first().id)) {
+				return
+			}
+		}
+	}
 }
 
 // Instructions iterates instructions by wrapping an internal BlockIterator. The

--- a/pkg/bpf/analyze/reachability.go
+++ b/pkg/bpf/analyze/reachability.go
@@ -174,10 +174,10 @@ func (r *Reachable) Funcs() iter.Seq2[Blocks, bool] {
 //
 // The BlockIterator itself is yielded so it can be used to start a backtracking
 // session.
-func (r *Reachable) Instructions() iter.Seq2[*BlockIterator, bool] {
-	return func(yield func(*BlockIterator, bool) bool) {
+func (r *Reachable) Instructions() iter.Seq2[*Iterator, bool] {
+	return func(yield func(*Iterator, bool) bool) {
 		iter := r.blocks.iterate(r.insns)
-		for iter.Next() {
+		for iter.NextInstruction() {
 			live := r.l.Get(iter.block.id)
 			if !yield(iter, live) {
 				return

--- a/pkg/bpf/analyze/reachability_test.go
+++ b/pkg/bpf/analyze/reachability_test.go
@@ -38,7 +38,7 @@ func symbols(insns asm.Instructions) map[string]struct{} {
 
 // eachLiveRef calls fn for each live symbol reference appearing in r.
 func eachLiveRef(r *Reachable, fn func(ref string)) {
-	for iter, live := range r.Iterate() {
+	for iter, live := range r.Instructions() {
 		if !live {
 			continue
 		}
@@ -50,6 +50,18 @@ func eachLiveRef(r *Reachable, fn func(ref string)) {
 			fn(ref)
 		}
 	}
+}
+
+func isLive(r *Reachable, id uint64) bool {
+	return r.l.Get(id)
+}
+
+func countAll(r *Reachable) uint64 {
+	return r.blocks.count()
+}
+
+func countLive(r *Reachable) uint64 {
+	return r.l.Popcount()
 }
 
 // allUnreachable asserts that all symbols appearing in insns are marked
@@ -179,13 +191,13 @@ func TestReachabilityBacktrackBlock(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 5, r.countAll())
-	assert.NotEqual(t, r.countAll(), r.countLive())
-	assert.True(t, r.isLive(0))
-	assert.True(t, r.isLive(1))
-	assert.False(t, r.isLive(2))
-	assert.True(t, r.isLive(3))
-	assert.True(t, r.isLive(4))
+	assert.EqualValues(t, 5, countAll(r))
+	assert.NotEqual(t, countAll(r), countLive(r))
+	assert.True(t, isLive(r, 0))
+	assert.True(t, isLive(r, 1))
+	assert.False(t, isLive(r, 2))
+	assert.True(t, isLive(r, 3))
+	assert.True(t, isLive(r, 4))
 }
 
 // This tests asserts that we do basic block analysis and dead code elimination
@@ -230,11 +242,11 @@ func TestReachabilityLongJump(t *testing.T) {
 	// 1: dead, since it is skipped by the first branch
 	// 2: live, we've determined the first branch is always taken
 	// 3: dead, since it's the target of the long jump that is never taken
-	assert.NotEqual(t, disabled.countAll(), disabled.countLive())
-	assert.True(t, disabled.isLive(0))
-	assert.False(t, disabled.isLive(1))
-	assert.True(t, disabled.isLive(2))
-	assert.False(t, disabled.isLive(3))
+	assert.NotEqual(t, countAll(disabled), countLive(disabled))
+	assert.True(t, isLive(disabled, 0))
+	assert.False(t, isLive(disabled, 1))
+	assert.True(t, isLive(disabled, 2))
+	assert.False(t, isLive(disabled, 3))
 
 	enabled, err := Reachability(blocks, insns, map[string]*ebpf.VariableSpec{
 		"enable_a": {SectionName: ".rodata", Offset: 0, Value: []byte{1}},
@@ -246,11 +258,11 @@ func TestReachabilityLongJump(t *testing.T) {
 	// 1: live, we've determined the first branch insn is never taken
 	// 2: dead, the long jump is taken
 	// 3: live, target of the long jump
-	assert.NotEqual(t, enabled.countAll(), enabled.countLive())
-	assert.True(t, enabled.isLive(0))
-	assert.True(t, enabled.isLive(1))
-	assert.False(t, enabled.isLive(2))
-	assert.True(t, enabled.isLive(3))
+	assert.NotEqual(t, countAll(enabled), countLive(enabled))
+	assert.True(t, isLive(enabled, 0))
+	assert.True(t, isLive(enabled, 1))
+	assert.False(t, isLive(enabled, 2))
+	assert.True(t, isLive(enabled, 3))
 }
 
 // Test that Reachability can be called concurrently. This is a regression test

--- a/pkg/bpf/analyze/reachability_test.go
+++ b/pkg/bpf/analyze/reachability_test.go
@@ -6,12 +6,14 @@ package analyze
 import (
 	"encoding/binary"
 	"io"
+	"iter"
 	"math"
 	"structs"
 	"testing"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -65,16 +67,13 @@ func countLive(r *Reachable) uint64 {
 }
 
 // allUnreachable asserts that all symbols appearing in insns are marked
-// unreachable in r, except for sym_i, which should never be marked
-// unreachable.
+// unreachable in r.
 func allUnreachable(t *testing.T, insns asm.Instructions, r *Reachable) {
 	t.Helper()
 
 	syms := symbols(insns)
 	eachLiveRef(r, func(ref string) {
-		if ref != "sym_i" {
-			assert.Nil(t, syms[ref], "symbol %q should be unreachable", ref)
-		}
+		assert.Nil(t, syms[ref], "symbol %q should be unreachable", ref)
 	})
 }
 
@@ -263,6 +262,77 @@ func TestReachabilityLongJump(t *testing.T) {
 	assert.True(t, isLive(enabled, 1))
 	assert.False(t, isLive(enabled, 2))
 	assert.True(t, isLive(enabled, 3))
+}
+
+func TestReachableFuncs(t *testing.T) {
+	fn := func(ins asm.Instruction, name string) asm.Instruction {
+		return btf.WithFuncMetadata(ins.WithSymbol(name), &btf.Func{Name: name})
+	}
+
+	insns := asm.Instructions{
+		// prog calls live, but never dead.
+		fn(asm.Call.Label("live"), "prog"),
+		asm.Return(),
+
+		// live spans multiple blocks; "ret" is a jump label, not a function.
+		fn(asm.JEq.Imm(asm.R1, 0, "ret"), "live"),
+		asm.Mov.Imm(asm.R0, 1),
+		asm.Return().WithSymbol("ret"),
+
+		// dead has no callers and contains a double-wide instruction.
+		fn(asm.LoadImm(asm.R0, 0, asm.DWord), "dead"),
+		asm.Return(),
+	}
+
+	// Marshal instructions to fix up references.
+	require.NoError(t, insns.Marshal(io.Discard, binary.LittleEndian))
+
+	blocks, err := computeBlocks(insns)
+	require.NoError(t, err)
+
+	r, err := Reachability(blocks, insns, nil)
+	require.NoError(t, err)
+
+	next, stop := iter.Pull2(r.Funcs())
+	defer stop()
+
+	f, l, ok := next()
+	require.True(t, ok)
+	assert.Equal(t, "prog", f.Name())
+	assert.True(t, l)
+	assert.Len(t, f, 1)
+
+	f, l, ok = next()
+	require.True(t, ok)
+	assert.Equal(t, "live", f.Name())
+	assert.True(t, l)
+	assert.Len(t, f, 3)
+
+	f, l, ok = next()
+	require.True(t, ok)
+	assert.Equal(t, "dead", f.Name())
+	assert.False(t, l)
+	assert.Len(t, f, 1)
+
+	_, _, ok = next()
+	assert.False(t, ok)
+
+	// Func-relative indices with pointers into the original insns.
+	nextIns, stopIns := iter.Pull2(f.Instructions(insns))
+	defer stopIns()
+
+	i, ins, ok := nextIns()
+	require.True(t, ok)
+	assert.Equal(t, 0, i)
+	assert.Same(t, &insns[5], ins)
+
+	i, ins, ok = nextIns()
+	require.True(t, ok)
+	assert.Equal(t, 1, i)
+	assert.Same(t, &insns[6], ins)
+
+	_, _, ok = nextIns()
+	assert.False(t, ok)
 }
 
 // Test that Reachability can be called concurrently. This is a regression test

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -251,6 +251,10 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 		return nil, nil, fmt.Errorf("resolving tail calls: %w", err)
 	}
 
+	if err := nopUnusedFuncs(spec, reach, logger); err != nil {
+		return nil, nil, fmt.Errorf("blinding unused global functions: %w", err)
+	}
+
 	fixed := fixedResources(spec, opts.Keep)
 	if err := removeUnusedMaps(spec, fixed, reach, logger); err != nil {
 		return nil, nil, fmt.Errorf("pruning unused maps: %w", err)

--- a/pkg/bpf/reachability.go
+++ b/pkg/bpf/reachability.go
@@ -12,8 +12,9 @@ import (
 )
 
 type reachableSpec struct {
-	*ebpf.ProgramSpec
 	*analyze.Reachable
+
+	prog *ebpf.ProgramSpec
 }
 
 type reachables map[string]*reachableSpec
@@ -33,7 +34,7 @@ func computeReachability(spec *ebpf.CollectionSpec) (reachables, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reachability analysis for program %s: %w", prog.Name, err)
 		}
-		out[name] = &reachableSpec{prog, r}
+		out[name] = &reachableSpec{r, prog}
 	}
 
 	return out, nil

--- a/pkg/bpf/unused_funcs.go
+++ b/pkg/bpf/unused_funcs.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// nop returns a no-op replacement for ins, preserving its raw width so
+// instruction offsets remain identical across ELF and verified programs
+// for easier debugging. Preserves the Instruction's metadata.
+func nop(ins *asm.Instruction) asm.Instruction {
+	if ins.OpCode.IsDWordLoad() {
+		return asm.LoadImm(asm.R0, 0, asm.DWord)
+	}
+	return asm.Mov.Imm(asm.R0, 0)
+}
+
+// nopUnusedFuncs replaces the bodies of functions without live callers with
+// nop sleds terminated by an exit.
+func nopUnusedFuncs(spec *ebpf.CollectionSpec, reach reachables, logger *slog.Logger) error {
+	for name, p := range spec.Programs {
+		r, ok := reach[name]
+		if !ok {
+			return fmt.Errorf("missing reachability information for program %s", name)
+		}
+
+		for f, live := range r.Funcs() {
+			if live {
+				continue
+			}
+
+			var last *asm.Instruction
+			for i, ins := range f.Instructions(p.Instructions) {
+				n := nop(ins)
+				if i == 0 {
+					// Keep symbol and BTF func info on the function's entry.
+					n = n.WithMetadata(ins.Metadata).
+						WithSource(asm.Comment(fmt.Sprintf("%s // (unused bpf2bpf function)", ins.Source())))
+				}
+				*ins = n
+				last = ins
+			}
+			if last == nil {
+				return fmt.Errorf("function %s in program %s has no instructions", f.Name(), name)
+			}
+
+			// Functions must end in an exit. The last insn of a function is always
+			// single-width (exit or jump), so this doesn't change instruction offsets.
+			*last = asm.Return().WithMetadata(last.Metadata)
+
+			if logger != nil {
+				logger.Debug("Replaced unused function with nop sled",
+					logfields.Prog, name,
+					logfields.Name, f.Name(),
+				)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/bpf/unused_maps.go
+++ b/pkg/bpf/unused_maps.go
@@ -77,7 +77,7 @@ func removeUnusedMaps(spec *ebpf.CollectionSpec, fixed *set.Set[string], reach r
 		}
 
 		// Record which maps are still referenced after reachability analysis.
-		for iter, live := range r.Iterate() {
+		for iter, live := range r.Instructions() {
 			ins := iter.Instruction()
 			if !ins.IsLoadFromMap() {
 				continue

--- a/pkg/bpf/unused_maps_test.go
+++ b/pkg/bpf/unused_maps_test.go
@@ -74,23 +74,26 @@ func TestPrivilegedUnusedMaps(t *testing.T) {
 
 	reach, err = computeReachability(spec)
 	require.NoError(t, err)
+	err = nopUnusedFuncs(spec, reach, nil)
+	require.NoError(t, err)
 	err = removeUnusedMaps(spec, nil, reach, nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, spec.Maps["map_a"])
 	assert.Nil(t, spec.Maps["map_b"])
-	// BPF functions are always visited to match the kernel's behavior pre-v6.8.
-	assert.NotNil(t, spec.Maps["map_static"])
-	assert.NotNil(t, spec.Maps["map_global"])
 	assert.True(t, slices.ContainsFunc(obj.Program.Instructions, func(ins asm.Instruction) bool {
 		return ins.Constant == poisonedMapLoad
 	}), "At least one instruction should have been poisoned")
 
+	// Dead (global/static) functions are stubbed out, allowing their maps to be
+	// pruned.
+	assert.Nil(t, spec.Maps["map_static"])
+	assert.Nil(t, spec.Maps["map_global"])
+
 	coll = mustNewCollection(t, spec)
 	freed, err = freedMaps(coll, nil)
 	assert.NoError(t, err)
-	// Depending on the kernel versions, map_static and map_global may be freed by the verifier.
-	assert.GreaterOrEqual(t, 2, len(freed))
+	assert.Empty(t, freed)
 }
 
 func TestPrivilegedUnusedMapsFalseNegative(t *testing.T) {

--- a/pkg/bpf/unused_tailcalls.go
+++ b/pkg/bpf/unused_tailcalls.go
@@ -43,11 +43,11 @@ func tailCallSlots(reach reachables) (map[uint32]*reachableSpec, error) {
 	// Build a map of tail call slots to reachableSpecs.
 	tails := make(map[uint32]*reachableSpec)
 	for _, r := range reach {
-		if !IsTailCall(r.ProgramSpec) {
+		if !IsTailCall(r.prog) {
 			continue
 		}
 
-		slot, err := tailCallSlot(r.ProgramSpec)
+		slot, err := tailCallSlot(r.prog)
 		if err != nil {
 			return nil, err
 		}
@@ -62,7 +62,7 @@ func tailCallSlots(reach reachables) (map[uint32]*reachableSpec, error) {
 func livePrograms(reach reachables, tails map[uint32]*reachableSpec, logger *slog.Logger) (*set.Set[*ebpf.ProgramSpec], error) {
 	visited := &set.Set[*ebpf.ProgramSpec]{}
 	for _, r := range reach {
-		if !isEntrypoint(r.ProgramSpec) {
+		if !isEntrypoint(r.prog) {
 			continue
 		}
 
@@ -75,12 +75,12 @@ func livePrograms(reach reachables, tails map[uint32]*reachableSpec, logger *slo
 }
 
 func visitProgram(r *reachableSpec, tails map[uint32]*reachableSpec, visited *set.Set[*ebpf.ProgramSpec], logger *slog.Logger) error {
-	if visited.Has(r.ProgramSpec) {
+	if visited.Has(r.prog) {
 		return nil
 	}
-	visited.Insert(r.ProgramSpec)
+	visited.Insert(r.prog)
 
-	for iter, live := range r.Iterate() {
+	for iter, live := range r.Instructions() {
 		if !live {
 			continue
 		}
@@ -131,7 +131,7 @@ func visitProgram(r *reachableSpec, tails map[uint32]*reachableSpec, visited *se
 		if ref != callsMap {
 			logger.Debug("Ignoring tail call into map",
 				logfields.Reference, ref,
-				logfields.Prog, r.ProgramSpec.Name,
+				logfields.Prog, r.prog.Name,
 			)
 			continue
 		}
@@ -141,7 +141,7 @@ func visitProgram(r *reachableSpec, tails map[uint32]*reachableSpec, visited *se
 				return err
 			}
 		} else {
-			return fmt.Errorf("missed tail call in program %s to slot %d at insn %d", r.ProgramSpec.Name, slot, iter.Index())
+			return fmt.Errorf("missed tail call in program %s to slot %d at insn %d", r.prog.Name, slot, iter.Index())
 		}
 	}
 

--- a/pkg/bpf/unused_tailcalls.go
+++ b/pkg/bpf/unused_tailcalls.go
@@ -141,7 +141,7 @@ func visitProgram(r *reachableSpec, tails map[uint32]*reachableSpec, visited *se
 				return err
 			}
 		} else {
-			return fmt.Errorf("missed tail call in program %s to slot %d at insn %d", r.prog.Name, slot, iter.Index())
+			return fmt.Errorf("missed tail call in program %s to slot %d at insn %d", r.prog.Name, slot, iter.InstructionIndex())
 		}
 	}
 


### PR DESCRIPTION
This PR adds bpf2bpf function pruning and refactors `bpf/analyze`'s block iterator to read a little clearer. Best reviewed per commit.

In a nutshell:
- bpf2bpf functions (both global and static) are no longer marked reachable by default and are now replaced with a series of `r0 = 0` instructions
- Rename BlockIterator to Iterator, as well as a few of its methods
- Make Iterator correctly iterate subslices of a slice of Blocks
- Convenience methods for getting btf.Func of a function's leading Block

Supersedes https://github.com/cilium/cilium/pull/46731.
Fixes: https://github.com/cilium/cilium/issues/45918.

```release-note
Prune unreachable BPF functions in the Cilium agent before loading the program
```

AIL:2