### PR TITLE
[backport v1.18] gateway-api: nodeSelector label with hostNetwork enabled

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
@@ -171,12 +172,17 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	cecTranslator := translation.NewCECTranslator(cfg)
 
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, cfg)
+	var nodeLabelSelector v1.LabelSelector
+	if cfg.HostNetworkConfig.NodeLabelSelector != nil {
+		nodeLabelSelector = v1.LabelSelector{MatchLabels: cfg.HostNetworkConfig.NodeLabelSelector.MatchLabels}
+	}
 
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,
 		gatewayAPITranslator,
 		params.Logger,
 		installedKinds,
+		nodeLabelSelector,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
 	}
@@ -269,12 +275,12 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 // registerReconcilers registers Gateway API reconcilers to the controller-runtime library manager.
 // optionalKinds are previously autodetected based on what CRDs are present in the cluster.
-func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) error {
+func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind, hostNetworkLabel v1.LabelSelector) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger),
-		newGatewayReconciler(mgr, translator, logger, installedCRDs),
+		newGatewayReconciler(mgr, translator, logger, installedCRDs, hostNetworkLabel),
 		newGammaReconciler(mgr, translator, logger),
 		newGatewayClassConfigReconciler(mgr, logger),
 	}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -50,19 +50,22 @@ type gatewayReconciler struct {
 	Scheme     *runtime.Scheme
 	translator translation.Translator
 
-	logger        *slog.Logger
-	installedCRDs []schema.GroupVersionKind
+	logger           *slog.Logger
+	installedCRDs    []schema.GroupVersionKind
+	hostNetworkLabel metav1.LabelSelector
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind, hostNetworkLabel metav1.LabelSelector) *gatewayReconciler {
+
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		translator:    translator,
-		logger:        scopedLog,
-		installedCRDs: installedCRDs,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		translator:       translator,
+		logger:           scopedLog,
+		installedCRDs:    installedCRDs,
+		hostNetworkLabel: hostNetworkLabel,
 	}
 }
 
@@ -543,7 +546,7 @@ func (r *gatewayReconciler) enqueueRequestForNodes(c client.Client, logger *slog
 
 		reqs := make([]reconcile.Request, 0, len(gateways))
 		svcList := &corev1.ServiceList{}
-		svcMap := make(map[string]struct{})
+		svcMap := make(map[types.UID]struct{})
 
 		// for each gateway, filter for the services owned by the gateway
 		for gw := range gateways {
@@ -557,7 +560,7 @@ func (r *gatewayReconciler) enqueueRequestForNodes(c client.Client, logger *slog
 			// if the service owned by the gateway is a nodeport, add to map of UID
 			for _, svc := range svcList.Items {
 				if svc.Spec.Type == "NodePort" {
-					svcMap[string(svc.GetOwnerReferences()[0].UID)] = struct{}{}
+					svcMap[svc.GetOwnerReferences()[0].UID] = struct{}{}
 				}
 			}
 		}
@@ -583,7 +586,7 @@ func (r *gatewayReconciler) enqueueRequestForNodes(c client.Client, logger *slog
 			if err := c.Get(ctx, gatewayNamespaceName, gateway); err != nil {
 				scopedLog.WarnContext(ctx, "Unable to get gateway", logfields.Error, err)
 			}
-			if _, err := svcMap[string(gateway.GetUID())]; err {
+			if _, err := svcMap[gateway.GetUID()]; err {
 				// there is no nodeport svc for this gateway, no need to reconcile
 				continue
 			}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -448,10 +448,15 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 		// NodePort service gets as many Node
 		// IP addresses as we can fit into Status
 		nodes := &corev1.NodeList{}
-		if err := r.Client.List(ctx, nodes); err != nil {
+		selector, err := metav1.LabelSelectorAsSelector(&r.hostNetworkLabel)
+		if err != nil {
+			return fmt.Errorf("could not parse the node label selector")
+		}
+		if err := r.Client.List(ctx, nodes, &client.ListOptions{
+			LabelSelector: selector,
+		}); err != nil {
 			return fmt.Errorf("unable to list nodes")
 		}
-
 		ips := make([]net.IP, 0)
 		for _, node := range nodes.Items {
 			if len(node.Status.Addresses) == 0 {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -27,6 +27,7 @@ import (
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
 func Test_Conformance(t *testing.T) {
@@ -65,6 +66,7 @@ func Test_Conformance(t *testing.T) {
 		disableServiceImport bool
 		wantErr              bool
 		hostNetwork          bool
+		nodeLabelSelector    metav1.LabelSelector
 	}{
 		{
 			name: "gateway-http-listener-isolation",
@@ -212,8 +214,13 @@ func Test_Conformance(t *testing.T) {
 		{name: "tlsroute-mixed-protocol-listeners", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "gateway-tlsroute-mixed", Namespace: "gateway-conformance-infra"}},
 		}},
+		// hostNetwork mode tests
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-nodelabel", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled-nodeselector", Namespace: "gateway-conformance-infra"}, wantErr: false}}, hostNetwork: true,
+			nodeLabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"role": "gateway",
+			}}},
 		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 	}
 
@@ -246,6 +253,7 @@ func Test_Conformance(t *testing.T) {
 					clientBuilder.WithIndex(&gatewayv1alpha2.TLSRoute{}, gatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
 
 					c := clientBuilder.Build()
+					nodeLabel := &slim_meta_v1.LabelSelector{MatchLabels: tt.nodeLabelSelector.MatchLabels}
 					if tt.hostNetwork {
 						gatewayAPITranslator = gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 							ServiceConfig: translation.ServiceConfig{
@@ -255,14 +263,16 @@ func Test_Conformance(t *testing.T) {
 								UseRemoteAddress: true,
 							},
 							HostNetworkConfig: translation.HostNetworkConfig{
-								Enabled: true,
+								Enabled:           true,
+								NodeLabelSelector: nodeLabel,
 							},
 						})
 					}
 					r := &gatewayReconciler{
-						Client:     c,
-						translator: gatewayAPITranslator,
-						logger:     logger,
+						Client:           c,
+						translator:       gatewayAPITranslator,
+						logger:           logger,
+						hostNetworkLabel: tt.nodeLabelSelector,
 					}
 
 					// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
@@ -1,0 +1,84 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled-nodeselector
+    io.cilium.gateway/owning-gateway: hostnetwork-enabled-nodeselector
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+  labels:
+    role: gateway
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker3
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.5
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/cec-hostnetwork-enabled-nodeselector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/cec-hostnetwork-enabled-nodeselector.yaml
@@ -1,0 +1,76 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled-nodeselector
+    cilium.io/use-original-source-address: "false"
+  name: cilium-gateway-hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: hostnetwork-enabled-nodeselector
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-hostnetwork-enabled-nodeselector
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.4
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute


### PR DESCRIPTION
[ upstream commit 165eefd20b043a11bd5a2cfff0c5c56a48ca7eb0 ]

Allows the use of node labels for when host network is enabled. Add in another test case, and clean up unnecessary code.

```release-note
gateway-api: node label selector for when hostNetwork is enabled
```

```upstream-prs
47463
```


