### PR TITLE
aws/ipam: Fix lock order inversion with the operator node

### DIFF
--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -58,7 +58,9 @@ type Node struct {
 	// node contains the general purpose fields of a node
 	node ipamNodeActions
 
-	// mutex protects members below this field
+	// mutex protects members below this field. The operator's nodemanager.Node
+	// lock is always taken before mutex, so no caller may reach n.node with
+	// this mutex held.
 	mutex lock.RWMutex
 
 	// enis is the list of ENIs attached to the node indexed by ENI ID.
@@ -111,11 +113,14 @@ func (n *Node) updateLogger() {
 func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 	k8sObj.Status.ENI.ENIs = map[string]types.ENI{}
 
+	// Read the instance ID before taking n.mutex, see the mutex field.
+	instanceID := n.node.InstanceID()
+
 	n.mutex.RLock()
 	usePrimary := n.usePrimaryAddress()
 	n.mutex.RUnlock()
 
-	n.foreachENI(usePrimary, func(e *types.ENI) error {
+	n.foreachENI(instanceID, usePrimary, func(e *types.ENI) error {
 		k8sObj.Status.ENI.ENIs[e.ID] = *e.DeepCopy()
 		return nil
 	})
@@ -160,10 +165,10 @@ func (n *Node) usePrimaryAddress() bool {
 //
 // fn receives a shallow copy of the inventory ENI whose Addresses slice is
 // freshly allocated when filtering; the shared inventory is never mutated.
-// This method does not take n.mutex; callers pass usePrimary computed under
-// the appropriate lock.
-func (n *Node) foreachENI(usePrimary bool, fn func(e *types.ENI) error) {
-	n.manager.ForeachInstance(n.node.InstanceID(),
+// This method does not take n.mutex; callers pass instanceID and usePrimary
+// read under the appropriate lock, or none.
+func (n *Node) foreachENI(instanceID string, usePrimary bool, fn func(e *types.ENI) error) {
+	n.manager.ForeachInstance(instanceID,
 		func(_, _ string, iface ipamTypes.Interface) error {
 			e, ok := iface.(*types.ENI)
 			if !ok {
@@ -939,6 +944,8 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 		return nil, stats, nodemanager.ErrLimitsNotFound
 	}
 
+	// Read the instance ID before taking n.mutex, see the mutex field.
+	instanceID := n.node.InstanceID()
 	available = ipamTypes.AllocationMap{}
 
 	n.mutex.Lock()
@@ -957,7 +964,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	// * Any excluded interfaces will be subtracted from this total.
 	stats.NodeCapacity *= limits.Adapters
 
-	n.foreachENI(n.usePrimaryAddress(),
+	n.foreachENI(instanceID, n.usePrimaryAddress(),
 		func(e *types.ENI) error {
 			n.enis[e.ID] = *e
 

--- a/pkg/aws/ipam/node_lock_order_test.go
+++ b/pkg/aws/ipam/node_lock_order_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/aws/api/mock"
+	"github.com/cilium/cilium/pkg/aws/ipam/limits"
+	"github.com/cilium/cilium/pkg/aws/types"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+// TestResyncInterfacesAndIPsLockOrder verifies that this Node never calls into
+// the operator's nodemanager.Node while holding its own lock. The operator side
+// holds nodemanager.Node.mutex across downcalls into ops (GetAttachedCIDRs,
+// GetMaximumAllocatableIPv4), both of which take our lock, so an upcall from
+// under our lock closes an AB-BA cycle that wedges the whole ENI allocator.
+//
+// The onInstanceID hook stands in for the operator: it tries to take our lock
+// from another goroutine while the upcall is in flight, which is exactly what
+// the nodemanager does, and fails the test if it cannot.
+func TestResyncInterfacesAndIPsLockOrder(t *testing.T) {
+	const instanceID = "i-testLockOrder-0"
+
+	mockEC2API := mock.NewAPI(nil, nil, nil, nil)
+	limitsGetter, err := limits.NewLimitsGetter(hivetest.Logger(t), mockEC2API, limits.TriggerMinInterval, limits.EC2apiTimeout, limits.EC2apiRetryCount)
+	require.NoError(t, err)
+
+	cn := newCiliumNode("node1", withInstanceType("m5.large"),
+		func(cn *v2.CiliumNode) {
+			cn.Spec.InstanceID = instanceID
+		},
+	)
+	im := ipamTypes.NewInstanceMap()
+	im.Update(instanceID, &types.ENI{ID: "eni-a"})
+
+	ipamNode := &mockIPAMNode{instanceID: instanceID}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		node:       ipamNode,
+		k8sObj:     cn,
+		manager: &InstancesManager{
+			logger:       hivetest.Logger(t),
+			instances:    im,
+			ec2api:       mockEC2API,
+			limitsGetter: limitsGetter,
+		},
+		enis: map[string]types.ENI{},
+	}
+	n.logger.Store(hivetest.Logger(t))
+	ipamNode.ops = n
+
+	var upcalls int
+	ipamNode.onInstanceID = func() {
+		upcalls++
+		acquired := make(chan struct{})
+		go func() {
+			n.mutex.Lock()
+			n.mutex.Unlock()
+			close(acquired)
+		}()
+		select {
+		case <-acquired:
+		case <-time.After(5 * time.Second):
+			t.Error("Node.mutex is held across the upcall into n.node, inverting the lock order with nodemanager.Node")
+		}
+	}
+
+	_, _, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	require.NoError(t, err)
+
+	n.PopulateStatusFields(cn.DeepCopy())
+
+	// Guard against the hook silently never running.
+	require.Equal(t, 2, upcalls)
+}

--- a/pkg/aws/ipam/node_primary_address_test.go
+++ b/pkg/aws/ipam/node_primary_address_test.go
@@ -43,7 +43,7 @@ func TestForeachENIPrimaryAddressFiltering(t *testing.T) {
 
 	collect := func(usePrimary bool) []netip.Addr {
 		var got []netip.Addr
-		n.foreachENI(usePrimary, func(e *types.ENI) error {
+		n.foreachENI(instanceID, usePrimary, func(e *types.ENI) error {
 			for _, a := range e.Addresses {
 				got = append(got, a.Addr)
 			}

--- a/pkg/aws/ipam/node_stat_test.go
+++ b/pkg/aws/ipam/node_stat_test.go
@@ -110,16 +110,25 @@ type mockIPAMNode struct {
 	instanceID       string
 	prefixDelegation bool
 	ops              nodemanager.NodeOperations
+
+	// onInstanceID, when set, runs on every InstanceID() call.
+	onInstanceID func()
 }
 
 func (m *mockIPAMNode) SetOpts(nodemanager.NodeOperations)           {}
 func (m *mockIPAMNode) SetPoolMaintainer(nodemanager.PoolMaintainer) {}
 func (m *mockIPAMNode) UpdatedResource(*v2.CiliumNode) bool          { panic("not impl") }
 func (m *mockIPAMNode) Update(*v2.CiliumNode)                        {}
-func (m *mockIPAMNode) InstanceID() string                           { return m.instanceID }
 func (m *mockIPAMNode) IsPrefixDelegationEnabled() bool              { return m.prefixDelegation }
 func (m *mockIPAMNode) Ops() nodemanager.NodeOperations              { return m.ops }
 func (m *mockIPAMNode) SetRunning(_ bool)                            { panic("not impl") }
+
+func (m *mockIPAMNode) InstanceID() string {
+	if m.onInstanceID != nil {
+		m.onInstanceID()
+	}
+	return m.instanceID
+}
 
 var _ ipamNodeActions = (*mockIPAMNode)(nil)
 


### PR DESCRIPTION
foreachENI() calls n.node.InstanceID(), which read locks the operator's
nodemanager.Node, and ResyncInterfacesAndIPs() calls it under its own write lock. The
operator takes the pair the other way around, holding nodemanager.Node across downcalls
into ops that read lock the aws Node. On an EKS cluster the two wedged for six minutes,
and because one side holds the NodeManager lock, that stopped ENI allocation for every
node rather than only the one being resynced. Seen in a Conformance EKS with IPsec
leg[1].

This PR reads the instance ID before taking n.mutex and passes it into foreachENI(), so
the aws Node lock only ever nests inside the operator's. The instance ID does not change
for the life of a node, so reading it earlier cannot change what a resync computes.

1: https://github.com/cilium/cilium/actions/runs/34500404944/job/102950415736

This PR was prepared with AIL:3. I personally checked the new lock-order test failing
against the pre-fix ordering.
