### PR TITLE
docs: fix 'allows to use' grammar in CNI chaining intro

### DIFF
--- a/Documentation/installation/cni-chaining.rst
+++ b/Documentation/installation/cni-chaining.rst
@@ -10,7 +10,7 @@
 CNI Chaining
 ************
 
-CNI chaining allows to use Cilium in combination with other CNI plugins.
+CNI chaining allows you to use Cilium in combination with other CNI plugins.
 
 With Cilium CNI chaining, the base network connectivity and IP address management
 is managed by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

Fix non-idiomatic grammar in the CNI chaining introduction.

This PR was prepared with AIL:2. I personally verified the wording against the surrounding paragraph and confirmed the single-line docs change.

Fixes: #48688

```release-note
docs: fix "allows to use" grammar in CNI chaining intro
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request