### PR TITLE
Makefile: Order the bpf codegen ahead of the Go builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) $(SUBDIR_OPERATOR_CONTAINER) plugins tool
 # which is then used to filter out items such as "tools/mount" and "tools/sysctlfx"
 SUBDIRS := $(filter-out $(foreach dir,$(SUBDIRS),$(dir)/%),$(SUBDIRS))
 
+# The bpf subdir regenerates Go sources under pkg/datapath that every other subdir compiles, so it cannot run alongside them.
+SUBDIRS_DATAPATH_GEN := bpf
+SUBDIRS_GO := $(filter-out $(SUBDIRS_DATAPATH_GEN),$(SUBDIRS))
+
 # Space-separated list of Go packages to test, equivalent to 'go test' package patterns.
 # Because is treated as a Go package pattern, the special '...' sequence is supported,
 # meaning 'all subpackages of the given package'.
@@ -59,7 +63,10 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=
 
 TEST_UNITTEST_LDFLAGS=
 
-build: $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
+.PHONY: build
+build: ## Builds all the components for Cilium by executing make in the respective sub directories.
+	$(QUIET)$(MAKE) $(SUBMAKEOPTS) $(SUBDIRS_DATAPATH_GEN)
+	$(QUIET)$(MAKE) $(SUBMAKEOPTS) $(SUBDIRS_GO)
 
 build-container: ## Builds components required for cilium-agent container.
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i all; done


### PR DESCRIPTION
Under `make build -j $(nproc)` the build occasionally fails with

  ../pkg/datapath/maps/maps_generated.go:1:1: expected 'package', found 'EOF'

because a Go compile read that tracked file while `go tool dpgen` had truncated it and
not yet written the rendered bytes. bpf, whose default goal regenerates those sources,
sits in the same flat SUBDIRS list as the subdirs that compile them, and build is a
single unordered fan-out over that list, so -j is free to start both at once. Seen in
the per-commit build job[1].

This PR runs bpf to completion before any of the Go subdirs start. Their own -j still
flows through the jobserver, so the only cost is that bpf's objects and codegen are now
strictly serial.

1: https://github.com/cilium/cilium/actions/runs/34468070242/job/102841430347

This PR was prepared with AIL:3. I personally checked the `make --dry-run build` trace.
