### PR TITLE
azure/ipam: Skip interfaces without a MAC address

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -419,6 +419,24 @@ func (c *Client) ListAllNetworkInterfaces(ctx context.Context) ([]*armnetwork.In
 	return append(networkInterfaces, vmInterfaces...), nil
 }
 
+// skipInterface reports whether a parsed interface must be withheld from the
+// instance cache, and therefore from CiliumNode.Status.Azure.Interfaces.
+func skipInterface(logger *slog.Logger, i *types.AzureInterface) bool {
+	if i == nil {
+		return false
+	}
+	if !i.MAC.IsValid() {
+		logger.Warn(
+			"Ignoring interface without a MAC address, it is likely still provisioning",
+			logfields.Interface, i.Name,
+			logfields.ID, i.ID,
+		)
+		return true
+	}
+
+	return false
+}
+
 // ParseInterfacesIntoInstanceMap parses network interfaces into an InstanceMap
 // This allows re-parsing the same network interface data with different subnet maps
 // without making additional Azure API calls
@@ -426,9 +444,11 @@ func (c *Client) ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.
 	instances := ipamTypes.NewInstanceMap()
 
 	for _, iface := range networkInterfaces {
-		if instanceID, azureInterface := parseInterface(c.logger, iface, subnets, c.usePrimary); instanceID != "" {
-			instances.Update(instanceID, azureInterface)
+		instanceID, azureInterface := parseInterface(c.logger, iface, subnets, c.usePrimary)
+		if instanceID == "" || skipInterface(c.logger, azureInterface) {
+			continue
 		}
+		instances.Update(instanceID, azureInterface)
 	}
 
 	return instances
@@ -457,6 +477,9 @@ func (c *Client) ParseInterfacesIntoInstance(networkInterfaces []*armnetwork.Int
 
 	for _, networkInterface := range networkInterfaces {
 		_, azureInterface := parseInterface(c.logger, networkInterface, subnets, c.usePrimary)
+		if skipInterface(c.logger, azureInterface) {
+			continue
+		}
 		instance.Interfaces[azureInterface.ID] = azureInterface
 	}
 


### PR DESCRIPTION
### Problem

Azure network interfaces which are still provisioning are returned by the API without a MAC address. Parsing those into the instance cache puts an interface with an empty MAC into CiliumNode.Status.Azure.Interfaces, which the agent cannot match to any link on the node.

This results in panics on the agent which eventually recover once the MAC info is synced.

<img width="1382" height="289" alt="Screenshot 2026-09-11 at 13 29 54" src="https://github.com/user-attachments/assets/4fb8d390-206c-496e-9e6d-8821481f681e" />

I also pulled audit logs from one node where this happened:
- We first see an update from the cilium operator that fills all the fields except mac address:
<img width="300" alt="before-mac" src="https://github.com/user-attachments/assets/867f3440-9437-42f6-a925-a842658d09a3" />

- Then about a minute and a half later the cilium operator rewrites the status with the mac address:
<img width="300" alt="after-mac" src="https://github.com/user-attachments/assets/31a18373-4eb2-4400-b565-a377a0e32d53" />

The problem appeared on release v1.20 due to changes in the way the agent starts up and what it has to wait for before configuring ip rules and routes.

### Solution

Withhold such interfaces from both ParseInterfacesIntoInstanceMap and ParseInterfacesIntoInstance, and log a warning so the skip is visible. They are picked up by a later resync once Azure has assigned the MAC.

This PR was prepared with AIL:3. I let the agent find and suggest a fix for the bug which I then reviewed and reworked.

```release-note
azure: Fixed an issue where an interface with an empty MAC field would be reported back the the cilium agent causing it to crash on startup when trying to configure the routes.
```