### PR TITLE
renovate: Disable platform commits for Go module updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -366,6 +366,14 @@
       ]
     },
     {
+      // Signing a >1100-file vendor commit through the GitHub API times out.
+      "platformCommit": "disabled",
+      "matchFileNames": [
+        "go.mod",
+        "go.sum"
+      ]
+    },
+    {
       // Avoid updating patch releases of golang in go.mod
       "enabled": false,
       "matchFileNames": [


### PR DESCRIPTION
Since Renovate runs as a GitHub App, it creates its commits through the GitHub API to have them signed by GitHub (cf. platformCommit [1]). For Go module updates, those commits also carry the vendor/ changes and are therefore huge: 1127 files in each of the last two attempts. The tree creation API call takes more than 10s for such commits and GitHub answers with a 502. Renovate treats that as fatal and doesn't create the branch, so the "all go dependencies main" group never becomes a PR and simply sits in the dependency dashboard under "Other Branches".

Let's disable platform commits for go.mod and go.sum so that Renovate pushes these branches with git directly. The resulting commits won't be signed by GitHub anymore, but we don't enforce that and the signature is lost anyway as soon as the branch is rebased.

This commit was prepared with AIL:3. I personally checked the two Renovate run logs and ran the repository's own renovate-config-validator over the result.

1: https://docs.renovatebot.com/configuration-options/#platformcommit