### PR TITLE
v1.18 Backports 2026-09-11

### DIFF
--- a/.github/actions/kind-external-targets/action.sh
+++ b/.github/actions/kind-external-targets/action.sh
@@ -36,11 +36,6 @@ openssl req -new -x509 -nodes -days 365 \
     -subj "/O=Cilium/CN=Cilium CA" \
     -out ca-cert.pem
 
-# Create a secret with the CA certificate, will be used by L7 tests as trused CA for
-# connections between Envoy and our external services
-kubectl create ns external-target-secrets
-kubectl -n external-target-secrets create secret generic custom-ca --from-file=ca.crt=ca-cert.pem
-
 # Create a cerificate signing request and private key for external services
 # Note only the primary external target is in the common name.
 openssl req -newkey rsa:2048 -nodes \
@@ -143,12 +138,20 @@ for container in webserver other-webserver; do
 	fi
 done
 
-# Get the current CoreDNS config file
-kubectl -n kube-system get configmap/coredns -o json | jq ".data.Corefile" -r  > Corefile
+# Iterate over every requested context, defaulting to the current context.
+read -r -a contexts <<< "${KUBE_CONTEXTS:-$(kubectl config current-context)}"
+for context in "${contexts[@]}"; do
+    # Create a secret with the CA certificate, will be used by L7 tests as trusted CA for
+    # connections between Envoy and our external services
+    kubectl --context "$context" create ns external-target-secrets
+    kubectl --context "$context" -n external-target-secrets create secret generic custom-ca --from-file=ca.crt=ca-cert.pem
 
-# We use the fake `cilium` TLD. CoreDNS allows us to specify DNS config per TLD.
-# Simply resolve our fake domains with a embedded hosts file.
-cat >> Corefile << EOF
+    # Get the current CoreDNS config file
+    kubectl --context "$context" -n kube-system get configmap/coredns -o json | jq ".data.Corefile" -r > Corefile
+
+    # We use the fake `cilium` TLD. CoreDNS allows us to specify DNS config per TLD.
+    # Simply resolve our fake domains with a embedded hosts file.
+    cat >> Corefile << EOF
 cilium:53 {
     hosts {
         $IP4TARGET $TARGETNAME
@@ -159,10 +162,10 @@ cilium:53 {
 }
 EOF
 
-# Turn the Corefile back into a JSON string
-cat Corefile | jq -asR '.' > Corefile.json
-# Create a patch for the CoreDNS configmap
-echo "{}" | jq ".data.Corefile = $(cat Corefile.json)" - > patch.json
-# Patch the CoreDNS configmap
-kubectl -n kube-system patch configmap/coredns --patch-file patch.json
-
+    # Turn the Corefile back into a JSON string
+    cat Corefile | jq -asR '.' > Corefile.json
+    # Create a patch for the CoreDNS configmap
+    echo "{}" | jq ".data.Corefile = $(cat Corefile.json)" - > patch.json
+    # Patch the CoreDNS configmap
+    kubectl --context "$context" -n kube-system patch configmap/coredns --patch-file patch.json
+done

--- a/.github/actions/kind-external-targets/action.yaml
+++ b/.github/actions/kind-external-targets/action.yaml
@@ -3,6 +3,9 @@ description: |
   Add additional containers to the kind network which can be
   used as external targets for cilium-cli connectivity tests.
 inputs:
+  kube_contexts:
+    description: "Space-separated names of kubeconfig contexts of the target clusters. Defaults to the current context if unspecified"
+    required: false
   kind_network:
     description: "Name of the docker network created for kind"
     required: true
@@ -30,6 +33,8 @@ runs:
   steps:
     - id: add_targets
       shell: bash
+      env:
+        KUBE_CONTEXTS: ${{ inputs.kube_contexts }}
       run: |
         bash ./.github/actions/kind-external-targets/action.sh \
           ${{ inputs.kind_network }} \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -381,39 +381,11 @@ jobs:
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --flow-validation=disabled \
-            --test-concurrency=5 \
-            --multi-cluster=${{ env.contextName2 }} \
-            --external-target=google.com. \
-            --include-unsafe-tests \
-            --collect-sysdump-on-failure \
-            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'" \
-
-          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
-            CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
-              --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
-              --deployment-pod-annotations='{ \
-                  \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
-                  \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
-              }'"
-          fi
-
-          # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
-          # in GitHub runners: https://github.com/actions/runner-images/issues/668
-          if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
-            CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
-              --test='!/pod-to-world' \
-              --test='!/pod-to-cidr'"
-          fi
 
           echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
             ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS} ${CILIUM_INSTALL_MULTIPOOL_IPAM}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster1="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster2="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2}" >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
           echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
