### PR TITLE
envoy: track coalesced ADS snapshot updates

### DIFF
--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -1412,6 +1412,105 @@ func TestEnvoyAdsMultipleVersionsSentBeforeAckReceived(t *testing.T) {
 	stopEnvoy()
 }
 
+// Repro for https://github.com/cilium/cilium/issues/43519:
+// ADS may coalesce a tracked snapshot into a newer untracked snapshot, leaving
+// the earlier completion stuck even after Envoy ACKs the newer snapshot.
+func TestEnvoyAdsUntrackedSnapshotCompletesEarlierTrackedUpdate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	if os.Getenv("CILIUM_ENABLE_ENVOY_UNIT_TEST") == "" {
+		t.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
+	}
+
+	logging.SetLogLevel(slog.LevelDebug)
+	flowdebug.Enable()
+
+	testRunDir, err := os.MkdirTemp("", "envoy_go_test")
+	require.NoError(t, err)
+	t.Logf("run directory: %s", testRunDir)
+
+	localEndpointStore := newLocalEndpointStore()
+	logger := hivetest.Logger(t)
+
+	xdsServer := newADSServer(logger, testipcache.NewMockIPCache(), localEndpointStore,
+		xdsServerConfig{
+			envoySocketDir:    util.GetSocketDir(testRunDir),
+			proxyGID:          1337,
+			httpNormalizePath: true,
+			metrics:           xds.NewXDSMetric(),
+			envoyXDSMode:      config.EnvoyXDSModeADS,
+		},
+		nil, nil)
+	require.NotNil(t, xdsServer)
+
+	go func() {
+		err = xdsServer.run(t.Context())
+		require.NoError(t, err)
+	}()
+	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
+	require.NotNil(t, accessLogServer)
+	go func() {
+		err = accessLogServer.run(t.Context())
+		require.NoError(t, err)
+	}()
+
+	// Publish tracked snapshot A before Envoy connects. Its completion can only
+	// be resolved by a response/ACK for this version or a newer version.
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	trackedWaitGroup := completion.NewWaitGroup(waitCtx)
+	err = xdsServer.AddListener(ctx, "tracked-listener", policy.ParserTypeHTTP, 18081, true, false, trackedWaitGroup, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, xdsServer.cache.GetCompletionCallbacks().PendingCompletionCount())
+
+	trackedSnapshot, err := xdsServer.cache.GetSnapshot(localNodeID)
+	require.NoError(t, err)
+	trackedVersion := trackedSnapshot.GetVersion(ListenerTypeURL)
+	require.NotEmpty(t, trackedVersion)
+
+	// Publish newer snapshot B without a wait group, mirroring the untracked
+	// NPDS snapshot produced by the synthetic ingress endpoint. Since Envoy has
+	// not connected yet, it can receive only B and A is guaranteed to be
+	// coalesced.
+	err = xdsServer.AddListener(ctx, "untracked-listener", policy.ParserTypeHTTP, 18082, true, false, nil, nil)
+	require.NoError(t, err)
+	untrackedSnapshot, err := xdsServer.cache.GetSnapshot(localNodeID)
+	require.NoError(t, err)
+	untrackedVersion := untrackedSnapshot.GetVersion(ListenerTypeURL)
+	require.NotEmpty(t, untrackedVersion)
+	require.NotEqual(t, trackedVersion, untrackedVersion)
+	require.Equal(t, 1, xdsServer.cache.GetCompletionCallbacks().PendingCompletionCount())
+
+	starter := &onDemandXdsStarter{logger: logger}
+	envoyProxy, err := starter.startStandaloneEnvoyInternal(standaloneEnvoyConfig{
+		runDir:                         testRunDir,
+		logPath:                        filepath.Join(testRunDir, "cilium-envoy.log"),
+		baseID:                         43,
+		connectTimeout:                 1,
+		maxActiveDownstreamConnections: 100,
+		defaultLogLevel:                "debug",
+		maxConnections:                 10,
+		maxRequests:                    100,
+		maxConcurrentRetries:           10,
+		maxPendingRequests:             1024,
+		xdsMode:                        config.EnvoyXDSModeADS,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, envoyProxy)
+	t.Log("started Envoy after both snapshots were published")
+	stopEnvoy := cleanupStandaloneEnvoy(t, envoyProxy)
+
+	// Confirm Envoy applied B. Its ACK must also release the completion
+	// associated with the older coalesced snapshot A.
+	requireEnvoyConfigDumpContains(t, envoyProxy.GetAdminClient(), "ListenersConfigDump", "untracked-listener")
+	err = trackedWaitGroup.Wait()
+	require.NoError(t, err, "ACK of the newer snapshot should complete the older coalesced update")
+	require.Zero(t, xdsServer.cache.GetCompletionCallbacks().PendingCompletionCount())
+
+	stopEnvoy()
+}
+
 func TestEnvoyAdsMultipleVersionsSentBeforeNackReceived(t *testing.T) {
 	s := setupEnvoySuite(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)

--- a/pkg/envoy/xds_server_ads.go
+++ b/pkg/envoy/xds_server_ads.go
@@ -1023,7 +1023,10 @@ func (s *adsServer) updateSnapshot(ctx context.Context, resources *xds.Resources
 
 	if oldSnapshot == nil || len(updatedTypeURLsInSnapshot) > 0 || s.cache.AreDifferentSnapshots(oldSnapshot, newSnapshot) {
 		var revertFunc func()
-		if wg != nil {
+		// Untracked snapshots can coalesce older tracked updates in ADS. Preserve
+		// their rollback as well so a NACK of the resulting response restores all
+		// updates represented by it, newest first.
+		if wg != nil || changes != nil {
 			revertFunc = s.buildRevert(ctx, nodeId, resources, changes)
 		}
 		err = s.cache.UpdateSnapshot(ctx, nodeId, newSnapshot, wg, completionTypeURLs, revertFunc)

--- a/pkg/envoy/xdsnew/cache.go
+++ b/pkg/envoy/xdsnew/cache.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	callbacks "github.com/cilium/cilium/pkg/envoy/xdsnew/callbacks"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -636,15 +637,22 @@ func (c *cacheImpl) UpdateSnapshot(ctx context.Context, nodeID string, newSnapsh
 
 	completions := make([]*completion.Completion, 0, len(updatedTypeURLS))
 	immediateCompletions := make([]immediateCompletion, 0, 1)
+	handledTypeURLs := make(map[string]struct{}, len(updatedTypeURLS))
+	oldSnapshot, _ := c.GetSnapshot(nodeID)
 	if wg != nil && len(updatedTypeURLS) > 0 {
-		oldSnapshot, _ := c.GetSnapshot(nodeID)
 		for typeURL, completionCallback := range updatedTypeURLS {
-			comp := wg.AddCompletionWithCallback(nil, completionCallback)
+			handledTypeURLs[typeURL] = struct{}{}
+			version := newSnapshot.GetVersion(typeURL)
+			owner := c.completionCbs.NewTypeVersionCompletionOwner(nodeID, typeURL, version)
+			comp := wg.AddCompletionWithCallback(owner, completionCallback)
 			if typeURL == NetworkPolicyTypeURL && len(newSnapshot.GetResources(NetworkPolicyTypeURL)) == 0 {
-				immediateCompletions = append(immediateCompletions, immediateCompletion{comp: comp})
+				immediateCompletions = append(immediateCompletions, immediateCompletion{
+					comp:                      comp,
+					typeURL:                   typeURL,
+					completeUnsentCompletions: true,
+				})
 				continue
 			}
-			version := newSnapshot.GetVersion(typeURL)
 			versionChanged := oldSnapshot == nil || oldSnapshot.GetVersion(typeURL) != version
 			registered, err := c.completionCbs.AddTypeVersionCompletion(comp, version, typeURL, nodeID, versionChanged, revertFunc)
 			if !registered {
@@ -659,13 +667,56 @@ func (c *cacheImpl) UpdateSnapshot(ctx context.Context, nodeID string, newSnapsh
 			completions = append(completions, comp)
 		}
 	}
+
+	// A newer snapshot may be published without a completion, for example when
+	// the synthetic ingress endpoint updates NPDS. Record changed versions while
+	// older completions are pending so a response for the newer snapshot can
+	// claim and eventually complete coalesced updates.
+	markers := make([]*callbacks.TypeVersionMarker, 0, len(snapshotResourceTypes))
+	completeUnsentTypeURLs := make([]string, 0, 1)
+	for _, typeURL := range snapshotResourceTypes {
+		if _, handled := handledTypeURLs[typeURL]; handled {
+			continue
+		}
+		// An empty NPDS snapshot intentionally does not wait for an ACK.
+		if typeURL == NetworkPolicyTypeURL && len(newSnapshot.GetResources(typeURL)) == 0 {
+			completeUnsentTypeURLs = append(completeUnsentTypeURLs, typeURL)
+			continue
+		}
+		version := newSnapshot.GetVersion(typeURL)
+		versionChanged := oldSnapshot == nil || oldSnapshot.GetVersion(typeURL) != version
+		marker, completeUnsent := c.completionCbs.AddTypeVersionMarker(version, typeURL, nodeID, versionChanged, revertFunc)
+		if marker != nil {
+			markers = append(markers, marker)
+		}
+		if completeUnsent {
+			completeUnsentTypeURLs = append(completeUnsentTypeURLs, typeURL)
+		}
+	}
 	err := c.SetSnapshot(ctx, nodeID, newSnapshot)
 
 	if err != nil {
-		for _, comp := range completions {
-			c.completionCbs.RemoveTypeVersionCompletion(comp)
+		// go-control-plane stores a snapshot before delivering responses and can
+		// return an error after the new snapshot is already observable. Treat that
+		// case as committed so callback ordering and resourcesInSnapshot stay in
+		// sync with the underlying cache.
+		currentSnapshot, getErr := c.GetSnapshot(nodeID)
+		committed := getErr == nil && !c.AreDifferentSnapshots(currentSnapshot, newSnapshot)
+		if !committed {
+			for _, comp := range completions {
+				c.completionCbs.RemoveTypeVersionCompletion(comp)
+			}
+			for _, marker := range markers {
+				c.completionCbs.RemoveTypeVersionMarker(marker)
+			}
+			return err
 		}
-		return err
+		c.logger.Debug("Snapshot was installed despite response delivery error",
+			logfields.NodeID, nodeID,
+			logfields.Error, err)
+	}
+	for _, typeURL := range completeUnsentTypeURLs {
+		c.completionCbs.CompleteUnsentPendingCompletions(nodeID, typeURL, nil)
 	}
 	for _, completion := range immediateCompletions {
 		if completion.completeUnsentCompletions {

--- a/pkg/envoy/xdsnew/cache_test.go
+++ b/pkg/envoy/xdsnew/cache_test.go
@@ -5,6 +5,7 @@ package xdsnew
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -36,9 +37,10 @@ import (
 )
 
 type mockSnapshotCache struct {
-	snapshots      map[string]cache.ResourceSnapshot
-	setSnapshotErr error
-	clearCalled    map[string]bool
+	snapshots                map[string]cache.ResourceSnapshot
+	setSnapshotErr           error
+	storeSnapshotBeforeError bool
+	clearCalled              map[string]bool
 
 	// Call tracking
 	setSnapshotCalls   []setSnapshotCall
@@ -66,6 +68,9 @@ func newMockSnapshotCache() *mockSnapshotCache {
 
 func (m *mockSnapshotCache) SetSnapshot(ctx context.Context, node string, snapshot cache.ResourceSnapshot) error {
 	m.setSnapshotCalls = append(m.setSnapshotCalls, setSnapshotCall{ctx: ctx, nodeID: node, snapshot: snapshot})
+	if m.storeSnapshotBeforeError {
+		m.snapshots[node] = snapshot
+	}
 	if m.setSnapshotErr != nil {
 		return m.setSnapshotErr
 	}
@@ -910,6 +915,135 @@ func TestUpdateSnapshot_CompletesUnsentCoalescedNetworkPolicyUpdates(t *testing.
 	assert.NoError(t, bCallbackErrs[0])
 	require.Len(t, aCallbackErrs, 1)
 	assert.NoError(t, aCallbackErrs[0])
+}
+
+func TestUpdateSnapshot_TrackedPolicyCompletionFollowsUntrackedNewerVersion(t *testing.T) {
+	mock := newMockSnapshotCache()
+	c := newTestCacheWithHasher(mock)
+
+	const nodeID = "node1"
+	_, snapA := networkPolicySnapshot(t, c, 1)
+	_, snapB := networkPolicySnapshot(t, c, 2)
+	_, snapC := networkPolicySnapshot(t, c, 3)
+
+	// Establish the version Envoy has already accepted.
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapA, nil, nil, nil))
+	ackNetworkPolicyVersion(t, c, nodeID, snapA.GetVersion(NetworkPolicyTypeURL))
+
+	wgB := completion.NewWaitGroup(context.Background())
+	defer wgB.Cancel()
+
+	// A normal endpoint policy update waits for the NPDS ACK.
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapB, wgB,
+		map[string]func(error){NetworkPolicyTypeURL: nil}, nil))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	// reserved:ingress can publish a newer snapshot with wg=nil. If
+	// go-control-plane coalesces B and sends only C, ACK(C) must complete B.
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapC, nil, nil, nil))
+	ackNetworkPolicyVersion(t, c, nodeID, snapC.GetVersion(NetworkPolicyTypeURL))
+
+	require.Zero(t, c.completionCbs.PendingCompletionCount())
+	require.NoError(t, wgB.Wait())
+}
+
+func TestUpdateSnapshot_UntrackedAlreadyAcceptedVersionCompletesPendingUpdate(t *testing.T) {
+	mock := newMockSnapshotCache()
+	c := newTestCacheWithHasher(mock)
+
+	const nodeID = "node1"
+	_, snapA := networkPolicySnapshot(t, c, 1)
+	_, snapB := networkPolicySnapshot(t, c, 2)
+
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapA, nil, nil, nil))
+	ackNetworkPolicyVersion(t, c, nodeID, snapA.GetVersion(NetworkPolicyTypeURL))
+
+	wgB := completion.NewWaitGroup(context.Background())
+	defer wgB.Cancel()
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapB, wgB,
+		map[string]func(error){NetworkPolicyTypeURL: nil}, nil))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	// Returning to A needs no new response because Envoy has already accepted
+	// A. Publishing it without a wait group must still complete unsent B.
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapA, nil, nil, nil))
+	require.Zero(t, c.completionCbs.PendingCompletionCount())
+	require.NoError(t, wgB.Wait())
+}
+
+func TestUpdateSnapshot_FailedUntrackedUpdateRemovesVersionMarker(t *testing.T) {
+	mock := newMockSnapshotCache()
+	c := newTestCacheWithHasher(mock)
+
+	const nodeID = "node1"
+	_, snapA := networkPolicySnapshot(t, c, 1)
+	_, snapB := networkPolicySnapshot(t, c, 2)
+
+	wgA := completion.NewWaitGroup(context.Background())
+	defer wgA.Cancel()
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapA, wgA,
+		map[string]func(error){NetworkPolicyTypeURL: nil}, nil))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	mock.setSnapshotErr = errors.New("snapshot publication failed")
+	require.Error(t, c.UpdateSnapshot(context.Background(), nodeID, snapB, nil, nil, nil))
+	mock.setSnapshotErr = nil
+
+	// A response for the unpublished version must not claim A's completion.
+	ackNetworkPolicyVersion(t, c, nodeID, snapB.GetVersion(NetworkPolicyTypeURL))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	ackNetworkPolicyVersion(t, c, nodeID, snapA.GetVersion(NetworkPolicyTypeURL))
+	require.Zero(t, c.completionCbs.PendingCompletionCount())
+	require.NoError(t, wgA.Wait())
+}
+
+func TestUpdateSnapshot_EmptyPolicySnapshotCompletesPendingUpdate(t *testing.T) {
+	mock := newMockSnapshotCache()
+	c := newTestCacheWithHasher(mock)
+
+	const nodeID = "node1"
+	_, nonemptySnapshot := networkPolicySnapshot(t, c, 1)
+	emptySnapshot, err := c.GenerateSnapshot(emptyResources(), c.logger)
+	require.NoError(t, err)
+
+	wg := completion.NewWaitGroup(context.Background())
+	defer wg.Cancel()
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, nonemptySnapshot, wg,
+		map[string]func(error){NetworkPolicyTypeURL: nil}, nil))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	// Envoy does not ACK an empty NPDS snapshot. Once that snapshot is
+	// installed, it supersedes and must release the older pending update.
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, emptySnapshot, nil, nil, nil))
+	require.Zero(t, c.completionCbs.PendingCompletionCount())
+	require.NoError(t, wg.Wait())
+}
+
+func TestUpdateSnapshot_ErrorAfterStoreKeepsVersionMarker(t *testing.T) {
+	mock := newMockSnapshotCache()
+	c := newTestCacheWithHasher(mock)
+
+	const nodeID = "node1"
+	_, snapA := networkPolicySnapshot(t, c, 1)
+	_, snapB := networkPolicySnapshot(t, c, 2)
+
+	wgA := completion.NewWaitGroup(context.Background())
+	defer wgA.Cancel()
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapA, wgA,
+		map[string]func(error){NetworkPolicyTypeURL: nil}, nil))
+	require.Equal(t, 1, c.completionCbs.PendingCompletionCount())
+
+	// go-control-plane installs the snapshot before it delivers watch
+	// responses. A canceled delivery can therefore return an error even though
+	// the new version is now the cache's authoritative state.
+	mock.storeSnapshotBeforeError = true
+	mock.setSnapshotErr = errors.New("response delivery failed after store")
+	require.NoError(t, c.UpdateSnapshot(context.Background(), nodeID, snapB, nil, nil, nil))
+
+	ackNetworkPolicyVersion(t, c, nodeID, snapB.GetVersion(NetworkPolicyTypeURL))
+	require.Zero(t, c.completionCbs.PendingCompletionCount())
+	require.NoError(t, wgA.Wait())
 }
 
 // --- GetVersion ---

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
@@ -33,6 +33,7 @@ type versionEntry struct {
 	version     string
 	completions set.Set[*completion.Completion]
 	rollback    func()
+	markerID    uint64
 }
 
 // aggregateRollback combines rollback functions in update order. The returned
