### PR TITLE
bpf: terminate IPIP from an external L4 load balancer delivered to a service frontend

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -851,6 +851,72 @@ annotation must be set at service creation time and should not be changed during
 the lifetime of that service. Changing the value of the annotations or removing
 them while the service is installed breaks connections.
 
+**Terminating IPIP from an external L4 load balancer**
+
+The inbound IPIP termination also serves traffic from an external L4 load
+balancer such as Katran or IPVS that encapsulates client packets in IPIP (or
+IPv6-in-IPv6) towards the cluster. Such a load balancer picks a *real* from its
+own configured list and encapsulates to it; the real only says where to deliver
+the packet, not which backend serves it. Cilium tells this apart from its own
+DSR dispatch by the outer destination: if it is a LoadBalancer or externalIP
+frontend of a service for the inner destination port, the outer header is
+stripped and regular backend selection runs on the inner packet, translating the
+port as usual. The reply leaves the backend node directly towards the client with
+the load balancer's VIP as source, which is the DSR behaviour the external load
+balancer expects.
+
+To set this up, expose the same backends through two services:
+
+- one carrying the external load balancer's VIP as an ``externalIPs`` entry, so
+  that the inner packet finds a frontend. This address belongs to the load
+  balancer and must not be announced by the cluster;
+- one of type ``LoadBalancer`` whose address is the real, allocated from a
+  :ref:`lb_ipam` pool and announced by :ref:`bgp_control_plane`. With
+  ``externalTrafficPolicy: Local`` only nodes hosting a backend announce it, so
+  the load balancer never delivers to a node that would have to forward.
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: web-vip
+    spec:
+      selector:
+        app: web
+      externalIPs:
+        - 203.0.113.10        # the external load balancer's VIP
+      ports:
+        - port: 80
+          targetPort: 8080
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: web-real
+    spec:
+      type: LoadBalancer
+      selector:
+        app: web
+      externalTrafficPolicy: Local
+      ports:
+        - port: 80
+          targetPort: 8080
+
+Enable the termination with ``--enable-ipip-termination`` (``extraConfig`` in
+Helm) when Cilium's own DSR dispatch is not IPIP; with
+``loadBalancer.dsrDispatch=ipip`` it is on already. With
+``externalTrafficPolicy: Cluster`` a node may forward the request to a backend
+on another node using Cilium's own DSR dispatch. Under ``dsrDispatch=ipip``
+that hop is subject to the rule from the note at the top of this section: the
+IPIP encapsulation carries no port, so ``port`` and ``targetPort`` must be
+equal. Use the Geneve dispatch for services where they differ. The hop from the
+external load balancer itself is not affected, as the inner packet goes through
+regular backend selection.
+As with the rest of the IPIP termination, the outer header must carry no IP
+options. Inner packets with IPv6 extension headers or inner non-first fragments
+are not classified and are handled as before this feature.
+
 .. _Hybrid mode:
 
 Hybrid DSR and SNAT Mode

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1100,9 +1100,14 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 		if (CONFIG(enable_ipip_termination) && !from_host &&
 		    ip6->nexthdr == NEXTHDR_IPV6) {
 			const struct endpoint_info *ep_outer;
+			bool to_frontend = false;
 
 			ep_outer = lookup_ip6_endpoint(ip6);
-			if (ep_outer) {
+			/* See the IPv4 sibling block below. */
+			if (!ep_outer)
+				to_frontend = lb6_ipip_dst_is_frontend(ctx, ip6,
+								       data_end);
+			if (ep_outer || to_frontend) {
 				union v6addr outer_dst;
 
 				ipv6_addr_copy(&outer_dst,
@@ -1118,8 +1123,10 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 					ret = DROP_INVALID;
 					goto drop_err_ingress;
 				}
-				ctx_store_meta_ipv6(ctx, CB_FORCED_BACKEND_V6_1,
-						    &outer_dst);
+				if (ep_outer)
+					ctx_store_meta_ipv6(ctx,
+							    CB_FORCED_BACKEND_V6_1,
+							    &outer_dst);
 				/* See the IPv4 sibling block below for why we
 				 * have to clear the skip-nodeport flag here.
 				 */
@@ -1190,9 +1197,20 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 		    ip4->protocol == IPPROTO_IPIP &&
 		    ipv4_hdrlen(ip4) == sizeof(*ip4)) {
 			const struct endpoint_info *ep_outer;
+			bool to_frontend = false;
 
 			ep_outer = lookup_ip4_endpoint(ip4);
-			if (ep_outer) {
+			/* Not a local endpoint, but possibly a service frontend
+			 * that an external L4LB (Katran, IPVS, ...) delivered
+			 * to. Its outer dst says where to deliver, not which
+			 * backend serves, so strip without forcing a backend
+			 * and let nodeport select on the inner tuple. See
+			 * lb4_ipip_dst_is_frontend().
+			 */
+			if (!ep_outer)
+				to_frontend = lb4_ipip_dst_is_frontend(ctx, ip4,
+								       data_end);
+			if (ep_outer || to_frontend) {
 				__be32 outer_dst = ip4->daddr;
 
 				if (ctx_adjust_hroom(ctx, -(int)sizeof(*ip4),
@@ -1205,7 +1223,9 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 					ret = DROP_INVALID;
 					goto drop_err_ingress;
 				}
-				ctx_store_meta(ctx, CB_FORCED_BACKEND_V4, outer_dst);
+				if (ep_outer)
+					ctx_store_meta(ctx, CB_FORCED_BACKEND_V4,
+						       outer_dst);
 				/* If NodePort XDP acceleration ran upstream, it
 				 * couldn't classify the IPIP packet (no L4 to
 				 * extract a service tuple from) and signalled

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1081,6 +1081,39 @@ lb6_lookup_service(struct lb6_key *key, const bool east_west)
 	return __lb6_lookup_service(key);
 }
 
+/* lb6_ipip_dst_is_frontend - IPv6 sibling of lb4_ipip_dst_is_frontend(); see
+ * there for the rationale. The inner header must be followed directly by the
+ * L4 header: no extension headers, which also rules out fragments.
+ */
+static __always_inline bool
+lb6_ipip_dst_is_frontend(struct __ctx_buff *ctx, struct ipv6hdr *outer,
+			 void *data_end)
+{
+	struct ipv6hdr *inner = (void *)outer + sizeof(*outer);
+	const struct lb6_service *svc;
+	struct lb6_key key = {};
+	int l4_off;
+
+	if ((void *)inner + sizeof(*inner) > data_end)
+		return false;
+	if (inner->nexthdr != IPPROTO_TCP && inner->nexthdr != IPPROTO_UDP &&
+	    inner->nexthdr != IPPROTO_SCTP)
+		return false;
+
+	l4_off = ETH_HLEN + sizeof(*outer) + sizeof(*inner);
+	if (l4_load_port(ctx, l4_off + TCP_DPORT_OFF, &key.dport) < 0)
+		return false;
+
+	ipv6_addr_copy(&key.address, (union v6addr *)&outer->daddr);
+	key.proto = inner->nexthdr;
+
+	svc = lb6_lookup_service(&key, true);
+	if (!svc)
+		return false;
+
+	return lb6_svc_is_loadbalancer(svc) || lb6_svc_is_external_ip(svc);
+}
+
 /* lb6_lookup_wildcard_service - see lb4_lookup_wildcard_service. */
 static __always_inline const struct lb6_service *
 lb6_lookup_wildcard_service(struct lb6_key *key __maybe_unused)
@@ -1892,6 +1925,65 @@ lb4_lookup_service(struct lb4_key *key, const bool east_west)
 
 	key->scope = LB_LOOKUP_SCOPE_INT;
 	return __lb4_lookup_service(key);
+}
+
+/* lb4_ipip_dst_is_frontend - classify the outer dst of an IPIP packet as a
+ * delivery target of an external L4 load balancer.
+ *
+ * An external L4LB (Katran, IPVS, ...) picks a "real" from its own list and
+ * encapsulates the client's packet to it. The real says where to deliver,
+ * not which backend serves: the LB knows nothing about this cluster's
+ * backend set. Cilium's own DSR-IPIP dispatch is the opposite: there the
+ * outer dst is the backend that the LB node selected and must be honoured.
+ *
+ * The outer dst itself tells the two apart. A backend is a Pod or host
+ * address. A real that the cluster announces via BGP is a LoadBalancer or
+ * externalIP frontend, and the inner L4 port is that service's port. When
+ * {outer dst, inner dport, inner proto} resolves to such a frontend, the
+ * outer dst is a delivery target and ordinary backend selection on the inner
+ * tuple is the correct thing to do.
+ *
+ * NodePort, HostPort and ClusterIP frontends do not qualify. The first two
+ * live on node addresses, which are also legitimate hostNetwork backends of
+ * Cilium's own DSR, and the last is not routable from an external LB.
+ *
+ * Only the protocols that lb4_extract_tuple() load balances are considered,
+ * since the frontend lookup needs an L4 port. Inner packets without an L4
+ * header (non-first fragments) or with another protocol are not classified
+ * and take the existing path.
+ */
+static __always_inline bool
+lb4_ipip_dst_is_frontend(struct __ctx_buff *ctx, struct iphdr *outer,
+			 void *data_end)
+{
+	struct iphdr *inner = (void *)outer + sizeof(*outer);
+	const struct lb4_service *svc;
+	struct lb4_key key = {};
+	int l4_off;
+
+	if ((void *)inner + sizeof(*inner) > data_end)
+		return false;
+	if (inner->protocol != IPPROTO_TCP && inner->protocol != IPPROTO_UDP &&
+	    inner->protocol != IPPROTO_SCTP)
+		return false;
+	if (!ipfrag_has_l4_header(ipfrag_encode_ipv4(inner)))
+		return false;
+
+	/* TCP, UDP and SCTP all carry the destination port at the same
+	 * offset.
+	 */
+	l4_off = ETH_HLEN + sizeof(*outer) + ipv4_hdrlen(inner);
+	if (l4_load_port(ctx, l4_off + TCP_DPORT_OFF, &key.dport) < 0)
+		return false;
+
+	key.address = outer->daddr;
+	key.proto = inner->protocol;
+
+	svc = lb4_lookup_service(&key, true);
+	if (!svc)
+		return false;
+
+	return lb4_svc_is_loadbalancer(svc) || lb4_svc_is_external_ip(svc);
 }
 
 /* lb4_lookup_wildcard_service - Wildcard service lookup for NodePort and HostPort.

--- a/bpf/tests/tc_nodeport_lb4_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb4_ipip_termination.c
@@ -217,7 +217,8 @@ ASSIGN_CONFIG(bool, enable_ipip_termination, true)
  * pktgen__finish().
  */
 static __always_inline int
-pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
+__pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_src, __be32 outer_dst,
+		 __be32 inner_dst, __be16 inner_dport)
 {
 	struct pktgen builder;
 	struct iphdr *outer_l3, *inner_l3;
@@ -235,7 +236,7 @@ pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
 	outer_l3 = pktgen__push_default_iphdr(&builder);
 	if (!outer_l3)
 		return TEST_ERROR;
-	outer_l3->saddr = LB_NODE_IP;
+	outer_l3->saddr = outer_src;
 	outer_l3->daddr = outer_dst;
 
 	inner_l3 = pktgen__push_default_iphdr(&builder);
@@ -248,7 +249,7 @@ pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
 	if (!l4)
 		return TEST_ERROR;
 	l4->source = CLIENT_PORT;
-	l4->dest = FRONTEND_PORT;
+	l4->dest = inner_dport;
 	l4->syn = 1;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
@@ -275,6 +276,14 @@ pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
 	}
 
 	return 0;
+}
+
+/* Cilium's own DSR-IPIP dispatch: outer src is the LB node. */
+static __always_inline int
+pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
+{
+	return __pktgen_ipip_v4(ctx, LB_NODE_IP, outer_dst, inner_dst,
+				FRONTEND_PORT);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -587,4 +596,293 @@ int ipip_term_v4_xdp_handoff_check(struct __ctx_buff *ctx)
 			   l3->daddr);
 
 	test_finish();
+}
+
+/* -------------------------------------------------------------------------- */
+/* External L4LB tests.                                                       */
+/*                                                                            */
+/* An external L4LB (Katran, IPVS, ...) encapsulates the client's packet to a */
+/* "real" from its own list. The real says where to deliver, not which        */
+/* backend serves: the LB has no knowledge of this cluster's backend set. The */
+/* real is announced by the cluster via BGP, i.e. it is a LoadBalancer or     */
+/* externalIP frontend of the service. So when the outer dst is such a        */
+/* frontend for the inner port, the strip must run without stashing a forced  */
+/* backend, and ordinary selection on the inner tuple must pick the Pod.      */
+/*                                                                            */
+/* The backend port differs from the frontend port on purpose: the forced-    */
+/* backend path cannot translate ports, so a translated port is by itself     */
+/* proof that the forced path did not run.                                    */
+/* -------------------------------------------------------------------------- */
+
+#define EXT_LB_IP		v4_ext_two		/* the external LB box */
+#define EXT_VIP			v4_svc_three		/* the LB's VIP, inner dst */
+#define EXT_REAL_IP		IPV4(172, 16, 99, 9)	/* the LB's real, outer dst */
+#define EXT_BACKEND_PORT	tcp_svc_two		/* != FRONTEND_PORT */
+#define EXT_OTHER_PORT		__bpf_htons(9999)	/* no frontend on it */
+
+/* real_flags: the service flags of the frontend that sits on the real. */
+static __always_inline int ext_lb_setup(struct __ctx_buff *ctx, __u8 real_flags)
+{
+	/* The VIP: Katran's address, declared as an externalIP so that the
+	 * inner request finds a service. Never announced by the cluster.
+	 */
+	lb_v4_add_service_with_flags(EXT_VIP, FRONTEND_PORT, IPPROTO_TCP, 1, 3,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_EXTERNAL_IP, 0);
+	lb_v4_add_backend(EXT_VIP, FRONTEND_PORT, 1, 300,
+			  BACKEND_IP, EXT_BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* The real: announced by the cluster, same selector as the VIP. */
+	lb_v4_add_service_with_flags(EXT_REAL_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 4,
+				     SVC_FLAG_ROUTABLE | real_flags, 0);
+	lb_v4_add_backend(EXT_REAL_IP, FRONTEND_PORT, 1, 300,
+			  BACKEND_IP, EXT_BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
+
+	/* This node's own IP as a host endpoint, so that a node IP used as
+	 * the outer dst resolves and takes the pre-existing forced path.
+	 */
+	endpoint_v4_add_entry(BACKEND_NODE_IP, 0, 0, ENDPOINT_F_HOST,
+			      HOST_ID, 0, NULL, NULL);
+	ipcache_v4_add_entry(BACKEND_NODE_IP, 0, HOST_ID, 0, 0);
+
+	num_calls[RECORD_REDIRECT] = 0;
+	num_calls[RECORD_REDIRECT_PEER] = 0;
+	num_calls[RECORD_TAILCALL] = 0;
+	xdp_xfer_flags = 0;
+
+	return netdev_receive_packet(ctx);
+}
+
+static __always_inline void ext_lb_teardown(void)
+{
+	endpoint_v4_del_entry(BACKEND_IP);
+	endpoint_v4_del_entry(BACKEND_NODE_IP);
+}
+
+/* The outer dst is a LoadBalancer frontend: strip, select on the inner tuple,
+ * land on the Pod with the port translated and the client IP preserved.
+ */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_real")
+int ipip_term_v4_ext_lb_real_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v4(ctx, EXT_LB_IP, EXT_REAL_IP, EXT_VIP,
+				FRONTEND_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_real")
+int ipip_term_v4_ext_lb_real_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_real")
+int ipip_term_v4_ext_lb_real_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	ext_lb_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+	if (num_calls[RECORD_TAILCALL] != 1)
+		test_fatal("want 1 policy tail-call, got %u",
+			   num_calls[RECORD_TAILCALL]);
+	if (num_calls[RECORD_REDIRECT_PEER] != 1)
+		test_fatal("want 1 ctx_redirect_peer, got %u",
+			   num_calls[RECORD_REDIRECT_PEER]);
+	if (num_calls[RECORD_REDIRECT] != 0)
+		test_fatal("want 0 plain ctx_redirect, got %u",
+			   num_calls[RECORD_REDIRECT]);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->protocol != IPPROTO_TCP)
+		test_fatal("L3 proto is %u, want TCP: outer not stripped",
+			   l3->protocol);
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP is %x, want CLIENT", l3->saddr);
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP is %x, want BACKEND: real was forced as backend",
+			   l3->daddr);
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+	if (l4->dest != EXT_BACKEND_PORT)
+		test_fatal("dport %u, want backend port: forced path ran",
+			   bpf_ntohs(l4->dest));
+	if (!l4->syn)
+		test_fatal("TCP flags lost the SYN");
+
+	test_finish();
+}
+
+/* A node IP is a host endpoint, not a delivery target: the pre-existing
+ * forced-backend path applies and the inner is DNAT'd to the node with its
+ * port untranslated. This pins down that the frontend gate only fires for
+ * addresses that are not local endpoints.
+ */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_node_ip")
+int ipip_term_v4_ext_lb_node_ip_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v4(ctx, EXT_LB_IP, BACKEND_NODE_IP, EXT_VIP,
+				FRONTEND_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_node_ip")
+int ipip_term_v4_ext_lb_node_ip_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_node_ip")
+int ipip_term_v4_ext_lb_node_ip_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	ext_lb_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	if (num_calls[RECORD_REDIRECT_PEER] != 0)
+		test_fatal("redirected to a Pod, want the forced host path");
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->protocol != IPPROTO_TCP)
+		test_fatal("L3 proto is %u, want TCP: outer not stripped",
+			   l3->protocol);
+	if (l3->daddr != BACKEND_NODE_IP)
+		test_fatal("dst IP is %x, want NODE_IP: gate fired on a host endpoint",
+			   l3->daddr);
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->dest != FRONTEND_PORT)
+		test_fatal("dport %u, want frontend port", bpf_ntohs(l4->dest));
+
+	test_finish();
+}
+
+/* Shared check for the two negative cases below: nothing about the packet
+ * qualifies it, so the outer header must still be there and no Pod is
+ * involved. The rest is the pre-existing behaviour for unknown IPIP.
+ */
+static __always_inline int ext_lb_not_stripped_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	ext_lb_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	if (num_calls[RECORD_REDIRECT_PEER] != 0)
+		test_fatal("redirected to a Pod, want no termination");
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->protocol != IPPROTO_IPIP)
+		test_fatal("L3 proto is %u, want IPIP: outer was stripped",
+			   l3->protocol);
+	if (l3->daddr != EXT_REAL_IP)
+		test_fatal("outer dst changed");
+
+	test_finish();
+}
+
+/* The real is a frontend, but not on the inner port: not a delivery target. */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_port_mismatch")
+int ipip_term_v4_ext_lb_port_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v4(ctx, EXT_LB_IP, EXT_REAL_IP, EXT_VIP,
+				EXT_OTHER_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_port_mismatch")
+int ipip_term_v4_ext_lb_port_mismatch_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_port_mismatch")
+int ipip_term_v4_ext_lb_port_mismatch_check(struct __ctx_buff *ctx)
+{
+	return ext_lb_not_stripped_check(ctx);
+}
+
+/* The real is a frontend on the inner port, but a ClusterIP one: nothing an
+ * external LB can be pointed at, so not a delivery target either.
+ */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_clusterip")
+int ipip_term_v4_ext_lb_clusterip_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v4(ctx, EXT_LB_IP, EXT_REAL_IP, EXT_VIP,
+				FRONTEND_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_clusterip")
+int ipip_term_v4_ext_lb_clusterip_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb_setup(ctx, 0);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_ext_lb_clusterip")
+int ipip_term_v4_ext_lb_clusterip_check(struct __ctx_buff *ctx)
+{
+	return ext_lb_not_stripped_check(ctx);
 }

--- a/bpf/tests/tc_nodeport_lb6_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb6_ipip_termination.c
@@ -171,8 +171,8 @@ ASSIGN_CONFIG(bool, enable_ipip_termination, true)
  * fix up the OUTER nexthdr to NEXTHDR_IPV6 manually.
  */
 static __always_inline int
-pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
-	       const void *inner_dst)
+__pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_src,
+		 const void *outer_dst, const void *inner_dst, __be16 inner_dport)
 {
 	struct pktgen builder;
 	struct ipv6hdr *outer_l3, *inner_l3;
@@ -190,7 +190,7 @@ pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
 	outer_l3 = pktgen__push_default_ipv6hdr(&builder);
 	if (!outer_l3)
 		return TEST_ERROR;
-	memcpy(&outer_l3->saddr, (void *)v6_node_one, 16);
+	memcpy(&outer_l3->saddr, outer_src, 16);
 	memcpy(&outer_l3->daddr, outer_dst, 16);
 
 	inner_l3 = pktgen__push_default_ipv6hdr(&builder);
@@ -203,7 +203,7 @@ pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
 	if (!l4)
 		return TEST_ERROR;
 	l4->source = CLIENT_PORT;
-	l4->dest = FRONTEND_PORT;
+	l4->dest = inner_dport;
 	l4->syn = 1;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
@@ -228,6 +228,15 @@ pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
 	}
 
 	return 0;
