### PR TITLE
clustermesh: fix context cancellation race on remote connection restart

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -4,7 +4,9 @@
 package common
 
 import (
+	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -151,6 +153,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					return err
 				}
 
+				ctx, cancel := context.WithCancel(ctx)
 				extraOpts := rc.makeExtraOpts(clusterLock, ciliumConfig)
 				backend, errChan := rc.remoteClientFactory(ctx, rc.logger, rc.configPath, extraOpts)
 
@@ -174,6 +177,8 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					default:
 						rc.logger.Warn("Unable to establish etcd connection to remote cluster", logfields.Error, err)
 					}
+
+					cancel()
 					return err
 				}
 
@@ -184,7 +189,6 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				rc.etcdClusterID = etcdClusterID
 				rc.mutex.Unlock()
 
-				ctx, cancel := context.WithCancel(ctx)
 				configChanged := make(chan struct{})
 				rc.wg.Go(func() {
 					rc.watchdog(ctx, backend, clusterLock, configChanged)
@@ -356,7 +360,7 @@ func (rc *remoteCluster) waitForClusterConfig(
 ) (types.CiliumClusterConfig, error) {
 	const clusterConfigRetrievalTimeout = 3 * time.Minute
 
-	ctx, cancel := context.WithTimeout(ctx, clusterConfigRetrievalTimeout)
+	cctx, cancel := context.WithTimeout(ctx, clusterConfigRetrievalTimeout)
 	defer cancel()
 
 	rc.mutex.Lock()
@@ -382,10 +386,11 @@ func (rc *remoteCluster) waitForClusterConfig(
 		rc.mutex.Unlock()
 
 		return config, nil
-	case <-ctx.Done():
+	case <-cctx.Done():
 	}
 
-	return types.CiliumClusterConfig{}, fmt.Errorf("failed to retrieve cluster configuration: %w", ctx.Err())
+	return types.CiliumClusterConfig{}, fmt.Errorf("failed to retrieve cluster configuration: %w",
+		cmp.Or(cctx.Err(), ctx.Err(), errors.New("config updates watcher terminated unexpectedly")))
 }
 
 func (rc *remoteCluster) makeExtraOpts(clusterLock *clusterLock, ciliumConfig CiliumEtcdConfig) kvstore.ExtraOptions {


### PR DESCRIPTION
We have recently started witnessing rare occurrences of a warning along the lines of `failed to retrieve cluster configuration: %!w(<nil>)` in CI, that looks related to the changes from 19d18a510666 ("clustermesh: restart connection on config update").

It turns out that this can happen due to a rare race condition during the context cancellation chain. Indeed, the root controller DoFunc context (let's call it ctx0) is used to derive two contexts, one leveraged internally by the etcd client (ctx1), and one for the rest of the DoFunc logic (ctx2). Yet, given that these two contexts are siblings, there's a race window in which ctx1 may already been canceled, while ctx2 is still alive.

Hence, it can happen that the clustercfg watcher terminates and the `configUpdates` channel gets closed; in turn `waitForClusterConfig` unblocks, and returns a wrapped nil error given that ctx3, derived from ctx2, has not been canceled yet. Subsequently, we enter into the error handling path that short-circuits the emission of the warning if the ctx2 has been canceled, which has not, and emit the spurious warning.

Let's get this fixed by moving the ctx2 context definition so that ctx1 becomes its descendant, rather than its sibling, to ensure that ctx2 has always been already canceled when ctx1 gets canceled, and prevent the possibility of the spurious warning. While being there, let's also refine the error reported by `waitForClusterConfig`, to ensure that it never wraps a nil one even if there were a bug that caused the channel to be closed too early.

Figured the root cause with the help of AI; the description and fix are prepared by a human.

Fixes https://github.com/cilium/cilium/issues/48286