### PR TITLE
docs: add Hetzner Cloud native routing guide and uRPF masquerade warning

### DIFF
--- a/Documentation/installation/k8s-install-hetzner.rst
+++ b/Documentation/installation/k8s-install-hetzner.rst
@@ -1,0 +1,147 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _k8s_install_hetzner:
+
+Installation on Hetzner Cloud
+=============================
+
+This guide covers installing Cilium on `Hetzner Cloud
+<https://www.hetzner.com/cloud>`_ private networks in native routing mode,
+including multi-datacenter clusters.
+
+.. note::
+
+   The Cilium community does not currently maintain automated testing for
+   Hetzner Cloud. This guide is provided on a best-effort basis; use it at
+   your own risk and verify the configuration against your cluster setup.
+
+**Default Configuration:**
+
+================ =================== ===============
+Datapath         IPAM                Datastore
+================ =================== ===============
+Native Routing   Kubernetes PodCIDR  Kubernetes CRD
+================ =================== ===============
+
+Prerequisites
+-------------
+
+* A Hetzner Cloud project with a `private network
+  <https://docs.hetzner.com/cloud/networks/getting-started/creating-a-network>`_
+  configured. Cluster nodes should attach to a subnet within that network
+  (e.g. ``10.0.1.0/24``).
+* Nodes may be private-only (no public IPv4). A gateway node or NAT router
+  with a public IP is required for egress.
+* For multi-datacenter clusters (nodes spread across ``fsn1``, ``nbg1``,
+  ``hel1``), see the :ref:`hetzner_multi_dc` section below.
+
+Install Cilium
+--------------
+
+Use the pod CIDR (``10.42.0.0/16`` in this example, adjust to match your
+``--cluster-cidr``) as the native routing CIDR:
+
+.. code-block:: shell-session
+
+    helm install cilium cilium/cilium \
+      --namespace kube-system \
+      --set ipam.mode=kubernetes \
+      --set kubeProxyReplacement=true \
+      --set k8sServiceHost=<API_SERVER_IP> \
+      --set k8sServicePort=6443 \
+      --set routingMode=native \
+      --set autoDirectNodeRoutes=true \
+      --set ipv4NativeRoutingCIDR=10.42.0.0/16
+
+Or as a Helm values file:
+
+.. code-block:: yaml
+
+    ipam:
+      mode: kubernetes
+    kubeProxyReplacement: true
+    k8sServiceHost: <API_SERVER_IP>
+    k8sServicePort: 6443
+    routingMode: native
+    autoDirectNodeRoutes: true
+    # Set to Pod CIDR only, NOT the full Hetzner private network CIDR.
+    # See the Common Issues section below for details.
+    ipv4NativeRoutingCIDR: "10.42.0.0/16"
+
+With this configuration:
+
+* **Pod-to-pod** (intra-cluster): Traffic is directly routed to destinations within ``10.42.0.0/16`` without masquerade.
+* **Pod-to-external** (non-cluster hosts, Internet): Traffic to destinations outside ``10.42.0.0/16`` is masqueraded to the node's registered IP, satisfying Hetzner uRPF.
+
+.. _hetzner_multi_dc:
+
+Multi-Datacenter Clusters
+--------------------------
+
+Hetzner private networks provide direct L2 connectivity within a single
+datacenter and are L3-routed between datacenters (``fsn1`` ↔ ``nbg1`` ↔
+``hel1``). ``auto-direct-node-routes`` installs direct host routes between
+nodes and relies on L2 ARP for next-hop resolution. Nodes in different DCs
+cannot resolve each other via ARP across the L3 boundary.
+
+Add ``directRoutingSkipUnreachable: true`` to prevent Cilium from installing
+direct routes to nodes it cannot reach at L2 (cross-DC nodes). Traffic to
+those nodes falls back to the Hetzner L3 router, which correctly routes it:
+
+.. code-block:: yaml
+
+    routingMode: native
+    autoDirectNodeRoutes: true
+    directRoutingSkipUnreachable: true
+    ipv4NativeRoutingCIDR: "10.42.0.0/16"
+
+Internal Load Balancer VIPs (L2 Announcements)
+------------------------------------------------
+
+To expose cluster-internal services at a stable private IP without
+provisioning a public Hetzner Load Balancer, use Cilium's L2 announcements
+feature. ARP announcements are not forwarded across the Hetzner L3 router
+between datacenters, so ``CiliumL2AnnouncementPolicy`` resources should be
+pinned to nodes in the same datacenter as the hosts consuming the VIP.
+
+See :ref:`l2_announcements` for full configuration details.
+
+.. _hetzner_common_issues:
+
+Common Issues
+-------------
+
+.. _hetzner_urpf:
+
+Unicast Reverse Path Forwarding (uRPF)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hetzner Cloud private networks implement `unicast reverse path forwarding
+(uRPF)
+<https://docs.hetzner.com/networking/networks/faq/#why-do-packets-with-source-ips-not-related-to-the-server-get-dropped>`_
+at the virtual network gateway. The gateway validates every packet's source IP
+against the IP prefixes registered to the originating server (assigned IPs,
+alias IPs, or routes designating the server as a gateway). Packets with an
+unrecognised source IP are silently dropped.
+
+Pod IPs (e.g. ``10.42.0.0/16``) are not registered server prefixes. If
+``ipv4-native-routing-cidr`` is set to the full private-network CIDR
+(e.g. ``10.0.0.0/8``), Cilium will not masquerade pod traffic destined for
+non-cluster hosts in that network, causing timeouts on connections from
+Pod IPs towards IPs in the full private network CIDR range.
+
+.. caution::
+
+   Do **not** set ``ipv4-native-routing-cidr`` to the full Hetzner private
+   network CIDR (e.g. ``10.0.0.0/8``). Set it to the pod CIDR only, as shown
+   in the `Install Cilium`_ section above.
+
+This failure is easily masked during testing: when ``auto-direct-node-routes``
+is enabled Cilium installs direct host routes for peer pod CIDRs, so
+pod-to-pod cross-node traffic bypasses the Hetzner gateway entirely. Only
+traffic from pods to non-cluster hosts in the same private network (e.g.
+other VMs, a separate k8s cluster, a gateway node) is affected.