+}
+
+/* Cilium's own DSR-IPIP dispatch: outer src is the LB node. */
+static __always_inline int
+pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
+	       const void *inner_dst)
+{
+	return __pktgen_ipip_v6(ctx, (void *)v6_node_one, outer_dst, inner_dst,
+				FRONTEND_PORT);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -510,6 +519,245 @@ int ipip_term_v6_xdp_handoff_check(struct __ctx_buff *ctx)
 		test_fatal("post-decap nexthdr is %u, expected TCP", l3->nexthdr);
 	if (memcmp(&l3->daddr, (void *)v6_pod_two, 16) != 0)
 		test_fatal("post-decap dst IP is not BACKEND - forced-backend DNAT skipped (stale skip-nodeport hint from XDP)");
+
+	test_finish();
+}
+
+/* -------------------------------------------------------------------------- */
+/* External L4LB tests, mirroring the IPv4 sibling file; see there for the    */
+/* rationale. The outer dst is the LB's real, a LoadBalancer frontend of the  */
+/* service, so it is a delivery target: strip without forcing a backend and   */
+/* let ordinary selection on the inner tuple pick the Pod.                    */
+/* -------------------------------------------------------------------------- */
+
+#define EXT_BACKEND_PORT	tcp_svc_two		/* != FRONTEND_PORT */
+#define EXT_OTHER_PORT		__bpf_htons(9999)	/* no frontend on it */
+
+static const __u8 ext_lb_ip6[16]   = {0x20, 0x01, 0, 0, 0, 0, 0, 0,
+				      0, 0, 0, 0, 0, 0, 0, 1};
+static const __u8 ext_vip6[16]     = v6_svc_three_addr;
+static const __u8 ext_real_ip6[16] = {0xfd, 0x10, 0, 0, 0, 0, 0, 0,
+				      0, 0, 0, 0, 0, 0, 0x99, 9};
+
+static __always_inline int ext_lb6_setup(struct __ctx_buff *ctx, __u8 real_flags)
+{
+	union v6addr vip, real, backend, host;
+
+	memcpy(&vip, (void *)ext_vip6, 16);
+	memcpy(&real, (void *)ext_real_ip6, 16);
+	memcpy(&backend, (void *)v6_pod_two, 16);
+	memcpy(&host, (void *)v6_node_one, 16);
+
+	lb_v6_add_service_with_flags(&vip, FRONTEND_PORT, IPPROTO_TCP, 1, 3,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_EXTERNAL_IP, 0);
+	lb_v6_add_backend(&vip, FRONTEND_PORT, 1, 300, &backend,
+			  EXT_BACKEND_PORT, IPPROTO_TCP, 0);
+
+	lb_v6_add_service_with_flags(&real, FRONTEND_PORT, IPPROTO_TCP, 1, 4,
+				     SVC_FLAG_ROUTABLE | real_flags, 0);
+	lb_v6_add_backend(&real, FRONTEND_PORT, 1, 300, &backend,
+			  EXT_BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry(&backend, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry(&backend, 0, 112233, 0, 0);
+
+	endpoint_v6_add_entry(&host, 0, 0, ENDPOINT_F_HOST, HOST_ID, NULL, NULL);
+	ipcache_v6_add_entry(&host, 0, HOST_ID, 0, 0);
+
+	num_calls[RECORD_REDIRECT] = 0;
+	num_calls[RECORD_REDIRECT_PEER] = 0;
+	num_calls[RECORD_TAILCALL] = 0;
+	xdp_xfer_flags = 0;
+
+	return netdev_receive_packet(ctx);
+}
+
+static __always_inline void ext_lb6_teardown(void)
+{
+	endpoint_v6_del_entry((const union v6addr *)v6_pod_two);
+	endpoint_v6_del_entry((const union v6addr *)v6_node_one);
+}
+
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_real")
+int ipip_term_v6_ext_lb_real_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v6(ctx, (void *)ext_lb_ip6, (void *)ext_real_ip6,
+				(void *)ext_vip6, FRONTEND_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_real")
+int ipip_term_v6_ext_lb_real_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb6_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_real")
+int ipip_term_v6_ext_lb_real_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	ext_lb6_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+	if (num_calls[RECORD_TAILCALL] != 1)
+		test_fatal("want 1 policy tail-call, got %u",
+			   num_calls[RECORD_TAILCALL]);
+	if (num_calls[RECORD_REDIRECT_PEER] != 1)
+		test_fatal("want 1 ctx_redirect_peer, got %u",
+			   num_calls[RECORD_REDIRECT_PEER]);
+	if (num_calls[RECORD_REDIRECT] != 0)
+		test_fatal("want 0 plain ctx_redirect, got %u",
+			   num_calls[RECORD_REDIRECT]);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->nexthdr != IPPROTO_TCP)
+		test_fatal("nexthdr is %u, want TCP: outer not stripped",
+			   l3->nexthdr);
+	if (memcmp(&l3->saddr, (void *)v6_pod_one, 16) != 0)
+		test_fatal("src IP is not CLIENT");
+	if (memcmp(&l3->daddr, (void *)v6_pod_two, 16) != 0)
+		test_fatal("dst IP is not BACKEND: real was forced as backend");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+	if (l4->dest != EXT_BACKEND_PORT)
+		test_fatal("dport %u, want backend port: forced path ran",
+			   bpf_ntohs(l4->dest));
+
+	test_finish();
+}
+
+/* A node IP is a host endpoint, not a delivery target: forced path, port
+ * untranslated.
+ */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_node_ip")
+int ipip_term_v6_ext_lb_node_ip_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v6(ctx, (void *)ext_lb_ip6, (void *)v6_node_one,
+				(void *)ext_vip6, FRONTEND_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_node_ip")
+int ipip_term_v6_ext_lb_node_ip_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb6_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_node_ip")
+int ipip_term_v6_ext_lb_node_ip_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	ext_lb6_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	if (num_calls[RECORD_REDIRECT_PEER] != 0)
+		test_fatal("redirected to a Pod, want the forced host path");
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->nexthdr != IPPROTO_TCP)
+		test_fatal("nexthdr is %u, want TCP: outer not stripped",
+			   l3->nexthdr);
+	if (memcmp(&l3->daddr, (void *)v6_node_one, 16) != 0)
+		test_fatal("dst is not NODE_IP: gate fired on a host endpoint");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->dest != FRONTEND_PORT)
+		test_fatal("dport %u, want frontend port", bpf_ntohs(l4->dest));
+
+	test_finish();
+}
+
+/* The real is a frontend, but not on the inner port: not stripped. */
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_port_mismatch")
+int ipip_term_v6_ext_lb_port_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	return __pktgen_ipip_v6(ctx, (void *)ext_lb_ip6, (void *)ext_real_ip6,
+				(void *)ext_vip6, EXT_OTHER_PORT);
+}
+
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_port_mismatch")
+int ipip_term_v6_ext_lb_port_mismatch_setup(struct __ctx_buff *ctx)
+{
+	return ext_lb6_setup(ctx, SVC_FLAG_LOADBALANCER);
+}
+
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_ext_lb_port_mismatch")
+int ipip_term_v6_ext_lb_port_mismatch_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ext_lb6_teardown();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	if (num_calls[RECORD_REDIRECT_PEER] != 0)
+		test_fatal("redirected to a Pod, want no termination");
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->nexthdr != NEXTHDR_IPV6)
+		test_fatal("nexthdr is %u, want IPV6: outer was stripped",
+			   l3->nexthdr);
 
 	test_finish();
 }


