### PR TITLE
fqdn: index the pre-expiry snapshot in ReplaceFromCacheByNames

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/netip"
 	"regexp"
 	"slices"
@@ -394,10 +393,24 @@ func (c *DNSCache) UpdateFromCache(update *DNSCache) {
 	}
 }
 
+type ipName struct {
+	ip   netip.Addr
+	name string
+}
+
+// oldEntryIndex is the pre-expiry IP -> names snapshot as a set of pairs.
+// Scanning the slice form instead is O(N^2) when many names share an address.
+type oldEntryIndex map[ipName]struct{}
+
+func (i oldEntryIndex) contains(ip netip.Addr, name string) bool {
+	_, ok := i[ipName{ip: ip, name: name}]
+	return ok
+}
+
 // partialRestoreFromCache is a utility function that upserts the entries of one DNSCache into another.
 // It takes a set of existing entries to ensure that it will only upsert IPs and IP->name mappings that is
 // part of that mapping.
-func (c *DNSCache) partialRestoreFromCache(update *DNSCache, namesToUpdate []string, oldEntries map[netip.Addr][]string) {
+func (c *DNSCache) partialRestoreFromCache(update *DNSCache, namesToUpdate []string, oldEntries oldEntryIndex) {
 	update.mu.RLock()
 	defer update.mu.RUnlock()
 
@@ -409,7 +422,7 @@ func (c *DNSCache) partialRestoreFromCache(update *DNSCache, namesToUpdate []str
 		for _, newEntry := range newEntries {
 			newIps := make([]netip.Addr, 0, len(newEntry.IPs))
 			for _, ip := range newEntry.IPs {
-				if names, found := oldEntries[ip]; found && slices.Contains(names, newEntry.Name) {
+				if oldEntries.contains(ip, newEntry.Name) {
 					newIps = append(newIps, ip)
 				}
 			}
@@ -448,13 +461,19 @@ func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*D
 	// Dump the existing IP->[names...] mapping that can be used to decide
 	// what information should be restored from the local caches.
 	oldEntries := c.getIPsLocked()
+	oldIndex := make(oldEntryIndex)
+	for ip, names := range oldEntries {
+		for _, name := range names {
+			oldIndex[ipName{ip: ip, name: name}] = struct{}{}
+		}
+	}
 
 	// Remove any DNS name in namesToUpdate with a lookup before "now". This
 	// effectively deletes all lookups because we're holding the lock.
 	c.forceExpireByNames(time.Now(), namesToUpdate)
 
 	for update := range c.updated {
-		c.partialRestoreFromCache(update, namesToUpdate, oldEntries)
+		c.partialRestoreFromCache(update, namesToUpdate, oldIndex)
 	}
 
 	c.updated.Clear()
@@ -673,7 +692,11 @@ func (c *DNSCache) getIPsLocked() map[netip.Addr][]string {
 	out := make(map[netip.Addr][]string, len(c.reverse))
 
 	for ip, names := range c.reverse {
-		out[ip] = slices.Collect(maps.Keys(names))
+		slice := make([]string, 0, len(names))
+		for name := range names {
+			slice = append(slice, name)
+		}
+		out[ip] = slice
 	}
 
 	return out

--- a/pkg/fqdn/replace_test.go
+++ b/pkg/fqdn/replace_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fqdn
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// ReplaceFromCacheByNames must only restore (ip, name) pairs that were already
+// present before the expiry. GC must never introduce a mapping the DNS path has
+// not seen, because the DNS path is what waits for ipcache propagation.
+func TestReplaceFromCacheByNamesOnlyRestoresKnownPairs(t *testing.T) {
+	var (
+		ip1 = netip.MustParseAddr("10.0.0.1")
+		ip2 = netip.MustParseAddr("10.0.0.2")
+		now = time.Now()
+	)
+
+	t.Run("known pair is restored", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+		ep.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+
+		global.ReplaceFromCacheByNames([]string{"a.example.com"}, ep)
+		require.Equal(t, []netip.Addr{ip1}, global.Lookup("a.example.com"))
+	})
+
+	t.Run("unknown pair is not introduced", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+		ep.Update(now, "a.example.com", []netip.Addr{ip1, ip2}, 3600)
+
+		global.ReplaceFromCacheByNames([]string{"a.example.com"}, ep)
+		require.Equal(t, []netip.Addr{ip1}, global.Lookup("a.example.com"),
+			"ip2 was never in the global cache and must not be added by GC")
+	})
+
+	// Membership must be tested per (ip, name) pair, not per IP: testing only
+	// whether the IP is known would wrongly restore this pair.
+	t.Run("known IP under a different name is not introduced", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+		global.Update(now, "b.example.com", []netip.Addr{ip2}, 3600)
+		ep.Update(now, "a.example.com", []netip.Addr{ip1, ip2}, 3600)
+
+		global.ReplaceFromCacheByNames([]string{"a.example.com"}, ep)
+		require.Equal(t, []netip.Addr{ip1}, global.Lookup("a.example.com"),
+			"ip2 is known, but not for this name, so it must not be restored")
+		require.ElementsMatch(t, []string{"b.example.com"}, global.LookupIP(ip2))
+	})
+
+	t.Run("name absent from the endpoint cache is dropped", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "gone.example.com", []netip.Addr{ip1}, 3600)
+
+		global.ReplaceFromCacheByNames([]string{"gone.example.com"}, ep)
+		require.Empty(t, global.Lookup("gone.example.com"))
+	})
+
+	t.Run("names outside namesToUpdate are untouched", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+		global.Update(now, "keep.example.com", []netip.Addr{ip2}, 3600)
+
+		global.ReplaceFromCacheByNames([]string{"a.example.com"}, ep)
+		require.Equal(t, []netip.Addr{ip2}, global.Lookup("keep.example.com"))
+	})
+
+	t.Run("many names on one IP all restore", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		names := []string{"a.example.com", "b.example.com", "c.example.com"}
+		for _, n := range names {
+			global.Update(now, n, []netip.Addr{ip1}, 3600)
+			ep.Update(now, n, []netip.Addr{ip1}, 3600)
+		}
+
+		global.ReplaceFromCacheByNames(names, ep)
+		for _, n := range names {
+			require.Equal(t, []netip.Addr{ip1}, global.Lookup(n), "name %s", n)
+		}
+		require.ElementsMatch(t, names, global.LookupIP(ip1))
+	})
+
+	t.Run("returned snapshot describes the pre-expiry state", func(t *testing.T) {
+		global, ep := NewDNSCache(0), NewDNSCache(0)
+		global.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+		ep.Update(now, "a.example.com", []netip.Addr{ip1}, 3600)
+
+		old := global.ReplaceFromCacheByNames([]string{"a.example.com"}, ep)
+		require.Contains(t, old, ip1)
+		require.Contains(t, old[ip1], "a.example.com")
+	})
+}


### PR DESCRIPTION
partialRestoreFromCache tested membership with slices.Contains against a flattened IP -> []string snapshot, so it walked every name recorded for an IP once per restored entry. That is O(N^2) when many names resolve to the same address.

The DNS garbage collector builds exactly that shape: a zombie is keyed by IP and carries every name that resolved to it, so one alive zombie pushes all of its names into both namesToClean and activeConnections against a single address. Both sides of the scan are then the same N, and the walk holds the cache lock that every DNS response needs.

Index the snapshot as a flat set of (IP, name) pairs instead, and size the name slices in getIPsLocked from the reverse entries they are built from.

50,000 names on one IP: 5091ms -> 158ms, at roughly 4MB more per call (52.2MB -> 56.1MB) for the index.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
