### PR TITLE
chore: fix print-downgrade-version.sh to find the previous patch

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -168,6 +168,7 @@ jobs:
         with:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
+          fetch-tags: true
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -239,6 +239,7 @@ jobs:
         with:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
+          fetch-tags: true
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables

--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -60,6 +60,8 @@ case "${1}" in
         ;;
 esac
 
+REMOTE_ORIGIN="${REMOTE_ORIGIN:-origin}"
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 VERSION="${VERSION-"$(cat "${SCRIPT_DIR}/../../VERSION")"}"
 if [[ "${VERSION}" =~ ([0-9^]+)\.([0-9^]+)\.([0-9^]+).* ]] ; then
@@ -72,17 +74,19 @@ else
 fi
 
 tag_exists() {
-    local tag="refs/tags/${1}"
+    local tag="${1}"
 
     # Check if the tag is already present locally.
-    if git rev-parse --verify --end-of-options "${tag}" &> /dev/null; then
+    if git rev-parse --verify --end-of-options "refs/tags/${tag}" &> /dev/null; then
         return 0
     fi
 
-    # If not, try to fetch it from origin.
+    # If not, check whether the tag exists on the remote. We no longer assume
+    # tags have been pre-fetched (e.g. shallow clones in CI won't have them),
+    # so ls-remote is the source of truth for tag existence.
     #
     # Note: Stuff we tried before in the past (for the patch release case),
-    # instead of calling "git fetch" in this script:
+    # instead of querying the remote in this script:
     #
     # - Downloading the tags directly in the CI workflow YAML file, by passing
     #   "fetch-tags: true" to the checkout Action. This does not work with
@@ -94,20 +98,73 @@ tag_exists() {
     #   and assume we're on a release preparation PR in that case. This does
     #   not work well, however, if the release manager pushes additional fixes
     #   on top of the prep commit.
-    >&2 echo "INFO: tag '${tag}' not present locally, trying to fetch it from origin"
-    git fetch --depth=1 origin "+${tag}:${tag}" &> /dev/null || true
-
-    # Retry after the fetch attempt.
-    if git rev-parse --verify --end-of-options "${tag}" &> /dev/null; then
+    >&2 echo "INFO: tag '${tag}' not present locally, checking remote '${REMOTE_ORIGIN}'"
+    if git ls-remote --tags --exit-code "${REMOTE_ORIGIN}" "refs/tags/${tag}" &> /dev/null; then
         return 0
     fi
 
     return 1
 }
 
+find_previous_tag_for_version() {
+    local version="${1}" major minor
+    local tag_suffix="${TAG_SUFFIX:-}"
+
+    if [[ ! "${version}" =~ ^([0-9]+)\.([0-9]+)\. ]] ; then
+        >&2 echo "ERROR: failed to parse version '${version}'"
+        return 1
+    fi
+
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+
+    # Query the remote directly — tags are not assumed to be pre-fetched.
+    mapfile -t candidate_tags < <(
+        git ls-remote --tags --refs "${REMOTE_ORIGIN}" 'refs/tags/v*' \
+            | awk '{print $NF}' \
+            | sed 's|refs/tags/||' \
+            | sort -rV
+    )
+    for tag in "${candidate_tags[@]}"; do
+        local tag_version="${tag#v}"
+        # parse version into major, minor, patch, optional suffix (e.g. -cee.N)
+        if [[ "${tag_version}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.+)?$ ]] ; then
+            local t_major="${BASH_REMATCH[1]}"
+            local t_minor="${BASH_REMATCH[2]}"
+            local t_patch="${BASH_REMATCH[3]}"
+            local t_suffix="${BASH_REMATCH[4]:-}"
+
+            # Only consider tags matching the expected suffix family:
+            #   - OSS build (no TAG_SUFFIX): accept only tags with no suffix.
+            #   - Enterprise build (TAG_SUFFIX like "-cee.N"): accept ANY
+            #     "-cee.*" tag, not just the exact TAG_SUFFIX, so downgrades
+            #     across rebuild numbers (e.g. -cee.1 → -cee.2) still work.
+            #   - Other suffix families: require an exact match.
+            if [[ -z "${tag_suffix}" ]]; then
+                [[ -z "${t_suffix}" ]] || continue
+            elif [[ "${tag_suffix}" == -cee.* ]]; then
+                [[ "${t_suffix}" == -cee.* ]] || continue
+            else
+                [[ "${t_suffix}" == "${tag_suffix}" ]] || continue
+            fi
+
+            # Check if this tag is older than the given version.
+            if [[ "${t_major}" -lt "${major}" ]] || \
+               [[ "${t_major}" -eq "${major}" && "${t_minor}" -lt "${minor}" ]] || \
+               [[ "${t_major}" -eq "${major}" && "${t_minor}" -eq "${minor}" && "${t_patch}" -lt "${PATCH}" ]] ; then
+                echo "${tag}"
+                return 0
+            fi
+        fi
+    done
+
+    >&2 echo "ERROR: failed to find tag older than version '${version}'"
+    return 1
+}
+
 print_prev_patch() {
     local version="${1}" major="${2}" minor="${3}" patch="${4}"
-    local tag
+    local previous_tag
 
     # If we're on the development branch, there is no previous patch release to
     # downgrade to. Calling workflow should typically skip the job.
@@ -127,12 +184,12 @@ print_prev_patch() {
     # Hack: When working on a patch release preparation PR, file VERSION
     # contains the new value for the release that is yet to be tagged and
     # published. So if the tag does not exist, we want to downgrade to the
-    # previous patch release, by computing the (assumed) previous tag value.
+    # previous patch release, by looking up the newest older tag on the remote.
     #
-    # Only run this step if we're in a Git repository with a remote named
-    # "origin".
+    # Only run this step if we're in a Git repository with the expected remote
+    # configured.
     if git rev-parse --is-inside-work-tree &> /dev/null && \
-        git remote | grep -q '^origin$' ; then
+        git remote | grep -q "^${REMOTE_ORIGIN}$" ; then
 
         if ! tag_exists "${tag}"; then
             # If the patch version is 0, we cannot decrement it further.
@@ -141,15 +198,14 @@ print_prev_patch() {
                 exit 1
             fi
 
-            >&2 echo "INFO: tag '${tag}' not found, assuming we're on a release preparation Pull Request: decrementing patch release number"
-            tag="v${major}.${minor}.$((patch - 1))${TAG_SUFFIX:-}"
+            >&2 echo "INFO: tag '${tag}' not found. Querying remote '${REMOTE_ORIGIN}' for previous patch version."
 
-            # Note: Based on the current usage of this script in workflows, we
-            # assume that the version computed by decrementing the patch number
-            # exists, and we don't check for its existence here. If it does not
-            # exist at this stage, the calling workflow will try to downgrade
-            # to an inexistent version and fail loudly, which is the desired
-            # behaviour.
+            if previous_tag=$(find_previous_tag_for_version "${version}") ; then
+                tag="${previous_tag}"
+            else
+                >&2 echo "ERROR: failed to deduce patch release previous to version '${version}' (no older tag found)"
+                exit 1
+            fi
         fi
     fi
 
@@ -158,6 +214,7 @@ print_prev_patch() {
 
 print_prev_branch() {
     local version="${1}" major="${2}" minor="${3}"
+    local branch_suffix="${BRANCH_SUFFIX:-}"
 
     # If the minor version is 0, we cannot decrement it further.
     if [[ "${minor}" == "0" ]] ; then
@@ -165,10 +222,25 @@ print_prev_branch() {
         exit 1
     fi
 
-    # Print the previous stable version by decrementing the minor version and
-    # trimming the patch version.
-    minor=$((minor - 1))
-    echo "v${major}.${minor}${BRANCH_SUFFIX:-}"
+    # Query the remote directly — stable branches are not assumed to be
+    # present in a shallow clone. Loop through them to find the newest branch
+    # older than the current version.
+    while read -r ref ; do
+        local branch="${ref#refs/heads/}"
+        if [[ "${branch}" =~ ^v([0-9]+)\.([0-9]+)${branch_suffix}$ ]] ; then
+            local b_major="${BASH_REMATCH[1]}"
+            local b_minor="${BASH_REMATCH[2]}"
+
+            if [[ "${b_major}" -lt "${major}" ]] || \
+               [[ "${b_major}" -eq "${major}" && "${b_minor}" -lt "${minor}" ]] ; then
+                echo "${branch}"
+                return 0
+            fi
+        fi
+    done < <(git ls-remote --heads "${REMOTE_ORIGIN}" 'refs/heads/v*' | awk '{print $NF}' | sort -rV)
+
+    >&2 echo "ERROR: failed to find branch older than version '${version}'"
+    exit 1
 }
 
 # If user passed "patch" as first argument, print the latest patch version.


### PR DESCRIPTION
Instead of blindly decrementing the tag and branch versions, use git commands to find the values.

Motivation:

When we create a release tag but not able to publish images (which has happened in the past), we needed to create exceptions in this script to skip the downgrade version that does not have artifacts.

This PR will actually look at remote tags and then compute the downgrade patch and stable vesions.