### PR TITLE
v1.19 Backports 2026-09-11

### DIFF
--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -29,6 +29,9 @@ inputs:
   external-other-target:
     description: "Extra DNS name for testing connectivity outside the cluster"
     required: false
+  external-target-fake-dns:
+    description: "Use DNS override for external targets in wildcard tests"
+    required: false
   flow-validation:
     default: false
     description: "Enable flow validation in the connectivity test"
@@ -83,6 +86,10 @@ runs:
           CONNECTIVITY_TEST_DEFAULTS+=("--external-other-target=${{ inputs.external-other-target }}")
         fi
 
+
+        if [ "${{ inputs.external-target-fake-dns }}" == "true" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-fake-dns")
+        fi
 
         if [ "${{ inputs.include-unsafe-tests }}" == "true" ]; then
           CONNECTIVITY_TEST_DEFAULTS+=("--include-unsafe-tests")

--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -29,6 +29,12 @@ inputs:
   external-other-target:
     description: "Extra DNS name for testing connectivity outside the cluster"
     required: false
+  external-target-ca-namespace:
+    description: "Namespace of the CA secret for the external target"
+    required: false
+  external-target-ca-name:
+    description: "Name of the CA secret for the external target"
+    required: false
   external-target-fake-dns:
     description: "Use DNS override for external targets in wildcard tests"
     required: false
@@ -84,6 +90,12 @@ runs:
         fi
         if [ -n "${{ inputs.external-other-target }}" ]; then
           CONNECTIVITY_TEST_DEFAULTS+=("--external-other-target=${{ inputs.external-other-target }}")
+        fi
+        if [ -n "${{ inputs.external-target-ca-namespace }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-ca-namespace=${{ inputs.external-target-ca-namespace }}")
+        fi
+        if [ -n "${{ inputs.external-target-ca-name }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-ca-name=${{ inputs.external-target-ca-name }}")
         fi
 
 

--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -38,6 +38,10 @@ inputs:
   external-target-fake-dns:
     description: "Use DNS override for external targets in wildcard tests"
     required: false
+  external-target-ipv6-capable:
+    description: "Whether the external target is IPv6 capable"
+    required: false
+    default: "false"
   flow-validation:
     default: false
     description: "Enable flow validation in the connectivity test"
@@ -76,6 +80,7 @@ runs:
           "--external-cidr=${{ inputs.external-cidr }}" \
           "--external-ip=${{ inputs.external-ip }}" \
           "--external-other-ip=${{ inputs.external-other-ip }}" \
+          "--external-target-ipv6-capable=${{ inputs.external-target-ipv6-capable }}" \
           "--hubble=${{ inputs.hubble }}" \
         )
 

--- a/.github/actions/kind-external-targets/action.sh
+++ b/.github/actions/kind-external-targets/action.sh
@@ -47,11 +47,6 @@ openssl req -new -x509 -nodes -days 365 \
     -subj "/O=Cilium/CN=Cilium CA" \
     -out ca-cert.pem
 
-# Create a secret with the CA certificate, will be used by L7 tests as trused CA for
-# connections between Envoy and our external services
-kubectl create ns external-target-secrets
-kubectl -n external-target-secrets create secret generic custom-ca --from-file=ca.crt=ca-cert.pem
-
 # Create a cerificate signing request and private key for external services
 # Note only the primary external target is in the common name.
 openssl req -newkey rsa:2048 -nodes \
@@ -154,12 +149,20 @@ for container in webserver other-webserver; do
 	fi
 done
 
-# Get the current CoreDNS config file
-kubectl -n kube-system get configmap/coredns -o json | jq ".data.Corefile" -r  > Corefile
+# Iterate over every requested context, defaulting to the current context.
+read -r -a contexts <<< "${KUBE_CONTEXTS:-$(kubectl config current-context)}"
+for context in "${contexts[@]}"; do
+    # Create a secret with the CA certificate, will be used by L7 tests as trusted CA for
+    # connections between Envoy and our external services
+    kubectl --context "$context" create ns external-target-secrets
+    kubectl --context "$context" -n external-target-secrets create secret generic custom-ca --from-file=ca.crt=ca-cert.pem
 
