### PR TITLE
 fix: include named port labels in Operator managed ciliumidentity

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -6,6 +6,7 @@ package ciliumendpointslice
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strconv"
 	"time"
@@ -18,6 +19,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/operator/pkg/ciliumidentity"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -486,7 +488,19 @@ func (c *SlimController) resolvePodPlacement(pod *slim_corev1.Pod) (string, *key
 		return "", nil, errSkipPodEvent
 	}
 
-	cidKey, err := getPodCIDKey(pod, c.logger, c.reconciler.namespaceStore, c.reconciler.clusterInfo)
+	var existingCID *cilium_api_v2.CiliumIdentity
+	if cidName, exists := c.manager.getCIDForCEP(GetCEPNameFromPod(pod)); exists {
+		cid, cidExists, cidErr := c.reconciler.cidStore.GetByKey(resource.Key{Name: string(cidName)})
+		if cidErr != nil {
+			return "", nil, cidErr
+		}
+		if !cidExists {
+			return "", nil, fmt.Errorf("CID name %q exists for pod %s/%s, but the CiliumIdentity was not found", cidName, pod.Namespace, pod.Name)
+		}
+		existingCID = cid
+	}
+
+	cidKey, err := ciliumidentity.GetCIDKeyForPod(c.logger, pod, c.reconciler.namespaceStore, c.reconciler.clusterInfo, existingCID)
 	if err != nil {
 		c.logger.Debug("could not get labels for pod",
 			logfields.K8sPodName, pod.Name,

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -14,16 +14,13 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/operator/pkg/ciliumidentity"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -458,13 +455,4 @@ func getNodeNameForPod(pod *slim_corev1.Pod) (string, error) {
 		return "", fmt.Errorf("pod has empty node name")
 	}
 	return pod.Spec.NodeName, nil
-}
-
-func getPodCIDKey(pod *slim_corev1.Pod, logger *slog.Logger, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (*key.GlobalIdentity, error) {
-	k8sLabels, err := ciliumidentity.GetRelevantLabelsForPod(logger, pod, nsStore, clusterInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get relevant labels for pod: %w", err)
-	}
-	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
-	return cidKey, nil
 }

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -26,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -281,11 +283,15 @@ func (r *reconciler) cidIsUsedInCEPOrCES(cidName string) bool {
 // 1. CID exists: No action.
 // 2. CID doesn't exist: Create CID.
 func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
-	k8sLabels, err := GetRelevantLabelsForPod(r.logger, pod, r.nsStore, r.clusterInfo)
+	assignedCID, err := r.assignedCIDForPod(pod)
 	if err != nil {
-		return fmt.Errorf("failed to get relevant labels for pod: %w", err)
+		return err
 	}
-	cidKey := key.GetCIDKeyFromLabels(k8sLabels, labels.LabelSourceK8s)
+
+	cidKey, err := GetCIDKeyForPod(r.logger, pod, r.nsStore, r.clusterInfo, assignedCID)
+	if err != nil {
+		return fmt.Errorf("failed to get CID key for pod: %w", err)
+	}
 
 	r.cidCreateLock.Lock()
 	defer r.cidCreateLock.Unlock()
@@ -305,7 +311,7 @@ func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
 			logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 			logfields.CIDName, cidName,
 			logfields.IdentityOld, prevCIDName,
-			logfields.Labels, k8sLabels)
+			logfields.Labels, cidKey.GetAsMap())
 	}
 
 	if isNewCID {
@@ -347,15 +353,95 @@ func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, erro
 	return allocatedID.String(), true, nil
 }
 