@@ -88,6 +89,27 @@ func (vo *orderedCompletions) append(version string, c *completion.Completion, r
 		completions: set.NewSet(c),
 		rollback:    rollback,
 	})
+}
+
+// appendMarker records a snapshot version that has no completion of its own.
+// The marker allows a response for this version to claim completions belonging
+// to older snapshots that go-control-plane coalesced into it.
+func (vo *orderedCompletions) appendMarker(version string, markerID uint64, rollback func()) {
+	*vo = append(*vo, versionEntry{
+		version:     version,
+		completions: set.NewSet[*completion.Completion](),
+		rollback:    rollback,
+		markerID:    markerID,
+	})
+}
+
+func (vo *orderedCompletions) hasPendingCompletions() bool {
+	for i := range *vo {
+		if !(*vo)[i].completions.Empty() {
+			return true
+		}
+	}
+	return false
 }
 
 // removeRange removes entries in [start, end), preserving order and releasing
@@ -199,6 +221,9 @@ type CompletionCallbacks struct {
 	// stream. Envoy is configured with SetNodeOnFirstMessageOnly, so subsequent
 	// ACK/NACK requests can omit Node even though completions are keyed by node ID.
 	streamNodeIDs map[int64]string
+	// nextMarkerID uniquely identifies version-only ordering entries so an update
+	// that definitely was not published can remove the exact entry it registered.
+	nextMarkerID uint64
 }
 
 func NewCompletionCallbacks(logger *slog.Logger) *CompletionCallbacks {
@@ -255,15 +280,41 @@ func (cb *CompletionCallbacks) removeFromOrderedCompletions(c *completion.Comple
 			entry := &(*vo)[i]
 			if entry.completions.Has(c) {
 				entry.completions.Remove(c)
-				if entry.completions.Empty() {
+				if entry.completions.Empty() && entry.markerID == 0 {
 					vo.remove(i)
 				}
-				if len(*vo) == 0 {
+				if !vo.hasPendingCompletions() {
 					delete(cb.completionsOrders, key)
 				}
 				return
 			}
 		}
+	}
+}
+
+type typeVersionCompletionOwner struct {
+	callbacks *CompletionCallbacks
+	nodeID    string
+	typeURL   string
+	version   string
+}
+
+func (o *typeVersionCompletionOwner) ID() string {
+	return fmt.Sprintf("nodeID:%s,typeURL:%s,version:%s", o.nodeID, o.typeURL, o.version)
+}
+
+func (o *typeVersionCompletionOwner) CleanupAfterWait(c *completion.Completion) {
+	o.callbacks.RemoveTypeVersionCompletion(c)
+}
+
+// NewTypeVersionCompletionOwner returns an owner that removes a completion
+// from the xDS callback state if its wait group ends before an ACK or NACK.
+func (cb *CompletionCallbacks) NewTypeVersionCompletionOwner(nodeID, typeURL, version string) completion.Owner {
+	return &typeVersionCompletionOwner{
+		callbacks: cb,
+		nodeID:    nodeID,
+		typeURL:   typeURL,
+		version:   version,
 	}
 }
 
@@ -411,6 +462,77 @@ func (cb *CompletionCallbacks) AddTypeVersionCompletion(c *completion.Completion
 	return true, nil
 }
 
+// AddTypeVersionMarker records a changed snapshot version that has no
+// completion of its own. It returns completeUnsent when Envoy has already
+// ACKed this version and older pending completions should be completed after
+// the snapshot is published successfully.
+func (cb *CompletionCallbacks) AddTypeVersionMarker(version, typeURL, nodeID string, versionChanged bool, revertFunc func()) (marker *TypeVersionMarker, completeUnsent bool) {
+	if version == "" || !versionChanged {
+		return nil, false
+	}
+
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	key := completionsOrderKey(nodeID, typeURL)
+	vo, ok := cb.completionsOrders[key]
+	// A marker is only needed to carry older pending completions across this
+	// untracked version.
+	if !ok || !vo.hasPendingCompletions() {
+		return nil, false
+	}
+
+	state := cb.responseStates[key]
+	if state.pendingVersion == "" && state.acceptedVersion == version {
+		return nil, true
+	}
+
+	cb.nextMarkerID++
+	marker = &TypeVersionMarker{key: key, id: cb.nextMarkerID}
+	vo.appendMarker(version, marker.id, revertFunc)
+	cb.Log.Debug("Added snapshot version marker",
+		logfields.XDSTypeURL, typeURL,
+		logfields.Version, version,
+		logfields.NodeID, nodeID)
+	return marker, false
+}
+
+// TypeVersionMarker identifies an ordering entry for a snapshot version that
+// does not have a completion of its own.
+type TypeVersionMarker struct {
+	key string
+	id  uint64
+}
+
+// RemoveTypeVersionMarker removes a marker for an update that was confirmed
+// not to have been installed in the snapshot cache. If a response has already
+// associated completions with it, keep it for the eventual ACK or NACK.
+func (cb *CompletionCallbacks) RemoveTypeVersionMarker(marker *TypeVersionMarker) {
+	if marker == nil {
+		return
+	}
+
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	vo, ok := cb.completionsOrders[marker.key]
+	if !ok {
+		return
+	}
+	for i := range *vo {
+		entry := &(*vo)[i]
+		if entry.markerID == marker.id {
+			if entry.completions.Empty() {
+				vo.remove(i)
+			}
+			break
+		}
+	}
+	if !vo.hasPendingCompletions() {
+		delete(cb.completionsOrders, marker.key)
+	}
+}
+
 // OnFetchRequest implements server.Callbacks.
 func (cb *CompletionCallbacks) OnFetchRequest(context.Context, *discovery.DiscoveryRequest) error {
 	return nil
@@ -485,7 +607,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 			for _, c := range completed {
 				delete(cb.pendingCompletions, c)
 			}
-			if len(*vo) == 0 {
+			if !vo.hasPendingCompletions() {
 				delete(cb.completionsOrders, key)
 			}
 		}
@@ -528,7 +650,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 				logfields.XDSTypeURL, typeURL,
 				logfields.Version, req.GetVersionInfo())
 		}