@@ -435,6 +407,10 @@ jobs:
             KUBEPROXYMODE=${{ matrix.kube-proxy }} \
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
+      - name: Create docker network
+        uses: ./.github/actions/kind-external-network
+        id: network
+
       - name: Create Kind cluster 1
         uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0
         with:
@@ -454,6 +430,54 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+      - name: Add external targets to kind cluster
+        uses: ./.github/actions/kind-external-targets
+        id: external_targets
+        with:
+          kube_contexts: ${{ env.contextName1 }} ${{ env.contextName2 }}
+          kind_network: ${{ steps.network.outputs.kind_network }}
+          ipv4_external_target: ${{ steps.network.outputs.ipv4_external_target }}
+          ipv4_other_external_target: ${{ steps.network.outputs.ipv4_other_external_target }}
+          ipv6_external_target: ${{ steps.network.outputs.ipv6_external_target }}
+          ipv6_other_external_target: ${{ steps.network.outputs.ipv6_other_external_target }}
+
+      - name: Get connectivity test flags
+        id: connectivity_flags
+        run: |
+          FLAGS=" \
+            --multi-cluster=${{ env.contextName2 }} \
+            --hubble=false \
+            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
+            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
+            --flow-validation=disabled \
+            --test-concurrency=5 \
+            --include-unsafe-tests \
+            --collect-sysdump-on-failure \
+            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>' \
+            --external-target=${{ steps.external_targets.outputs.external_target_name }} \
+            --external-other-target=${{ steps.external_targets.outputs.other_external_target_name }} \
+            --external-cidr=${{ steps.network.outputs.ipv4_external_cidr }} \
+            --external-cidrv6=${{ steps.network.outputs.ipv6_external_cidr }} \
+            --external-ip=${{ steps.network.outputs.ipv4_external_target }} \
+            --external-other-ip=${{ steps.network.outputs.ipv4_other_external_target }} \
+            --external-ipv6=${{ steps.network.outputs.ipv6_external_target }} \
+            --external-other-ipv6=${{ steps.network.outputs.ipv6_other_external_target }} \
+            --external-target-ca-namespace=external-target-secrets \
+            --external-target-ca-name=custom-ca \
+            --external-target-ipv6-capable=true \
+          "
+
+          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
+            FLAGS="$FLAGS \
+              --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
+              --deployment-pod-annotations='{ \
+                  \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
+                  \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
+              }'"
+          fi
+
+          echo flags=${FLAGS} >> $GITHUB_OUTPUT
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@c5e42236c7d90bd50e7975ac587f77782666a0aa # v0.20.0
@@ -500,6 +524,7 @@ jobs:
         uses: ./.github/actions/kvstore
         with:
           clusters: 2
+          network: ${{ steps.network.outputs.kind_network }}
 
       - name: Create the secret containing the kvstore credentials
         if: matrix.mode == 'external'
@@ -660,7 +685,7 @@ jobs:
 
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
-          cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.connectivity_flags.outputs.flags }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})" \
           --expected-drop-reasons='+No node ID found'
@@ -678,7 +703,7 @@ jobs:
           echo "current_drops: $total_drops"
           if [[ "$total_drops" != ${{ steps.no_nodeid_drops_prev.outputs.total_drops }} ]]; then
             # run no-unexpected-packet-drops connectivity to collect sysdumps
-            cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.connectivity_flags.outputs.flags }} \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - no-node-id-drops.xml" \
             --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})" \
             --test 'no-unexpected-packet-drops'


### PR DESCRIPTION
 * [x] #48250 (@giorio94) :warning: resolved conflicts
    :information_source: Skipped the first commit, as the corresponding action doesn't exist in v1.18, and then open-coded the configuration of the connectivity test flags directly in the workflow.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 48250
```
