### PR TITLE
aws: configure each ENI's own IPv6 address on the link

### DIFF
--- a/pkg/aws/agent/device.go
+++ b/pkg/aws/agent/device.go
@@ -119,6 +119,7 @@ func validateENIConfig(node *ciliumv2.CiliumNode) error {
 type eniDeviceConfig struct {
 	name         string
 	ip           netip.Addr
+	ipv6         netip.Addr
 	cidr         netip.Prefix
 	mtu          int
 	usePrimaryIP bool
@@ -151,6 +152,7 @@ func configureENIDevices(logger *slog.Logger, oldNode, newNode *ciliumv2.CiliumN
 			addedENIByMac[eni.MAC] = eniDeviceConfig{
 				name:         name,
 				ip:           eni.IP.Addr,
+				ipv6:         eni.IPv6.Addr,
 				cidr:         eni.Subnet.CIDR.Masked(),
 				mtu:          mtuConfig.GetDeviceMTU(),
 				usePrimaryIP: usePrimary,
@@ -312,6 +314,19 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sy
 		err = sysctl.Disable([]string{"net", "ipv4", "conf", link.Attrs().Name, "rp_filter"})
 		if err != nil {
 			return fmt.Errorf("failed to disable rp_filter on link %q: %w", link.Attrs().Name, err)
+		}
+	}
+
+	// Set the ENI's auto-assigned IPv6 address so that traffic the host stack
+	// forwards out this ENI can be sourced from an address the interface owns.
+	// Without it the source falls back to another ENI's address and AWS
+	// silently discards the packet.
+	if cfg.ipv6.IsValid() {
+		err := netlink.AddrAdd(link, &netlink.Addr{
+			IPNet: netipx.PrefixIPNet(netip.PrefixFrom(cfg.ipv6, cfg.ipv6.BitLen())),
+		})
+		if err != nil && !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("failed to set eni ipv6 address %q on link %q: %w", cfg.ipv6, link.Attrs().Name, err)
 		}
 	}
 

--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -471,6 +471,32 @@ retry:
 	}
 }
 
+// eniDeviceIPv6 returns the IPv6 address to configure the ENI device itself
+// with, or the zero Addr if the ENI has no IPv6 address at all.
+func eniDeviceIPv6(iface *ec2_types.NetworkInterface, eni *types.ENI) (netip.Addr, error) {
+	var lowest netip.Addr
+	for _, a := range iface.Ipv6Addresses {
+		addrStr := aws.ToString(a.Ipv6Address)
+		if addrStr == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(addrStr)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("unable to parse ENI IPv6 address %q: %w", addrStr, err)
+		}
+		if aws.ToBool(a.IsPrimaryIpv6) {
+			return addr, nil
+		}
+		if !lowest.IsValid() || addr.Less(lowest) {
+			lowest = addr
+		}
+	}
+	if lowest.IsValid() {
+		return lowest, nil
+	}
+	return eni.DeriveIPv6FromPrefixes(), nil
+}
+
 // parseENI parses a ec2.NetworkInterface as returned by the EC2 service API,
 // converts it into a types.ENI object.
 //
@@ -582,6 +608,12 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 		}
 		eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(p))
 	}
+
+	ipv6, err := eniDeviceIPv6(iface, eni)
+	if err != nil {
+		return "", nil, err
+	}
+	eni.IPv6 = iputil.AddrFrom(ipv6)
 
 	// An Association can be present without a public IPv4 address (e.g. an
 	// IPv6-only, carrier or customer-owned-IP association), in which case

--- a/pkg/aws/api/api_test.go
+++ b/pkg/aws/api/api_test.go
@@ -194,3 +194,95 @@ func TestParseENIPublicIP(t *testing.T) {
 		})
 	}
 }