-		if len(*vo) == 0 {
+		if !vo.hasPendingCompletions() {
 			delete(cb.completionsOrders, key)
 		}
 	}
@@ -583,7 +705,7 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 			for _, c := range completed {
 				delete(cb.pendingCompletions, c)
 			}
-			if len(*vo) == 0 {
+			if !vo.hasPendingCompletions() {
 				delete(cb.completionsOrders, key)
 			}
 		}

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"log/slog"
 	"slices"
+	"strings"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -240,6 +241,11 @@ type responseState struct {
 	// pendingVersion is the version in the most recent response for which we have
 	// not yet observed an ACK or NACK.
 	pendingVersion string
+	// pendingNonce and pendingStreamID identify that exact response. The
+	// go-control-plane callback runs before its own stale-nonce check, so these
+	// fields prevent an old request from completing or reverting a newer update.
+	pendingNonce    string
+	pendingStreamID int64
 	// acceptedVersion is the version Envoy most recently ACKed for this type.
 	acceptedVersion string
 	// rejectedVersion/rejectedErr remember the latest NACKed version so a
@@ -562,7 +568,35 @@ func (cb *CompletionCallbacks) OnStreamOpen(ctx context.Context, streamID int64,
 // OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 func (cb *CompletionCallbacks) OnStreamClosed(streamID int64, node *core.Node) {
 	cb.mutex.Lock()
+	nodeID := cb.streamNodeIDs[streamID]
+	if nodeID == "" {
+		nodeID = node.GetId()
+	}
 	delete(cb.streamNodeIDs, streamID)
+
+	// Once the last stream for a node closes, its ACK state no longer describes
+	// the next Envoy process. Keep pending completion order so a replacement
+	// stream can satisfy it, but require fresh responses and ACKs.
+	streamStillOpen := false
+	for _, openNodeID := range cb.streamNodeIDs {
+		if openNodeID == nodeID {
+			streamStillOpen = true
+			break
+		}
+	}
+	if nodeID != "" && !streamStillOpen {
+		prefix := nodeID + "\x00"
+		for key, state := range cb.responseStates {
+			if !strings.HasPrefix(key, prefix) {
+				continue
+			}
+			state.pendingVersion = ""
+			state.pendingNonce = ""
+			state.pendingStreamID = 0
+			state.acceptedVersion = ""
+			cb.responseStates[key] = state
+		}
+	}
 	cb.mutex.Unlock()
 
 	cb.Log.Info("OnStreamClosed", logfields.XDSStreamID, streamID)
@@ -573,20 +607,37 @@ func (cb *CompletionCallbacks) OnStreamClosed(streamID int64, node *core.Node) {
 func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.DiscoveryRequest) error {
 	cb.mutex.Lock()
 	nodeID := cb.nodeIDForRequest(streamID, req)
-	if req.VersionInfo == "" {
-		// This means this is the first request on the stream, so we can ignore it for completion purposes since there is no version to ACK.
+	typeURL := req.GetTypeUrl()
+	key := completionsOrderKey(nodeID, typeURL)
+	if req.VersionInfo == "" && req.GetResponseNonce() == "" && req.GetErrorDetail() == nil {
+		// This is a fresh subscription, not an ACK or NACK. Any accepted version
+		// belongs to an earlier Envoy stream and must not satisfy new updates.
+		state := cb.responseStates[key]
+		state.pendingVersion = ""
+		state.pendingNonce = ""
+		state.pendingStreamID = 0
+		state.acceptedVersion = ""
+		cb.responseStates[key] = state
 		cb.mutex.Unlock()
 		return nil
 	}
-	typeURL := req.GetTypeUrl()
-	key := completionsOrderKey(nodeID, typeURL)
+
+	state := cb.responseStates[key]
+	if req.GetResponseNonce() != "" &&
+		(state.pendingNonce == "" || state.pendingStreamID != streamID || state.pendingNonce != req.GetResponseNonce()) {
+		cb.Log.Debug("Ignoring stale xDS ACK/NACK",
+			logfields.XDSTypeURL, typeURL,
+			logfields.Version, req.GetVersionInfo(),
+			logfields.NodeID, nodeID)
+		cb.mutex.Unlock()
+		return nil
+	}
 
 	var completed []*completion.Completion
 	var completeErr error
 	var revertFunc func()
 
 	if req.GetErrorDetail() != nil {
-		state := cb.responseStates[key]
 		rejectedVersion := state.pendingVersion
 		if rejectedVersion == "" {
 			rejectedVersion = req.GetVersionInfo()
@@ -594,6 +645,8 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 		nackErr := fmt.Errorf("NACK from %s for %s version %s: %s",
 			nodeID, typeURL, rejectedVersion, req.GetErrorDetail().GetMessage())
 		state.pendingVersion = ""
+		state.pendingNonce = ""
+		state.pendingStreamID = 0
 		state.acceptedVersion = req.GetVersionInfo()
 		state.rejectedVersion = rejectedVersion
 		state.rejectedErr = nackErr
@@ -633,12 +686,13 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 	}
 
 	// ACK received: complete this version and all earlier versions in the version order.
-	state := cb.responseStates[key]
 	state.acceptedVersion = req.GetVersionInfo()
 	state.rejectedVersion = ""
 	state.rejectedErr = nil
 	if state.pendingVersion == req.GetVersionInfo() {
 		state.pendingVersion = ""
+		state.pendingNonce = ""
+		state.pendingStreamID = 0
 	}
 	cb.responseStates[key] = state
 
@@ -724,6 +778,8 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 	}
 
 	state.pendingVersion = version
+	state.pendingNonce = resp.GetNonce()
+	state.pendingStreamID = streamID
 	if state.rejectedVersion == version {
 		state.rejectedVersion = ""
 		state.rejectedErr = nil

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
@@ -292,6 +292,82 @@ func TestCompletionFollowsNewerResponseVersion(t *testing.T) {
 	}
 }
 
+func TestCompletionFollowsUntrackedVersionMarker(t *testing.T) {
+	for _, tt := range orderedCompletionTypeURLs {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newTestCompletionCallbacks()
+			wg, comp := newTestCompletion(t)
+
+			registerTypeVersionCompletion(t, cb, comp, tt.typeURL, "version-1")
+			marker, completeUnsent := cb.AddTypeVersionMarker("version-2", tt.typeURL, "node-1", true, nil)
+			require.NotNil(t, marker)
+			require.False(t, completeUnsent)
+
+			sendTypeVersionResponse(cb, tt.typeURL, "version-2")
+			ackTypeVersionResponse(t, cb, tt.typeURL, "version-2")
+
+			require.Zero(t, cb.PendingCompletionCount())
+			require.NoError(t, wg.Wait())
+		})
+	}
+}
+
+func TestRemoveUnpublishedTypeVersionMarker(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	_, comp := newTestCompletion(t)
+	registerTypeVersionCompletion(t, cb, comp, listenerTypeURL, "version-1")
+
+	marker, completeUnsent := cb.AddTypeVersionMarker("version-2", listenerTypeURL, "node-1", true, nil)
+	require.NotNil(t, marker)
+	require.False(t, completeUnsent)
+
+	key := completionsOrderKey("node-1", listenerTypeURL)
+	require.Len(t, *cb.completionsOrders[key], 2)
+	cb.RemoveTypeVersionMarker(marker)
+	require.Len(t, *cb.completionsOrders[key], 1)
+	require.Equal(t, "version-1", (*cb.completionsOrders[key])[0].version)
+}
+
+func TestWaitCancellationRemovesCompletionAndVersionMarkers(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := completion.NewWaitGroup(ctx)
+	t.Cleanup(wg.Cancel)
+	comp := wg.AddCompletionWithCallback(
+		cb.NewTypeVersionCompletionOwner("node-1", listenerTypeURL, "version-1"),
+		nil,
+	)
+	registerTypeVersionCompletion(t, cb, comp, listenerTypeURL, "version-1")
+
+	for _, version := range []string{"version-2", "version-3", "version-4"} {
+		marker, completeUnsent := cb.AddTypeVersionMarker(version, listenerTypeURL, "node-1", true, nil)
+		require.NotNil(t, marker)
+		require.False(t, completeUnsent)
+	}
+
+	cancel()
+	require.ErrorIs(t, wg.Wait(), context.Canceled)
+	require.Zero(t, cb.PendingCompletionCount())
+	_, exists := cb.completionsOrders[completionsOrderKey("node-1", listenerTypeURL)]
+	require.False(t, exists)
+}
+
+func TestUntrackedAlreadyAcceptedVersionCompletesUnsentUpdates(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	wg, comp := newTestCompletion(t)
+
+	ackTypeVersionResponse(t, cb, listenerTypeURL, "version-2")
+	registerTypeVersionCompletion(t, cb, comp, listenerTypeURL, "version-1")
+
+	marker, completeUnsent := cb.AddTypeVersionMarker("version-2", listenerTypeURL, "node-1", true, nil)
+	require.Nil(t, marker)
+	require.True(t, completeUnsent)
+
+	cb.CompleteUnsentPendingCompletions("node-1", listenerTypeURL, nil)
+	require.Zero(t, cb.PendingCompletionCount())
+	require.NoError(t, wg.Wait())
+}
+
 func TestNACKRevertsAllCoalescedUpdates(t *testing.T) {
 	cb := newTestCompletionCallbacks()
 	reverted := make([]string, 0, 3)

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
@@ -56,16 +56,19 @@ func sendTypeVersionResponse(cb *CompletionCallbacks, typeURL, version string) {
 		&discovery.DiscoveryResponse{
 			VersionInfo: version,
 			TypeUrl:     typeURL,
+			Nonce:       "nonce-" + version,
 		},
 	)
 }
 
 func ackTypeVersionResponse(t *testing.T, cb *CompletionCallbacks, typeURL, version string) {
 	t.Helper()
+	state := cb.responseStates[completionsOrderKey("node-1", typeURL)]
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
-		Node:        &core.Node{Id: "node-1"},
-		TypeUrl:     typeURL,
-		VersionInfo: version,
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       typeURL,
+		VersionInfo:   version,
+		ResponseNonce: state.pendingNonce,
 	}))
 }
 