-# We use the fake `cilium` TLD. CoreDNS allows us to specify DNS config per TLD.
-# Simply resolve our fake domains with a embedded hosts file.
-cat >> Corefile << EOF
+    # Get the current CoreDNS config file
+    kubectl --context "$context" -n kube-system get configmap/coredns -o json | jq ".data.Corefile" -r > Corefile
+
+    # We use the fake `cilium` TLD. CoreDNS allows us to specify DNS config per TLD.
+    # Simply resolve our fake domains with a embedded hosts file.
+    cat >> Corefile << EOF
 cilium:53 {
     hosts {
         $IP4TARGET $TARGETNAME
@@ -170,10 +173,10 @@ cilium:53 {
 }
 EOF
 
-# Turn the Corefile back into a JSON string
-cat Corefile | jq -asR '.' > Corefile.json
-# Create a patch for the CoreDNS configmap
-echo "{}" | jq ".data.Corefile = $(cat Corefile.json)" - > patch.json
-# Patch the CoreDNS configmap
-kubectl -n kube-system patch configmap/coredns --patch-file patch.json
-
+    # Turn the Corefile back into a JSON string
+    cat Corefile | jq -asR '.' > Corefile.json
+    # Create a patch for the CoreDNS configmap
+    echo "{}" | jq ".data.Corefile = $(cat Corefile.json)" - > patch.json
+    # Patch the CoreDNS configmap
+    kubectl --context "$context" -n kube-system patch configmap/coredns --patch-file patch.json
+done

--- a/.github/actions/kind-external-targets/action.yaml
+++ b/.github/actions/kind-external-targets/action.yaml
@@ -3,6 +3,9 @@ description: |
   Add additional containers to the kind network which can be
   used as external targets for cilium-cli connectivity tests.
 inputs:
+  kube_contexts:
+    description: "Space-separated names of kubeconfig contexts of the target clusters. Defaults to the current context if unspecified"
+    required: false
   kind_network:
     description: "Name of the docker network created for kind"
     required: true
@@ -34,6 +37,8 @@ runs:
   steps:
     - id: add_targets
       shell: bash
+      env:
+        KUBE_CONTEXTS: ${{ inputs.kube_contexts }}
       run: |
         bash ./.github/actions/kind-external-targets/action.sh \
           ${{ inputs.lvh }} \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -288,14 +288,6 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          hubble: false
-          include-unsafe-tests: true
-          test-concurrency: 5
-
       - name: Set up job variables for GHA environment
         id: vars
         run: |
@@ -405,32 +397,10 @@ jobs:
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
-            --multi-cluster=${{ env.contextName2 }} \
-            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'"
-
-          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
-            CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
-              --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
-              --deployment-pod-annotations='{ \
-                  \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
-                  \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
-              }'"
-          fi
-
-          # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
-          # in GitHub runners: https://github.com/actions/runner-images/issues/668
-          if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
-            CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
-              --test='!/pod-to-world' \
-              --test='!/pod-to-cidr'"
-          fi
-
           echo cilium_install_defaults="${CILIUM_INSTALL_WAIT} ${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
             ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS} ${CILIUM_INSTALL_MULTIPOOL_IPAM}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster1="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster2="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2}" >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
           echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
@@ -452,6 +422,10 @@ jobs:
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
+      - name: Create docker network
+        uses: ./.github/actions/kind-external-network
+        id: network
+
       - name: Create Kind cluster 1
         uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0
         with:
@@ -471,6 +445,54 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+      - name: Add external targets to kind cluster
+        uses: ./.github/actions/kind-external-targets
+        id: external_targets
+        with:
+          kube_contexts: ${{ env.contextName1 }} ${{ env.contextName2 }}
+          kind_network: ${{ steps.network.outputs.kind_network }}
+          ipv4_external_target: ${{ steps.network.outputs.ipv4_external_target }}
+          ipv4_other_external_target: ${{ steps.network.outputs.ipv4_other_external_target }}
+          ipv6_external_target: ${{ steps.network.outputs.ipv6_external_target }}
+          ipv6_other_external_target: ${{ steps.network.outputs.ipv6_other_external_target }}
+
+      - name: Get default connectivity test flags
+        id: connectivity_flags_default
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-cidr: ${{ steps.network.outputs.ipv4_external_cidr }}
+          external-cidrv6: ${{ steps.network.outputs.ipv6_external_cidr }}
+          external-ip: ${{ steps.network.outputs.ipv4_external_target }}
+          external-ipv6: ${{ steps.network.outputs.ipv6_external_target }}
+          external-other-ip: ${{ steps.network.outputs.ipv4_other_external_target }}
+          external-other-ipv6: ${{ steps.network.outputs.ipv6_other_external_target }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-ipv6-capable: true
+
+      - name: Get connectivity test flags
+        id: connectivity_flags
+        run: |
+          FLAGS="${{ steps.connectivity_flags_default.outputs.test_flags }} \
+            --multi-cluster=${{ env.contextName2 }} \
+            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'"
+
+          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
+            FLAGS="$FLAGS \
+              --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
+              --deployment-pod-annotations='{ \
+                  \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
+                  \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
+              }'"
+          fi
+
+          echo flags=${FLAGS} >> $GITHUB_OUTPUT
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@c5e42236c7d90bd50e7975ac587f77782666a0aa # v0.20.0
@@ -527,6 +549,7 @@ jobs:
         uses: ./.github/actions/kvstore
         with:
           clusters: 2
+          network: ${{ steps.network.outputs.kind_network }}
 
       - name: Create the secret containing the kvstore credentials
         if: matrix.mode == 'external'
@@ -688,7 +711,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         id: run-tests
         run: |
-          cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.connectivity_flags.outputs.flags }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})" \
           --expected-drop-reasons='+No node ID found'
@@ -706,7 +729,7 @@ jobs:
           echo "current_drops: $total_drops"
           if [[ "$total_drops" != ${{ steps.no_nodeid_drops_prev.outputs.total_drops }} ]]; then
             # run no-unexpected-packet-drops connectivity to collect sysdumps
-            cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.connectivity_flags.outputs.flags }} \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - no-node-id-drops.xml" \
             --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})" \
             --test 'no-unexpected-packet-drops'

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -142,6 +142,9 @@ jobs:
           external-other-ipv6: ${{ steps.external_network.outputs.ipv6_other_external_target }}
           external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
           external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-ipv6-capable: true
 
       - name: Set up job variables
         id: vars
@@ -158,9 +161,7 @@ jobs:
             --helm-set=envoy.enabled=false \
             --helm-set=ipv6.enabled=true \
             --wait=false"
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
-            --external-target-ca-namespace=external-target-secrets --external-target-ca-name=custom-ca \
-            --external-target-ipv6-capable"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo "test default: ${CONNECTIVITY_TEST_DEFAULTS}"
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT


### PR DESCRIPTION
 * [x] #48250 (@giorio94)

Additionally backported the `cli-test-config` action changes introduced in https://github.com/cilium/cilium/commit/a889dd7929eabd9d9adb469b2b8f6ef7d07bc99b and https://github.com/cilium/cilium/commit/4d5ca1d043995e9ec8c153a59bea850f3b98811c, as pre-requisites.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 48250
```
