### PR TITLE
datapath/loader: include BPF source in template hash

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -470,11 +470,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e endpoint.Conf
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if e.IsHost() {
-		// Only used to differentiate between host endpoint template and other templates.
-		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")
-	}
-
 	// Local delivery metrics should always be set for endpoint programs.
 	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
 

--- a/pkg/datapath/loader/hash.go
+++ b/pkg/datapath/loader/hash.go
@@ -58,6 +58,16 @@ func (d datapathHash) hashTemplate(c linuxConfig.Writer, epCfg endpoint.Config) 
 	if err := c.WriteTemplateConfig(h, epCfg); err != nil {
 		return "", err
 	}
+
+	// Host and workload endpoints use different BPF source files, but share
+	// the template cache. Keep their cache keys separate even when their
+	// generated template configuration is otherwise identical.
+	templateSource := endpointProg
+	if epCfg.IsHost() {
+		templateSource = hostEndpointProg
+	}
+	_, _ = h.Write([]byte("\x00" + templateSource))
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -84,6 +84,13 @@ func TestHashTemplate(t *testing.T) {
 	b, err := base.hashTemplate(cfg, &ep)
 	require.NoError(t, err)
 	require.Equal(t, a, b)
+
+	// The host endpoint must not share the workload endpoint template cache
+	// entry, even with the exact same configuration.
+	hostEP := testutils.NewTestHostEndpoint(t)
+	hostHash, err := base.hashTemplate(cfg, &hostEP)
+	require.NoError(t, err)
+	require.NotEqual(t, a, hostHash)
 }
 
 type fakeConfigWriter []byte


### PR DESCRIPTION
Host and workload endpoints share the BPF template cache, but compile from different BPF sources: `bpf_lxc.c` and `bpf_host.c`. Keep their cache entries distinct by including the source file name in the template hash instead of relying on the otherwise unused `HOST_ENDPOINT` macro.

Also add a test to ensure that host and workload endpoint template hashes do not collide.

AIL: 0

cc @ekoops