--- a/Documentation/installation/k8s-toc.rst
+++ b/Documentation/installation/k8s-toc.rst
@@ -13,6 +13,7 @@ Installation with K8s distributions
    :glob:
 
    k8s-install-external-etcd
+   k8s-install-hetzner
    k8s-install-openshift-okd
    k8s-install-broadcom-vmware-esxi-nsx
    k3s

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -56,6 +56,7 @@ GiB
 Gospodarek
 Graf
 Gunawardena
+Hetzner
 Holzheu
 Huapeng
 Hypercalls
@@ -295,6 +296,7 @@ ctf
 customConf
 daemonset
 datacenter
+datacenters
 datagram
 datagrams
 datapath
@@ -866,6 +868,7 @@ tunables
 tunings
 tunnelProtocol
 txtar
+uRPF
 ubuntu
 udp
 ui
@@ -885,6 +888,7 @@ unmanaged
 unmarshalled
 unmigrated
 unpaginated
+unrecognised
 unselect
 unsettable
 untriaged


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

> **Note:** This is a replacement for #47527, which was accidentally closed due to an unintended PR body edit.

AIL:3 — AI generated content, human fully directed and structured.

Adds a new installation guide for Hetzner Cloud covering native routing mode,
including a common pitfall with `ipv4-native-routing-cidr` on Hetzner's private
networks, multi-datacenter cluster configuration, and internal load balancer
VIPs via L2 announcements. See the commit description for full details.

## Changes

- `Documentation/installation/k8s-install-hetzner.rst` — new guide
- `Documentation/installation/k8s-toc.rst` — add entry to TOC

```release-note
docs: add Hetzner Cloud native routing installation guide
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request