-// GetRelevantLabelsForPod returns the pod and namespace labels for a given pod
-func GetRelevantLabelsForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo) (map[string]string, error) {
+func (r *reconciler) assignedCIDForPod(pod *slim_corev1.Pod) (*cilium_api_v2.CiliumIdentity, error) {
+	cidName, err := r.assignedCIDNameForPod(pod)
+	if err != nil {
+		return nil, err
+	}
+	if cidName == "" {
+		return nil, nil
+	}
+
+	cid, exists, err := r.cidStore.GetByKey(cidResourceKey(cidName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing CID %q for pod %s/%s: %w", cidName, pod.Namespace, pod.Name, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("CID name %q exists for pod %s/%s, but the CiliumIdentity was not found", cidName, pod.Namespace, pod.Name)
+	}
+	return cid, nil
+}
+
+func (r *reconciler) assignedCIDNameForPod(pod *slim_corev1.Pod) (string, error) {
+	if !r.cesEnabled {
+		cep, exists, err := r.cepStore.GetByKey(podResourceKey(pod.Name, pod.Namespace))
+		if err != nil {
+			return "", fmt.Errorf("failed to get CEP for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		if !exists || cep.Status.Identity == nil || cep.Status.Identity.ID == 0 {
+			return "", nil
+		}
+		for _, owner := range cep.OwnerReferences {
+			if owner.Kind == "Pod" && pod.UID != "" && owner.UID != pod.UID {
+				return "", nil
+			}
+		}
+		return strconv.FormatInt(cep.Status.Identity.ID, 10), nil
+	}
+
+	for _, ces := range r.cesStore.List() {
+		if ces.Namespace != pod.Namespace {
+			continue
+		}
+		for _, cep := range ces.Endpoints {
+			if cep.Name != pod.Name || cep.IdentityID == 0 {
+				continue
+			}
+			if cep.PodUID != "" && pod.UID != "" && cep.PodUID != string(pod.UID) {
+				return "", nil
+			}
+			return strconv.FormatInt(cep.IdentityID, 10), nil
+		}
+	}
+	return "", nil
+}
+
+func namedPortLabelsFromCID(cid *cilium_api_v2.CiliumIdentity) labels.LabelArray {
+	if cid == nil {
+		return nil
+	}
+
+	var namedPortLabels labels.LabelArray
+	for _, lbl := range key.GetCIDKeyFromLabels(cid.SecurityLabels, "").LabelArray {
+		if lbl.Source == labels.LabelSourceGenerated && ciliumio.IsNamedPortsIdentityLabelName(lbl.Key) {
+			namedPortLabels = append(namedPortLabels, lbl)
+		}
+	}
+	return namedPortLabels
+}
+
+// GetCIDKeyForPod returns the GlobalIdentity key for a pod. New pods derive
+// named-port labels from pod metadata, while existing pods retain the exact
+// named-port labels from their existing identity.
+func GetCIDKeyForPod(logger *slog.Logger, pod *slim_corev1.Pod, nsStore resource.Store[*slim_corev1.Namespace], clusterInfo cmtypes.ClusterInfo, existingCID *cilium_api_v2.CiliumIdentity) (*key.GlobalIdentity, error) {
 	ns, err := getNamespace(pod.Namespace, nsStore)
 	if err != nil {
 		return nil, err
 	}
 
-	_, labelsMap := k8s.GetPodMetadata(logger, clusterInfo, ns, pod)
-	return labelsMap, nil
+	namedPorts, labelsMap := k8s.GetPodMetadata(logger, clusterInfo, ns, pod)
+	lbs := labels.Map2Labels(labelsMap, labels.LabelSourceK8s)
+	if existingCID == nil {
+		for _, lbl := range k8s.NamedPortsIdentityLabels(namedPorts) {
+			lbs[lbl.Key] = lbl
+		}
+	} else {
+		for _, lbl := range namedPortLabelsFromCID(existingCID) {
+			lbs[lbl.Key] = lbl
+		}
+	}
+	idLabels, _ := labelsfilter.Filter(lbs)
+	return &key.GlobalIdentity{LabelArray: idLabels.LabelArray()}, nil
 }
 
 func getNamespace(namespace string, nsStore resource.Store[*slim_corev1.Namespace]) (*slim_corev1.Namespace, error) {

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	k8sTesting "k8s.io/client-go/testing"
 
 	"github.com/cilium/cilium/operator/k8s"
@@ -480,7 +481,7 @@ func TestReconcileNS(t *testing.T) {
 	}
 }
 
-func TestGetRelevantLabelsForPodDoesNotIncludeGeneratedNamedPorts(t *testing.T) {
+func TestGetCIDKeyForPodNamedPorts(t *testing.T) {
 	ctx := t.Context()
 	reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, false)
 	defer cleanupFunc()
@@ -497,9 +498,148 @@ func TestGetRelevantLabelsForPodDoesNotIncludeGeneratedNamedPorts(t *testing.T) 
 		}},
 	}}
 
