### PR TITLE
renovate: Migrate the last custom manager and fail on warnings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1238,8 +1238,9 @@
       "packageNameTemplate": "ubuntu"
     },
     {
-      "fileMatch": [
-        "^\\.custom-gcl\\.yaml$"
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.custom-gcl\\.yaml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+version:\\s+'?(?<currentValue>[^'\"\\s]+)'?"

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -23,4 +23,4 @@ jobs:
           export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:44.65.5@sha256:4e10f76a79f1c597f427f83c788a9f5b14a6295784c4cb68307b89b0a954abce
           docker run --rm --entrypoint "renovate-config-validator" \
             -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
-            ${RENOVATE_IMAGE} "/renovate.json5"
+            ${RENOVATE_IMAGE} --strict "/renovate.json5"


### PR DESCRIPTION
Renovate renamed the customManagers fileMatch option to managerFilePatterns
and we converted all thirteen occurrences last December. The kube-api-linter
manager landed a day later still using fileMatch, so every Renovate run since
opens with:

  WARN: Config needs migrating

renovate-config-validator reports a pending migration as a warning and still
exits 0, and our workflow only looks at that exit code, so the warning lands in
the log of a green check that nobody opens. That is how the entry survived nine
months of runs.

This converts that last entry, taking the replacement from
renovate-config-validator, which wraps the pattern in slashes so it stays a
regular expression rather than a glob, and passes --strict to the validator so
that a warning, an error or a pending migration fails the job.

Unrelated pull requests will now go red whenever a Renovate release deprecates
an option we still use, however that is exactly the signal we have been
throwing away.

This PR was prepared with AIL:3. I personally checked that --strict fails on
the configuration before this change and passes after.
