### PR TITLE
renovate: Keep LLVM major version for stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -627,6 +627,17 @@
       ]
     },
     {
+      // LLVM major bumps require careful scrutiny (datapath verifier, etc.),
+      // so they are done manually in main and never backported.
+      "enabled": false,
+      "matchPackageNames": [
+        "quay.io/cilium/cilium-llvm"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
       // Avoid updating patch version for statedb as it might contain breaking changes
       "enabled": false,
       "matchPackageNames": [


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/48619#issuecomment-5615236702