### PR DESCRIPTION
## Problem

Since #46103 inbound IPIP / IPv6-in-IPv6 is terminated on netdev ingress when the outer destination is a local endpoint, and that endpoint is honoured as the backend via `CB_FORCED_BACKEND_V4/V6`. That is correct for Cilium's own DSR dispatch, where the outer dst *is* the backend the LB node selected.

An external L4 load balancer (Katran, IPVS, ...) encapsulates to a *real* from its own list. The real says where to deliver, not which backend serves: the external LB knows nothing about the cluster's backend set. Today that leaves no usable real. A node IP is forced as the backend and the inner request is DNAT'd to `NODE_IP:port` where nothing listens; a BGP-announced address that is not a local endpoint is not terminated at all and is dropped by `lb4_extract_tuple()` as `DROP_UNKNOWN_L4`.

## Change

The outer destination itself tells the two cases apart. A backend is a Pod or host address. A real that the cluster announces via BGP is a LoadBalancer or externalIP frontend of the service, on that service's port.

So, in the strip block of `bpf_host.c`, when the endpoint lookup on the outer dst fails, look up `{outer dst, inner dport, inner proto}` as a service. If it is a LoadBalancer or externalIP frontend, strip the outer header without stashing a forced backend and let nodeport run regular backend selection on the inner tuple, which also translates the port. Every path that terminated before is unchanged: the frontend lookup only runs where the endpoint lookup found nothing, and the forced backend is stashed exactly where it was.

Per family this is one helper in `bpf/lib/lb.h` (`lb{4,6}_ipip_dst_is_frontend()`) and a two-line change in the strip block. No flag, no map, no API.

Fixes: #48657

```release-note
Inbound IPIP termination now serves traffic from external L4 load balancers such as Katran or IPVS: when the outer destination is a LoadBalancer or externalIP frontend of the service, the packet is decapsulated and goes through regular backend selection, with port translation and the client IP preserved.
```
