### PR TITLE
docs: fix typos in kvstore and deny policy pages

### DIFF
--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -164,7 +164,7 @@ further details.
 Debugging
 =========
 
-The contents stored in the kvstore can be queued and manipulate using the
+The contents stored in the kvstore can be queried and manipulated using the
 ``cilium kvstore`` command. For additional details, see the command reference.
 
 Example:

--- a/Documentation/security/policy/deny.rst
+++ b/Documentation/security/policy/deny.rst
@@ -16,7 +16,7 @@ Deny policies take precedence over allow policies, regardless of whether they
 are a Cilium Network Policy, a Clusterwide Cilium Network Policy or even a
 Kubernetes Network Policy.
 
-Similarly to "allow" policies, Pods will enter default-deny mode as soon a
+Similarly to "allow" policies, Pods will enter default-deny mode as soon as a
 single policy selects it.
 
 If multiple allow and deny policies are applied to the same pod, the following


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

Fixes two typos in the documentation: "queued and manipulate" instead of "queried and manipulated" in kvstore.rst, and a missing "as" in deny.rst ("as soon a single policy" instead of "as soon as a single policy").

```release-note
docs: fix typos in kvstore and deny policy pages
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
