### PR TITLE
datapath: turn `TRACE_SOCK_NOTIFY` into runtime config

### DIFF
--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -11,8 +11,6 @@
  * @xlate_point: pre- or post- service translation point for load-balancing
  * @dst_ip:	 pre- or post- service translation destination ip address
  * @dst_port:	 pre- or post- service translation destination port
- *
- * If TRACE_SOCK_NOTIFY is not defined, the API will be compiled in as a NOP.
  */
 #pragma once
 
@@ -35,6 +33,8 @@ enum {
 #define TRACE_SOCK_EXTENSION
 #define trace_sock_extension_hook(ctx, msg) do {} while (0)
 #endif
+
+DECLARE_CONFIG(bool, enable_socket_lb_tracing, "Enable socket-based service load-balancing tracing")
 
 /* L4 protocol for the trace event */
 enum l4_protocol {
@@ -74,7 +74,6 @@ struct trace_sock_notify {
 	TRACE_SOCK_EXTENSION
 };
 
-#ifdef TRACE_SOCK_NOTIFY
 static __always_inline enum l4_protocol
 parse_protocol(__u32 l4_proto) {
 	switch (l4_proto) {
@@ -119,10 +118,11 @@ emit_trace_sock_notify(enum xlate_point xlate_point, bool is_connect)
 }
 
 static __always_inline void
-send_trace_sock_notify4(struct __ctx_sock *ctx,
-			enum xlate_point xlate_point,
-			__u32 dst_ip, __u16 dst_port,
-			bool is_connect)
+__send_trace_sock_notify4(struct __ctx_sock *ctx,
+			  enum xlate_point xlate_point,
+			  __u32 dst_ip,
+			  __u16 dst_port,
+			  bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8 = {};
 	struct ratelimit_key rkey = {
@@ -162,11 +162,22 @@ send_trace_sock_notify4(struct __ctx_sock *ctx,
 }
 
 static __always_inline void
-send_trace_sock_notify6(struct __ctx_sock *ctx,
+send_trace_sock_notify4(struct __ctx_sock *ctx,
 			enum xlate_point xlate_point,
-			const union v6addr *dst_addr,
-			__u16 dst_port,
+			__u32 dst_ip, __u16 dst_port,
 			bool is_connect)
+{
+	if (!CONFIG(enable_socket_lb_tracing))
+		return;
+	__send_trace_sock_notify4(ctx, xlate_point, dst_ip, dst_port, is_connect);
+}
+
+static __always_inline void
+__send_trace_sock_notify6(struct __ctx_sock *ctx,
+			  enum xlate_point xlate_point,
+			  const union v6addr *dst_addr,
+			  __u16 dst_port,
+			  bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8;
 	struct ratelimit_key rkey = {
@@ -207,21 +218,15 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 	trace_sock_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events, BPF_F_CURRENT_CPU, &msg, sizeof(msg));
 }
-#else
-static __always_inline void
-send_trace_sock_notify4(struct __ctx_sock *ctx __maybe_unused,
-			enum xlate_point xlate_point __maybe_unused,
-			__u32 dst_ip __maybe_unused, __u16 dst_port __maybe_unused,
-			bool is_connect __maybe_unused)
-{
-}
 
 static __always_inline void
-send_trace_sock_notify6(struct __ctx_sock *ctx __maybe_unused,
-			enum xlate_point xlate_point __maybe_unused,
-			const union v6addr *dst_addr __maybe_unused,
-			__u16 dst_port __maybe_unused,
-			bool is_connect __maybe_unused)
+send_trace_sock_notify6(struct __ctx_sock *ctx,
+			enum xlate_point xlate_point,
+			const union v6addr *dst_addr,
+			__u16 dst_port,
+			bool is_connect)
 {
+	if (!CONFIG(enable_socket_lb_tracing))
+		return;
+	__send_trace_sock_notify6(ctx, xlate_point, dst_addr, dst_port, is_connect);
 }
-#endif /* TRACE_SOCK_NOTIFY */

--- a/pkg/datapath/config/sock_config.go
+++ b/pkg/datapath/config/sock_config.go
@@ -20,6 +20,8 @@ type BPFSock struct {
 	EnableLRP bool `config:"enable_lrp"`
 	// Enable routes when service has 0 endpoints.
 	EnableNoServiceEndpointsRoutable bool `config:"enable_no_service_endpoints_routable"`
+	// Enable socket-based service load-balancing tracing.
+	EnableSocketLBTracing bool `config:"enable_socket_lb_tracing"`
 	// Cookie identifying the network namespace treated as the host namespace.
 	HostNetNSCookie uint64 `config:"host_netns_cookie"`
 	// Cgroup class ID identifying MKE containers treated as host-networked.
@@ -33,5 +35,6 @@ type BPFSock struct {
 }
 
 func NewBPFSock(node Node) *BPFSock {
-	return &BPFSock{false, false, false, false, false, 0x0, 0x0, 0x0, 0x0, node}
+	return &BPFSock{false, false, false, false, false, false, 0x0, 0x0, 0x0, 0x0,
+		node}
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -215,9 +215,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		if option.Config.UnsafeDaemonConfigOption.EnableSocketLBPeer {
 			cDefinesMap["ENABLE_SOCKET_LB_PEER"] = "1"
 		}
-		if option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing {
-			cDefinesMap["TRACE_SOCK_NOTIFY"] = "1"
-		}
 	}
 
 	cDefinesMap["NODEPORT_NEIGH6_SIZE"] = fmt.Sprintf("%d", option.Config.NeighMapEntriesGlobal)

--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -118,6 +118,7 @@ func baseSockPermutations() *loadPermutationBuilder {
 			setBasePermutations(&t.Node)
 			t.EnableIPv4Fragments = true
 			t.EnableIPv6Fragments = true
+			t.EnableSocketLBTracing = true
 		}),
 		Increment(func(t *config.BPFSock, v bool) {
 			if v {

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -116,6 +116,8 @@ func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 		cfg.HostNetNSCookie = cookie
 	}
 
+	cfg.EnableSocketLBTracing = option.Config.UnsafeDaemonConfigOption.EnableSocketLBTracing
+
 	coll, commit, cleanup, err := collLoader.Load(ctx, logger, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		Constants:   cfg,


### PR DESCRIPTION
This PR migrates `TRACE_SOCK_NOTIFY` config macro to runtime config. The new runtime config parameter is called `enable_socket_lb_tracing`.

Related: https://github.com/cilium/cilium/issues/42646

AIL: 0