-	k8sLabels, err := GetRelevantLabelsForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo)
-	require.NoError(t, err)
-	require.NotContains(t, k8sLabels, ciliumio.NamedPortsIdentityLabelName)
+	namedPortsKey := labels.LabelSourceGenerated + ":" + ciliumio.NamedPortsIdentityLabelName
+
+	t.Run("new pod", func(t *testing.T) {
+		cidKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo, nil)
+		require.NoError(t, err)
+		require.Equal(t, "http.TCP.8080", cidKey.GetAsMap()[namedPortsKey])
+	})
+
+	t.Run("existing pod", func(t *testing.T) {
+		cidKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo, &capi_v2.CiliumIdentity{})
+		require.NoError(t, err)
+		require.NotContains(t, cidKey.GetAsMap(), namedPortsKey)
+	})
+
+	t.Run("existing pod preserves prior named ports", func(t *testing.T) {
+		existingCID := cidtest.NewCID("1000", testLbsA)
+		existingCID.SecurityLabels[namedPortsKey] = "http.TCP.80"
+
+		cidKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo, existingCID)
+		require.NoError(t, err)
+		require.Equal(t, "http.TCP.80", cidKey.GetAsMap()[namedPortsKey])
+	})
+
+	t.Run("new and existing pods use the same named-port label key", func(t *testing.T) {
+		newCIDKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo, nil)
+		require.NoError(t, err)
+
+		existingCID := cidtest.NewCID("1000", testLbsA)
+		existingCID.SecurityLabels[namedPortsKey] = "http.TCP.8080"
+		existingCIDKey, err := GetCIDKeyForPod(hivetest.Logger(t), pod, reconciler.nsStore, reconciler.clusterInfo, existingCID)
+		require.NoError(t, err)
+
+		require.Contains(t, newCIDKey.GetAsMap(), namedPortsKey)
+		require.Contains(t, existingCIDKey.GetAsMap(), namedPortsKey)
+		require.Equal(t, newCIDKey.GetAsMap()[namedPortsKey], existingCIDKey.GetAsMap()[namedPortsKey])
+	})
+}
+
+func TestAssignedCIDForPod(t *testing.T) {
+	const cidName = "1000"
+
+	newPod := func() *slim_corev1.Pod {
+		pod := cidtest.NewPod("pod1", "ns1", testLbsA, "node1")
+		pod.UID = types.UID("pod-uid")
+		return pod
+	}
+	addCID := func(t *testing.T, r *reconciler, withNamedPorts bool) *capi_v2.CiliumIdentity {
+		t.Helper()
+		cid := cidtest.NewCID(cidName, testLbsA)
+		if withNamedPorts {
+			cid.SecurityLabels[labels.LabelSourceGenerated+":"+ciliumio.NamedPortsIdentityLabelName] = "http.TCP.8080"
+		}
+		require.NoError(t, r.cidStore.CacheStore().Add(cid))
+		return cid
+	}
+
+	t.Run("pod without endpoint is new and CID should be nil", func(t *testing.T) {
+		r, _, _, cleanup := testNewReconciler(t, t.Context(), false)
+		defer cleanup()
+
+		cid, err := r.assignedCIDForPod(newPod())
+		require.NoError(t, err)
+		require.Nil(t, cid)
+	})
+
+	t.Run("pod with existing CEP keeps existing identity", func(t *testing.T) {
+		r, _, _, cleanup := testNewReconciler(t, t.Context(), false)
+		defer cleanup()
+		pod := newPod()
+		expectedCID := addCID(t, r, false)
+		require.NoError(t, r.cepStore.CacheStore().Add(&capi_v2.CiliumEndpoint{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+			Status:     capi_v2.EndpointStatus{Identity: &capi_v2.EndpointIdentity{ID: 1000}},
+		}))
+
+		cid, err := r.assignedCIDForPod(pod)
+		require.NoError(t, err)
+		require.NotNil(t, cid)
+		require.Equal(t, expectedCID, cid)
+		require.Empty(t, namedPortLabelsFromCID(cid))
+	})
+
+	t.Run("pod with named-port CEP keeps named-port identity", func(t *testing.T) {
+		r, _, _, cleanup := testNewReconciler(t, t.Context(), false)
+		defer cleanup()
+		pod := newPod()
+		expectedCID := addCID(t, r, true)
+		require.NoError(t, r.cepStore.CacheStore().Add(&capi_v2.CiliumEndpoint{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+			Status:     capi_v2.EndpointStatus{Identity: &capi_v2.EndpointIdentity{ID: 1000}},
+		}))
+
+		cid, err := r.assignedCIDForPod(pod)
+		require.NoError(t, err)
+		require.NotNil(t, cid)
+		require.Equal(t, expectedCID, cid)
+		require.Equal(t, "http.TCP.8080", namedPortLabelsFromCID(cid)[0].Value)
+	})
+
+	t.Run("replacement pod ignores stale CEP", func(t *testing.T) {
+		r, _, _, cleanup := testNewReconciler(t, t.Context(), false)
+		defer cleanup()
+		// newPod() creates a pod with UID "pod-uid".
+		pod := newPod()
+		require.NoError(t, r.cepStore.CacheStore().Add(&capi_v2.CiliumEndpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind: "Pod",
+					UID:  types.UID("old-pod-uid"),
+				}},
+			},
+			Status: capi_v2.EndpointStatus{Identity: &capi_v2.EndpointIdentity{ID: 1000}},
+		}))
+
+		cid, err := r.assignedCIDForPod(pod)
+		require.NoError(t, err)
+		require.Nil(t, cid)
+	})
+
+	t.Run("pod with existing CES endpoint keeps existing identity", func(t *testing.T) {
+		r, _, _, cleanup := testNewReconciler(t, t.Context(), true)
+		defer cleanup()
+		pod := newPod()
+		expectedCID := addCID(t, r, false)
+		require.NoError(t, r.cesStore.CacheStore().Add(&capi_v2a1.CiliumEndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: "ces1"},
+			Namespace:  pod.Namespace,
+			Endpoints: []capi_v2a1.CoreCiliumEndpoint{{
+				Name:       pod.Name,
+				IdentityID: 1000,
+				PodUID:     string(pod.UID),
+			}},
+		}))
+
+		cid, err := r.assignedCIDForPod(pod)
+		require.NoError(t, err)
+		require.NotNil(t, cid)
+		require.Equal(t, expectedCID, cid)
+		require.Empty(t, namedPortLabelsFromCID(cid))
+	})
 }
 
 func TestHandleStoreCIDMatch(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [ ] Thanks for contributing!



Fixes: https://github.com/cilium/cilium/issues/47214
Extension of this PR considering only new pods: https://github.com/cilium/cilium/pull/48033

When identity-management-mode is set to `operator` or `both`, the operator allocates CiliumIdentity for pods. It derives the identity key from the labels returned by `k8s.GetPodMetadata()` while discarding the named port labels. cilium-agent computes its key from the same metadata but also includes the generated named port labels, so for any pod declaring a named port the two keys never matched. The operator created an identity the agent would never select and the pod could not be created. Compute the operator side key with `GetCIDKeyForPod()`, which merges the generated named port labels into the pod labels and applies `labelsfilter.Filter()` before building the `key.GlobalIdentity`, matching what the agent does.

Named port labels are only derived from pod metadata for pods that do not yet have an identity. A pod that already has one keeps its currently assigned named port labels, so existing pods are not moved to a new identity. The assigned identity is resolved from the pod's CiliumEndpoint, or from the matching CiliumEndpointSlice entry when CES is enabled. 
`getPodCIDKey()` is removed from the ciliumendpointslice reconciler and `resolvePodPlacement()` now calls the shared `GetCIDKeyForPod()`


```release-note
Fixes a bug that prevents cilium identity creation for pods with named ports when operator-managed-identity was enabled.
```

This PR was prepared with AIL:3. I personally reviewed this.
