### PR TITLE
fix(envoy): skip unchanged network policy snapshots

### DIFF
--- a/pkg/envoy/xds_server_ads.go
+++ b/pkg/envoy/xds_server_ads.go
@@ -22,6 +22,7 @@ import (
 	envoy_extensions_listener_tls_inspector_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	envoy_config_http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_config_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -617,13 +618,17 @@ func (s *adsServer) UpdateNetworkPolicy(ctx context.Context, ep endpoint.Endpoin
 		s.localEndpointStore.setLocalEndpoint(ep)
 	}
 
+	snapshotUpdated := false
 	for _, nodeId := range nodeIDs {
 		resources := s.cache.GetAllResources(nodeId)
 		if resources == nil {
 			resources = &xds.Resources{}
 		}
-		resources = resources.DeepCopy()
 		oldPolicy, existed := resources.NetworkPolicies[resourceName]
+		if existed && proto.Equal(oldPolicy, networkPolicy) {
+			continue
+		}
+		resources = resources.DeepCopy()
 		resources.NetworkPolicies[resourceName] = networkPolicy
 		var callbackTypeURLs map[string]func(error)
 		if waitForACK {
@@ -633,8 +638,9 @@ func (s *adsServer) UpdateNetworkPolicy(ctx context.Context, ep endpoint.Endpoin
 			&resourceChanges{networkPolicies: []savedEntry[*cilium.NetworkPolicy]{{key: resourceName, value: oldPolicy, existed: existed}}}); err != nil {
 			return err, nil, nil
 		}
+		snapshotUpdated = true
 	}
-	if !waitForACK {
+	if !waitForACK || !snapshotUpdated {
 		callback(nil)
 	}
 

--- a/pkg/envoy/xds_server_ads_test.go
+++ b/pkg/envoy/xds_server_ads_test.go
@@ -1181,3 +1181,84 @@ func TestStartAdsGRPCServerContextCanceledBeforeResolve(t *testing.T) {
 	err := <-errCh
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+func TestUpdateNetworkPolicyUnchangedPolicySkipsSnapshotUpdate(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	config := xdsServerConfig{
+		envoySocketDir:       t.TempDir(),
+		policyRestoreTimeout: 30 * time.Second,
+	}
+	cache := xdsnew.NewCache(logger, true)
+	server := newADSServerWithCache(cache, logger, nil, GetLocalEndpointStoreForTest(), config, certificatemanager.NewMockSecretManagerInline(), nil)
+	ctx := context.Background()
+
+	require.NoError(t, server.UpsertEnvoyResources(ctx, DEFAULT_RESOURCES, nil))
+
+	wg := completion.NewWaitGroup(ctx)
+	defer wg.Cancel()
+
+	mockEp := &testableEndpointUpdater{id: 1, ipv4: "127.0.0.1"}
+	mockPolicy1 := policy.NewEndpointPolicyForTest(types.MockSelectorSnapshot())
+
+	// 1. First UpdateNetworkPolicy establishes the initial NetworkPolicy resource.
+	err, revertFunc, finalizeFunc := server.UpdateNetworkPolicy(ctx, mockEp, mockPolicy1, wg)
+	require.NoError(t, err)
+	require.NotNil(t, revertFunc)
+	require.NotNil(t, finalizeFunc)
+
+	require.Eventually(t, func() bool {
+		return mockEp.proxyPolicyUpdateCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	snap1, err := cache.GetSnapshot(localNodeID)
+	require.NoError(t, err)
+	require.NotNil(t, snap1)
+	ver1 := snap1.GetVersion(xdsnew.NetworkPolicyTypeURL)
+
+	// 2. Second UpdateNetworkPolicy with identical policy should skip snapshot generation.
+	wg2 := completion.NewWaitGroup(ctx)
+	defer wg2.Cancel()
+
+	err, revertFunc2, finalizeFunc2 := server.UpdateNetworkPolicy(ctx, mockEp, mockPolicy1, wg2)
+	require.NoError(t, err)
+	require.NotNil(t, revertFunc2)
+	require.NotNil(t, finalizeFunc2)
+
+	require.Eventually(t, func() bool {
+		return mockEp.proxyPolicyUpdateCount.Load() == 2
+	}, time.Second, 10*time.Millisecond)
+
+	snap2, err := cache.GetSnapshot(localNodeID)
+	require.NoError(t, err)
+	require.NotNil(t, snap2)
+	ver2 := snap2.GetVersion(xdsnew.NetworkPolicyTypeURL)
+
+	// Assert the snapshot instance and version did not change on the second call.
+	require.Equal(t, snap1, snap2)
+	require.Equal(t, ver1, ver2)
+
+	// 3. UpdateNetworkPolicy with a genuinely changed policy should trigger a new snapshot.
+	mockPolicy2 := policy.NewEndpointPolicyForTest(types.MockSelectorSnapshot())
+	mockPolicy2.SelectorPolicy.L4Policy.Revision = 2
+	mockPolicy2.SelectorPolicy.L4Policy.Ingress.PortRules = L4PolicyMap1
+
+	wg3 := completion.NewWaitGroup(ctx)
+	defer wg3.Cancel()
+
+	err, revertFunc3, finalizeFunc3 := server.UpdateNetworkPolicy(ctx, mockEp, mockPolicy2, wg3)
+	require.NoError(t, err)
+	require.NotNil(t, revertFunc3)
+	require.NotNil(t, finalizeFunc3)
+
+	require.Eventually(t, func() bool {
+		return mockEp.proxyPolicyUpdateCount.Load() == 3
+	}, time.Second, 10*time.Millisecond)
+
+	snap3, err := cache.GetSnapshot(localNodeID)
+	require.NoError(t, err)
+	require.NotNil(t, snap3)
+	ver3 := snap3.GetVersion(xdsnew.NetworkPolicyTypeURL)
+
+	require.NotEqual(t, snap2, snap3)
+	require.NotEqual(t, ver2, ver3)
+}


### PR DESCRIPTION
Fixes #48548

## Summary

CiliumIdentity churn can cause UpdateNetworkPolicy to regenerate and
marshal an identical xDS NetworkPolicy snapshot repeatedly, resulting
in unnecessary CPU usage.

This change compares the existing NetworkPolicy resource with the new
policy before calling updateSnapshot(). When the policy is unchanged,
snapshot regeneration is skipped while preserving the existing callback
and policy-update behavior.

## Changes

- Skip xDS snapshot regeneration when the NetworkPolicy resource is unchanged.
- Preserve callback behavior for both changed and unchanged policies.
- Add regression coverage for unchanged and changed NetworkPolicy updates.

## Testing

- `GOOS=linux go test -c ./pkg/envoy`
- `GOOS=linux go test -c ./pkg/envoy/xdsnew`
- `git diff --check`

The runtime test could not be executed locally because the development
environment is macOS and the package requires Linux-specific BPF/netlink
symbols. Docker was also unavailable because the Docker daemon was not
running. Runtime validation is therefore expected to occur in Linux CI.