### PR TITLE
fix(cilium-cli/connectivity): Fix race on test params map

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -752,7 +752,7 @@ func (ct *ConnectivityTest) deployNamespace(ctx context.Context, client *k8s.Cli
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        namespaceName,
-				Annotations: ct.params.NamespaceAnnotations,
+				Annotations: maps.Clone(ct.params.NamespaceAnnotations),
 				Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
 			},
 		}


### PR DESCRIPTION
In `check.(*ConnectivityTest).deployNamespace()` the `ct.params.NamespaceAnnotations` map is shared among test runners, but was mutated during namespace setup when `clustermesh.defaultGlobalNamespace` is `false`. Fix by cloning the map.

Fixes: 9ae977cec56c ("ci: Add global namespace support for connectivity tests")

`params` is copied by value:
https://github.com/cilium/cilium/blob/aff96d5610693e1cd8ef0d2023f7ffbe4ee34f1f/cilium-cli/cli/connectivity.go#L338

and the aliased map `ct.params.NamespaceAnnotations` is mutated (through `namespace.Annotations`):
https://github.com/cilium/cilium/blob/aff96d5610693e1cd8ef0d2023f7ffbe4ee34f1f/cilium-cli/connectivity/check/deployment.go#L767

Note that `namespace.Annotations` is always non-nil when run from the CLI.

Before the fix, the race is detected by `go build -race ./cilium-cli/cmd/cilium`:
```console
$ ./cilium connectivity test --test-concurrency=2 --flow-validation=disabled --hubble=false
...
✨ [kind-kind] Creating namespace cilium-test-ccnp2 for connectivity check...
✨ [kind-kind] Creating namespace cilium-test-ccnp2 for connectivity check...
WARNING: DATA RACE
...
Write at 0x00c00071aed0 by goroutine 42:
  runtime.mapassign_faststr()
      /usr/local/go/src/internal/runtime/maps/runtime_faststr.go:261 +0x0
  github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).deployNamespace()
      cilium/cilium/cilium-cli/connectivity/check/deployment.go:767 +0x40e
...
Previous write at 0x00c00071aed0 by goroutine 41:
  runtime.mapassign_faststr()
      /usr/local/go/src/internal/runtime/maps/runtime_faststr.go:261 +0x0
  github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).deployNamespace()
      cilium/cilium/cilium-cli/connectivity/check/deployment.go:767 +0x40e
```
Other races are reported, and not addressed here.

After the fix, this race is no longer reported.

This PR was prepared with AIL:1. I used AI to help diagnose. I manually checked the diagnosis, the test output, and I manually applied the fix.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request