+
+func TestParseENIIPv6(t *testing.T) {
+	// addr describes one entry of the ENI's assigned IPv6 addresses.
+	type addr struct {
+		ip      string
+		primary bool
+	}
+
+	newIface := func(addrs []addr, prefixes []string) *ec2_types.NetworkInterface {
+		iface := &ec2_types.NetworkInterface{
+			PrivateIpAddress: aws.String("10.0.0.1"),
+		}
+		for _, a := range addrs {
+			iface.Ipv6Addresses = append(iface.Ipv6Addresses, ec2_types.NetworkInterfaceIpv6Address{
+				Ipv6Address:   aws.String(a.ip),
+				IsPrimaryIpv6: aws.Bool(a.primary),
+			})
+		}
+		for _, p := range prefixes {
+			iface.Ipv6Prefixes = append(iface.Ipv6Prefixes, ec2_types.Ipv6PrefixSpecification{
+				Ipv6Prefix: aws.String(p),
+			})
+		}
+		return iface
+	}
+
+	tests := []struct {
+		name      string
+		addrs     []addr
+		prefixes  []string
+		want      string
+		wantError bool
+	}{
+		{
+			name: "no IPv6 address or prefix leaves the ENI without an IPv6 address",
+		},
+		{
+			name:     "address is taken out of the delegated prefix",
+			prefixes: []string{"2001:db8:0:1::/80"},
+			want:     "2001:db8:0:1:0:ffff:ffff:ffff",
+		},
+		{
+			name:     "address is taken out of the lowest delegated prefix",
+			prefixes: []string{"2001:db8:0:1:0:1::/80", "2001:db8:0:1::/80"},
+			want:     "2001:db8:0:1:0:ffff:ffff:ffff",
+		},
+		{
+			name:  "the only assigned address is used",
+			addrs: []addr{{ip: "2001:db8:0:2::5"}},
+			want:  "2001:db8:0:2::5",
+		},
+		{
+			name:  "the primary address wins over the other assigned ones",
+			addrs: []addr{{ip: "2001:db8:0:2::5"}, {ip: "2001:db8:0:2::9", primary: true}},
+			want:  "2001:db8:0:2::9",
+		},
+		{
+			name:  "the lowest address is picked when none is primary",
+			addrs: []addr{{ip: "2001:db8:0:2::9"}, {ip: "2001:db8:0:2::5"}, {ip: "2001:db8:0:2::7"}},
+			want:  "2001:db8:0:2::5",
+		},
+		{
+			name:     "an assigned address outside the delegated prefix wins over the prefix",
+			addrs:    []addr{{ip: "2001:db8:0:2::5", primary: true}},
+			prefixes: []string{"2001:db8:0:1::/80"},
+			want:     "2001:db8:0:2::5",
+		},
+		{
+			name:      "a malformed assigned address is an error",
+			addrs:     []addr{{ip: "not-an-ip"}},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, eni, err := parseENI(newIface(tt.addrs, tt.prefixes), nil, nil)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, eni)
+
+			if tt.want == "" {
+				assert.False(t, eni.IPv6.IsValid())
+				return
+			}
+			assert.Equal(t, tt.want, eni.IPv6.String())
+		})
+	}
+}

--- a/pkg/aws/api/mock/mock.go
+++ b/pkg/aws/api/mock/mock.go
@@ -354,6 +354,7 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 			panic("Unable to allocate IPv6 from allocator")
 		}
 		eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(pfx))
+		eni.IPv6 = iputil.AddrFrom(eni.DeriveIPv6FromPrefixes())
 	}
 
 	subnet.AvailableAddresses -= numAddresses
@@ -672,6 +673,7 @@ func (e *API) AssignENIIPv6Prefix(ctx context.Context, eniID string) error {
 				return fmt.Errorf("unable to allocate IPv6 prefix: %w", err)
 			}
 			eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(pfx))
+			eni.IPv6 = iputil.AddrFrom(eni.DeriveIPv6FromPrefixes())
 			return nil
 		}
 	}