@@ -391,14 +394,154 @@ func TestNACKRevertsAllCoalescedUpdates(t *testing.T) {
 	// reverse order to restore the snapshot that preceded the response.
 	sendTypeVersionResponse(cb, listenerTypeURL, "version-3")
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
-		Node:        &core.Node{Id: "node-1"},
-		TypeUrl:     listenerTypeURL,
-		VersionInfo: "version-0",
-		ErrorDetail: &status.Status{Message: "rejected listener"},
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-0",
+		ResponseNonce: "nonce-version-3",
+		ErrorDetail:   &status.Status{Message: "rejected listener"},
 	}))
 
 	require.Equal(t, []string{"version-3", "version-2", "version-1"}, reverted)
 	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestNACKOfUntrackedVersionRevertsTrackedPredecessor(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	wg, comp := newTestCompletion(t)
+	reverted := make([]string, 0, 2)
+
+	registered, err := cb.AddTypeVersionCompletion(
+		comp,
+		"version-1",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-1") },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+	marker, completeUnsent := cb.AddTypeVersionMarker(
+		"version-2",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-2") },
+	)
+	require.NotNil(t, marker)
+	require.False(t, completeUnsent)
+
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-2")
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-0",
+		ResponseNonce: "nonce-version-2",
+		ErrorDetail:   &status.Status{Message: "rejected listener"},
+	}))
+
+	require.Equal(t, []string{"version-2", "version-1"}, reverted)
+	require.Zero(t, cb.PendingCompletionCount())
+	require.Error(t, wg.Wait())
+}
+
+func TestStaleNACKDoesNotAffectNewerResponse(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	wg, comp := newTestCompletion(t)
+	reverted := make([]string, 0, 2)
+
+	registered, err := cb.AddTypeVersionCompletion(
+		comp,
+		"version-1",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-1") },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+	marker, completeUnsent := cb.AddTypeVersionMarker(
+		"version-2",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-2") },
+	)
+	require.NotNil(t, marker)
+	require.False(t, completeUnsent)
+
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-2")
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-0",
+		ResponseNonce: "nonce-version-1",
+		ErrorDetail:   &status.Status{Message: "stale rejection"},
+	}))
+
+	require.Empty(t, reverted)
+	require.Equal(t, 1, cb.PendingCompletionCount())
+	requireCompletionPending(t, comp)
+
+	ackTypeVersionResponse(t, cb, listenerTypeURL, "version-2")
+	require.NoError(t, wg.Wait())
+	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestFirstResponseNACKWithEmptyAcceptedVersion(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	wg, comp := newTestCompletion(t)
+	reverted := false
+
+	registered, err := cb.AddTypeVersionCompletion(
+		comp,
+		"version-1",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = true },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
+
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "",
+		ResponseNonce: "nonce-version-1",
+		ErrorDetail:   &status.Status{Message: "first response rejected"},
+	}))
+
+	require.True(t, reverted)
+	require.Zero(t, cb.PendingCompletionCount())
+	require.Error(t, wg.Wait())
+}
+
+func TestStreamCloseClearsResponseState(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
+	key := completionsOrderKey("node-1", listenerTypeURL)
+	require.Equal(t, "version-1", cb.responseStates[key].pendingVersion)
+
+	cb.OnStreamClosed(1, &core.Node{Id: "node-1"})
+	state := cb.responseStates[key]
+	require.Empty(t, state.pendingVersion)
+	require.Empty(t, state.pendingNonce)
+	require.Empty(t, state.acceptedVersion)
+}
+
+func TestFreshSubscriptionClearsAcceptedVersion(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	ackTypeVersionResponse(t, cb, listenerTypeURL, "version-1")
+	key := completionsOrderKey("node-1", listenerTypeURL)
+	require.Equal(t, "version-1", cb.responseStates[key].acceptedVersion)
+
+	require.NoError(t, cb.OnStreamRequest(2, &discovery.DiscoveryRequest{
+		Node:    &core.Node{Id: "node-1"},
+		TypeUrl: listenerTypeURL,
+	}))
+	require.Empty(t, cb.responseStates[key].acceptedVersion)
 }
 
 func TestNACKRollbackStopsAtLastACKedVersion(t *testing.T) {
@@ -435,10 +578,11 @@ func TestNACKRollbackStopsAtLastACKedVersion(t *testing.T) {
 
 	sendTypeVersionResponse(cb, listenerTypeURL, "version-3")
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
-		Node:        &core.Node{Id: "node-1"},
-		TypeUrl:     listenerTypeURL,
-		VersionInfo: "version-1",
-		ErrorDetail: &status.Status{Message: "rejected listener"},
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-1",
+		ResponseNonce: "nonce-version-3",
+		ErrorDetail:   &status.Status{Message: "rejected listener"},
 	}))
 
 	require.Equal(t, []string{"version-3", "version-2"}, reverted)
