### PR TITLE
datapath: adding VRF device spec and reporting of tbid in devices statedb

### DIFF
--- a/pkg/datapath/linux/device/reconciler.go
+++ b/pkg/datapath/linux/device/reconciler.go
@@ -153,7 +153,7 @@ func (ops *ops) Update(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision,
 		if err == nil {
 			err = ops.handle.LinkAdd(nl)
 		}
-	} else {
+	} else if obj.DeviceSpec.CanModify() {
 		err = ops.handle.LinkModify(nl)
 	}
 	if err != nil {

--- a/pkg/datapath/linux/device/scripttest/device_test.go
+++ b/pkg/datapath/linux/device/scripttest/device_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
-	"github.com/cilium/cilium/pkg/datapath/linux/device"
 	linuxdevice "github.com/cilium/cilium/pkg/datapath/linux/device"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
@@ -135,37 +134,54 @@ func testDesiredDevicesCmds(db *statedb.DB, dm linuxdevice.ManagerOperations, de
 	addDeviceCmd := script.Command(
 		script.CmdUsage{
 			Summary: "Add a device",
-			Args:    "owner device-file",
+			Args:    "owner type device-file",
 		},
 		func(state *script.State, args ...string) (script.WaitFunc, error) {
-			if len(args) != 2 {
+			if len(args) != 3 {
 				return nil, script.ErrUsage
 			}
 
-			owner := dm.GetOrRegisterOwner(args[0])
-
-			deviceFile, err := os.ReadFile(state.Path(args[1]))
+			deviceFile, err := os.ReadFile(state.Path(args[2]))
 			if err != nil {
-				return nil, fmt.Errorf("failed to read device file %q: %w", args[1], err)
+				return nil, fmt.Errorf("failed to read device file %q: %w", args[2], err)
 			}
 
-			var device *device.DesiredVLANDeviceSpec
-			if err := yaml.Unmarshal(deviceFile, &device); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal device file %q: %w", args[1], err)
+			var (
+				deviceName string
+				spec       linuxdevice.DesiredDeviceSpec
+			)
+			switch args[1] {
+			case "vlan":
+				vlan := &linuxdevice.DesiredVLANDeviceSpec{}
+				if err := yaml.Unmarshal(deviceFile, vlan); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal device file %q: %w", args[2], err)
+				}
+
+				parent, _, found := devTbl.Get(db.ReadTxn(), tables.DeviceByName(vlan.ParentName))
+				if !found {
+					return nil, fmt.Errorf("parent device %q not found for VLAN device %q", vlan.ParentName, vlan.Name)
+				}
+				vlan.ParentIndex = parent.Index
+				deviceName, spec = vlan.Name, vlan
+
+			case "vrf":
+				vrf := &linuxdevice.DesiredVRFDeviceSpec{}
+				if err := yaml.Unmarshal(deviceFile, vrf); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal device file %q: %w", args[2], err)
+				}
+				deviceName, spec = vrf.Name, vrf
+
+			default:
+				return nil, fmt.Errorf("unsupported device type %q", args[1])
 			}
 
-			dev, _, found := devTbl.Get(db.ReadTxn(), tables.DeviceByName(device.ParentName))
-			if !found {
-				return nil, fmt.Errorf("parent device %q not found for VLAN device %q", device.ParentName, device.Name)
-			}
-			device.ParentIndex = dev.Index
-
-			if err := dm.UpsertDevice(linuxdevice.DesiredDevice{
+			owner := dm.GetOrRegisterOwner(args[0])
+			if err := dm.UpsertDeviceWait(linuxdevice.DesiredDevice{
 				Owner:      owner,
-				Name:       device.Name,
-				DeviceSpec: device,
-			}); err != nil {
-				return nil, fmt.Errorf("failed to upsert device %q: %w", device.Name, err)
+				Name:       deviceName,
+				DeviceSpec: spec,
+			}, 5*time.Second); err != nil {
+				return nil, fmt.Errorf("failed to upsert device %q: %w", deviceName, err)
 			}
 
 			return nil, nil

--- a/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
@@ -10,7 +10,7 @@ hive/start
 db/cmp devices devices.table
 
 # owner tries to take over same device
-add-device owner1 eth0.10.yaml
+! add-device owner1 vlan eth0.10.yaml
 remove-owner owner1
 
 # make sure reconciler does not cleanup incorrectly

--- a/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
@@ -5,8 +5,8 @@ link/set eth0 up
 
 hive/start
 
-add-device owner1 eth0.10.yaml
-add-device owner1 eth0.20.yaml
+add-device owner1 vlan eth0.10.yaml
+add-device owner1 vlan eth0.20.yaml
 
 # validate tables are populated correctly
 db/cmp desired-devices desired-device.1.table
@@ -23,7 +23,7 @@ add-initializer owner1
 hive/start
 
 # Add device again after restart, but only eth0.10 device
-add-device owner1 eth0.10.yaml
+add-device owner1 vlan eth0.10.yaml
 
 # Mark initializer as finished so pruning can proceed
 finish-initializer owner1

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan-recreate.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan-recreate.txtar
@@ -10,14 +10,14 @@ link/set eth0 up
 hive/start
 
 # Create the VLAN device, wait for it to be reconciled and record its ifindex.
-add-device owner1 eth0.10.yaml
+add-device owner1 vlan eth0.10.yaml
 db/cmp devices devices.1.table
 db/get devices --index=name eth0.10 --columns=Index -o index.create.txt
 
 # Re-apply with only the MTU changed (a mutable attribute). The reconciler must
 # call LinkModify. Wait for the MTU update to land (devices.2.table), then assert
 # the ifindex is unchanged -> the device was modified in place, not recreated.
-add-device owner1 eth0.10-mtu.yaml
+add-device owner1 vlan eth0.10-mtu.yaml
 db/cmp devices devices.2.table
 db/get devices --index=name eth0.10 --columns=Index -o index.mtu.txt
 cmp index.mtu.txt index.create.txt
@@ -26,7 +26,7 @@ cmp index.mtu.txt index.create.txt
 # change it, so the reconciler deletes and re-adds the device. We also bump the
 # MTU so the devices table has an observable change to wait on.
 # Then assert the ifindex changed -> recreated.
-add-device owner1 eth0.10-vlan.yaml
+add-device owner1 vlan eth0.10-vlan.yaml
 db/cmp devices devices.3.table
 db/get devices --index=name eth0.10 --columns=Index -o index.vlan.txt
 ! cmp index.vlan.txt index.mtu.txt

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
@@ -5,8 +5,8 @@ link/set eth0 up
 
 hive/start
 
-add-device owner1 eth0.10.yaml
-add-device owner2 eth0.20.yaml
+add-device owner1 vlan eth0.10.yaml
+add-device owner2 vlan eth0.20.yaml
 
 # validate tables are populated correctly
 db/cmp desired-devices desired-device.1.table
@@ -20,7 +20,7 @@ db/cmp desired-devices desired-device.2.table
 db/cmp devices devices.2.table
 
 # update MTU
-add-device owner2 eth0.20-updated.yaml
+add-device owner2 vlan eth0.20-updated.yaml
 
 # revalidate data
 db/cmp desired-devices desired-device.3.table

--- a/pkg/datapath/linux/device/scripttest/testdata/vrf.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vrf.txtar
@@ -1,0 +1,54 @@
+# A VRF device is preserved while its routing table is unchanged and recreated
+# when the table-id changes.
+
+hive/start
+
+add-device owner1 vrf vrf-blue-intf.table-1000.yaml
+db/cmp desired-devices desired-device.table-1000.table
+db/cmp devices devices.vrf-table-1000.table
+db/get devices --index=name vrf-blue-intf --columns=Index -o index.created.txt
+
+# Reapplying the same spec must not recreate the device.
+add-device owner1 vrf vrf-blue-intf.table-1000.yaml
+db/get devices --index=name vrf-blue-intf --columns=Index -o index.unchanged.txt
+cmp index.created.txt index.unchanged.txt
+
+# Changing the routing table requires a new VRF link.
+add-device owner1 vrf vrf-blue-intf.table-2000.yaml
+db/cmp desired-devices desired-device.table-2000.table
+db/cmp devices devices.vrf-table-2000.table
+
+remove-owner owner1
+db/cmp devices devices.empty.table
+
+hive/stop
+
+-- vrf-blue-intf.table-1000.yaml --
+name: vrf-blue-intf
+table: 1000
+
+-- vrf-blue-intf.table-2000.yaml --
+name: vrf-blue-intf
+table: 2000
+
+-- desired-device.table-1000.table --
+Owner    Name             Properties
+owner1   vrf-blue-intf    Type=vrf, Table=1000
+
+-- desired-device.table-2000.table --
+Owner    Name             Properties
+owner1   vrf-blue-intf    Type=vrf, Table=2000
+
+-- devices.vrf-table-1000.table --
+Name             Type     VRFTable   OperStatus
+lo               device   0          down
+vrf-blue-intf    vrf      1000       up
+
+-- devices.vrf-table-2000.table --
+Name             Type     VRFTable   OperStatus
+lo               device   0          down
+vrf-blue-intf    vrf      2000       up
+
+-- devices.empty.table --
+Name   Type
+lo     device

--- a/pkg/datapath/linux/device/table.go
+++ b/pkg/datapath/linux/device/table.go
@@ -84,6 +84,8 @@ type DesiredDeviceSpec interface {
 	// existing device. Returning true unconditionally causes a destructive
 	// delete+add on every reconcile (including periodic refresh).
 	NeedsRecreate(existing netlink.Link) bool
+	// CanModify reports whether the device supports in-place updates.
+	CanModify() bool
 }
 
 type DesiredDevice struct {

--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -17,6 +17,10 @@ type DesiredVLANDeviceSpec struct {
 	MTU         int    `json:"mtu" yaml:"mtu"`
 	ParentName  string `json:"parentName" yaml:"parentName"`
 	ParentIndex int    `json:"parentIndex" yaml:"parentIndex"`
+	// MasterName and MasterIndex bind the device into a VRF or a bridge. Zero leaves it
+	// where it is: netlink only takes a master when one is given.
+	MasterName  string `json:"masterName" yaml:"masterName"`
+	MasterIndex int    `json:"masterIndex" yaml:"masterIndex"`
 }
 
 var _ DesiredDeviceSpec = (*DesiredVLANDeviceSpec)(nil)
@@ -27,6 +31,7 @@ func (d *DesiredVLANDeviceSpec) ToNetlink() (netlink.Link, error) {
 			Name:        d.Name,
 			MTU:         d.MTU,
 			ParentIndex: d.ParentIndex,
+			MasterIndex: d.MasterIndex,
 		},
 		VlanId: d.VLANID,
 	}, nil
@@ -35,7 +40,7 @@ func (d *DesiredVLANDeviceSpec) ToNetlink() (netlink.Link, error) {
 // NeedsRecreate reports whether the existing VLAN device must be recreated. The
 // VLAN ID and parent interface are immutable, so a recreate is only
 // needed when one of those differs from the desired spec. Mutable attributes (e.g.
-// MTU) are handled in-place via LinkModify.
+// MTU, master) are handled in-place via LinkModify.
 func (d *DesiredVLANDeviceSpec) NeedsRecreate(existing netlink.Link) bool {
 	vlan, ok := existing.(*netlink.Vlan)
 	if !ok {
@@ -51,8 +56,14 @@ func (d *DesiredVLANDeviceSpec) CanModify() bool {
 }
 
 func (d *DesiredVLANDeviceSpec) Properties() string {
-	return fmt.Sprintf("Type=vlan, ParentDevice=%s (%d), VLAN=%d",
+	props := fmt.Sprintf("Type=vlan, ParentDevice=%s (%d), VLAN=%d",
 		d.ParentName, d.ParentIndex, d.VLANID)
+
+	if d.MasterIndex != 0 {
+		props += fmt.Sprintf(", Master=%s (%d)", d.MasterName, d.MasterIndex)
+	}
+
+	return props
 }
 
 func (d *DesiredVLANDeviceSpec) MarshalYAML() (any, error) {

--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -46,6 +46,10 @@ func (d *DesiredVLANDeviceSpec) NeedsRecreate(existing netlink.Link) bool {
 	return vlan.VlanId != d.VLANID || vlan.ParentIndex != d.ParentIndex
 }
 
+func (d *DesiredVLANDeviceSpec) CanModify() bool {
+	return true
+}
+
 func (d *DesiredVLANDeviceSpec) Properties() string {
 	return fmt.Sprintf("Type=vlan, ParentDevice=%s (%d), VLAN=%d",
 		d.ParentName, d.ParentIndex, d.VLANID)

--- a/pkg/datapath/linux/device/vrf.go
+++ b/pkg/datapath/linux/device/vrf.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+	"go.yaml.in/yaml/v3"
+)
+
+type DesiredVRFDeviceSpec struct {
+	Name string `json:"name" yaml:"name"`
+	// Table is immutable after the link is created.
+	Table uint32 `json:"table" yaml:"table"`
+}
+
+var _ DesiredDeviceSpec = (*DesiredVRFDeviceSpec)(nil)
+
+func (d *DesiredVRFDeviceSpec) ToNetlink() (netlink.Link, error) {
+	return &netlink.Vrf{
+		LinkAttrs: netlink.LinkAttrs{Name: d.Name},
+		Table:     d.Table,
+	}, nil
+}
+
+// NeedsRecreate reports whether type or routing table differs.
+func (d *DesiredVRFDeviceSpec) NeedsRecreate(existing netlink.Link) bool {
+	vrf, ok := existing.(*netlink.Vrf)
+	if !ok {
+		return true
+	}
+	return vrf.Table != d.Table
+}
+
+func (d *DesiredVRFDeviceSpec) CanModify() bool {
+	return false
+}
+
+func (d *DesiredVRFDeviceSpec) Properties() string {
+	return fmt.Sprintf("Type=vrf, Table=%d", d.Table)
+}
+
+func (d *DesiredVRFDeviceSpec) MarshalYAML() (any, error) {
+	return yaml.Marshal(*d)
+}
+
+func (d *DesiredVRFDeviceSpec) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*d)
+}

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -426,6 +426,11 @@ func populateFromLink(d *tables.Device, link netlink.Link) {
 	d.MasterIndex = a.MasterIndex
 	d.Type = link.Type()
 	d.OperStatus = a.OperState.String()
+
+	// A VRF's routing table is immutable link state.
+	if vrf, ok := link.(*netlink.Vrf); ok {
+		d.VRFTable = vrf.Table
+	}
 }
 
 // processBatch processes a batch of address, link and route updates.

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -68,6 +68,13 @@ db/cmp devices --grep dummy devices_empty.table
 db/cmp routes routes_empty.table
 db/cmp neighbors neighbors_empty.table
 
+# A VRF exposes its routing table in the devices table.
+exec ip link add vrf-blue-intf type vrf table 1000
+db/cmp --grep='^vrf-blue-intf' devices devices_vrf.table
+
+exec ip link del vrf-blue-intf
+db/cmp --grep='^vrf-blue-intf' devices devices_empty.table
+
 # Add dummy2.
 exec ip link add dummy2 type dummy
 exec ip link set dummy2 addrgenmode none
@@ -192,6 +199,11 @@ dummy2 (longinterfacename)            true       dummy  192.168.2.12  unknown
 -- devices_dummy3_altnames.table --
 Name                                         Selected   Type   Addresses     OperStatus
 dummy3 (altdummy, anotherlonginterfacename)  false      dummy  192.168.3.13  up
+
+-- devices_vrf.table --
+Name             Type   VRFTable
+vrf-blue-intf    vrf    1000
+
 -- devices_placeholder --
 
 

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -112,6 +112,7 @@ type Device struct {
 	Addrs        []DeviceAddress // Addresses assigned to the device
 	RawFlags     uint32          // Raw interface flags
 	Type         string          // Device type, e.g. "veth" etc.
+	VRFTable     uint32          // VRF routing table; zero for other device types
 	MasterIndex  int             // Index of the master device (e.g. bridge or bonding device)
 	OperStatus   string          // Operational status, e.g. "up", "lower-layer-down"
 
@@ -141,6 +142,7 @@ func (*Device) TableHeader() []string {
 		"Index",
 		"Selected",
 		"Type",
+		"VRFTable",
 		"MTU",
 		"HWAddr",
 		"Flags",
@@ -163,6 +165,7 @@ func (d *Device) TableRow() []string {
 		fmt.Sprintf("%d", d.Index),
 		fmt.Sprintf("%v", d.Selected),
 		d.Type,
+		fmt.Sprintf("%d", d.VRFTable),
 		fmt.Sprintf("%d", d.MTU),
 		d.HardwareAddr.String(),
 		d.Flags.String(),

--- a/pkg/datapath/tables/zz_generated.deepequal.go
+++ b/pkg/datapath/tables/zz_generated.deepequal.go
@@ -84,6 +84,9 @@ func (in *Device) DeepEqual(other *Device) bool {
 	if in.Type != other.Type {
 		return false
 	}
+	if in.VRFTable != other.VRFTable {
+		return false
+	}
 	if in.MasterIndex != other.MasterIndex {
 		return false
 	}


### PR DESCRIPTION
Add Linux VRF support to the desired-device reconciler. This provides the datapath plumbing needed by consumers to create VRF devices and bind VLAN devices to them.

AIL:3 

```release-note
Add desired-device support for Linux VRF links and VRF-bound VLAN devices.
```