--- a/pkg/aws/types/types.go
+++ b/pkg/aws/types/types.go
@@ -4,6 +4,10 @@
 package types
 
 import (
+	"net/netip"
+
+	"go4.org/netipx"
+
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/mac"
@@ -176,6 +180,11 @@ type ENI struct {
 	// +optional
 	IPv6Prefixes []iputil.Prefix `json:"ipv6-prefixes,omitempty"`
 
+	// IPv6 is the IPv6 address reserved for use by the ENI device itself
+	//
+	// +optional
+	IPv6 iputil.Addr `json:"ipv6,omitzero"`
+
 	// SecurityGroups are the security groups associated with the ENI
 	SecurityGroups []string `json:"security-groups,omitempty"`
 
@@ -198,6 +207,26 @@ func (e *ENI) DeepCopyInterface() ipamTypes.Interface {
 // InterfaceID returns the identifier of the interface
 func (e *ENI) InterfaceID() string {
 	return e.ID
+}
+
+// DeriveIPv6FromPrefixes returns an IPv6 address carved out of the ENI's
+// delegated prefixes, or the zero Addr if the ENI has none.
+func (e *ENI) DeriveIPv6FromPrefixes() netip.Addr {
+	var lowest netip.Prefix
+	for _, prefix := range e.IPv6Prefixes {
+		if !prefix.IsValid() {
+			continue
+		}
+		if !lowest.IsValid() || prefix.Addr().Less(lowest.Addr()) {
+			lowest = prefix.Prefix
+		}
+	}
+
+	if !lowest.IsValid() {
+		return netip.Addr{}
+	}
+
+	return netipx.PrefixLastIP(lowest)
 }
 
 // IsExcludedBySpec returns true if the ENI is excluded by the provided spec and

--- a/pkg/aws/types/zz_generated.deepcopy.go
+++ b/pkg/aws/types/zz_generated.deepcopy.go
@@ -82,6 +82,7 @@ func (in *ENI) DeepCopyInto(out *ENI) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.IPv6.DeepCopyInto(&out.IPv6)
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]string, len(*in))

--- a/pkg/aws/types/zz_generated.deepequal.go
+++ b/pkg/aws/types/zz_generated.deepequal.go
@@ -145,6 +145,10 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 		}
 	}
 
+	if !in.IPv6.DeepEqual(&other.IPv6) {
+		return false
+	}
+
 	if ((in.SecurityGroups != nil) && (other.SecurityGroups != nil)) || ((in.SecurityGroups == nil) != (other.SecurityGroups == nil)) {
 		in, other := &in.SecurityGroups, &other.SecurityGroups
 		if other == nil {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -630,6 +630,10 @@ spec:
                         ip:
                           description: IP is the primary IP of the ENI
                           type: string
+                        ipv6:
+                          description: IPv6 is the IPv6 address reserved for use by
+                            the ENI device itself
+                          type: string
                         ipv6-prefixes:
                           description: IPv6Prefixes is the list of all IPv6 /80 delegated
                             prefixes associated with the ENI

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.34.4"
+	CustomResourceDefinitionSchemaVersion = "1.34.5"
 )


### PR DESCRIPTION
### Problem

Cilium did not put an IPv6 address on secondary ENIs' netlink devices. Traffic the host stack forwards out a secondary ENI was then sourced from another ENI's address (the primary), which AWS silently discards because of the source/destination check. Pod-sourced NodePort traffic in `kube-proxy-replacement=false` mode is the visible casualty.

### Solution

This selects an IPv6 from the addresses or the prefixes reported by the AWS API, making sure the address cannot collide with a pod IPv6. Then the agent picks up that address and adds it to the network device.

The choice of the ENI's IPv6 address is made as follows:
- If a primary IPv6 is attached, select it
- Otherwise, choose the lowest attached single IPv6
- Otherwise, choose the last IPv6 from the lowest attached IPv6 prefix

While the IPv6 prefix is used for pods, the allocator actually truncates it to the first 65536 addresses. So the last IP of the /80 prefix will never be used by a pod.

This PR was prepared with AIL:2. I planned it using and agent and combined human and AI code to implement it.

```release-note
pkg/aws: Secondary ENIs get an IPv6 configured to their netlink devices to make sure nodeports work when using kube-proxy.
```