@@ -466,10 +610,11 @@ func TestNACKRollsBackCompletionRegisteredWithoutVersion(t *testing.T) {
 	// before Envoy can NACK it.
 	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
-		Node:        &core.Node{Id: "node-1"},
-		TypeUrl:     listenerTypeURL,
-		VersionInfo: "version-0",
-		ErrorDetail: &status.Status{Message: "rejected listener"},
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-0",
+		ResponseNonce: "nonce-version-1",
+		ErrorDetail:   &status.Status{Message: "rejected listener"},
 	}))
 
 	require.True(t, reverted)
@@ -510,10 +655,11 @@ func TestNACKDoesNotRollbackNewerUpdate(t *testing.T) {
 	require.True(t, registered)
 
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
-		Node:        &core.Node{Id: "node-1"},
-		TypeUrl:     listenerTypeURL,
-		VersionInfo: "version-0",
-		ErrorDetail: &status.Status{Message: "rejected listener"},
+		Node:          &core.Node{Id: "node-1"},
+		TypeUrl:       listenerTypeURL,
+		VersionInfo:   "version-0",
+		ResponseNonce: "nonce-version-2",
+		ErrorDetail:   &status.Status{Message: "rejected listener"},
 	}))
 
 	require.Equal(t, []string{"version-2", "version-1"}, reverted)


### PR DESCRIPTION
An untracked ads snapshot (with no wait group) can supersede an older tracked snapshot before go-control-plane sends a response. If Envoy only acks the newer version, the older completion remains pending until the proxy update times out.
Record untracked versions in completion order so the response actually sent can claim earlier completions and rollback functions. Match acks and nacks to their nonce and stream, and clean up state when waits or streams end.

While testing multiple ads responses I found that go-control-plane invokes request callback before performing its stale-nonce check. Thats why a stale ACK/NACK for an older response could be associated with the latest pendingVersion, potentially completing or rolling back the wrong updates. The stream id prevents response state from an earlier ads stream from being reused in case when envoy reconnects. 

Fixes: #43519 

AI Influence Level: Ai has been used to setup the repro environment and for reproducing the bug

